### PR TITLE
feat(notion): add 5 novel commands — sql, since, context, graph, bulk

### DIFF
--- a/library/productivity/notion/internal/cli/bulk.go
+++ b/library/productivity/notion/internal/cli/bulk.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Vincent Lauriat and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/mvanhorn/printing-press-library/library/productivity/notion/internal/store"
+)
+
+func newNovelBulkCmd(flags *rootFlags) *cobra.Command {
+	var flagDb string
+	var flagFilter []string
+	var flagSet string
+
+	cmd := &cobra.Command{
+		Use:   "bulk <database-id>",
+		Short: "Update hundreds of Notion records matching a filter in seconds — no clicking.",
+		Long: `Batch-update Notion pages in a database. Finds matching records via the local
+store, then patches each via the live Notion API.
+
+--filter key=value        Filter by property (repeatable). Matches select.name, status.name, checkbox.
+--set '{"Key":{...}}'     Raw Notion properties JSON to apply to each matched page.
+
+Requires NOTION_TOKEN. Run 'notion-pp-cli sync' first to find matching records.
+
+Examples:
+  notion-pp-cli bulk <db-id> --filter "Status=In Progress" --set '{"Status":{"select":{"name":"Done"}}}'
+  notion-pp-cli bulk <db-id> --filter "Priority=High" --set '{"Priority":{"select":{"name":"Medium"}}}' --dry-run`,
+		Annotations: map[string]string{"mcp:read-only": "false"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+			if flagSet == "" {
+				return usageErr(fmt.Errorf("--set is required (Notion properties JSON, e.g. '{\"Status\":{\"select\":{\"name\":\"Done\"}}}')"))
+			}
+
+			var propsUpdate map[string]any
+			if err := json.Unmarshal([]byte(flagSet), &propsUpdate); err != nil {
+				return usageErr(fmt.Errorf("--set must be valid JSON: %w", err))
+			}
+
+			dbID := args[0]
+			if flagDb == "" {
+				flagDb = defaultDBPath("notion-pp-cli")
+			}
+			localDB, err := store.OpenReadOnly(flagDb)
+			if err != nil {
+				return fmt.Errorf("opening local database: %w\nRun 'notion-pp-cli sync' first.", err)
+			}
+			defer localDB.Close()
+
+			// Query: pages whose parent is the given database.
+			// Filter is applied in Go to avoid SQL injection from property names.
+			rows, err := localDB.DB().QueryContext(cmd.Context(),
+				`SELECT id, data FROM resources
+				 WHERE resource_type = 'pages'
+				 AND (json_extract(data, '$.parent.database_id') = ?
+				      OR json_extract(data, '$.parent.database_id') = ?)`,
+				dbID, strings.ReplaceAll(dbID, "-", ""),
+			)
+			if err != nil {
+				return fmt.Errorf("query failed: %w", err)
+			}
+			defer rows.Close()
+
+			type candidate struct {
+				id   string
+				data []byte
+			}
+			var candidates []candidate
+			for rows.Next() {
+				var id string
+				var data []byte
+				if err := rows.Scan(&id, &data); err != nil {
+					continue
+				}
+				candidates = append(candidates, candidate{id: id, data: data})
+			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("querying candidates: %w", err)
+			}
+
+			// Apply Go-side filters against property values.
+			var ids []string
+			for _, c := range candidates {
+				if bulkMatchesFilters(c.data, flagFilter) {
+					ids = append(ids, c.id)
+				}
+			}
+
+			if len(ids) == 0 {
+				if flags.asJSON {
+					return flags.printJSON(cmd, map[string]any{"updated": 0, "errors": 0, "ids": []string{}})
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(), "No matching records found.\n")
+				return nil
+			}
+
+			fmt.Fprintf(cmd.ErrOrStderr(), "Found %d record(s) to update.\n", len(ids))
+
+			if !flags.yes && !flags.noInput {
+				return usageErr(fmt.Errorf("pass --yes to confirm updating %d records", len(ids)))
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			type patchResult struct {
+				ID    string `json:"id"`
+				Error string `json:"error,omitempty"`
+			}
+			var updated, errCount int
+			var results []patchResult
+
+			for _, id := range ids {
+				body := map[string]any{"properties": propsUpdate}
+				_, _, patchErr := c.Patch("/v1/pages/"+id, body)
+				if patchErr != nil {
+					errCount++
+					results = append(results, patchResult{ID: id, Error: patchErr.Error()})
+				} else {
+					updated++
+					results = append(results, patchResult{ID: id})
+				}
+			}
+
+			if !flags.asJSON {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Updated %d record(s), %d error(s).\n", updated, errCount)
+			}
+			return flags.printJSON(cmd, map[string]any{
+				"updated": updated,
+				"errors":  errCount,
+				"results": results,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&flagDb, "db", "", "Local database path (default: ~/.local/share/github.com/mvanhorn/printing-press-library/library/productivity/notion/data.db)")
+	cmd.Flags().StringSliceVar(&flagFilter, "filter", nil, "Filter by property (key=value, repeatable)")
+	cmd.Flags().StringVar(&flagSet, "set", "", "Notion properties JSON to apply (e.g. '{\"Status\":{\"select\":{\"name\":\"Done\"}}}')")
+	return cmd
+}
+
+// bulkMatchesFilters checks whether a page's JSON data satisfies all key=value filter pairs.
+// Matches against common Notion property shapes: select.name, status.name, checkbox.
+func bulkMatchesFilters(data []byte, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return false
+	}
+	propsRaw, ok := obj["properties"]
+	if !ok {
+		return false
+	}
+	var props map[string]json.RawMessage
+	if err := json.Unmarshal(propsRaw, &props); err != nil {
+		return false
+	}
+
+	for _, f := range filters {
+		k, v, ok := strings.Cut(f, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+
+		propRaw, ok := props[k]
+		if !ok {
+			return false
+		}
+		var prop map[string]json.RawMessage
+		if err := json.Unmarshal(propRaw, &prop); err != nil {
+			return false
+		}
+
+		matched := false
+		// select / status
+		for _, typeKey := range []string{"select", "status"} {
+			if typeRaw, ok := prop[typeKey]; ok {
+				var inner map[string]string
+				if json.Unmarshal(typeRaw, &inner) == nil {
+					if inner["name"] == v {
+						matched = true
+						break
+					}
+				}
+			}
+		}
+		// checkbox
+		if !matched {
+			if cbRaw, ok := prop["checkbox"]; ok {
+				var cb bool
+				if json.Unmarshal(cbRaw, &cb) == nil {
+					cbStr := "false"
+					if cb {
+						cbStr = "true"
+					}
+					if cbStr == v || v == "1" && cb || v == "0" && !cb {
+						matched = true
+					}
+				}
+			}
+		}
+		// rich_text plain_text
+		if !matched {
+			if rtRaw, ok := prop["rich_text"]; ok {
+				text := extractRichText(rtRaw)
+				if text == v {
+					matched = true
+				}
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}

--- a/library/productivity/notion/internal/cli/context.go
+++ b/library/productivity/notion/internal/cli/context.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Vincent Lauriat and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/mvanhorn/printing-press-library/library/productivity/notion/internal/store"
+)
+
+type workspaceContext struct {
+	GeneratedAt  string             `json:"generated_at"`
+	SyncStates   []syncStateEntry   `json:"sync_states"`
+	Databases    []json.RawMessage  `json:"databases,omitempty"`
+	RecentEdits  []json.RawMessage  `json:"recent_edits,omitempty"`
+	TotalRecords int                `json:"total_records"`
+}
+
+type syncStateEntry struct {
+	ResourceType string `json:"resource_type"`
+	TotalCount   int    `json:"total_count"`
+	LastSyncedAt string `json:"last_synced_at,omitempty"`
+}
+
+func newNovelContextCmd(flags *rootFlags) *cobra.Command {
+	var flagSince string
+	var flagLimit int
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "context",
+		Short: "Dump the full workspace context as structured JSON — database schemas, property types, recent changes",
+		Long: `Produce a structured JSON snapshot of the local Notion workspace — useful for
+passing to an LLM agent. Output includes:
+  - Per-resource sync state (counts, last-synced timestamps)
+  - Database and data source schemas (property names and types)
+  - Recently edited pages (when --since is set)
+
+Run 'notion-pp-cli sync' first to populate the local database.
+
+Examples:
+  notion-pp-cli context --json
+  notion-pp-cli context --since 7d --json
+  notion-pp-cli context | pbcopy`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+			if dbPath == "" {
+				dbPath = defaultDBPath("notion-pp-cli")
+			}
+			db, err := store.OpenReadOnly(dbPath)
+			if err != nil {
+				return fmt.Errorf("opening local database: %w\nRun 'notion-pp-cli sync' first to populate the local database.", err)
+			}
+			defer db.Close()
+			rawDB := db.DB()
+
+			// 1. Sync states — close rows before opening the next query.
+			syncRows, err := rawDB.QueryContext(cmd.Context(),
+				`SELECT resource_type, total_count, last_synced_at FROM sync_state ORDER BY resource_type`)
+			if err != nil {
+				return fmt.Errorf("querying sync_state: %w", err)
+			}
+			var syncStates []syncStateEntry
+			var totalRecords int
+			for syncRows.Next() {
+				var rt string
+				var count int
+				var syncedAt sql.NullString
+				if err := syncRows.Scan(&rt, &count, &syncedAt); err != nil {
+					continue
+				}
+				e := syncStateEntry{ResourceType: rt, TotalCount: count}
+				if syncedAt.Valid {
+					e.LastSyncedAt = syncedAt.String
+				}
+				syncStates = append(syncStates, e)
+				totalRecords += count
+			}
+			syncRows.Close()
+			if err := syncRows.Err(); err != nil {
+				return fmt.Errorf("iterating sync_state: %w", err)
+			}
+
+			// 2. Database schemas — compact to schema-relevant fields only.
+			schemaRows, err := rawDB.QueryContext(cmd.Context(),
+				`SELECT data FROM resources
+				 WHERE resource_type IN ('data_sources', 'databases')
+				 ORDER BY json_extract(data, '$.last_edited_time') DESC
+				 LIMIT 50`)
+			if err != nil {
+				return fmt.Errorf("querying database schemas: %w", err)
+			}
+			var databases []json.RawMessage
+			for schemaRows.Next() {
+				var data string
+				if err := schemaRows.Scan(&data); err != nil {
+					continue
+				}
+				var obj map[string]json.RawMessage
+				if err := json.Unmarshal([]byte(data), &obj); err != nil {
+					continue
+				}
+				compact := make(map[string]json.RawMessage, 7)
+				for _, k := range []string{"id", "object", "title", "url", "properties", "last_edited_time", "created_time"} {
+					if v, ok := obj[k]; ok {
+						compact[k] = v
+					}
+				}
+				if b, err := json.Marshal(compact); err == nil {
+					databases = append(databases, b)
+				}
+			}
+			schemaRows.Close()
+			if err := schemaRows.Err(); err != nil {
+				return fmt.Errorf("iterating database schemas: %w", err)
+			}
+
+			// 3. Recent edits (only when --since is set).
+			var recentEdits []json.RawMessage
+			if flagSince != "" {
+				since, err := parseSinceArg(flagSince)
+				if err != nil {
+					return usageErr(fmt.Errorf("invalid --since value %q: %w", flagSince, err))
+				}
+				sinceStr := since.UTC().Format(time.RFC3339)
+				editRows, err := rawDB.QueryContext(cmd.Context(),
+					`SELECT data FROM resources
+					 WHERE resource_type IN ('pages', 'data_sources')
+					 AND json_extract(data, '$.last_edited_time') >= ?
+					 ORDER BY json_extract(data, '$.last_edited_time') DESC
+					 LIMIT ?`,
+					sinceStr, flagLimit,
+				)
+				if err != nil {
+					return fmt.Errorf("querying recent edits: %w", err)
+				}
+				for editRows.Next() {
+					var data string
+					if err := editRows.Scan(&data); err != nil {
+						continue
+					}
+					recentEdits = append(recentEdits, json.RawMessage(data))
+				}
+				editRows.Close()
+				if err := editRows.Err(); err != nil {
+					return fmt.Errorf("iterating recent edits: %w", err)
+				}
+			}
+
+			if syncStates == nil {
+				syncStates = []syncStateEntry{}
+			}
+			out := workspaceContext{
+				GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+				SyncStates:   syncStates,
+				Databases:    databases,
+				RecentEdits:  recentEdits,
+				TotalRecords: totalRecords,
+			}
+			return flags.printJSON(cmd, out)
+		},
+	}
+	cmd.Flags().StringVar(&flagSince, "since", "", "Include recent edits since this duration or timestamp (e.g. 7d, 2024-01-01)")
+	cmd.Flags().IntVar(&flagLimit, "limit", 100, "Maximum recent edits when --since is set")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/github.com/mvanhorn/printing-press-library/library/productivity/notion/data.db)")
+	return cmd
+}

--- a/library/productivity/notion/internal/cli/graph.go
+++ b/library/productivity/notion/internal/cli/graph.go
@@ -1,0 +1,245 @@
+// Copyright 2026 Vincent Lauriat and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/mvanhorn/printing-press-library/library/productivity/notion/internal/store"
+)
+
+type graphNode struct {
+	ID       string       `json:"id"`
+	Title    string       `json:"title,omitempty"`
+	Type     string       `json:"type,omitempty"`
+	Children []*graphNode `json:"children,omitempty"`
+}
+
+func newNovelGraphCmd(flags *rootFlags) *cobra.Command {
+	var flagDepth int
+	var flagFormat string
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "graph <page-or-database-id>",
+		Short: "Follow Notion relation properties across databases to any depth — output as tree, JSON, or Graphviz DOT.",
+		Long: `Traverse Notion relation properties starting from a page or database ID.
+Reads entirely from the local sync store — no API calls required.
+Run 'notion-pp-cli sync' first to populate the local database.
+
+Output formats:
+  tree   Indented text tree (default)
+  json   JSON tree with nested children arrays
+  dot    Graphviz DOT format for use with dot/graphviz
+
+Examples:
+  notion-pp-cli graph <page-id>
+  notion-pp-cli graph <page-id> --depth 5 --format dot
+  notion-pp-cli graph <page-id> --format json --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+			if dbPath == "" {
+				dbPath = defaultDBPath("notion-pp-cli")
+			}
+			db, err := store.OpenReadOnly(dbPath)
+			if err != nil {
+				return fmt.Errorf("opening local database: %w\nRun 'notion-pp-cli sync' first to populate the local database.", err)
+			}
+			defer db.Close()
+
+			root, err := buildGraphNode(cmd.Context(), db.DB(), args[0], flagDepth, map[string]bool{})
+			if err != nil {
+				return fmt.Errorf("building graph: %w", err)
+			}
+			if root == nil {
+				return notFoundErr(fmt.Errorf("page or database %q not found in local store\nRun 'notion-pp-cli sync' to populate.", args[0]))
+			}
+
+			switch flagFormat {
+			case "json":
+				return flags.printJSON(cmd, root)
+			case "dot":
+				fmt.Fprintln(cmd.OutOrStdout(), "digraph notion {")
+				emitDOT(cmd, root)
+				fmt.Fprintln(cmd.OutOrStdout(), "}")
+			default:
+				printGraphTree(cmd, root, 0)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&flagDepth, "depth", 3, "Maximum relation traversal depth")
+	cmd.Flags().StringVar(&flagFormat, "format", "tree", "Output format: tree, json, or dot")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/github.com/mvanhorn/printing-press-library/library/productivity/notion/data.db)")
+	return cmd
+}
+
+func buildGraphNode(ctx context.Context, rawDB *sql.DB, id string, depth int, visited map[string]bool) (*graphNode, error) {
+	if depth < 0 || visited[id] {
+		return nil, nil
+	}
+	visited[id] = true
+
+	var data string
+	err := rawDB.QueryRowContext(ctx, `SELECT data FROM resources WHERE id = ? LIMIT 1`, id).Scan(&data)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(data), &obj); err != nil {
+		return nil, err
+	}
+
+	node := &graphNode{ID: id}
+	if t, ok := obj["object"]; ok {
+		var s string
+		if json.Unmarshal(t, &s) == nil {
+			node.Type = s
+		}
+	}
+	node.Title = extractNotionTitle(obj)
+
+	if depth == 0 {
+		return node, nil
+	}
+
+	// Traverse relation properties.
+	if propsRaw, ok := obj["properties"]; ok {
+		var props map[string]json.RawMessage
+		if json.Unmarshal(propsRaw, &props) == nil {
+			for _, propVal := range props {
+				var prop map[string]json.RawMessage
+				if json.Unmarshal(propVal, &prop) != nil {
+					continue
+				}
+				typeRaw, ok := prop["type"]
+				if !ok {
+					continue
+				}
+				var propType string
+				if json.Unmarshal(typeRaw, &propType) != nil || propType != "relation" {
+					continue
+				}
+				relRaw, ok := prop["relation"]
+				if !ok {
+					continue
+				}
+				var relations []map[string]json.RawMessage
+				if json.Unmarshal(relRaw, &relations) != nil {
+					continue
+				}
+				for _, rel := range relations {
+					idRaw, ok := rel["id"]
+					if !ok {
+						continue
+					}
+					var relID string
+					if json.Unmarshal(idRaw, &relID) != nil || relID == "" {
+						continue
+					}
+					child, err := buildGraphNode(ctx, rawDB, relID, depth-1, visited)
+					if err != nil || child == nil {
+						continue
+					}
+					node.Children = append(node.Children, child)
+				}
+			}
+		}
+	}
+	return node, nil
+}
+
+func extractNotionTitle(obj map[string]json.RawMessage) string {
+	if propsRaw, ok := obj["properties"]; ok {
+		var props map[string]json.RawMessage
+		if json.Unmarshal(propsRaw, &props) == nil {
+			for _, k := range []string{"title", "Title", "Name", "name"} {
+				if propRaw, ok := props[k]; ok {
+					if title := extractTitleFromProp(propRaw); title != "" {
+						return title
+					}
+				}
+			}
+		}
+	}
+	if titleRaw, ok := obj["title"]; ok {
+		return extractRichText(titleRaw)
+	}
+	return ""
+}
+
+func extractTitleFromProp(raw json.RawMessage) string {
+	var prop map[string]json.RawMessage
+	if json.Unmarshal(raw, &prop) != nil {
+		return ""
+	}
+	if titleArr, ok := prop["title"]; ok {
+		return extractRichText(titleArr)
+	}
+	return ""
+}
+
+func extractRichText(raw json.RawMessage) string {
+	var items []map[string]json.RawMessage
+	if json.Unmarshal(raw, &items) != nil {
+		return ""
+	}
+	var parts []string
+	for _, item := range items {
+		if pt, ok := item["plain_text"]; ok {
+			var s string
+			if json.Unmarshal(pt, &s) == nil && s != "" {
+				parts = append(parts, s)
+			}
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+func printGraphTree(cmd *cobra.Command, node *graphNode, indent int) {
+	prefix := strings.Repeat("  ", indent)
+	title := node.Title
+	if title == "" {
+		title = "(untitled)"
+	}
+	typeLabel := ""
+	if node.Type != "" {
+		typeLabel = " [" + node.Type + "]"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s%s%s  %s\n", prefix, title, typeLabel, node.ID)
+	for _, child := range node.Children {
+		printGraphTree(cmd, child, indent+1)
+	}
+}
+
+func emitDOT(cmd *cobra.Command, node *graphNode) {
+	label := node.Title
+	if label == "" {
+		label = node.ID
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "  %q [label=%q];\n", node.ID, label)
+	for _, child := range node.Children {
+		childLabel := child.Title
+		if childLabel == "" {
+			childLabel = child.ID
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "  %q [label=%q];\n", child.ID, childLabel)
+		fmt.Fprintf(cmd.OutOrStdout(), "  %q -> %q;\n", node.ID, child.ID)
+		emitDOT(cmd, child)
+	}
+}

--- a/library/productivity/notion/internal/cli/root.go
+++ b/library/productivity/notion/internal/cli/root.go
@@ -198,6 +198,11 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newNotionSearchPromotedCmd(flags))
 	rootCmd.AddCommand(newStaleCmd(flags))
 	rootCmd.AddCommand(newChangedCmd(flags))
+	rootCmd.AddCommand(newNovelSqlCmd(flags))
+	rootCmd.AddCommand(newNovelSinceCmd(flags))
+	rootCmd.AddCommand(newNovelContextCmd(flags))
+	rootCmd.AddCommand(newNovelGraphCmd(flags))
+	rootCmd.AddCommand(newNovelBulkCmd(flags))
 	rootCmd.AddCommand(newVersionCliCmd())
 
 	return rootCmd

--- a/library/productivity/notion/internal/cli/since.go
+++ b/library/productivity/notion/internal/cli/since.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Vincent Lauriat and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/mvanhorn/printing-press-library/library/productivity/notion/internal/store"
+)
+
+func newNovelSinceCmd(flags *rootFlags) *cobra.Command {
+	var flagType string
+	var flagLimit int
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "since <duration-or-timestamp>",
+		Short: "See everything that changed in your Notion workspace since a timestamp — new pages, property edits, archived items.",
+		Long: `Show all Notion pages and resources edited since a given time.
+Reads entirely from the local sync store — no API calls required.
+
+Duration formats: 7d, 24h, 1w, 30m
+Timestamp formats: 2024-01-01, 2024-01-01T15:04:05Z
+
+Run 'notion-pp-cli sync' first to populate the local database.
+
+Examples:
+  notion-pp-cli since 7d
+  notion-pp-cli since 1w --type pages
+  notion-pp-cli since 2024-06-01 --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+
+			since, err := parseSinceArg(args[0])
+			if err != nil {
+				return usageErr(fmt.Errorf("invalid timestamp %q: %w\nExpected duration (7d, 24h, 1w) or timestamp (2024-01-01)", args[0], err))
+			}
+
+			if dbPath == "" {
+				dbPath = defaultDBPath("notion-pp-cli")
+			}
+			db, err := store.OpenReadOnly(dbPath)
+			if err != nil {
+				return fmt.Errorf("opening local database: %w\nRun 'notion-pp-cli sync' first to populate the local database.", err)
+			}
+			defer db.Close()
+
+			sinceStr := since.UTC().Format(time.RFC3339)
+			editedPath := "$.last_edited_time"
+
+			var (
+				querySQL  string
+				queryArgs []any
+			)
+			if flagType != "" {
+				querySQL = fmt.Sprintf(
+					`SELECT data FROM resources
+					 WHERE resource_type = ?
+					 AND json_extract(data, '%s') IS NOT NULL
+					 AND json_extract(data, '%s') >= ?
+					 ORDER BY json_extract(data, '%s') DESC
+					 LIMIT ?`,
+					editedPath, editedPath, editedPath,
+				)
+				queryArgs = []any{flagType, sinceStr, flagLimit}
+			} else {
+				querySQL = fmt.Sprintf(
+					`SELECT data FROM resources
+					 WHERE resource_type IN ('pages', 'data_sources', 'databases', 'blocks')
+					 AND json_extract(data, '%s') IS NOT NULL
+					 AND json_extract(data, '%s') >= ?
+					 ORDER BY json_extract(data, '%s') DESC
+					 LIMIT ?`,
+					editedPath, editedPath, editedPath,
+				)
+				queryArgs = []any{sinceStr, flagLimit}
+			}
+
+			rows, err := db.DB().QueryContext(cmd.Context(), querySQL, queryArgs...)
+			if err != nil {
+				return fmt.Errorf("since query failed: %w", err)
+			}
+			defer rows.Close()
+
+			var results []json.RawMessage
+			for rows.Next() {
+				var data string
+				if err := rows.Scan(&data); err != nil {
+					return err
+				}
+				results = append(results, json.RawMessage(data))
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+
+			if len(results) == 0 {
+				if flags.asJSON {
+					return flags.printJSON(cmd, []json.RawMessage{})
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(), "No changes since %s.\n", since.Format("2006-01-02 15:04:05 UTC"))
+				return nil
+			}
+
+			prov := localProvenance(db, flagType, "user_requested")
+			printProvenance(cmd, len(results), prov)
+
+			raw, err := json.Marshal(results)
+			if err != nil {
+				return err
+			}
+			return printOutputWithFlags(cmd.OutOrStdout(), raw, flags)
+		},
+	}
+	cmd.Flags().StringVar(&flagType, "type", "", "Filter by resource type (e.g. pages, data_sources)")
+	cmd.Flags().IntVar(&flagLimit, "limit", 500, "Maximum results to return")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/github.com/mvanhorn/printing-press-library/library/productivity/notion/data.db)")
+	return cmd
+}
+
+// parseSinceArg parses a duration ("7d", "24h", "1w", "30m") or ISO timestamp string.
+func parseSinceArg(s string) (time.Time, error) {
+	if t, err := parseSinceDuration(s); err == nil {
+		return t, nil
+	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognized format")
+}

--- a/library/productivity/notion/internal/cli/sql.go
+++ b/library/productivity/notion/internal/cli/sql.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Vincent Lauriat and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/mvanhorn/printing-press-library/library/productivity/notion/internal/store"
+)
+
+func newNovelSqlCmd(flags *rootFlags) *cobra.Command {
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "sql <query>",
+		Short: "Run raw SQL across your entire synced Notion workspace — join Tasks with Projects, filter by any property",
+		Long: `Run arbitrary read-only SQL against the local SQLite database populated by 'notion-pp-cli sync'.
+
+Tables available:
+  resources       All synced resources (id, resource_type, data JSON, synced_at, updated_at)
+  sync_state      Per-resource sync state (resource_type, last_cursor, last_synced_at, total_count)
+  children        Block children (id, blocks_id, data JSON, synced_at)
+  query           Data source query results (id, data_sources_id, data JSON, synced_at)
+  users           Users (id, data JSON, synced_at, avatar_url, name, type)
+  resources_fts   Full-text search index (virtual, FTS5)
+
+Use json_extract(data, '$.field') to access JSON properties.
+
+Examples:
+  notion-pp-cli sql "SELECT resource_type, COUNT(*) n FROM resources GROUP BY resource_type"
+  notion-pp-cli sql "SELECT json_extract(data,'$.title[0].plain_text') title, json_extract(data,'$.last_edited_time') edited FROM resources WHERE resource_type='pages' LIMIT 10"
+  notion-pp-cli sql "SELECT * FROM sync_state"`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+			if dbPath == "" {
+				dbPath = defaultDBPath("notion-pp-cli")
+			}
+			db, err := store.OpenReadOnly(dbPath)
+			if err != nil {
+				return fmt.Errorf("opening local database: %w\nRun 'notion-pp-cli sync' first to populate the local database.", err)
+			}
+			defer db.Close()
+
+			rows, err := db.DB().QueryContext(cmd.Context(), args[0])
+			if err != nil {
+				return fmt.Errorf("query failed: %w", err)
+			}
+			defer rows.Close()
+
+			cols, err := rows.Columns()
+			if err != nil {
+				return fmt.Errorf("getting columns: %w", err)
+			}
+
+			var results []map[string]any
+			for rows.Next() {
+				vals := make([]any, len(cols))
+				ptrs := make([]any, len(cols))
+				for i := range vals {
+					ptrs[i] = &vals[i]
+				}
+				if err := rows.Scan(ptrs...); err != nil {
+					return fmt.Errorf("scanning row: %w", err)
+				}
+				row := make(map[string]any, len(cols))
+				for i, col := range cols {
+					v := vals[i]
+					if b, ok := v.([]byte); ok {
+						v = string(b)
+					}
+					row[col] = v
+				}
+				results = append(results, row)
+			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("iterating rows: %w", err)
+			}
+			if results == nil {
+				results = []map[string]any{}
+			}
+			return flags.printJSON(cmd, results)
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/github.com/mvanhorn/printing-press-library/library/productivity/notion/data.db)")
+	return cmd
+}


### PR DESCRIPTION
## Summary

- **`sql`** — run raw read-only SQL across the local SQLite workspace store; lets power users and LLM agents query the full Notion graph without learning the sync API
- **`since <duration-or-timestamp>`** — show all resources edited since a duration (`7d`, `1w`) or ISO timestamp; instant from local store, no API calls
- **`context`** — structured JSON workspace snapshot (sync states, database schemas, recent edits) designed for piping into LLM agents
- **`graph <page-id>`** — traverse Notion relation properties to configurable depth; outputs tree, JSON, or Graphviz DOT
- **`bulk <database-id>`** — batch-update pages matching a filter (`--filter key=value`) by applying a Notion properties patch (`--set`) via the live API

All five integrate with the existing `sync`/`stale`/`changed` local-store pipeline. `bulk` is the only command that hits the live API.

## Verification

- `go build ./...` — clean
- `shipcheck` — 6/6 legs PASS (verify 25/25, validate-narrative, dogfood, workflow-verify, verify-skill, scorecard 92/100 Grade A)
- `go test ./...` — 274 passed

## Test plan

- [ ] `notion-pp-cli sql "SELECT resource_type, COUNT(*) n FROM resources GROUP BY resource_type"` after a sync
- [ ] `notion-pp-cli since 7d --json`
- [ ] `notion-pp-cli context --json | jq .sync_states`
- [ ] `notion-pp-cli graph <page-id> --format dot`
- [ ] `notion-pp-cli bulk <db-id> --filter "Status=Done" --set '{"Status":{"select":{"name":"Archived"}}}' --dry-run`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)