### PR TITLE
feat: per-CLI release ledgers

### DIFF
--- a/.github/workflows/update-cli-release-ledger.yml
+++ b/.github/workflows/update-cli-release-ledger.yml
@@ -1,0 +1,120 @@
+name: Update per-CLI release ledger
+
+# Assigns per-CLI release versions after library changes merge to main. This
+# keeps CHANGELOG.md, .printing-press-release.json, and the compiled runtime
+# version in sync without making contributors manually bump 233 independent
+# CLIs or fight changelog conflicts in feature PRs.
+#
+# Source of truth: tools/release-ledger/main.go.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'library/**'
+      - 'tools/release-ledger/**'
+      - '.github/workflows/update-cli-release-ledger.yml'
+  workflow_dispatch:
+    inputs:
+      changed_from:
+        description: 'Base ref/sha to diff from'
+        required: false
+      changed_to:
+        description: 'Head ref/sha to diff to'
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update:
+    name: Update and commit
+    runs-on: ubuntu-latest
+    # Share one push lane with the other generated-artifact workflows. They
+    # all commit back to main after source changes land, so serializing avoids
+    # non-fast-forward push races.
+    concurrency:
+      group: generated-artifact-push-main
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.ADMIN_PUSH_PAT }}
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.3'
+      - name: Resolve release metadata
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          changed_from="${{ inputs.changed_from || github.event.before }}"
+          changed_to="${{ inputs.changed_to || github.sha }}"
+          if [ -z "$changed_from" ] || [ "$changed_from" = "0000000000000000000000000000000000000000" ]; then
+            changed_from="$(git rev-list --max-parents=0 HEAD | tail -n 1)"
+          fi
+          if [ -z "$changed_to" ]; then
+            changed_to="$(git rev-parse HEAD)"
+          fi
+
+          pr_number="$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/${GITHUB_REPOSITORY}/commits/${changed_to}/pulls" \
+            --jq '.[0].number // ""' 2>/dev/null || true)"
+          pr_title="$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/${GITHUB_REPOSITORY}/commits/${changed_to}/pulls" \
+            --jq '.[0].title // ""' 2>/dev/null || true)"
+          pr_url="$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/${GITHUB_REPOSITORY}/commits/${changed_to}/pulls" \
+            --jq '.[0].html_url // ""' 2>/dev/null || true)"
+          if [ -z "$pr_title" ]; then
+            pr_title="$(git log -1 --pretty=%s "$changed_to")"
+          fi
+
+          {
+            echo "changed_from=$changed_from"
+            echo "changed_to=$changed_to"
+            echo "released_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "pr_number=$pr_number"
+            echo "pr_title<<EOF"
+            echo "$pr_title"
+            echo "EOF"
+            echo "pr_url=$pr_url"
+          } >> "$GITHUB_OUTPUT"
+      - name: Run release-ledger
+        run: |
+          set -euo pipefail
+          args=(
+            --changed-from "${{ steps.meta.outputs.changed_from }}"
+            --changed-to "${{ steps.meta.outputs.changed_to }}"
+            --released-at "${{ steps.meta.outputs.released_at }}"
+            --source-commit "${{ steps.meta.outputs.changed_to }}"
+            --change-title "${{ steps.meta.outputs.pr_title }}"
+          )
+          if [ -n "${{ steps.meta.outputs.pr_number }}" ]; then
+            args+=(--change-pr "${{ steps.meta.outputs.pr_number }}")
+          fi
+          if [ -n "${{ steps.meta.outputs.pr_url }}" ]; then
+            args+=(--change-url "${{ steps.meta.outputs.pr_url }}")
+          fi
+          go run ./tools/release-ledger/main.go "${args[@]}"
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- library; then
+            echo "No release-ledger changes; nothing to commit."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add library
+          git commit -m "chore(releases): update CLI release ledger [skip ci]"
+          git pull --rebase origin main
+          git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ The normal flow is:
 
 1. `cli-printing-press` generates or improves a printed CLI in the local working library (`~/printing-press/library/<api-slug>/`) and archives proofs/manuscripts.
 2. Publish tooling moves the finished CLI into this repo under `library/<category>/<cli-slug>/`, with provenance in `.printing-press.json`.
-3. This repo updates `registry.json` and `cli-skills/pp-*`, and the npm installer consumes the live catalog.
+3. This repo updates per-CLI release metadata, `registry.json`, and `cli-skills/pp-*`, and the npm installer consumes the live catalog.
 
 Use this distinction in your own language: **generator repo** or **Printing Press** for `cli-printing-press`; **published library** or **catalog repo** for this repo; **local library** for the generated working-copy library, commonly `~/printing-press/library`.
 
@@ -82,6 +82,7 @@ The following are **not** new CLI / reprint changes and are fine to land via a n
 - `tools/sweep-canonical/` runs that retrofit canonical shape across all entries.
 - CI changes under `.github/workflows/`, repo-root docs, or installer changes under `npm/`.
 - Manual edits to the generator-output files (`registry.json`, `cli-skills/pp-*/SKILL.md`) — don't; those are bot-regenerated post-merge.
+- Manual release-version bumps or changelog release entries — don't; `CHANGELOG.md`, `.printing-press-release.json`, and runtime `version` stamping are owned by the post-merge release-ledger workflow described below.
 
 ### What to do instead, when the change *is* a new CLI / reprint
 
@@ -170,6 +171,7 @@ npm/                                — @mvanhorn/printing-press npm installer w
 
 registry.json                       — top-level catalog: every CLI's name, category, description, path, MCP metadata
 tools/generate-skills/              — regenerates cli-skills/pp-*
+tools/release-ledger/               — assigns per-CLI release versions after merges
 .github/scripts/verify-skill/       — Python verifier that checks SKILL.md matches shipped Go source
 .github/workflows/                  — CI: verify-skills.yml, generate-skills.yml
 ```
@@ -194,6 +196,39 @@ Inside any published CLI directory, `.printing-press.json` is machine-readable p
 - `printing_press_version` — generator version that produced this CLI
 
 Some CLIs have no archived spec on disk (docs-driven, sniff-driven, plan-driven). Tooling that assumes `spec.json` exists breaks on those — check before reading.
+
+## Per-CLI release ledger: changelog, release manifest, runtime version
+
+Each published CLI has its own release history because users install one CLI at a time from this repo. The release identity is intentionally distinct from `.printing-press.json`'s `printing_press_version`: the former answers "which published version of this CLI do I have?", while the latter answers "which generator binary produced the base artifact?"
+
+Release versions use `YYYY.M.N`, where `N` is the release count for that CLI within the month. Example: if `x-twitter` gets three library releases in June 2026, the third is `2026.6.3`. The value is not a date and does not require a day component.
+
+Do not ask contributors or agents to manually bump release versions. After a PR lands on `main`, `.github/workflows/update-cli-release-ledger.yml` runs `tools/release-ledger/` against the changed CLI directories and commits:
+
+- `library/<category>/<slug>/.printing-press-release.json` — current release metadata, PR/source commit, generator provenance copied from `.printing-press.json`.
+- `library/<category>/<slug>/CHANGELOG.md` — topmost release note for the merge that changed the CLI.
+- The generated runtime version variable in `internal/cli/root.go` or `internal/cli/version.go` when present, plus `cmd/*-pp-mcp/main.go` for MCP server versions when present.
+
+This workflow is post-merge by design. It prevents open PRs from conflicting on shared changelog/version files and lets older PRs merge without being rebased solely to catch up release counters. In normal feature or fix PRs:
+
+- Do not edit `.printing-press-release.json`.
+- Do not add a new `CHANGELOG.md` release section.
+- Do not hand-edit `var version = ...` for release bookkeeping.
+- Do update the CLI's README/SKILL/patch metadata when your user-facing change needs documentation; the release workflow will summarize the merge after it lands.
+
+For new-CLI PRs, blank release-ledger skeletons are acceptable. For reprints or
+other PRs that replace an existing `library/<category>/<slug>/` tree, preserve
+the existing `.printing-press-release.json` and `CHANGELOG.md` from `main`
+instead of taking the freshly generated skeletons. The post-merge workflow uses
+those existing files to increment the next CalVer release and retain changelog
+history; deleting them in the replacement PR resets the ledger before automation
+can do the right thing.
+
+If the release ledger itself drifts or a historical CLI is missing these files, run the scoped repair from the repo root and commit only the intended release-ledger outputs:
+
+```bash
+go run ./tools/release-ledger/main.go --init-missing
+```
 
 ## Attribution: creator + contributors
 

--- a/library/accounting/qbo/.printing-press-release.json
+++ b/library/accounting/qbo/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "qbo",
+  "cli_name": "qbo-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.20.1",
+  "run_id": "qbo-fixture-read-20260604",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/accounting/qbo/CHANGELOG.md
+++ b/library/accounting/qbo/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/accounting/qbo/internal/cli/root.go
+++ b/library/accounting/qbo/internal/cli/root.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 // Execute runs the CLI.
 func Execute() error {

--- a/library/accounting/xero/.printing-press-release.json
+++ b/library/accounting/xero/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "xero",
+  "cli_name": "xero-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.20.1",
+  "run_id": "xero-fixture-read-20260604",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/accounting/xero/CHANGELOG.md
+++ b/library/accounting/xero/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/accounting/xero/internal/cli/root.go
+++ b/library/accounting/xero/internal/cli/root.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 // Execute runs the CLI.
 func Execute() error {

--- a/library/ai/elevenlabs/.printing-press-release.json
+++ b/library/ai/elevenlabs/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "elevenlabs",
+  "cli_name": "elevenlabs-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.2",
+  "run_id": "20260513T152516Z-e836a3fe",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/ai/elevenlabs/CHANGELOG.md
+++ b/library/ai/elevenlabs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/ai/elevenlabs/internal/cli/root.go
+++ b/library/ai/elevenlabs/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/ai/midjourney/.printing-press-release.json
+++ b/library/ai/midjourney/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "midjourney",
+  "cli_name": "midjourney-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.13.0",
+  "run_id": "20260523-212652",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/ai/midjourney/CHANGELOG.md
+++ b/library/ai/midjourney/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/ai/midjourney/internal/cli/root.go
+++ b/library/ai/midjourney/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/ai/ollama-cloud/.printing-press-release.json
+++ b/library/ai/ollama-cloud/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "ollama-cloud",
+  "cli_name": "ollama-cloud-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260524-003533",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/ai/ollama-cloud/CHANGELOG.md
+++ b/library/ai/ollama-cloud/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/ai/ollama-cloud/internal/cli/root.go
+++ b/library/ai/ollama-cloud/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/ai/ollama-cloud/internal/config"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/ai/openrouter/.printing-press-release.json
+++ b/library/ai/openrouter/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "openrouter",
+  "cli_name": "openrouter-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.0",
+  "run_id": "20260509-165428",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/ai/openrouter/CHANGELOG.md
+++ b/library/ai/openrouter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/ai/openrouter/internal/cli/root.go
+++ b/library/ai/openrouter/internal/cli/root.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/ai/surgegraph/.printing-press-release.json
+++ b/library/ai/surgegraph/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "surgegraph",
+  "cli_name": "surgegraph-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.0",
+  "run_id": "20260512-171718",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/ai/surgegraph/CHANGELOG.md
+++ b/library/ai/surgegraph/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/ai/surgegraph/internal/cli/root.go
+++ b/library/ai/surgegraph/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/ai/twelvelabs/.printing-press-release.json
+++ b/library/ai/twelvelabs/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "twelvelabs",
+  "cli_name": "twelvelabs-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.21.0",
+  "run_id": "20260605-150627",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/ai/twelvelabs/CHANGELOG.md
+++ b/library/ai/twelvelabs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/ai/twelvelabs/internal/cli/version.go
+++ b/library/ai/twelvelabs/internal/cli/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // version is the printed CLI's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "2026.6.1"
 
 // newVersionCmd prints the CLI name and version. Shared by the HTTP and device
 // generators so both printed-CLI shapes carry an identical version command.

--- a/library/ai/wavespeed/.printing-press-release.json
+++ b/library/ai/wavespeed/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "wavespeed",
+  "cli_name": "wavespeed-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.1",
+  "run_id": "20260527-214905",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/ai/wavespeed/CHANGELOG.md
+++ b/library/ai/wavespeed/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/ai/wavespeed/internal/cli/root.go
+++ b/library/ai/wavespeed/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/cloud/azure-functions-admin/.printing-press-release.json
+++ b/library/cloud/azure-functions-admin/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "azure-functions-admin",
+  "cli_name": "azure-functions-admin-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.1",
+  "run_id": "20260530-083324",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/cloud/azure-functions-admin/CHANGELOG.md
+++ b/library/cloud/azure-functions-admin/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/cloud/azure-functions-admin/internal/cli/root.go
+++ b/library/cloud/azure-functions-admin/internal/cli/root.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/cloud/cf-domain/.printing-press-release.json
+++ b/library/cloud/cf-domain/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "cf-domain",
+  "cli_name": "cf-domain-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.3.0",
+  "run_id": "cf-domain-registrar-20260511-local-hardening",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/cloud/cf-domain/CHANGELOG.md
+++ b/library/cloud/cf-domain/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/cloud/cf-domain/internal/cli/root.go
+++ b/library/cloud/cf-domain/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/cloud/cloud-run-admin/.printing-press-release.json
+++ b/library/cloud/cloud-run-admin/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "cloud-run-admin",
+  "cli_name": "cloud-run-admin-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.1",
+  "run_id": "20260507T171842Z-6844a8b4",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/cloud/cloud-run-admin/CHANGELOG.md
+++ b/library/cloud/cloud-run-admin/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/cloud/cloud-run-admin/internal/cli/root.go
+++ b/library/cloud/cloud-run-admin/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/cloud/digitalocean/.printing-press-release.json
+++ b/library/cloud/digitalocean/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "digitalocean",
+  "cli_name": "digitalocean-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.1",
+  "run_id": "20260509T153152Z-d4554011",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/cloud/digitalocean/CHANGELOG.md
+++ b/library/cloud/digitalocean/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/cloud/digitalocean/internal/cli/root.go
+++ b/library/cloud/digitalocean/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/cloud/here-now/.printing-press-release.json
+++ b/library/cloud/here-now/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "here-now",
+  "cli_name": "here-now-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260530-170355",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/cloud/here-now/CHANGELOG.md
+++ b/library/cloud/here-now/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/cloud/here-now/internal/cli/root.go
+++ b/library/cloud/here-now/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/cloud/render/.printing-press-release.json
+++ b/library/cloud/render/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "render",
+  "cli_name": "render-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.0",
+  "run_id": "20260509-092314",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/cloud/render/CHANGELOG.md
+++ b/library/cloud/render/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/cloud/render/internal/cli/root.go
+++ b/library/cloud/render/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/amazon-ads/.printing-press-release.json
+++ b/library/commerce/amazon-ads/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "amazon-ads",
+  "cli_name": "amazon-ads-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.1",
+  "run_id": "20260527-233111",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/amazon-ads/CHANGELOG.md
+++ b/library/commerce/amazon-ads/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/amazon-ads/internal/cli/root.go
+++ b/library/commerce/amazon-ads/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/amazon-orders/.printing-press-release.json
+++ b/library/commerce/amazon-orders/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "amazon-orders",
+  "cli_name": "amazon-orders-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260510-105710",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/amazon-orders/CHANGELOG.md
+++ b/library/commerce/amazon-orders/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/amazon-orders/internal/cli/root.go
+++ b/library/commerce/amazon-orders/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/amazon-seller/.printing-press-release.json
+++ b/library/commerce/amazon-seller/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "amazon-seller",
+  "cli_name": "amazon-seller-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.10.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/amazon-seller/CHANGELOG.md
+++ b/library/commerce/amazon-seller/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/amazon-seller/internal/cli/root.go
+++ b/library/commerce/amazon-seller/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/blacklane/.printing-press-release.json
+++ b/library/commerce/blacklane/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "blacklane",
+  "cli_name": "blacklane-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.1",
+  "run_id": "20260601-000336",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/blacklane/CHANGELOG.md
+++ b/library/commerce/blacklane/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/blacklane/internal/cli/root.go
+++ b/library/commerce/blacklane/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/commerce/craigslist/.printing-press-release.json
+++ b/library/commerce/craigslist/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "craigslist",
+  "cli_name": "craigslist-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.0",
+  "run_id": "20260502-152300",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/craigslist/CHANGELOG.md
+++ b/library/commerce/craigslist/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/craigslist/internal/cli/root.go
+++ b/library/commerce/craigslist/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/doordash/.printing-press-release.json
+++ b/library/commerce/doordash/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "doordash",
+  "cli_name": "doordash-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.12.0",
+  "run_id": "20260515-181004",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/doordash/CHANGELOG.md
+++ b/library/commerce/doordash/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/doordash/internal/cli/root.go
+++ b/library/commerce/doordash/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/ebay/.printing-press-release.json
+++ b/library/commerce/ebay/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "ebay",
+  "cli_name": "ebay-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.0.1",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/ebay/CHANGELOG.md
+++ b/library/commerce/ebay/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/ebay/internal/cli/root.go
+++ b/library/commerce/ebay/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/facebook-marketplace/.printing-press-release.json
+++ b/library/commerce/facebook-marketplace/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "facebook-marketplace",
+  "cli_name": "facebook-marketplace-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.6.1",
+  "run_id": "20260518-135804",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/facebook-marketplace/CHANGELOG.md
+++ b/library/commerce/facebook-marketplace/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/facebook-marketplace/internal/cli/root.go
+++ b/library/commerce/facebook-marketplace/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/fedex/.printing-press-release.json
+++ b/library/commerce/fedex/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "fedex",
+  "cli_name": "fedex-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.0",
+  "run_id": "20260502-152509",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/fedex/CHANGELOG.md
+++ b/library/commerce/fedex/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/fedex/internal/cli/root.go
+++ b/library/commerce/fedex/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/gumroad/.printing-press-release.json
+++ b/library/commerce/gumroad/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "gumroad",
+  "cli_name": "gumroad-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.3.0",
+  "run_id": "20260511-134339",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/gumroad/CHANGELOG.md
+++ b/library/commerce/gumroad/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/gumroad/internal/cli/root.go
+++ b/library/commerce/gumroad/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/harris-teeter/.printing-press-release.json
+++ b/library/commerce/harris-teeter/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "harris-teeter",
+  "cli_name": "harris-teeter-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.2",
+  "run_id": "20260517-190052",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/harris-teeter/CHANGELOG.md
+++ b/library/commerce/harris-teeter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/harris-teeter/internal/cli/root.go
+++ b/library/commerce/harris-teeter/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/instacart/.printing-press-release.json
+++ b/library/commerce/instacart/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "instacart",
+  "cli_name": "instacart-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "1.2.1",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/instacart/CHANGELOG.md
+++ b/library/commerce/instacart/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/loopnet/.printing-press-release.json
+++ b/library/commerce/loopnet/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "loopnet",
+  "cli_name": "loopnet-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260520-165006",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/loopnet/CHANGELOG.md
+++ b/library/commerce/loopnet/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/loopnet/internal/cli/root.go
+++ b/library/commerce/loopnet/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/offerup/.printing-press-release.json
+++ b/library/commerce/offerup/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "offerup",
+  "cli_name": "offerup-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.1",
+  "run_id": "20260531-200239",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/offerup/CHANGELOG.md
+++ b/library/commerce/offerup/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/offerup/internal/cli/root.go
+++ b/library/commerce/offerup/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/printify/.printing-press-release.json
+++ b/library/commerce/printify/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "printify",
+  "cli_name": "printify-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.14.0",
+  "run_id": "20260524-134133",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/printify/CHANGELOG.md
+++ b/library/commerce/printify/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/printify/internal/cli/root.go
+++ b/library/commerce/printify/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/commerce/printify/internal/config"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/restaurant365-odata/.printing-press-release.json
+++ b/library/commerce/restaurant365-odata/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "restaurant365-odata",
+  "cli_name": "restaurant365-odata-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.1",
+  "run_id": "20260530-231734",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/restaurant365-odata/CHANGELOG.md
+++ b/library/commerce/restaurant365-odata/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/restaurant365-odata/internal/cli/root.go
+++ b/library/commerce/restaurant365-odata/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/shopify/.printing-press-release.json
+++ b/library/commerce/shopify/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "shopify",
+  "cli_name": "shopify-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.14.0",
+  "run_id": "20260524-085902",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/shopify/CHANGELOG.md
+++ b/library/commerce/shopify/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/shopify/internal/cli/root.go
+++ b/library/commerce/shopify/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/slickdeals/.printing-press-release.json
+++ b/library/commerce/slickdeals/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "slickdeals",
+  "cli_name": "slickdeals-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.1",
+  "run_id": "20260509-232351",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/slickdeals/CHANGELOG.md
+++ b/library/commerce/slickdeals/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/slickdeals/internal/cli/root.go
+++ b/library/commerce/slickdeals/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.3.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/squarespace/.printing-press-release.json
+++ b/library/commerce/squarespace/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "squarespace",
+  "cli_name": "squarespace-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.1",
+  "run_id": "20260512-123445",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/squarespace/CHANGELOG.md
+++ b/library/commerce/squarespace/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/squarespace/internal/cli/root.go
+++ b/library/commerce/squarespace/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/tiktok-shop/.printing-press-release.json
+++ b/library/commerce/tiktok-shop/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "tiktok-shop",
+  "cli_name": "tiktok-shop-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.8.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/tiktok-shop/CHANGELOG.md
+++ b/library/commerce/tiktok-shop/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/tiktok-shop/internal/cli/root.go
+++ b/library/commerce/tiktok-shop/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.1.0"
+var version = "2026.6.1"
 var noColor bool
 
 type rootFlags struct {

--- a/library/commerce/ucp/.printing-press-release.json
+++ b/library/commerce/ucp/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "ucp",
+  "cli_name": "ucp-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.13.1",
+  "run_id": "20260524-004358",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/ucp/CHANGELOG.md
+++ b/library/commerce/ucp/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/ucp/internal/cli/root.go
+++ b/library/commerce/ucp/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.3.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/commerce/yahoo-finance/.printing-press-release.json
+++ b/library/commerce/yahoo-finance/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "yahoo-finance",
+  "cli_name": "yahoo-finance-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.14.0",
+  "run_id": "20260524-221143",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/commerce/yahoo-finance/CHANGELOG.md
+++ b/library/commerce/yahoo-finance/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/commerce/yahoo-finance/internal/cli/root.go
+++ b/library/commerce/yahoo-finance/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/agent-capture/.printing-press-release.json
+++ b/library/developer-tools/agent-capture/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "agent-capture",
+  "cli_name": "agent-capture-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "0.4.0",
+  "run_id": "20260405-115134",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/agent-capture/CHANGELOG.md
+++ b/library/developer-tools/agent-capture/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/airframe/.printing-press-release.json
+++ b/library/developer-tools/airframe/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "airframe",
+  "cli_name": "airframe-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.2",
+  "run_id": "20260513-023951",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/airframe/CHANGELOG.md
+++ b/library/developer-tools/airframe/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/airframe/internal/cli/root.go
+++ b/library/developer-tools/airframe/internal/cli/root.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.1.0"
+var version = "2026.6.1"
 
 // Persistent flags shared by every subcommand. Empty strings/zero values
 // indicate "fall back to defaults" (see store.DefaultDBPath, etc.).

--- a/library/developer-tools/apify/.printing-press-release.json
+++ b/library/developer-tools/apify/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "apify",
+  "cli_name": "apify-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260518-132617",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/apify/CHANGELOG.md
+++ b/library/developer-tools/apify/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/apify/internal/cli/root.go
+++ b/library/developer-tools/apify/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/apple-docs/.printing-press-release.json
+++ b/library/developer-tools/apple-docs/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "apple-docs",
+  "cli_name": "apple-docs-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.1",
+  "run_id": "20260528-170611",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/apple-docs/CHANGELOG.md
+++ b/library/developer-tools/apple-docs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/apple-docs/internal/cli/root.go
+++ b/library/developer-tools/apple-docs/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/company-goat/.printing-press-release.json
+++ b/library/developer-tools/company-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "company-goat",
+  "cli_name": "company-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "2.3.9",
+  "run_id": "20260427-121015",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/company-goat/CHANGELOG.md
+++ b/library/developer-tools/company-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/company-goat/internal/cli/root.go
+++ b/library/developer-tools/company-goat/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/docker-hub/.printing-press-release.json
+++ b/library/developer-tools/docker-hub/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "docker-hub",
+  "cli_name": "docker-hub-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/docker-hub/CHANGELOG.md
+++ b/library/developer-tools/docker-hub/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/docker-hub/internal/cli/root.go
+++ b/library/developer-tools/docker-hub/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/domain-goat/.printing-press-release.json
+++ b/library/developer-tools/domain-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "domain-goat",
+  "cli_name": "domain-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.4.0",
+  "run_id": "20260512-093229",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/domain-goat/CHANGELOG.md
+++ b/library/developer-tools/domain-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/domain-goat/internal/cli/root.go
+++ b/library/developer-tools/domain-goat/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/firecrawl/.printing-press-release.json
+++ b/library/developer-tools/firecrawl/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "firecrawl",
+  "cli_name": "firecrawl-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/firecrawl/CHANGELOG.md
+++ b/library/developer-tools/firecrawl/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/firecrawl/internal/cli/root.go
+++ b/library/developer-tools/firecrawl/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/godaddy/.printing-press-release.json
+++ b/library/developer-tools/godaddy/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "godaddy",
+  "cli_name": "godaddy-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.11.0",
+  "run_id": "20260522-124732",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/godaddy/CHANGELOG.md
+++ b/library/developer-tools/godaddy/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/godaddy/internal/cli/root.go
+++ b/library/developer-tools/godaddy/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/namecheap/.printing-press-release.json
+++ b/library/developer-tools/namecheap/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "namecheap",
+  "cli_name": "namecheap-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.6.0",
+  "run_id": "20260514-namecheap",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/namecheap/CHANGELOG.md
+++ b/library/developer-tools/namecheap/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/namecheap/internal/cli/root.go
+++ b/library/developer-tools/namecheap/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/nse-india/.printing-press-release.json
+++ b/library/developer-tools/nse-india/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "nse-india",
+  "cli_name": "nse-india-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.4",
+  "run_id": "20260508-113209",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/nse-india/CHANGELOG.md
+++ b/library/developer-tools/nse-india/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/nse-india/internal/cli/root.go
+++ b/library/developer-tools/nse-india/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/nvd/.printing-press-release.json
+++ b/library/developer-tools/nvd/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "nvd",
+  "cli_name": "nvd-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/nvd/CHANGELOG.md
+++ b/library/developer-tools/nvd/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/nvd/internal/cli/root.go
+++ b/library/developer-tools/nvd/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/openfda/.printing-press-release.json
+++ b/library/developer-tools/openfda/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "openfda",
+  "cli_name": "openfda-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.0",
+  "run_id": "20260509-174725",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/openfda/CHANGELOG.md
+++ b/library/developer-tools/openfda/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/openfda/internal/cli/root.go
+++ b/library/developer-tools/openfda/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/openipa/.printing-press-release.json
+++ b/library/developer-tools/openipa/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "openipa",
+  "cli_name": "openipa-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.6.1",
+  "run_id": "20260514-212234",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/openipa/CHANGELOG.md
+++ b/library/developer-tools/openipa/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/openipa/internal/cli/root.go
+++ b/library/developer-tools/openipa/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/pdok-location/.printing-press-release.json
+++ b/library/developer-tools/pdok-location/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "pdok-location",
+  "cli_name": "pdok-location-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260520-150244",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/pdok-location/CHANGELOG.md
+++ b/library/developer-tools/pdok-location/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/pdok-location/internal/cli/root.go
+++ b/library/developer-tools/pdok-location/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/posthog/.printing-press-release.json
+++ b/library/developer-tools/posthog/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "posthog",
+  "cli_name": "posthog-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.0",
+  "run_id": "20260512-010008",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/posthog/CHANGELOG.md
+++ b/library/developer-tools/posthog/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/posthog/internal/cli/root.go
+++ b/library/developer-tools/posthog/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/postman-explore/.printing-press-release.json
+++ b/library/developer-tools/postman-explore/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "postman-explore",
+  "cli_name": "postman-explore-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.0.1",
+  "run_id": "20260429-230407",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/postman-explore/CHANGELOG.md
+++ b/library/developer-tools/postman-explore/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/postman-explore/internal/cli/root.go
+++ b/library/developer-tools/postman-explore/internal/cli/root.go
@@ -19,7 +19,7 @@ import (
 )
 
 // PATCH: keep runtime --version aligned with the generated manifest version.
-var version = "3.0.1"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON       bool

--- a/library/developer-tools/pypi/.printing-press-release.json
+++ b/library/developer-tools/pypi/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "pypi",
+  "cli_name": "pypi-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/pypi/CHANGELOG.md
+++ b/library/developer-tools/pypi/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/pypi/internal/cli/root.go
+++ b/library/developer-tools/pypi/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/scrape-creators/.printing-press-release.json
+++ b/library/developer-tools/scrape-creators/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "scrape-creators",
+  "cli_name": "scrape-creators-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.2.1",
+  "run_id": "20260501-171858",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/scrape-creators/CHANGELOG.md
+++ b/library/developer-tools/scrape-creators/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/scrape-creators/internal/cli/root.go
+++ b/library/developer-tools/scrape-creators/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/sec-edgar/.printing-press-release.json
+++ b/library/developer-tools/sec-edgar/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "sec-edgar",
+  "cli_name": "sec-edgar-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260511-180534",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/sec-edgar/CHANGELOG.md
+++ b/library/developer-tools/sec-edgar/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/sec-edgar/internal/cli/root.go
+++ b/library/developer-tools/sec-edgar/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/supabase/.printing-press-release.json
+++ b/library/developer-tools/supabase/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "supabase",
+  "cli_name": "supabase-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.1",
+  "run_id": "20260512-165514",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/supabase/CHANGELOG.md
+++ b/library/developer-tools/supabase/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/supabase/internal/cli/root.go
+++ b/library/developer-tools/supabase/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/trigger-dev/.printing-press-release.json
+++ b/library/developer-tools/trigger-dev/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "trigger-dev",
+  "cli_name": "trigger-dev-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.10.0",
+  "run_id": "20260507-000200",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/trigger-dev/CHANGELOG.md
+++ b/library/developer-tools/trigger-dev/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/trigger-dev/internal/cli/root.go
+++ b/library/developer-tools/trigger-dev/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/developer-tools/uspto-tsdr/.printing-press-release.json
+++ b/library/developer-tools/uspto-tsdr/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "uspto-tsdr",
+  "cli_name": "uspto-tsdr-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.0",
+  "run_id": "20260509-135942",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/developer-tools/uspto-tsdr/CHANGELOG.md
+++ b/library/developer-tools/uspto-tsdr/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/developer-tools/uspto-tsdr/internal/cli/root.go
+++ b/library/developer-tools/uspto-tsdr/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/devices/adminbyrequest/.printing-press-release.json
+++ b/library/devices/adminbyrequest/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "adminbyrequest",
+  "cli_name": "adminbyrequest-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.2",
+  "run_id": "20260513-165311",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/devices/adminbyrequest/CHANGELOG.md
+++ b/library/devices/adminbyrequest/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/devices/adminbyrequest/internal/cli/root.go
+++ b/library/devices/adminbyrequest/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/devices/dreo/.printing-press-release.json
+++ b/library/devices/dreo/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "dreo",
+  "cli_name": "dreo-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260517-015408",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/devices/dreo/CHANGELOG.md
+++ b/library/devices/dreo/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/devices/dreo/internal/cli/root.go
+++ b/library/devices/dreo/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/devices/hayward-omnilogic/.printing-press-release.json
+++ b/library/devices/hayward-omnilogic/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "hayward-omnilogic",
+  "cli_name": "hayward-omnilogic-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260510-160303",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/devices/hayward-omnilogic/CHANGELOG.md
+++ b/library/devices/hayward-omnilogic/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/devices/hayward-omnilogic/internal/cli/root.go
+++ b/library/devices/hayward-omnilogic/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/devices/tesla/.printing-press-release.json
+++ b/library/devices/tesla/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "tesla",
+  "cli_name": "tesla-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.10.0",
+  "run_id": "20260519-225351",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/devices/tesla/CHANGELOG.md
+++ b/library/devices/tesla/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/devices/tesla/internal/cli/root.go
+++ b/library/devices/tesla/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/devices/vestaboard/.printing-press-release.json
+++ b/library/devices/vestaboard/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "vestaboard",
+  "cli_name": "vestaboard-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260529-212647",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/devices/vestaboard/CHANGELOG.md
+++ b/library/devices/vestaboard/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/devices/vestaboard/internal/cli/root.go
+++ b/library/devices/vestaboard/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/devices/walkingpad/.printing-press-release.json
+++ b/library/devices/walkingpad/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "walkingpad",
+  "cli_name": "walkingpad-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.20.0",
+  "run_id": "20260603-000413",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/devices/walkingpad/CHANGELOG.md
+++ b/library/devices/walkingpad/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/devices/walkingpad/internal/cli/version.go
+++ b/library/devices/walkingpad/internal/cli/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // version is the printed CLI's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "2026.6.1"
 
 // newVersionCmd prints the CLI name and version. Shared by the HTTP and device
 // generators so both printed-CLI shapes carry an identical version command.

--- a/library/devices/whoop/.printing-press-release.json
+++ b/library/devices/whoop/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "whoop",
+  "cli_name": "whoop-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.1.0",
+  "run_id": "20260509-091026",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/devices/whoop/CHANGELOG.md
+++ b/library/devices/whoop/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/devices/whoop/internal/cli/root.go
+++ b/library/devices/whoop/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/education/ankiweb/.printing-press-release.json
+++ b/library/education/ankiweb/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "ankiweb",
+  "cli_name": "ankiweb-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.16.0",
+  "run_id": "20260525-182034",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/education/ankiweb/CHANGELOG.md
+++ b/library/education/ankiweb/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/education/ankiweb/internal/cli/root.go
+++ b/library/education/ankiweb/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/education/lawhub/.printing-press-release.json
+++ b/library/education/lawhub/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "lawhub",
+  "cli_name": "lawhub-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "manual-go-cobra",
+  "run_id": "20260515-014700",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/education/lawhub/CHANGELOG.md
+++ b/library/education/lawhub/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/allrecipes/.printing-press-release.json
+++ b/library/food-and-dining/allrecipes/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "allrecipes",
+  "cli_name": "allrecipes-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.8.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/allrecipes/CHANGELOG.md
+++ b/library/food-and-dining/allrecipes/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/allrecipes/internal/cli/root.go
+++ b/library/food-and-dining/allrecipes/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/anylist/.printing-press-release.json
+++ b/library/food-and-dining/anylist/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "anylist",
+  "cli_name": "anylist-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.6.1",
+  "run_id": "20260514-120439",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/anylist/CHANGELOG.md
+++ b/library/food-and-dining/anylist/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/anylist/internal/cli/root.go
+++ b/library/food-and-dining/anylist/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/coffee-goat/.printing-press-release.json
+++ b/library/food-and-dining/coffee-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "coffee-goat",
+  "cli_name": "coffee-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260520-110818",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/coffee-goat/CHANGELOG.md
+++ b/library/food-and-dining/coffee-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/coffee-goat/internal/cli/root.go
+++ b/library/food-and-dining/coffee-goat/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/dominos/.printing-press-release.json
+++ b/library/food-and-dining/dominos/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "dominos",
+  "cli_name": "dominos-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.9.1+pr639+dominos-rebase",
+  "run_id": "20260505-175548",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/dominos/CHANGELOG.md
+++ b/library/food-and-dining/dominos/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/dominos/internal/cli/root.go
+++ b/library/food-and-dining/dominos/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/food52/.printing-press-release.json
+++ b/library/food-and-dining/food52/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "food52",
+  "cli_name": "food52-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.2.1",
+  "run_id": "20260501-164925",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/food52/CHANGELOG.md
+++ b/library/food-and-dining/food52/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/food52/internal/cli/root.go
+++ b/library/food-and-dining/food52/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/jimmy-johns/.printing-press-release.json
+++ b/library/food-and-dining/jimmy-johns/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "jimmy-johns",
+  "cli_name": "jimmy-johns-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260511-034611",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/jimmy-johns/CHANGELOG.md
+++ b/library/food-and-dining/jimmy-johns/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/jimmy-johns/internal/cli/root.go
+++ b/library/food-and-dining/jimmy-johns/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/ordertogo/.printing-press-release.json
+++ b/library/food-and-dining/ordertogo/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "ordertogo",
+  "cli_name": "ordertogo-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260510-083403",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/ordertogo/CHANGELOG.md
+++ b/library/food-and-dining/ordertogo/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/ordertogo/internal/cli/root.go
+++ b/library/food-and-dining/ordertogo/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/pagliacci/.printing-press-release.json
+++ b/library/food-and-dining/pagliacci/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "pagliacci",
+  "cli_name": "pagliacci-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.7.0",
+  "run_id": "20260503-000558",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/pagliacci/CHANGELOG.md
+++ b/library/food-and-dining/pagliacci/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/pagliacci/internal/cli/root.go
+++ b/library/food-and-dining/pagliacci/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/rappi/.printing-press-release.json
+++ b/library/food-and-dining/rappi/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "rappi",
+  "cli_name": "rappi-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.1",
+  "run_id": "20260518-200403",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/rappi/CHANGELOG.md
+++ b/library/food-and-dining/rappi/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/rappi/internal/cli/root.go
+++ b/library/food-and-dining/rappi/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/recipe-goat/.printing-press-release.json
+++ b/library/food-and-dining/recipe-goat/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "recipe-goat",
+  "cli_name": "recipe-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/recipe-goat/CHANGELOG.md
+++ b/library/food-and-dining/recipe-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/recipe-goat/internal/cli/root.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/table-reservation-goat/.printing-press-release.json
+++ b/library/food-and-dining/table-reservation-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "table-reservation-goat",
+  "cli_name": "table-reservation-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260509-110540",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/table-reservation-goat/CHANGELOG.md
+++ b/library/food-and-dining/table-reservation-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/table-reservation-goat/internal/cli/root.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/root.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/food-and-dining/wolt/.printing-press-release.json
+++ b/library/food-and-dining/wolt/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "wolt",
+  "cli_name": "wolt-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.12.0",
+  "run_id": "20260523T141801Z-fb7995c2",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/food-and-dining/wolt/CHANGELOG.md
+++ b/library/food-and-dining/wolt/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/food-and-dining/wolt/internal/cli/root.go
+++ b/library/food-and-dining/wolt/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/marketing/ahrefs/.printing-press-release.json
+++ b/library/marketing/ahrefs/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "ahrefs",
+  "cli_name": "ahrefs-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.4.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/ahrefs/CHANGELOG.md
+++ b/library/marketing/ahrefs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/ahrefs/internal/cli/root.go
+++ b/library/marketing/ahrefs/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/beehiiv/.printing-press-release.json
+++ b/library/marketing/beehiiv/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "beehiiv",
+  "cli_name": "beehiiv-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260510-144732",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/beehiiv/CHANGELOG.md
+++ b/library/marketing/beehiiv/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/beehiiv/internal/cli/root.go
+++ b/library/marketing/beehiiv/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/bento/.printing-press-release.json
+++ b/library/marketing/bento/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "bento",
+  "cli_name": "bento-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.11.0",
+  "run_id": "20260526-094831",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/bento/CHANGELOG.md
+++ b/library/marketing/bento/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/bento/internal/cli/root.go
+++ b/library/marketing/bento/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/marketing/botsee/.printing-press-release.json
+++ b/library/marketing/botsee/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "botsee",
+  "cli_name": "botsee-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.11.0",
+  "run_id": "20260521-231949",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/botsee/CHANGELOG.md
+++ b/library/marketing/botsee/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/botsee/internal/cli/root.go
+++ b/library/marketing/botsee/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/clarity/.printing-press-release.json
+++ b/library/marketing/clarity/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "clarity",
+  "cli_name": "clarity-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.1",
+  "run_id": "20260508-113436",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/clarity/CHANGELOG.md
+++ b/library/marketing/clarity/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/clarity/internal/cli/root.go
+++ b/library/marketing/clarity/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/customer-io/.printing-press-release.json
+++ b/library/marketing/customer-io/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "customer-io",
+  "cli_name": "customer-io-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.0",
+  "run_id": "20260507-031036",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/customer-io/CHANGELOG.md
+++ b/library/marketing/customer-io/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/customer-io/internal/cli/root.go
+++ b/library/marketing/customer-io/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/dub/.printing-press-release.json
+++ b/library/marketing/dub/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "dub",
+  "cli_name": "dub-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.1",
+  "run_id": "20260502-153038",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/dub/CHANGELOG.md
+++ b/library/marketing/dub/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/dub/internal/cli/root.go
+++ b/library/marketing/dub/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/emailoctopus/.printing-press-release.json
+++ b/library/marketing/emailoctopus/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "emailoctopus",
+  "cli_name": "emailoctopus-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260517-015019",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/emailoctopus/CHANGELOG.md
+++ b/library/marketing/emailoctopus/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/emailoctopus/internal/cli/root.go
+++ b/library/marketing/emailoctopus/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/erank/.printing-press-release.json
+++ b/library/marketing/erank/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "erank",
+  "cli_name": "erank-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260531-142147",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/erank/CHANGELOG.md
+++ b/library/marketing/erank/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/erank/internal/cli/root.go
+++ b/library/marketing/erank/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/marketing/everbee/.printing-press-release.json
+++ b/library/marketing/everbee/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "everbee",
+  "cli_name": "everbee-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260522-153448",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/everbee/CHANGELOG.md
+++ b/library/marketing/everbee/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/everbee/internal/cli/root.go
+++ b/library/marketing/everbee/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/google-ads/.printing-press-release.json
+++ b/library/marketing/google-ads/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "google-ads",
+  "cli_name": "google-ads-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.10.0",
+  "run_id": "20260506-162403",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/google-ads/CHANGELOG.md
+++ b/library/marketing/google-ads/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/google-ads/internal/cli/root.go
+++ b/library/marketing/google-ads/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/google-search-console/.printing-press-release.json
+++ b/library/marketing/google-search-console/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "google-search-console",
+  "cli_name": "google-search-console-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.0",
+  "run_id": "20260509-053752",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/google-search-console/CHANGELOG.md
+++ b/library/marketing/google-search-console/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/google-search-console/internal/cli/root.go
+++ b/library/marketing/google-search-console/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/kit/.printing-press-release.json
+++ b/library/marketing/kit/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "kit",
+  "cli_name": "kit-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260519-111411",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/kit/CHANGELOG.md
+++ b/library/marketing/kit/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/kit/internal/cli/root.go
+++ b/library/marketing/kit/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/klaviyo/.printing-press-release.json
+++ b/library/marketing/klaviyo/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "klaviyo",
+  "cli_name": "klaviyo-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.5.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/klaviyo/CHANGELOG.md
+++ b/library/marketing/klaviyo/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/klaviyo/internal/cli/root.go
+++ b/library/marketing/klaviyo/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/mailchimp/.printing-press-release.json
+++ b/library/marketing/mailchimp/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "mailchimp",
+  "cli_name": "mailchimp-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260517-014518",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/mailchimp/CHANGELOG.md
+++ b/library/marketing/mailchimp/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/mailchimp/internal/cli/root.go
+++ b/library/marketing/mailchimp/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/meta-ads/.printing-press-release.json
+++ b/library/marketing/meta-ads/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "meta-ads",
+  "cli_name": "meta-ads-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.1",
+  "run_id": "20260528-183943",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/meta-ads/CHANGELOG.md
+++ b/library/marketing/meta-ads/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/meta-ads/internal/cli/root.go
+++ b/library/marketing/meta-ads/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/producthunt/.printing-press-release.json
+++ b/library/marketing/producthunt/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "producthunt",
+  "cli_name": "producthunt-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.2.1",
+  "run_id": "20260501-170103",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/producthunt/CHANGELOG.md
+++ b/library/marketing/producthunt/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/producthunt/internal/cli/root.go
+++ b/library/marketing/producthunt/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/semrush/.printing-press-release.json
+++ b/library/marketing/semrush/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "semrush",
+  "cli_name": "semrush-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.14.0",
+  "run_id": "20260524-232429",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/semrush/CHANGELOG.md
+++ b/library/marketing/semrush/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/semrush/internal/cli/root.go
+++ b/library/marketing/semrush/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/stackadapt/.printing-press-release.json
+++ b/library/marketing/stackadapt/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "stackadapt",
+  "cli_name": "stackadapt-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.1",
+  "run_id": "20260530-185509",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/stackadapt/CHANGELOG.md
+++ b/library/marketing/stackadapt/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/stackadapt/internal/cli/root.go
+++ b/library/marketing/stackadapt/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/marketing/trendhunter/.printing-press-release.json
+++ b/library/marketing/trendhunter/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "trendhunter",
+  "cli_name": "trendhunter-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.1",
+  "run_id": "20260513-134344",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/trendhunter/CHANGELOG.md
+++ b/library/marketing/trendhunter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/trendhunter/internal/cli/root.go
+++ b/library/marketing/trendhunter/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/marketing/trustpilot/.printing-press-release.json
+++ b/library/marketing/trustpilot/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "trustpilot",
+  "cli_name": "trustpilot-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.6.1",
+  "run_id": "20260515-075905",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/marketing/trustpilot/CHANGELOG.md
+++ b/library/marketing/trustpilot/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/marketing/trustpilot/internal/cli/root.go
+++ b/library/marketing/trustpilot/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/archive-is/.printing-press-release.json
+++ b/library/media-and-entertainment/archive-is/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "archive-is",
+  "cli_name": "archive-is-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "1.2.1",
+  "run_id": "20260410-233336",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/archive-is/CHANGELOG.md
+++ b/library/media-and-entertainment/archive-is/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/archive-is/internal/cli/root.go
+++ b/library/media-and-entertainment/archive-is/internal/cli/root.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.1.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/art-goat/.printing-press-release.json
+++ b/library/media-and-entertainment/art-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "art-goat",
+  "cli_name": "art-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.11.0",
+  "run_id": "20260521-062440",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/art-goat/CHANGELOG.md
+++ b/library/media-and-entertainment/art-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/art-goat/internal/cli/root.go
+++ b/library/media-and-entertainment/art-goat/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.2.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/bandsintown/.printing-press-release.json
+++ b/library/media-and-entertainment/bandsintown/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "bandsintown",
+  "cli_name": "bandsintown-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.2",
+  "run_id": "20260513-075126",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/bandsintown/CHANGELOG.md
+++ b/library/media-and-entertainment/bandsintown/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/bandsintown/internal/cli/root.go
+++ b/library/media-and-entertainment/bandsintown/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/blu-ray/.printing-press-release.json
+++ b/library/media-and-entertainment/blu-ray/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "blu-ray",
+  "cli_name": "blu-ray-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260517-014459",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/blu-ray/CHANGELOG.md
+++ b/library/media-and-entertainment/blu-ray/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/blu-ray/internal/cli/root.go
+++ b/library/media-and-entertainment/blu-ray/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/dice-fm/.printing-press-release.json
+++ b/library/media-and-entertainment/dice-fm/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "dice-fm",
+  "cli_name": "dice-fm-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.12.0",
+  "run_id": "20260511-193451",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/dice-fm/CHANGELOG.md
+++ b/library/media-and-entertainment/dice-fm/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/dice-fm/internal/cli/root.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/digg/.printing-press-release.json
+++ b/library/media-and-entertainment/digg/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "digg",
+  "cli_name": "digg-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.6",
+  "run_id": "20260508-234057",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/digg/CHANGELOG.md
+++ b/library/media-and-entertainment/digg/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/digg/internal/cli/root.go
+++ b/library/media-and-entertainment/digg/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/drudgereport/.printing-press-release.json
+++ b/library/media-and-entertainment/drudgereport/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "drudgereport",
+  "cli_name": "drudgereport-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.10.0",
+  "run_id": "20260521-061607",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/drudgereport/CHANGELOG.md
+++ b/library/media-and-entertainment/drudgereport/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/drudgereport/internal/cli/root.go
+++ b/library/media-and-entertainment/drudgereport/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/espn/.printing-press-release.json
+++ b/library/media-and-entertainment/espn/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "espn",
+  "cli_name": "espn-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "1.2.1-0.20260409145412-b1128d0e07fd+dirty",
+  "run_id": "20260409-121709",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/espn/CHANGELOG.md
+++ b/library/media-and-entertainment/espn/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/espn/internal/cli/root.go
+++ b/library/media-and-entertainment/espn/internal/cli/root.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON  bool

--- a/library/media-and-entertainment/eventbrite/.printing-press-release.json
+++ b/library/media-and-entertainment/eventbrite/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "eventbrite",
+  "cli_name": "eventbrite-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.12.0",
+  "run_id": "20260523-141335",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/eventbrite/CHANGELOG.md
+++ b/library/media-and-entertainment/eventbrite/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/eventbrite/internal/cli/root.go
+++ b/library/media-and-entertainment/eventbrite/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/foxnews/.printing-press-release.json
+++ b/library/media-and-entertainment/foxnews/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "foxnews",
+  "cli_name": "foxnews-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.10.0",
+  "run_id": "20260603-120000",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/foxnews/CHANGELOG.md
+++ b/library/media-and-entertainment/foxnews/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/foxnews/internal/cli/root.go
+++ b/library/media-and-entertainment/foxnews/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 // noColor is set by --no-color and implied by --agent.
 var noColor bool

--- a/library/media-and-entertainment/goodreads/.printing-press-release.json
+++ b/library/media-and-entertainment/goodreads/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "goodreads",
+  "cli_name": "goodreads-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.11.0",
+  "run_id": "20260522-095940",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/goodreads/CHANGELOG.md
+++ b/library/media-and-entertainment/goodreads/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/goodreads/internal/cli/root.go
+++ b/library/media-and-entertainment/goodreads/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/media-and-entertainment/google-photos/.printing-press-release.json
+++ b/library/media-and-entertainment/google-photos/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "google-photos",
+  "cli_name": "google-photos-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.9.1",
+  "run_id": "20260505-152800",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/google-photos/CHANGELOG.md
+++ b/library/media-and-entertainment/google-photos/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/google-photos/internal/cli/root.go
+++ b/library/media-and-entertainment/google-photos/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON          bool

--- a/library/media-and-entertainment/hackernews/.printing-press-release.json
+++ b/library/media-and-entertainment/hackernews/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "hackernews",
+  "cli_name": "hackernews-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.9.0",
+  "run_id": "20260504-190931",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/hackernews/CHANGELOG.md
+++ b/library/media-and-entertainment/hackernews/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/hackernews/internal/cli/root.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/icloud/.printing-press-release.json
+++ b/library/media-and-entertainment/icloud/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "icloud",
+  "cli_name": "icloud-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260517-000000",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/icloud/CHANGELOG.md
+++ b/library/media-and-entertainment/icloud/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/marginalrevolution/.printing-press-release.json
+++ b/library/media-and-entertainment/marginalrevolution/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "marginalrevolution",
+  "cli_name": "marginalrevolution-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.1",
+  "run_id": "20260509-214203",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/marginalrevolution/CHANGELOG.md
+++ b/library/media-and-entertainment/marginalrevolution/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/marginalrevolution/internal/cli/root.go
+++ b/library/media-and-entertainment/marginalrevolution/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/mobalytics-lol/.printing-press-release.json
+++ b/library/media-and-entertainment/mobalytics-lol/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "mobalytics-lol",
+  "cli_name": "mobalytics-lol-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.12.0",
+  "run_id": "20260523-111659",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/mobalytics-lol/CHANGELOG.md
+++ b/library/media-and-entertainment/mobalytics-lol/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/mobalytics-lol/internal/cli/root.go
+++ b/library/media-and-entertainment/mobalytics-lol/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/movie-goat/.printing-press-release.json
+++ b/library/media-and-entertainment/movie-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "movie-goat",
+  "cli_name": "movie-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.8.0",
+  "run_id": "20260504-004256",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/movie-goat/CHANGELOG.md
+++ b/library/media-and-entertainment/movie-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/movie-goat/internal/cli/root.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/nasa-images/.printing-press-release.json
+++ b/library/media-and-entertainment/nasa-images/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "nasa-images",
+  "cli_name": "nasa-images-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260519-001814",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/nasa-images/CHANGELOG.md
+++ b/library/media-and-entertainment/nasa-images/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/nasa-images/internal/cli/root.go
+++ b/library/media-and-entertainment/nasa-images/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/podcast-goat/.printing-press-release.json
+++ b/library/media-and-entertainment/podcast-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "podcast-goat",
+  "cli_name": "podcast-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260517-103310",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/podcast-goat/CHANGELOG.md
+++ b/library/media-and-entertainment/podcast-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/podcast-goat/internal/cli/root.go
+++ b/library/media-and-entertainment/podcast-goat/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/podscan/.printing-press-release.json
+++ b/library/media-and-entertainment/podscan/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "podscan",
+  "cli_name": "podscan-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.1.0",
+  "run_id": "20260509-110700",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/podscan/CHANGELOG.md
+++ b/library/media-and-entertainment/podscan/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/podscan/internal/cli/root.go
+++ b/library/media-and-entertainment/podscan/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/pokeapi/.printing-press-release.json
+++ b/library/media-and-entertainment/pokeapi/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "pokeapi",
+  "cli_name": "pokeapi-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.0.1",
+  "run_id": "20260429-230641",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/pokeapi/CHANGELOG.md
+++ b/library/media-and-entertainment/pokeapi/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/pokeapi/internal/cli/root.go
+++ b/library/media-and-entertainment/pokeapi/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/setlist-fm/.printing-press-release.json
+++ b/library/media-and-entertainment/setlist-fm/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "setlist-fm",
+  "cli_name": "setlist-fm-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.3",
+  "run_id": "20260520-142155",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/setlist-fm/CHANGELOG.md
+++ b/library/media-and-entertainment/setlist-fm/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/setlist-fm/internal/cli/root.go
+++ b/library/media-and-entertainment/setlist-fm/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/skool/.printing-press-release.json
+++ b/library/media-and-entertainment/skool/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "skool",
+  "cli_name": "skool-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.6",
+  "run_id": "20260510-114931",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/skool/CHANGELOG.md
+++ b/library/media-and-entertainment/skool/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/skool/internal/cli/root.go
+++ b/library/media-and-entertainment/skool/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/spotify/.printing-press-release.json
+++ b/library/media-and-entertainment/spotify/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "spotify",
+  "cli_name": "spotify-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.2",
+  "run_id": "20260512-184940",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/spotify/CHANGELOG.md
+++ b/library/media-and-entertainment/spotify/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/spotify/internal/cli/root.go
+++ b/library/media-and-entertainment/spotify/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/steam-web/.printing-press-release.json
+++ b/library/media-and-entertainment/steam-web/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "steam-web",
+  "cli_name": "steam-web-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.6",
+  "run_id": "20260508-073948",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/steam-web/CHANGELOG.md
+++ b/library/media-and-entertainment/steam-web/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/steam-web/internal/cli/root.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/substack/.printing-press-release.json
+++ b/library/media-and-entertainment/substack/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "substack",
+  "cli_name": "substack-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260531-014452",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/substack/CHANGELOG.md
+++ b/library/media-and-entertainment/substack/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/substack/internal/cli/root.go
+++ b/library/media-and-entertainment/substack/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/config"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/suno/.printing-press-release.json
+++ b/library/media-and-entertainment/suno/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "suno",
+  "cli_name": "suno-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.14.0",
+  "run_id": "20260528-222057",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/suno/CHANGELOG.md
+++ b/library/media-and-entertainment/suno/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/suno/internal/cli/root.go
+++ b/library/media-and-entertainment/suno/internal/cli/root.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/media-and-entertainment/tella/.printing-press-release.json
+++ b/library/media-and-entertainment/tella/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "tella",
+  "cli_name": "tella-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.1",
+  "run_id": "20260509-180956",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/tella/CHANGELOG.md
+++ b/library/media-and-entertainment/tella/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/tella/internal/cli/root.go
+++ b/library/media-and-entertainment/tella/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/ticketmaster/.printing-press-release.json
+++ b/library/media-and-entertainment/ticketmaster/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "ticketmaster",
+  "cli_name": "ticketmaster-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260511-051647",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/ticketmaster/CHANGELOG.md
+++ b/library/media-and-entertainment/ticketmaster/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/ticketmaster/internal/cli/root.go
+++ b/library/media-and-entertainment/ticketmaster/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/wikipedia/.printing-press-release.json
+++ b/library/media-and-entertainment/wikipedia/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "wikipedia",
+  "cli_name": "wikipedia-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/wikipedia/CHANGELOG.md
+++ b/library/media-and-entertainment/wikipedia/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/wikipedia/internal/cli/root.go
+++ b/library/media-and-entertainment/wikipedia/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/youtube/.printing-press-release.json
+++ b/library/media-and-entertainment/youtube/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "youtube",
+  "cli_name": "youtube-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260515-050804",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/media-and-entertainment/youtube/CHANGELOG.md
+++ b/library/media-and-entertainment/youtube/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/media-and-entertainment/youtube/internal/cli/root.go
+++ b/library/media-and-entertainment/youtube/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/monitoring/adguard-home/.printing-press-release.json
+++ b/library/monitoring/adguard-home/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "adguard-home",
+  "cli_name": "adguard-home-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.14.0",
+  "run_id": "20260524-044214",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/monitoring/adguard-home/CHANGELOG.md
+++ b/library/monitoring/adguard-home/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/monitoring/adguard-home/internal/cli/root.go
+++ b/library/monitoring/adguard-home/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/monitoring/sentry/.printing-press-release.json
+++ b/library/monitoring/sentry/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "sentry",
+  "cli_name": "sentry-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.4.3",
+  "run_id": "20260502-124520",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/monitoring/sentry/CHANGELOG.md
+++ b/library/monitoring/sentry/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/monitoring/sentry/internal/cli/root.go
+++ b/library/monitoring/sentry/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/american-reindustrialization/.printing-press-release.json
+++ b/library/other/american-reindustrialization/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "american-reindustrialization",
+  "cli_name": "american-reindustrialization-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260519-002038",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/american-reindustrialization/CHANGELOG.md
+++ b/library/other/american-reindustrialization/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/american-reindustrialization/internal/cli/root.go
+++ b/library/other/american-reindustrialization/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/apartments/.printing-press-release.json
+++ b/library/other/apartments/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "apartments",
+  "cli_name": "apartments-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.8.0",
+  "run_id": "20260503-193955",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/apartments/CHANGELOG.md
+++ b/library/other/apartments/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/apartments/internal/cli/root.go
+++ b/library/other/apartments/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/ars-sicilia/.printing-press-release.json
+++ b/library/other/ars-sicilia/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "ars-sicilia",
+  "cli_name": "ars-sicilia-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.0",
+  "run_id": "20260528-181840",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/ars-sicilia/CHANGELOG.md
+++ b/library/other/ars-sicilia/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/ars-sicilia/internal/cli/root.go
+++ b/library/other/ars-sicilia/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/arxiv/.printing-press-release.json
+++ b/library/other/arxiv/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "arxiv",
+  "cli_name": "arxiv-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260511-053009",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/arxiv/CHANGELOG.md
+++ b/library/other/arxiv/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/arxiv/internal/cli/root.go
+++ b/library/other/arxiv/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/defillama/.printing-press-release.json
+++ b/library/other/defillama/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "defillama",
+  "cli_name": "defillama-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.16.0",
+  "run_id": "20260526-210536",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/defillama/CHANGELOG.md
+++ b/library/other/defillama/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/defillama/internal/cli/root.go
+++ b/library/other/defillama/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/edgar/.printing-press-release.json
+++ b/library/other/edgar/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "edgar",
+  "cli_name": "edgar-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.3.0",
+  "run_id": "20260513-115144",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/edgar/CHANGELOG.md
+++ b/library/other/edgar/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/edgar/internal/cli/root.go
+++ b/library/other/edgar/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/elezioni-sicilia/.printing-press-release.json
+++ b/library/other/elezioni-sicilia/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "elezioni-sicilia",
+  "cli_name": "elezioni-sicilia-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.0",
+  "run_id": "20260526-180400",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/elezioni-sicilia/CHANGELOG.md
+++ b/library/other/elezioni-sicilia/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/elezioni-sicilia/internal/cli/root.go
+++ b/library/other/elezioni-sicilia/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/function-health/.printing-press-release.json
+++ b/library/other/function-health/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "function-health",
+  "cli_name": "function-health-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260528-084148",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/function-health/CHANGELOG.md
+++ b/library/other/function-health/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/function-health/internal/cli/root.go
+++ b/library/other/function-health/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/gisis/.printing-press-release.json
+++ b/library/other/gisis/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "gisis",
+  "cli_name": "gisis-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.1",
+  "run_id": "20260527-211808",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/gisis/CHANGELOG.md
+++ b/library/other/gisis/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/gisis/internal/cli/root.go
+++ b/library/other/gisis/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/gravitus/.printing-press-release.json
+++ b/library/other/gravitus/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "gravitus",
+  "cli_name": "gravitus-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.11.0",
+  "run_id": "20260517-231116",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/gravitus/CHANGELOG.md
+++ b/library/other/gravitus/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/gravitus/internal/cli/root.go
+++ b/library/other/gravitus/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/greatclips/.printing-press-release.json
+++ b/library/other/greatclips/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "greatclips",
+  "cli_name": "greatclips-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260511-095555",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/greatclips/CHANGELOG.md
+++ b/library/other/greatclips/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/greatclips/internal/cli/root.go
+++ b/library/other/greatclips/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/numista/.printing-press-release.json
+++ b/library/other/numista/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "numista",
+  "cli_name": "numista-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260517-033846",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/numista/CHANGELOG.md
+++ b/library/other/numista/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/numista/internal/cli/root.go
+++ b/library/other/numista/internal/cli/root.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 var quotaPrintOnly bool
 var quotaPrintOnlyJSON bool

--- a/library/other/open-meteo/.printing-press-release.json
+++ b/library/other/open-meteo/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "open-meteo",
+  "cli_name": "open-meteo-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.1",
+  "run_id": "20260502-155141",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/open-meteo/CHANGELOG.md
+++ b/library/other/open-meteo/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/open-meteo/internal/cli/root.go
+++ b/library/other/open-meteo/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/openalex/.printing-press-release.json
+++ b/library/other/openalex/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "openalex",
+  "cli_name": "openalex-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260511-052407",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/openalex/CHANGELOG.md
+++ b/library/other/openalex/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/openalex/internal/cli/root.go
+++ b/library/other/openalex/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/pcgs/.printing-press-release.json
+++ b/library/other/pcgs/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "pcgs",
+  "cli_name": "pcgs-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260516-193948",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/pcgs/CHANGELOG.md
+++ b/library/other/pcgs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/pcgs/internal/cli/root.go
+++ b/library/other/pcgs/internal/cli/root.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/pvgis/.printing-press-release.json
+++ b/library/other/pvgis/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "pvgis",
+  "cli_name": "pvgis-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260518-214920",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/pvgis/CHANGELOG.md
+++ b/library/other/pvgis/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/pvgis/internal/cli/root.go
+++ b/library/other/pvgis/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/redfin/.printing-press-release.json
+++ b/library/other/redfin/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "redfin",
+  "cli_name": "redfin-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.8.0",
+  "run_id": "20260504-175601",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/redfin/CHANGELOG.md
+++ b/library/other/redfin/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/redfin/internal/cli/root.go
+++ b/library/other/redfin/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/ufo-goat/.printing-press-release.json
+++ b/library/other/ufo-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "ufo-goat",
+  "cli_name": "ufo-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.3",
+  "run_id": "20260508-101534",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/ufo-goat/CHANGELOG.md
+++ b/library/other/ufo-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/ufo-goat/internal/cli/root.go
+++ b/library/other/ufo-goat/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/usgs-earthquakes/.printing-press-release.json
+++ b/library/other/usgs-earthquakes/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "usgs-earthquakes",
+  "cli_name": "usgs-earthquakes-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260519-002226",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/usgs-earthquakes/CHANGELOG.md
+++ b/library/other/usgs-earthquakes/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/usgs-earthquakes/internal/cli/root.go
+++ b/library/other/usgs-earthquakes/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/other/weather-goat/.printing-press-release.json
+++ b/library/other/weather-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "weather-goat",
+  "cli_name": "weather-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "1.3.3-0.20260411222622-065697576de1+dirty",
+  "run_id": "20260411-153728",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/other/weather-goat/CHANGELOG.md
+++ b/library/other/weather-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/other/weather-goat/internal/cli/root.go
+++ b/library/other/weather-goat/internal/cli/root.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.1"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON       bool

--- a/library/payments/coingecko/.printing-press-release.json
+++ b/library/payments/coingecko/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "coingecko",
+  "cli_name": "coingecko-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "2.3.7",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/coingecko/CHANGELOG.md
+++ b/library/payments/coingecko/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/coingecko/internal/cli/root.go
+++ b/library/payments/coingecko/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/payments/exchangerate-api/.printing-press-release.json
+++ b/library/payments/exchangerate-api/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "exchangerate-api",
+  "cli_name": "exchangerate-api-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260517-025552",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/exchangerate-api/CHANGELOG.md
+++ b/library/payments/exchangerate-api/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/exchangerate-api/internal/cli/root.go
+++ b/library/payments/exchangerate-api/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/payments/kalshi/.printing-press-release.json
+++ b/library/payments/kalshi/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "kalshi",
+  "cli_name": "kalshi-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.9.0",
+  "run_id": "20260504-204550",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/kalshi/CHANGELOG.md
+++ b/library/payments/kalshi/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/kalshi/internal/cli/root.go
+++ b/library/payments/kalshi/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/payments/lemonsqueezy/.printing-press-release.json
+++ b/library/payments/lemonsqueezy/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "lemonsqueezy",
+  "cli_name": "lemonsqueezy-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260529-160048",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/lemonsqueezy/CHANGELOG.md
+++ b/library/payments/lemonsqueezy/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/lemonsqueezy/internal/cli/root.go
+++ b/library/payments/lemonsqueezy/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/payments/lunch-money/.printing-press-release.json
+++ b/library/payments/lunch-money/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "lunch-money",
+  "cli_name": "lunch-money-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.2",
+  "run_id": "20260513-094903",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/lunch-money/CHANGELOG.md
+++ b/library/payments/lunch-money/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/lunch-money/internal/cli/root.go
+++ b/library/payments/lunch-money/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/payments/mercury/.printing-press-release.json
+++ b/library/payments/mercury/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "mercury",
+  "cli_name": "mercury-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.10.0",
+  "run_id": "20260506-161557",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/mercury/CHANGELOG.md
+++ b/library/payments/mercury/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/mercury/internal/cli/root.go
+++ b/library/payments/mercury/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/payments/monarch-money/.printing-press-release.json
+++ b/library/payments/monarch-money/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "monarch-money",
+  "cli_name": "monarch-money-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.1",
+  "run_id": "manual-plan-20260509",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/monarch-money/CHANGELOG.md
+++ b/library/payments/monarch-money/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/monarch-money/internal/cli/root.go
+++ b/library/payments/monarch-money/internal/cli/root.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 // Execute runs the CLI.
 func Execute() error {

--- a/library/payments/pop/.printing-press-release.json
+++ b/library/payments/pop/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "pop",
+  "cli_name": "pop-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260518-132356",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/pop/CHANGELOG.md
+++ b/library/payments/pop/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/pop/internal/cli/root.go
+++ b/library/payments/pop/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/payments/revenuecat/.printing-press-release.json
+++ b/library/payments/revenuecat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "revenuecat",
+  "cli_name": "revenuecat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260530-071644",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/revenuecat/CHANGELOG.md
+++ b/library/payments/revenuecat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/revenuecat/internal/cli/root.go
+++ b/library/payments/revenuecat/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/payments/robinhood/.printing-press-release.json
+++ b/library/payments/robinhood/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "robinhood",
+  "cli_name": "robinhood-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.11.0",
+  "run_id": "20260522-162911",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/robinhood/CHANGELOG.md
+++ b/library/payments/robinhood/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/robinhood/internal/cli/root.go
+++ b/library/payments/robinhood/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/payments/splitwise/.printing-press-release.json
+++ b/library/payments/splitwise/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "splitwise",
+  "cli_name": "splitwise-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260528-002755",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/splitwise/CHANGELOG.md
+++ b/library/payments/splitwise/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/splitwise/internal/cli/root.go
+++ b/library/payments/splitwise/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 // Version returns the build version (set via -ldflags at release; "1.0.0" in a
 // plain go build). Exposed so the MCP server can report the same version as the CLI.

--- a/library/payments/stripe/.printing-press-release.json
+++ b/library/payments/stripe/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "stripe",
+  "cli_name": "stripe-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.1.0",
+  "run_id": "20260509-093200",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/payments/stripe/CHANGELOG.md
+++ b/library/payments/stripe/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/payments/stripe/internal/cli/root.go
+++ b/library/payments/stripe/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/breezedoc/.printing-press-release.json
+++ b/library/productivity/breezedoc/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "breezedoc",
+  "cli_name": "breezedoc-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260601-002955",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/breezedoc/CHANGELOG.md
+++ b/library/productivity/breezedoc/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/breezedoc/internal/cli/root.go
+++ b/library/productivity/breezedoc/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/cal-com/.printing-press-release.json
+++ b/library/productivity/cal-com/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "cal-com",
+  "cli_name": "cal-com-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.9.0",
+  "run_id": "20260504-205634",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/cal-com/CHANGELOG.md
+++ b/library/productivity/cal-com/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/cal-com/internal/cli/root.go
+++ b/library/productivity/cal-com/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/chrome-history/.printing-press-release.json
+++ b/library/productivity/chrome-history/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "chrome-history",
+  "cli_name": "chrome-history-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.13.0",
+  "run_id": "20260524-023512",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/chrome-history/CHANGELOG.md
+++ b/library/productivity/chrome-history/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/clockify/.printing-press-release.json
+++ b/library/productivity/clockify/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "clockify",
+  "cli_name": "clockify-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.14.0",
+  "run_id": "20260520-224501",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/clockify/CHANGELOG.md
+++ b/library/productivity/clockify/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/clockify/internal/cli/root.go
+++ b/library/productivity/clockify/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/etherpad/.printing-press-release.json
+++ b/library/productivity/etherpad/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "etherpad",
+  "cli_name": "etherpad-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260510T124341Z-e440f457",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/etherpad/CHANGELOG.md
+++ b/library/productivity/etherpad/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/etherpad/internal/cli/root.go
+++ b/library/productivity/etherpad/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/fathom/.printing-press-release.json
+++ b/library/productivity/fathom/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "fathom",
+  "cli_name": "fathom-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.6",
+  "run_id": "20260509-090403",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/fathom/CHANGELOG.md
+++ b/library/productivity/fathom/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/fathom/internal/cli/root.go
+++ b/library/productivity/fathom/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/figma/.printing-press-release.json
+++ b/library/productivity/figma/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "figma",
+  "cli_name": "figma-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.0",
+  "run_id": "20260509-190854",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/figma/CHANGELOG.md
+++ b/library/productivity/figma/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/figma/internal/cli/root.go
+++ b/library/productivity/figma/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/fireflies/.printing-press-release.json
+++ b/library/productivity/fireflies/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "fireflies",
+  "cli_name": "fireflies-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.6",
+  "run_id": "20260509-005754",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/fireflies/CHANGELOG.md
+++ b/library/productivity/fireflies/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/fireflies/internal/cli/root.go
+++ b/library/productivity/fireflies/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/freshservice/.printing-press-release.json
+++ b/library/productivity/freshservice/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "freshservice",
+  "cli_name": "freshservice-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.0",
+  "run_id": "20260512-170855",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/freshservice/CHANGELOG.md
+++ b/library/productivity/freshservice/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/freshservice/internal/cli/root.go
+++ b/library/productivity/freshservice/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/granola/.printing-press-release.json
+++ b/library/productivity/granola/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "granola",
+  "cli_name": "granola-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.4.0",
+  "run_id": "20260511-211333",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/granola/CHANGELOG.md
+++ b/library/productivity/granola/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/granola/internal/cli/root.go
+++ b/library/productivity/granola/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/marianatek/.printing-press-release.json
+++ b/library/productivity/marianatek/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "marianatek",
+  "cli_name": "marianatek-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.4.0",
+  "run_id": "20260511-194406",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/marianatek/CHANGELOG.md
+++ b/library/productivity/marianatek/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/marianatek/internal/cli/root.go
+++ b/library/productivity/marianatek/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/myfitnesspal/.printing-press-release.json
+++ b/library/productivity/myfitnesspal/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "myfitnesspal",
+  "cli_name": "myfitnesspal-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.6",
+  "run_id": "20260508-133559",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/myfitnesspal/CHANGELOG.md
+++ b/library/productivity/myfitnesspal/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/myfitnesspal/internal/cli/root.go
+++ b/library/productivity/myfitnesspal/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/notion/.printing-press-release.json
+++ b/library/productivity/notion/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "notion",
+  "cli_name": "notion-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.6",
+  "run_id": "20260508-225745",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/notion/CHANGELOG.md
+++ b/library/productivity/notion/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/notion/internal/cli/root.go
+++ b/library/productivity/notion/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/nylas/.printing-press-release.json
+++ b/library/productivity/nylas/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "nylas",
+  "cli_name": "nylas-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260518-164045",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/nylas/CHANGELOG.md
+++ b/library/productivity/nylas/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/nylas/internal/cli/root.go
+++ b/library/productivity/nylas/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/obsidian/.printing-press-release.json
+++ b/library/productivity/obsidian/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "obsidian",
+  "cli_name": "obsidian-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260520-111144",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/obsidian/CHANGELOG.md
+++ b/library/productivity/obsidian/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/obsidian/internal/cli/root.go
+++ b/library/productivity/obsidian/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/opensnow/.printing-press-release.json
+++ b/library/productivity/opensnow/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "opensnow",
+  "cli_name": "opensnow-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.3",
+  "run_id": "20260508-183509",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/opensnow/CHANGELOG.md
+++ b/library/productivity/opensnow/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/opensnow/internal/cli/root.go
+++ b/library/productivity/opensnow/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/outlook-calendar/.printing-press-release.json
+++ b/library/productivity/outlook-calendar/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "outlook-calendar",
+  "cli_name": "outlook-calendar-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260510-094714",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/outlook-calendar/CHANGELOG.md
+++ b/library/productivity/outlook-calendar/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/outlook-calendar/internal/cli/root.go
+++ b/library/productivity/outlook-calendar/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/outlook-email/.printing-press-release.json
+++ b/library/productivity/outlook-email/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "outlook-email",
+  "cli_name": "outlook-email-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260512-172123",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/outlook-email/CHANGELOG.md
+++ b/library/productivity/outlook-email/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/outlook-email/internal/cli/root.go
+++ b/library/productivity/outlook-email/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/resend/.printing-press-release.json
+++ b/library/productivity/resend/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "resend",
+  "cli_name": "resend-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.1",
+  "run_id": "20260514-152759",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/resend/CHANGELOG.md
+++ b/library/productivity/resend/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/resend/internal/cli/root.go
+++ b/library/productivity/resend/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/roam/.printing-press-release.json
+++ b/library/productivity/roam/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "roam",
+  "cli_name": "roam-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.1.0",
+  "run_id": "20260508-223718",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/roam/CHANGELOG.md
+++ b/library/productivity/roam/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/roam/internal/cli/root.go
+++ b/library/productivity/roam/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/safari-history/.printing-press-release.json
+++ b/library/productivity/safari-history/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "safari-history",
+  "cli_name": "safari-history-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.13.0",
+  "run_id": "20260523-231334",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/safari-history/CHANGELOG.md
+++ b/library/productivity/safari-history/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/sendgrid/.printing-press-release.json
+++ b/library/productivity/sendgrid/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "sendgrid",
+  "cli_name": "sendgrid-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260518-202518",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/sendgrid/CHANGELOG.md
+++ b/library/productivity/sendgrid/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/sendgrid/internal/cli/root.go
+++ b/library/productivity/sendgrid/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/slack/.printing-press-release.json
+++ b/library/productivity/slack/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "slack",
+  "cli_name": "slack-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "1.2.1",
+  "run_id": "20260409-073625",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/slack/CHANGELOG.md
+++ b/library/productivity/slack/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/slack/internal/cli/root.go
+++ b/library/productivity/slack/internal/cli/root.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.1.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON       bool

--- a/library/productivity/strava/.printing-press-release.json
+++ b/library/productivity/strava/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "strava",
+  "cli_name": "strava-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.11.0",
+  "run_id": "20260521-164944",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/strava/CHANGELOG.md
+++ b/library/productivity/strava/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/strava/internal/cli/root.go
+++ b/library/productivity/strava/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/productivity/superhuman/.printing-press-release.json
+++ b/library/productivity/superhuman/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "superhuman",
+  "cli_name": "superhuman-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.10.0",
+  "run_id": "20260512-165241",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/superhuman/CHANGELOG.md
+++ b/library/productivity/superhuman/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/superhuman/internal/cli/root.go
+++ b/library/productivity/superhuman/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.1.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON              bool

--- a/library/productivity/techmeme/.printing-press-release.json
+++ b/library/productivity/techmeme/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "techmeme",
+  "cli_name": "techmeme-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.3",
+  "run_id": "20260509-193944",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/techmeme/CHANGELOG.md
+++ b/library/productivity/techmeme/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/techmeme/internal/cli/root.go
+++ b/library/productivity/techmeme/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/tidycal/.printing-press-release.json
+++ b/library/productivity/tidycal/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "tidycal",
+  "cli_name": "tidycal-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260601-020228",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/tidycal/CHANGELOG.md
+++ b/library/productivity/tidycal/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/tidycal/internal/cli/root.go
+++ b/library/productivity/tidycal/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/zoho-expense/.printing-press-release.json
+++ b/library/productivity/zoho-expense/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "zoho-expense",
+  "cli_name": "zoho-expense-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.12.0",
+  "run_id": "20260523-163843",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/zoho-expense/CHANGELOG.md
+++ b/library/productivity/zoho-expense/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/zoho-expense/internal/cli/root.go
+++ b/library/productivity/zoho-expense/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/productivity/zoho-expense/internal/config"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/productivity/zoom/.printing-press-release.json
+++ b/library/productivity/zoom/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "zoom",
+  "cli_name": "zoom-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260519-094503",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/productivity/zoom/CHANGELOG.md
+++ b/library/productivity/zoom/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/productivity/zoom/internal/cli/root.go
+++ b/library/productivity/zoom/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/project-management/clickup/.printing-press-release.json
+++ b/library/project-management/clickup/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "clickup",
+  "cli_name": "clickup-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.2",
+  "run_id": "20260510-202319",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/project-management/clickup/CHANGELOG.md
+++ b/library/project-management/clickup/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/project-management/clickup/internal/cli/root.go
+++ b/library/project-management/clickup/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/project-management/jira/.printing-press-release.json
+++ b/library/project-management/jira/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "jira",
+  "cli_name": "jira-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.3.0",
+  "run_id": "20260511-114028",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/project-management/jira/CHANGELOG.md
+++ b/library/project-management/jira/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/project-management/jira/internal/cli/root.go
+++ b/library/project-management/jira/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/project-management/linear/.printing-press-release.json
+++ b/library/project-management/linear/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "linear",
+  "cli_name": "linear-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260518-232543",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/project-management/linear/CHANGELOG.md
+++ b/library/project-management/linear/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/project-management/linear/internal/cli/root.go
+++ b/library/project-management/linear/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/project-management/plane/.printing-press-release.json
+++ b/library/project-management/plane/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "plane",
+  "cli_name": "plane-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.20.1",
+  "run_id": "20260602-073610",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/project-management/plane/CHANGELOG.md
+++ b/library/project-management/plane/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/project-management/plane/internal/cli/root.go
+++ b/library/project-management/plane/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/sales-and-crm/conduyt-crm/.printing-press-release.json
+++ b/library/sales-and-crm/conduyt-crm/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "conduyt-crm",
+  "cli_name": "conduyt-crm-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.0",
+  "run_id": "20260509T181000Z-6513e1d0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/conduyt-crm/CHANGELOG.md
+++ b/library/sales-and-crm/conduyt-crm/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/sales-and-crm/conduyt-crm/internal/cli/root.go
+++ b/library/sales-and-crm/conduyt-crm/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/sales-and-crm/contact-goat/.printing-press-release.json
+++ b/library/sales-and-crm/contact-goat/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "contact-goat",
+  "cli_name": "contact-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "1.3.2",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/contact-goat/CHANGELOG.md
+++ b/library/sales-and-crm/contact-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/sales-and-crm/contact-goat/internal/cli/root.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/root.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.1.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON       bool

--- a/library/sales-and-crm/eu-tenders/.printing-press-release.json
+++ b/library/sales-and-crm/eu-tenders/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "eu-tenders",
+  "cli_name": "eu-tenders-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.6",
+  "run_id": "20260508-143927",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/eu-tenders/CHANGELOG.md
+++ b/library/sales-and-crm/eu-tenders/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/sales-and-crm/eu-tenders/internal/cli/root.go
+++ b/library/sales-and-crm/eu-tenders/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/sales-and-crm/gohighlevel/.printing-press-release.json
+++ b/library/sales-and-crm/gohighlevel/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "gohighlevel",
+  "cli_name": "gohighlevel-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260519-151335",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/gohighlevel/CHANGELOG.md
+++ b/library/sales-and-crm/gohighlevel/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/sales-and-crm/gohighlevel/internal/cli/root.go
+++ b/library/sales-and-crm/gohighlevel/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/sales-and-crm/gorgias/.printing-press-release.json
+++ b/library/sales-and-crm/gorgias/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "gorgias",
+  "cli_name": "gorgias-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.20.1",
+  "run_id": "20260512-201610",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/gorgias/CHANGELOG.md
+++ b/library/sales-and-crm/gorgias/CHANGELOG.md
@@ -5,6 +5,10 @@ follows [Keep a Changelog](https://keepachangelog.com/) with one section
 per released tag. Each entry summarizes what a user would notice on
 upgrade.
 
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+
 ## v0.1.7 — 2026-06-02
 
 ### Fixed

--- a/library/sales-and-crm/gorgias/cmd/gorgias-pp-mcp/main.go
+++ b/library/sales-and-crm/gorgias/cmd/gorgias-pp-mcp/main.go
@@ -29,7 +29,7 @@ const (
 // in priority order: ldflag (goreleaser builds), module version from
 // BuildInfo (`go install <module>@vX.Y.Z` builds), or this fallback
 // (local `go run` / `go build` from a working tree).
-var version = "0.0.0-dev"
+var version = "2026.6.1"
 
 // resolveVersion mirrors the CLI's cli.Version() logic so both binaries
 // report the same value when installed via `go install ...@vX.Y.Z`.

--- a/library/sales-and-crm/gorgias/internal/cli/root.go
+++ b/library/sales-and-crm/gorgias/internal/cli/root.go
@@ -24,7 +24,7 @@ import (
 // module version from the binary's BuildInfo (the typical "running from
 // `go run` in a working tree" case). CLI and MCP binaries share the same
 // fallback to keep introspection envelopes coherent across the pair.
-var version = "0.0.0-dev"
+var version = "2026.6.1"
 
 // Version returns the current build's version string. Resolution order:
 //

--- a/library/sales-and-crm/intercom/.printing-press-release.json
+++ b/library/sales-and-crm/intercom/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "intercom",
+  "cli_name": "intercom-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.14.0",
+  "run_id": "20260524-134520",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/intercom/CHANGELOG.md
+++ b/library/sales-and-crm/intercom/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/sales-and-crm/intercom/internal/cli/root.go
+++ b/library/sales-and-crm/intercom/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/sales-and-crm/jobber/.printing-press-release.json
+++ b/library/sales-and-crm/jobber/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "jobber",
+  "cli_name": "jobber-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.10.0",
+  "run_id": "20260522-234028",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/jobber/CHANGELOG.md
+++ b/library/sales-and-crm/jobber/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/sales-and-crm/jobber/internal/cli/root.go
+++ b/library/sales-and-crm/jobber/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/sales-and-crm/servicetitan-pricebook/.printing-press-release.json
+++ b/library/sales-and-crm/servicetitan-pricebook/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "servicetitan-pricebook",
+  "cli_name": "servicetitan-pricebook-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.6.1",
+  "run_id": "20260514-073613",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/servicetitan-pricebook/CHANGELOG.md
+++ b/library/sales-and-crm/servicetitan-pricebook/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/sales-and-crm/servicetitan-pricebook/internal/cli/root.go
+++ b/library/sales-and-crm/servicetitan-pricebook/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/sales-and-crm/smartlead/.printing-press-release.json
+++ b/library/sales-and-crm/smartlead/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "smartlead",
+  "cli_name": "smartlead-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.8.0",
+  "run_id": "20260516-065803",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/smartlead/CHANGELOG.md
+++ b/library/sales-and-crm/smartlead/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/sales-and-crm/smartlead/internal/cli/root.go
+++ b/library/sales-and-crm/smartlead/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/sales-and-crm/sumble/.printing-press-release.json
+++ b/library/sales-and-crm/sumble/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "sumble",
+  "cli_name": "sumble-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.11.0",
+  "run_id": "20260521-201949",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/sumble/CHANGELOG.md
+++ b/library/sales-and-crm/sumble/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/sales-and-crm/sumble/internal/cli/root.go
+++ b/library/sales-and-crm/sumble/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/sales-and-crm/tenderned/.printing-press-release.json
+++ b/library/sales-and-crm/tenderned/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "tenderned",
+  "cli_name": "tenderned-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.1",
+  "run_id": "20260527-084934",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/sales-and-crm/tenderned/CHANGELOG.md
+++ b/library/sales-and-crm/tenderned/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/sales-and-crm/tenderned/internal/cli/root.go
+++ b/library/sales-and-crm/tenderned/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/tenderned/internal/config"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/social-and-messaging/bird/.printing-press-release.json
+++ b/library/social-and-messaging/bird/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "bird",
+  "cli_name": "bird-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.2",
+  "run_id": "20260513-091340",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/social-and-messaging/bird/CHANGELOG.md
+++ b/library/social-and-messaging/bird/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/social-and-messaging/bird/internal/cli/root.go
+++ b/library/social-and-messaging/bird/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/social-and-messaging/multimail/.printing-press-release.json
+++ b/library/social-and-messaging/multimail/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "multimail",
+  "cli_name": "multimail-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "20260527-225904",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/social-and-messaging/multimail/CHANGELOG.md
+++ b/library/social-and-messaging/multimail/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/social-and-messaging/multimail/internal/cli/root.go
+++ b/library/social-and-messaging/multimail/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/social-and-messaging/multimail/internal/config"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/social-and-messaging/pushover/.printing-press-release.json
+++ b/library/social-and-messaging/pushover/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "pushover",
+  "cli_name": "pushover-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.1",
+  "run_id": "20260512-140827",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/social-and-messaging/pushover/CHANGELOG.md
+++ b/library/social-and-messaging/pushover/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/social-and-messaging/pushover/internal/cli/root.go
+++ b/library/social-and-messaging/pushover/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/social-and-messaging/twilio/.printing-press-release.json
+++ b/library/social-and-messaging/twilio/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "twilio",
+  "cli_name": "twilio-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.2.0",
+  "run_id": "20260509-120941",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/social-and-messaging/twilio/CHANGELOG.md
+++ b/library/social-and-messaging/twilio/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/social-and-messaging/twilio/internal/cli/root.go
+++ b/library/social-and-messaging/twilio/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/social-and-messaging/x-twitter/.printing-press-release.json
+++ b/library/social-and-messaging/x-twitter/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "x-twitter",
+  "cli_name": "x-twitter-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.20.1",
+  "run_id": "20260603-230951",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/social-and-messaging/x-twitter/CHANGELOG.md
+++ b/library/social-and-messaging/x-twitter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/social-and-messaging/x-twitter/internal/cli/root.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/travel/airbnb/.printing-press-release.json
+++ b/library/travel/airbnb/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "airbnb",
+  "cli_name": "airbnb-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.1",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/airbnb/CHANGELOG.md
+++ b/library/travel/airbnb/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/airbnb/internal/cli/root.go
+++ b/library/travel/airbnb/internal/cli/root.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/travel/alaska-airlines/.printing-press-release.json
+++ b/library/travel/alaska-airlines/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "alaska-airlines",
+  "cli_name": "alaska-airlines-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.5.1",
+  "run_id": "20260512-151223",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/alaska-airlines/CHANGELOG.md
+++ b/library/travel/alaska-airlines/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/alaska-airlines/internal/cli/root.go
+++ b/library/travel/alaska-airlines/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/travel/alltrails/.printing-press-release.json
+++ b/library/travel/alltrails/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "alltrails",
+  "cli_name": "alltrails-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.0",
+  "run_id": "20260526-193757",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/alltrails/CHANGELOG.md
+++ b/library/travel/alltrails/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/alltrails/internal/cli/root.go
+++ b/library/travel/alltrails/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/travel/booking-com/.printing-press-release.json
+++ b/library/travel/booking-com/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "booking-com",
+  "cli_name": "booking-com-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260519-175228",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/booking-com/CHANGELOG.md
+++ b/library/travel/booking-com/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/booking-com/internal/cli/root.go
+++ b/library/travel/booking-com/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/travel/delta-trip/.printing-press-release.json
+++ b/library/travel/delta-trip/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "delta-trip",
+  "cli_name": "delta-trip-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.12.0",
+  "run_id": "20260520-210157",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/delta-trip/CHANGELOG.md
+++ b/library/travel/delta-trip/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/delta-trip/internal/cli/root.go
+++ b/library/travel/delta-trip/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/travel/flight-goat/.printing-press-release.json
+++ b/library/travel/flight-goat/.printing-press-release.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "slug": "flight-goat",
+  "cli_name": "flight-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.6.0",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/flight-goat/CHANGELOG.md
+++ b/library/travel/flight-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/flight-goat/internal/cli/root.go
+++ b/library/travel/flight-goat/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/travel/hotel-goat/.printing-press-release.json
+++ b/library/travel/hotel-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "hotel-goat",
+  "cli_name": "hotel-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.13.0",
+  "run_id": "20260523-203231",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/hotel-goat/CHANGELOG.md
+++ b/library/travel/hotel-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/hotel-goat/internal/cli/root.go
+++ b/library/travel/hotel-goat/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/travel/hotel-tonight/.printing-press-release.json
+++ b/library/travel/hotel-tonight/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "hotel-tonight",
+  "cli_name": "hotel-tonight-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.9.0",
+  "run_id": "20260519-235715",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/hotel-tonight/CHANGELOG.md
+++ b/library/travel/hotel-tonight/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/hotel-tonight/internal/cli/root.go
+++ b/library/travel/hotel-tonight/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/travel/infotbm/.printing-press-release.json
+++ b/library/travel/infotbm/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "infotbm",
+  "cli_name": "infotbm-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.18.1",
+  "run_id": "20260527-173454",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/infotbm/CHANGELOG.md
+++ b/library/travel/infotbm/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/infotbm/internal/cli/root.go
+++ b/library/travel/infotbm/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/travel/nynj-world-cup-concierge/.printing-press-release.json
+++ b/library/travel/nynj-world-cup-concierge/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "nynj-world-cup-concierge",
+  "cli_name": "nynj-world-cup-concierge-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.19.0",
+  "run_id": "nynj-world-cup-concierge-20260531",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/nynj-world-cup-concierge/CHANGELOG.md
+++ b/library/travel/nynj-world-cup-concierge/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/nynj-world-cup-concierge/internal/cli/root.go
+++ b/library/travel/nynj-world-cup-concierge/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 // Execute runs the CLI.
 func Execute() error {

--- a/library/travel/pointhound/.printing-press-release.json
+++ b/library/travel/pointhound/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "pointhound",
+  "cli_name": "pointhound-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.4.0",
+  "run_id": "20260511-212436",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/pointhound/CHANGELOG.md
+++ b/library/travel/pointhound/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/pointhound/internal/cli/root.go
+++ b/library/travel/pointhound/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/travel/seats-aero/.printing-press-release.json
+++ b/library/travel/seats-aero/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "seats-aero",
+  "cli_name": "seats-aero-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "3.10.0",
+  "run_id": "20260506-seats-aero",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/seats-aero/CHANGELOG.md
+++ b/library/travel/seats-aero/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/seats-aero/internal/cli/root.go
+++ b/library/travel/seats-aero/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/travel/sncf-connect/.printing-press-release.json
+++ b/library/travel/sncf-connect/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "sncf-connect",
+  "cli_name": "sncf-connect-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.10.1",
+  "run_id": "20260521-213542",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/sncf-connect/CHANGELOG.md
+++ b/library/travel/sncf-connect/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/sncf-connect/internal/cli/root.go
+++ b/library/travel/sncf-connect/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON     bool

--- a/library/travel/tripadvisor/.printing-press-release.json
+++ b/library/travel/tripadvisor/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "tripadvisor",
+  "cli_name": "tripadvisor-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.22.1",
+  "run_id": "20260606-103633",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/tripadvisor/CHANGELOG.md
+++ b/library/travel/tripadvisor/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/tripadvisor/internal/cli/version.go
+++ b/library/travel/tripadvisor/internal/cli/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // version is the printed CLI's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "2026.6.1"
 
 // newVersionCmd prints the CLI name and version. Shared by the HTTP and device
 // generators so both printed-CLI shapes carry an identical version command.

--- a/library/travel/uk-train-goat/.printing-press-release.json
+++ b/library/travel/uk-train-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "uk-train-goat",
+  "cli_name": "uk-train-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.20.1",
+  "run_id": "20260603-220423",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/uk-train-goat/CHANGELOG.md
+++ b/library/travel/uk-train-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/uk-train-goat/internal/cli/root.go
+++ b/library/travel/uk-train-goat/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/travel/uk-train-goat/internal/config"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/travel/visit-detroit-blog/.printing-press-release.json
+++ b/library/travel/visit-detroit-blog/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "visit-detroit-blog",
+  "cli_name": "visit-detroit-blog-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.11.0",
+  "run_id": "20260522-180126",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/visit-detroit-blog/CHANGELOG.md
+++ b/library/travel/visit-detroit-blog/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/visit-detroit-blog/internal/cli/root.go
+++ b/library/travel/visit-detroit-blog/internal/cli/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/travel/wanderlust-goat/.printing-press-release.json
+++ b/library/travel/wanderlust-goat/.printing-press-release.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "slug": "wanderlust-goat",
+  "cli_name": "wanderlust-goat-pp-cli",
+  "version": "2026.6.1",
+  "released_at": "2026-06-08T00:00:00Z",
+  "source_commit": "40610a4e649ed7db2f033b1abff765949bbad99d",
+  "printing_press_version": "4.0.1",
+  "run_id": "20260507-163338",
+  "changes": [
+    {
+      "title": "Baseline release metadata added for this published CLI.",
+      "commit": "40610a4e649ed7db2f033b1abff765949bbad99d"
+    }
+  ]
+}

--- a/library/travel/wanderlust-goat/CHANGELOG.md
+++ b/library/travel/wanderlust-goat/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+

--- a/library/travel/wanderlust-goat/internal/cli/root.go
+++ b/library/travel/wanderlust-goat/internal/cli/root.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "2026.6.1"
 
 type rootFlags struct {
 	asJSON        bool

--- a/tools/release-ledger/go.mod
+++ b/tools/release-ledger/go.mod
@@ -1,0 +1,3 @@
+module release-ledger
+
+go 1.23

--- a/tools/release-ledger/main.go
+++ b/tools/release-ledger/main.go
@@ -1,0 +1,567 @@
+// release-ledger maintains per-CLI release metadata for the published library.
+//
+// The library deliberately assigns these versions after a PR merges instead of
+// asking contributors to edit 233 independent changelogs by hand. Versions use
+// YYYY.M.N, where N is the release count for that CLI within the month.
+//
+// Usage:
+//
+//	go run ./tools/release-ledger/main.go --init-missing
+//	go run ./tools/release-ledger/main.go --changed-from <sha> --changed-to <sha>
+//	go run ./tools/release-ledger/main.go --check --changed-from <sha> --changed-to <sha>
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	libraryDir          = "library"
+	releaseManifestName = ".printing-press-release.json"
+	changelogName       = "CHANGELOG.md"
+)
+
+var versionRe = regexp.MustCompile(`^(\d{4})\.(\d{1,2})\.(\d+)$`)
+var varStringRe = regexp.MustCompile(`(?m)(\bvar\s+%s\s*=\s*)"[^"]*"`)
+
+type releaseManifest struct {
+	SchemaVersion        int             `json:"schema_version"`
+	Slug                 string          `json:"slug"`
+	CLIName              string          `json:"cli_name,omitempty"`
+	Version              string          `json:"version"`
+	ReleasedAt           string          `json:"released_at"`
+	SourceCommit         string          `json:"source_commit"`
+	PrintingPressVersion string          `json:"printing_press_version,omitempty"`
+	RunID                string          `json:"run_id,omitempty"`
+	Changes              []releaseChange `json:"changes"`
+}
+
+type releaseChange struct {
+	Title  string `json:"title"`
+	PR     int    `json:"pr,omitempty"`
+	URL    string `json:"url,omitempty"`
+	Commit string `json:"commit,omitempty"`
+}
+
+type printingPressManifest struct {
+	APIName              string `json:"api_name"`
+	CLIName              string `json:"cli_name"`
+	PrintingPressVersion string `json:"printing_press_version"`
+	RunID                string `json:"run_id"`
+}
+
+type options struct {
+	initMissing  bool
+	check        bool
+	changedFrom  string
+	changedTo    string
+	releasedAt   time.Time
+	sourceCommit string
+	changeTitle  string
+	changePR     int
+	changeURL    string
+}
+
+type updateResult struct {
+	dir     string
+	version string
+	changed bool
+}
+
+func main() {
+	opts, err := parseFlags()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	results, err := run(opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var changed []updateResult
+	for _, result := range results {
+		if result.changed {
+			changed = append(changed, result)
+		}
+	}
+	if opts.check {
+		if len(changed) > 0 {
+			var paths []string
+			for _, result := range changed {
+				paths = append(paths, fmt.Sprintf("%s -> %s", result.dir, result.version))
+			}
+			log.Fatalf("release ledger drift detected:\n%s\nRun `go run ./tools/release-ledger/main.go` with the same scope and commit the result.", strings.Join(paths, "\n"))
+		}
+		fmt.Fprintln(os.Stderr, "release ledger is in sync")
+		return
+	}
+	fmt.Fprintf(os.Stderr, "updated %d CLI release ledger entries\n", len(changed))
+}
+
+func parseFlags() (options, error) {
+	var opts options
+	var releasedAt string
+	flag.BoolVar(&opts.initMissing, "init-missing", false, "initialize CLIs missing release metadata")
+	flag.BoolVar(&opts.check, "check", false, "exit non-zero if the selected release ledger entries would change")
+	flag.StringVar(&opts.changedFrom, "changed-from", "", "git ref to diff from when selecting changed CLIs")
+	flag.StringVar(&opts.changedTo, "changed-to", "", "git ref to diff to when selecting changed CLIs")
+	flag.StringVar(&releasedAt, "released-at", "", "release timestamp (RFC3339); defaults to now")
+	flag.StringVar(&opts.sourceCommit, "source-commit", "", "source commit SHA; defaults to HEAD")
+	flag.StringVar(&opts.changeTitle, "change-title", "", "human summary for the changelog entry")
+	flag.IntVar(&opts.changePR, "change-pr", 0, "pull request number for the changelog entry")
+	flag.StringVar(&opts.changeURL, "change-url", "", "pull request URL for the changelog entry")
+	flag.Parse()
+
+	if opts.initMissing && (opts.changedFrom != "" || opts.changedTo != "") {
+		return opts, errors.New("--init-missing cannot be combined with --changed-from/--changed-to")
+	}
+	if !opts.initMissing && (opts.changedFrom == "" || opts.changedTo == "") {
+		return opts, errors.New("use --init-missing or provide both --changed-from and --changed-to")
+	}
+	if releasedAt == "" {
+		opts.releasedAt = time.Now().UTC()
+	} else {
+		parsed, err := time.Parse(time.RFC3339, releasedAt)
+		if err != nil {
+			return opts, fmt.Errorf("parsing --released-at: %w", err)
+		}
+		opts.releasedAt = parsed.UTC()
+	}
+	if opts.sourceCommit == "" {
+		commit, err := gitOutput("rev-parse", "HEAD")
+		if err != nil {
+			return opts, fmt.Errorf("resolving HEAD: %w", err)
+		}
+		opts.sourceCommit = commit
+	}
+	if opts.changeTitle == "" {
+		if opts.initMissing {
+			opts.changeTitle = "Baseline release metadata added for this published CLI."
+		} else {
+			opts.changeTitle = "Published library update."
+		}
+	}
+	return opts, nil
+}
+
+func run(opts options) ([]updateResult, error) {
+	dirs, err := selectCLIDirs(opts)
+	if err != nil {
+		return nil, err
+	}
+	var results []updateResult
+	for _, dir := range dirs {
+		result, err := updateCLI(dir, opts)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func selectCLIDirs(opts options) ([]string, error) {
+	all, err := listCLIDirs(libraryDir)
+	if err != nil {
+		return nil, err
+	}
+	if opts.initMissing {
+		var out []string
+		for _, dir := range all {
+			if !exists(filepath.Join(dir, releaseManifestName)) || !exists(filepath.Join(dir, changelogName)) {
+				out = append(out, dir)
+			}
+		}
+		return out, nil
+	}
+
+	changed, err := changedCLIKeys(opts.changedFrom, opts.changedTo)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, dir := range all {
+		if changed[cliKeyFromDir(dir)] {
+			out = append(out, dir)
+		}
+	}
+	return out, nil
+}
+
+func listCLIDirs(root string) ([]string, error) {
+	categories, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	var dirs []string
+	for _, category := range categories {
+		if !category.IsDir() {
+			continue
+		}
+		categoryPath := filepath.Join(root, category.Name())
+		entries, err := os.ReadDir(categoryPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			dir := filepath.Join(categoryPath, entry.Name())
+			if exists(filepath.Join(dir, ".printing-press.json")) {
+				dirs = append(dirs, dir)
+			}
+		}
+	}
+	sort.Strings(dirs)
+	return dirs, nil
+}
+
+func changedCLIKeys(from, to string) (map[string]bool, error) {
+	out := make(map[string]bool)
+	diff, err := gitOutput("diff", "--name-only", "--diff-filter=ACMRT", from, to, "--", libraryDir)
+	if err != nil {
+		return out, err
+	}
+	for _, name := range strings.Split(diff, "\n") {
+		name = strings.TrimSpace(name)
+		if name == "" || isReleaseLedgerGeneratedPath(name) {
+			continue
+		}
+		if isRuntimeVersionPath(name) {
+			onlyStamp, err := isRuntimeVersionOnlyChange(from, to, name)
+			if err != nil {
+				return out, err
+			}
+			if onlyStamp {
+				continue
+			}
+		}
+		parts := strings.Split(name, "/")
+		if len(parts) >= 3 && parts[0] == libraryDir {
+			out[parts[1]+"/"+parts[2]] = true
+		}
+	}
+	return out, nil
+}
+
+func isReleaseLedgerGeneratedPath(name string) bool {
+	return strings.HasSuffix(name, "/"+releaseManifestName) ||
+		strings.HasSuffix(name, "/"+changelogName)
+}
+
+func isRuntimeVersionPath(name string) bool {
+	if strings.HasSuffix(name, "/internal/cli/root.go") || strings.HasSuffix(name, "/internal/cli/version.go") {
+		return true
+	}
+	parts := strings.Split(name, "/")
+	return len(parts) >= 5 && parts[0] == libraryDir && parts[len(parts)-1] == "main.go" &&
+		parts[len(parts)-3] == "cmd" && strings.HasSuffix(parts[len(parts)-2], "-pp-mcp")
+}
+
+func isRuntimeVersionOnlyChange(from, to, path string) (bool, error) {
+	diff, err := gitOutput("diff", "--unified=0", from, to, "--", path)
+	if err != nil {
+		return false, err
+	}
+	changed := false
+	for _, line := range strings.Split(diff, "\n") {
+		if line == "" || strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+			continue
+		}
+		if !strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "-") {
+			continue
+		}
+		changed = true
+		text := strings.TrimSpace(line[1:])
+		if !isRuntimeVersionStampLine(text) {
+			return false, nil
+		}
+	}
+	return changed, nil
+}
+
+func isRuntimeVersionStampLine(line string) bool {
+	for _, name := range []string{"version", "commit", "date"} {
+		re := regexp.MustCompile(fmt.Sprintf(`^var\s+%s\s*=\s*"[^"]*"$`, regexp.QuoteMeta(name)))
+		if re.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+func updateCLI(dir string, opts options) (updateResult, error) {
+	pp, err := readPrintingPressManifest(filepath.Join(dir, ".printing-press.json"))
+	if err != nil {
+		return updateResult{dir: dir}, err
+	}
+	current, err := readReleaseManifest(filepath.Join(dir, releaseManifestName))
+	if err != nil {
+		return updateResult{dir: dir}, err
+	}
+	nextVersion, err := nextReleaseVersion(current, opts)
+	if err != nil {
+		return updateResult{dir: dir}, fmt.Errorf("%s: %w", dir, err)
+	}
+	next := releaseManifest{
+		SchemaVersion:        1,
+		Slug:                 slugFromDir(dir),
+		CLIName:              pp.CLIName,
+		Version:              nextVersion,
+		ReleasedAt:           opts.releasedAt.Format(time.RFC3339),
+		SourceCommit:         opts.sourceCommit,
+		PrintingPressVersion: pp.PrintingPressVersion,
+		RunID:                pp.RunID,
+		Changes: []releaseChange{{
+			Title:  opts.changeTitle,
+			PR:     opts.changePR,
+			URL:    opts.changeURL,
+			Commit: opts.sourceCommit,
+		}},
+	}
+
+	changed := false
+	if changedFile, err := writeJSONIfChanged(filepath.Join(dir, releaseManifestName), next, opts.check); err != nil {
+		return updateResult{dir: dir}, err
+	} else if changedFile {
+		changed = true
+	}
+	if changedFile, err := updateChangelog(dir, next, opts, current.Version != "", opts.check); err != nil {
+		return updateResult{dir: dir}, err
+	} else if changedFile {
+		changed = true
+	}
+	if changedFile, err := stampRuntimeVersion(dir, next, opts.check); err != nil {
+		return updateResult{dir: dir}, err
+	} else if changedFile {
+		changed = true
+	}
+	return updateResult{dir: dir, version: nextVersion, changed: changed}, nil
+}
+
+func readPrintingPressManifest(path string) (printingPressManifest, error) {
+	var manifest printingPressManifest
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return manifest, err
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return manifest, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return manifest, nil
+}
+
+func readReleaseManifest(path string) (releaseManifest, error) {
+	var manifest releaseManifest
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return manifest, nil
+	}
+	if err != nil {
+		return manifest, err
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return manifest, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return manifest, nil
+}
+
+func nextReleaseVersion(current releaseManifest, opts options) (string, error) {
+	if current.Version != "" && current.SourceCommit == opts.sourceCommit {
+		return current.Version, nil
+	}
+	return nextVersion(current.Version, opts.releasedAt)
+}
+
+func nextVersion(current string, releasedAt time.Time) (string, error) {
+	year, month, sequence := releasedAt.Date()
+	if current == "" {
+		return fmt.Sprintf("%d.%d.1", year, int(month)), nil
+	}
+	matches := versionRe.FindStringSubmatch(current)
+	if matches == nil {
+		return "", fmt.Errorf("invalid release version %q, want YYYY.M.N", current)
+	}
+	currentYear, _ := strconv.Atoi(matches[1])
+	currentMonth, _ := strconv.Atoi(matches[2])
+	currentSequence, _ := strconv.Atoi(matches[3])
+	if currentYear == year && currentMonth == int(month) {
+		sequence = currentSequence + 1
+	} else {
+		sequence = 1
+	}
+	return fmt.Sprintf("%d.%d.%d", year, int(month), sequence), nil
+}
+
+func writeJSONIfChanged(path string, value any, check bool) (bool, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	data = append(data, '\n')
+	return writeIfChanged(path, data, check)
+}
+
+func updateChangelog(dir string, manifest releaseManifest, opts options, hasPriorRelease bool, check bool) (bool, error) {
+	path := filepath.Join(dir, changelogName)
+	entry := changelogEntry(manifest, opts, hasPriorRelease)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		data = []byte("# Changelog\n\nThis file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.\n\n")
+	} else if err != nil {
+		return false, err
+	} else if bytes.Contains(data, []byte("## "+manifest.Version+" - ")) {
+		return false, nil
+	}
+	next := insertChangelogEntry(data, entry)
+	return writeIfChanged(path, next, check)
+}
+
+func changelogEntry(manifest releaseManifest, opts options, hasPriorRelease bool) []byte {
+	var line string
+	if hasPriorRelease {
+		title := strings.TrimSpace(opts.changeTitle)
+		line = fmt.Sprintf("- %s", title)
+		if opts.changePR > 0 {
+			line += fmt.Sprintf(" (#%d)", opts.changePR)
+		}
+		if !strings.HasSuffix(line, ".") && !strings.HasSuffix(line, "!") && !strings.HasSuffix(line, "?") {
+			line += "."
+		}
+	} else {
+		line = "- Baseline release metadata added for this published CLI."
+	}
+	return []byte(fmt.Sprintf("## %s - %s\n\n%s\n\n", manifest.Version, opts.releasedAt.Format("2006-01-02"), line))
+}
+
+func insertChangelogEntry(existing, entry []byte) []byte {
+	normalized := bytes.TrimRight(existing, " \t\r\n")
+	if len(normalized) == 0 {
+		normalized = []byte("# Changelog")
+	}
+	normalized = append(normalized, '\n')
+	firstSection := bytes.Index(normalized, []byte("\n## "))
+	if firstSection < 0 {
+		out := append([]byte{}, normalized...)
+		out = append(out, '\n')
+		out = append(out, entry...)
+		return out
+	}
+	insertAt := firstSection + 1
+	out := append([]byte{}, normalized[:insertAt]...)
+	out = append(out, entry...)
+	out = append(out, normalized[insertAt:]...)
+	return out
+}
+
+func stampRuntimeVersion(dir string, manifest releaseManifest, check bool) (bool, error) {
+	var paths []string
+	for _, rel := range []string{
+		filepath.Join("internal", "cli", "version.go"),
+		filepath.Join("internal", "cli", "root.go"),
+	} {
+		path := filepath.Join(dir, rel)
+		if exists(path) {
+			paths = append(paths, path)
+		}
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "cmd", "*-pp-mcp", "main.go"))
+	if err != nil {
+		return false, err
+	}
+	paths = append(paths, matches...)
+
+	changed := false
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return changed, err
+		}
+		next, touched := replaceVarString(data, "version", manifest.Version)
+		if !touched {
+			continue
+		}
+		if bytes.Contains(next, []byte(`var commit = "`)) {
+			next, _ = replaceVarString(next, "commit", manifest.SourceCommit)
+		}
+		if bytes.Contains(next, []byte(`var date = "`)) {
+			next, _ = replaceVarString(next, "date", manifest.ReleasedAt)
+		}
+		if changedFile, err := writeIfChanged(path, next, check); err != nil {
+			return changed, err
+		} else if changedFile {
+			changed = true
+		}
+	}
+	return changed, nil
+}
+
+func replaceVarString(data []byte, name, value string) ([]byte, bool) {
+	re := regexp.MustCompile(fmt.Sprintf(varStringRe.String(), regexp.QuoteMeta(name)))
+	replaced := false
+	out := re.ReplaceAllFunc(data, func(match []byte) []byte {
+		if replaced {
+			return match
+		}
+		replaced = true
+		parts := re.FindSubmatch(match)
+		return []byte(string(parts[1]) + strconv.Quote(value))
+	})
+	return out, replaced
+}
+
+func writeIfChanged(path string, data []byte, check bool) (bool, error) {
+	current, err := os.ReadFile(path)
+	if err == nil && bytes.Equal(current, data) {
+		return false, nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	if check {
+		return true, nil
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func slugFromDir(dir string) string {
+	return filepath.Base(dir)
+}
+
+func cliKeyFromDir(dir string) string {
+	return filepath.Base(filepath.Dir(dir)) + "/" + filepath.Base(dir)
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func gitOutput(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/tools/release-ledger/main_test.go
+++ b/tools/release-ledger/main_test.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNextVersion(t *testing.T) {
+	releasedAt := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		current string
+		want    string
+	}{
+		{name: "initial", want: "2026.6.1"},
+		{name: "same month increments", current: "2026.6.3", want: "2026.6.4"},
+		{name: "new month resets", current: "2026.5.9", want: "2026.6.1"},
+		{name: "new year resets", current: "2025.12.9", want: "2026.6.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := nextVersion(tt.current, releasedAt)
+			if err != nil {
+				t.Fatalf("nextVersion() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("nextVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNextReleaseVersionIsIdempotentForSameSourceCommit(t *testing.T) {
+	releasedAt := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	got, err := nextReleaseVersion(releaseManifest{
+		Version:      "2026.6.3",
+		SourceCommit: "abc123",
+	}, options{releasedAt: releasedAt, sourceCommit: "abc123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "2026.6.3" {
+		t.Fatalf("nextReleaseVersion() = %q, want existing version", got)
+	}
+
+	got, err = nextReleaseVersion(releaseManifest{
+		Version:      "2026.6.3",
+		SourceCommit: "abc123",
+	}, options{releasedAt: releasedAt, sourceCommit: "def456"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "2026.6.4" {
+		t.Fatalf("nextReleaseVersion() = %q, want incremented version", got)
+	}
+}
+
+func TestChangedCLISlugsIgnoresReleaseLedgerFiles(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.name", "Test")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+
+	writeFile(t, repo, "library/social/x/.printing-press.json", "{}\n")
+	writeFile(t, repo, "library/social/x/README.md", "old\n")
+	writeFile(t, repo, "library/social/y/.printing-press.json", "{}\n")
+	writeFile(t, repo, "library/social/y/README.md", "old\n")
+	writeFile(t, repo, "library/social/z/.printing-press.json", "{}\n")
+	writeFile(t, repo, "library/social/z/internal/cli/root.go", "package cli\n\nvar version = \"1.0.0\"\n")
+	writeFile(t, repo, "library/social/real/.printing-press.json", "{}\n")
+	writeFile(t, repo, "library/social/real/internal/cli/root.go", "package cli\n\nvar version = \"1.0.0\"\n\nfunc run() {}\n")
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "initial")
+	base := gitOutputIn(t, repo, "rev-parse", "HEAD")
+
+	writeFile(t, repo, "library/social/x/CHANGELOG.md", "# Changelog\n")
+	writeFile(t, repo, "library/social/x/.printing-press-release.json", "{}\n")
+	writeFile(t, repo, "library/social/y/README.md", "new\n")
+	writeFile(t, repo, "library/social/z/internal/cli/root.go", "package cli\n\nvar version = \"2026.6.1\"\n")
+	writeFile(t, repo, "library/social/real/internal/cli/root.go", "package cli\n\nvar version = \"2026.6.1\"\n\nfunc run() { println(\"changed\") }\n")
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "update")
+	head := gitOutputIn(t, repo, "rev-parse", "HEAD")
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Fatalf("restore wd: %v", err)
+		}
+	})
+
+	got, err := changedCLIKeys(base, head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["social/x"] {
+		t.Fatalf("release-ledger-only changes should be ignored: %#v", got)
+	}
+	if !got["social/y"] {
+		t.Fatalf("non-release library change should select slug y: %#v", got)
+	}
+	if got["social/z"] {
+		t.Fatalf("runtime-version-only changes should be ignored: %#v", got)
+	}
+	if !got["social/real"] {
+		t.Fatalf("root.go with non-version changes should select slug real: %#v", got)
+	}
+}
+
+func TestInsertChangelogEntryPreservesPrologue(t *testing.T) {
+	existing := []byte(`# Changelog
+
+All notable changes are documented here.
+
+## v0.1.0 - 2026-05-01
+
+- Existing entry.
+`)
+	entry := []byte("## 2026.6.1 - 2026-06-08\n\n- Baseline release metadata added for this published CLI.\n\n")
+
+	got := string(insertChangelogEntry(existing, entry))
+	want := `# Changelog
+
+All notable changes are documented here.
+
+## 2026.6.1 - 2026-06-08
+
+- Baseline release metadata added for this published CLI.
+
+## v0.1.0 - 2026-05-01
+
+- Existing entry.
+`
+	if got != want {
+		t.Fatalf("insertChangelogEntry mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestUpdateChangelogSkipsExistingReleaseSection(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "library/social/x/CHANGELOG.md", "# Changelog\n\n## 2026.6.1 - 2026-06-08\n\n- Existing.\n")
+	changed, err := updateChangelog(
+		filepath.Join(repo, "library", "social", "x"),
+		releaseManifest{Version: "2026.6.1"},
+		options{releasedAt: time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC), changeTitle: "Existing"},
+		true,
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("updateChangelog should not duplicate an existing release section")
+	}
+}
+
+func TestUpdateCLIInitializesManifestChangelogAndRuntimeVersion(t *testing.T) {
+	repo := t.TempDir()
+	dir := filepath.Join(repo, "library", "social", "x-twitter")
+	writeFile(t, repo, "library/social/x-twitter/.printing-press.json", `{
+  "api_name": "x-twitter",
+  "cli_name": "x-twitter-pp-cli",
+  "printing_press_version": "4.20.1",
+  "run_id": "20260603-230951"
+}
+`)
+	writeFile(t, repo, "library/social/x-twitter/internal/cli/root.go", `package cli
+
+var version = "1.0.0"
+var other = "leave-me"
+`)
+
+	releasedAt := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	result, err := updateCLI(dir, options{
+		initMissing:  true,
+		releasedAt:   releasedAt,
+		sourceCommit: "abc123",
+		changeTitle:  "Baseline release metadata added for this published CLI.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.changed || result.version != "2026.6.1" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+
+	manifest := readFile(t, repo, "library/social/x-twitter/.printing-press-release.json")
+	for _, want := range []string{
+		`"version": "2026.6.1"`,
+		`"source_commit": "abc123"`,
+		`"printing_press_version": "4.20.1"`,
+	} {
+		if !strings.Contains(manifest, want) {
+			t.Fatalf("release manifest missing %q:\n%s", want, manifest)
+		}
+	}
+	changelog := readFile(t, repo, "library/social/x-twitter/CHANGELOG.md")
+	if !strings.Contains(changelog, "## 2026.6.1 - 2026-06-08") {
+		t.Fatalf("changelog missing release entry:\n%s", changelog)
+	}
+	root := readFile(t, repo, "library/social/x-twitter/internal/cli/root.go")
+	if !strings.Contains(root, `var version = "2026.6.1"`) {
+		t.Fatalf("root.go was not stamped:\n%s", root)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+}
+
+func gitOutputIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v failed: %v", args, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeFile(t *testing.T, root, rel, body string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, root, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary
- add a per-CLI release ledger tool and post-merge workflow that assigns `YYYY.M.N` versions, updates `CHANGELOG.md`, and stamps runtime version strings
- sweep existing library CLIs with baseline `2026.6.1` release manifests and changelogs without requiring contributors to hand-bump versions
- document the release-ledger contract for agents and ignore ledger/runtime-version-only changes when deciding which CLIs need a new release entry

## Validation
- `go test ./...` in `tools/release-ledger`
- `go run ./tools/release-ledger/main.go --changed-from HEAD --changed-to HEAD --released-at 2026-06-08T00:00:00Z --source-commit test --check`
- `go run ./tools/release-ledger/main.go --init-missing --released-at 2026-06-08T00:00:00Z --source-commit "$(git rev-parse HEAD)" --check`
- `go run ./tools/generate-registry/main.go --check`
- `git diff --check`
- `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`
- `go test ./...` in `library/social-and-messaging/x-twitter`
- `go test ./...` in `library/sales-and-crm/gorgias`
