### PR TITLE
feat(sec-edgar): add ownership command for DEF 14A beneficial-ownership extraction

### DIFF
--- a/library/developer-tools/sec-edgar/.printing-press-patches.json
+++ b/library/developer-tools/sec-edgar/.printing-press-patches.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "applied_at": "2026-06-08",
+  "base_run_id": "20260511-180534",
+  "base_printing_press_version": "4.2.2",
+  "patches": [
+    {
+      "id": "ownership-section-extraction",
+      "summary": "Add the `ownership` command: resolve a ticker/name/CIK, find the latest DEF 14A, fetch the document, and extract the \"Security Ownership of Certain Beneficial Owners\" section as readable text.",
+      "reason": "The beneficial-ownership table is present under a near-identical heading in every proxy statement, but no single SEC endpoint returns it; reaching it requires chaining submissions -> document fetch -> HTML section extraction. The command reuses the existing helpers (padCIK, fetchTickerMap, fetchSubmissions, archiveBase, fetchSECRaw) and adds only the HTML-to-text and heading-scoped extraction logic.",
+      "files": [
+        "internal/cli/ownership.go",
+        "internal/cli/ownership_test.go",
+        "internal/cli/root.go"
+      ],
+      "validated_outcome": "ownership MSFT extracts the real beneficial-ownership table from Microsoft's latest DEF 14A (Nadella, Hood, board, percentages); ExtractOwnershipSection scores the bounded span so a table-of-contents mention does not win over the real section."
+    }
+  ]
+}

--- a/library/developer-tools/sec-edgar/.printing-press.json
+++ b/library/developer-tools/sec-edgar/.printing-press.json
@@ -68,6 +68,11 @@
       "name": "13F holdings delta",
       "command": "holdings delta",
       "description": "Diff an institutional investor's 13F holdings across two consecutive quarters. Categorize each issuer as ADD / EXIT / INCREASE / DECREASE with share-count delta."
+    },
+    {
+      "name": "Beneficial-ownership section extraction",
+      "command": "ownership",
+      "description": "Resolve a ticker, name, or CIK, find the latest DEF 14A proxy, fetch the document, and extract the \"Security Ownership of Certain Beneficial Owners\" section as readable text."
     }
   ]
 }

--- a/library/developer-tools/sec-edgar/README.md
+++ b/library/developer-tools/sec-edgar/README.md
@@ -214,6 +214,16 @@ These capabilities aren't available in any other tool for this API.
   sec-edgar-pp-cli late-filers --since 90d --form 10-K --json
   ```
 
+### Proxy & ownership
+- **`ownership`** — Resolve a ticker, name, or CIK, find the company's latest DEF 14A proxy statement, fetch the document, and extract the "Security Ownership of Certain Beneficial Owners" section as readable text.
+
+  _The beneficial-ownership table is the one disclosure every proxy carries under a near-identical heading, and reaching it means chaining submissions → document fetch → HTML section extraction that no single SEC endpoint provides. Pick this when an agent needs who-owns-the-company straight from the proxy, not a list of filings._
+
+  ```bash
+  sec-edgar-pp-cli ownership MSFT --json
+  sec-edgar-pp-cli ownership AAPL --save apple-ownership.txt
+  ```
+
 ## Usage
 
 Run `sec-edgar-pp-cli --help` for the full command reference and flag list.

--- a/library/developer-tools/sec-edgar/SKILL.md
+++ b/library/developer-tools/sec-edgar/SKILL.md
@@ -111,6 +111,15 @@ These capabilities aren't available in any other tool for this API.
   sec-edgar-pp-cli late-filers --since 90d --form 10-K --json
   ```
 
+### Proxy & ownership
+- **`ownership`** — Resolve a ticker, name, or CIK, find the company's latest DEF 14A proxy statement, fetch the document, and extract the "Security Ownership of Certain Beneficial Owners" section as readable text.
+
+  _The beneficial-ownership table is present under a near-identical heading in every proxy, but reaching it means chaining submissions → document fetch → HTML section extraction that no single SEC endpoint provides. Pick this when an agent needs who-owns-the-company from the proxy itself._
+
+  ```bash
+  sec-edgar-pp-cli ownership MSFT --json
+  ```
+
 ## Command Reference
 
 **companies** — Company directory (ticker → CIK → name)

--- a/library/developer-tools/sec-edgar/internal/cli/ownership.go
+++ b/library/developer-tools/sec-edgar/internal/cli/ownership.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"fmt"
+	"html"
 	"os"
 	"regexp"
 	"sort"
@@ -21,35 +22,33 @@ import (
 // ---- HTML -> text -----------------------------------------------------------
 
 var (
-	ownReScriptStyle = regexp.MustCompile(`(?is)<(script|style)\b[^>]*>.*?</(script|style)>`)
-	ownReBlockTag    = regexp.MustCompile(`(?is)</?(p|div|tr|br|h[1-6]|li|table|thead|tbody)\b[^>]*>`)
-	ownReTag         = regexp.MustCompile(`(?s)<[^>]+>`)
-	ownReWS          = regexp.MustCompile(`[ \t]+`)
-	ownReBlankLines  = regexp.MustCompile(`\n{3,}`)
-	ownReNumericEnt  = regexp.MustCompile(`&#?[0-9a-zA-Z]+;`)
+	// Separate script/style regexes: RE2 has no backreferences, so a single
+	// `<(script|style)>...</(script|style)>` could match a `<script>` open
+	// against an unrelated `</style>` close. Matching each tag independently
+	// keeps the open/close pinned to the same element.
+	ownReScript     = regexp.MustCompile(`(?is)<script\b[^>]*>.*?</script>`)
+	ownReStyle      = regexp.MustCompile(`(?is)<style\b[^>]*>.*?</style>`)
+	ownReBlockTag   = regexp.MustCompile(`(?is)</?(p|div|tr|br|h[1-6]|li|table|thead|tbody)\b[^>]*>`)
+	ownReTag        = regexp.MustCompile(`(?s)<[^>]+>`)
+	ownReWS         = regexp.MustCompile(`[ \t]+`)
+	ownReBlankLines = regexp.MustCompile(`\n{3,}`)
 )
-
-var ownHTMLEntities = map[string]string{
-	"&nbsp;": " ", "&#160;": " ", "&#xa0;": " ",
-	"&amp;": "&", "&#38;": "&",
-	"&lt;": "<", "&gt;": ">",
-	"&quot;": "\"", "&#34;": "\"",
-	"&apos;": "'", "&#39;": "'", "&rsquo;": "'", "&lsquo;": "'",
-	"&ldquo;": "\"", "&rdquo;": "\"",
-	"&mdash;": "—", "&ndash;": "–", "&#8217;": "'", "&#8211;": "–", "&#8212;": "—",
-}
 
 // ownershipHTMLToText converts an HTML document to readable plain text:
 // scripts/styles removed, block-level tags turned into line breaks, remaining
-// tags stripped, entities decoded, and whitespace collapsed.
-func ownershipHTMLToText(html string) string {
-	s := ownReScriptStyle.ReplaceAllString(html, " ")
+// tags stripped, HTML entities decoded (named, decimal, and hex — via the
+// stdlib, so e.g. "&#37;" becomes "%" rather than being dropped), and
+// whitespace collapsed.
+func ownershipHTMLToText(doc string) string {
+	s := ownReScript.ReplaceAllString(doc, " ")
+	s = ownReStyle.ReplaceAllString(s, " ")
 	s = ownReBlockTag.ReplaceAllString(s, "\n")
 	s = ownReTag.ReplaceAllString(s, " ")
-	for ent, rep := range ownHTMLEntities {
-		s = strings.ReplaceAll(s, ent, rep)
-	}
-	s = ownReNumericEnt.ReplaceAllString(s, " ")
+	// Decode entities with the stdlib unescaper, then normalize non-breaking
+	// spaces (which decode to U+00A0) to plain spaces so the collapse below
+	// catches them.
+	s = html.UnescapeString(s)
+	s = strings.ReplaceAll(s, " ", " ")
 	lines := strings.Split(s, "\n")
 	for i, ln := range lines {
 		lines[i] = strings.TrimSpace(ownReWS.ReplaceAllString(ln, " "))
@@ -78,11 +77,17 @@ var ownershipHeadings = []string{
 }
 
 // ownershipNextHeadingRe matches the start of a plausible following section,
-// used to bound the extracted ownership text.
-var ownershipNextHeadingRe = regexp.MustCompile(`(?im)^\s*(item\s+\d+|proposal\s+\d+|equity compensation plan|executive compensation|section 16|certain relationships|related party transactions|audit committee|report of the|annex [a-z]|general information)\b`)
+// used to bound the extracted ownership text. It covers both numbered headings
+// ("Item 12", "Proposal 3") and the bare narrative headings ("Director
+// Compensation", "Board of Directors") that commonly follow the ownership
+// table without an "Item"/"Proposal" prefix.
+var ownershipNextHeadingRe = regexp.MustCompile(`(?im)^\s*(item\s+\d+|proposal\s+\d+|equity compensation plan|executive compensation|compensation discussion|director compensation|named executive|board of directors|corporate governance|section 16|certain relationships|related party transactions|audit committee|report of the|annex [a-z]|general information)\b`)
 
-// ownershipTokenRe scores how "ownership-ish" a span of text is.
-var ownershipTokenRe = regexp.MustCompile(`(?i)\b(shares?|beneficial|percent|stock|vanguard|blackrock|state street|holdings?|trustee)\b|%|\d{3,}`)
+// ownershipTokenRe scores how "ownership-ish" a span of text is. Alongside
+// generic terms it names a few recurring institutional-holder words (the big
+// index funds plus the common entity suffixes fund/corp/llc/trust) so the
+// scorer still discriminates for filers whose holders aren't the big three.
+var ownershipTokenRe = regexp.MustCompile(`(?i)\b(shares?|beneficial|percent|stock|vanguard|blackrock|state street|fund|corp|llc|trust|holdings?|trustee)\b|%|\d{3,}`)
 
 const (
 	ownershipMaxSectionLen  = 18000
@@ -157,11 +162,26 @@ func ExtractOwnershipSection(text string) OwnershipResult {
 
 	matches := ownershipTokenRe.FindAllStringIndex(text, -1)
 	if len(matches) > 0 {
-		bestCenter := matches[len(matches)/2][0]
-		start := bestCenter - ownershipFallbackWindow/2
-		if start < 0 {
-			start = 0
+		// Pick the densest window: for each token start, count how many token
+		// matches fall within an ownershipFallbackWindow-sized window beginning
+		// there and keep the start with the most. A two-pointer sweep over the
+		// already-sorted match starts keeps this linear. This replaces a naive
+		// "median match" center, which could land in a sparse region when
+		// tokens are spread across several distant sections.
+		bestStartIdx, bestCount, j := 0, 0, 0
+		for i := range matches {
+			if j < i {
+				j = i
+			}
+			for j < len(matches) && matches[j][0] < matches[i][0]+ownershipFallbackWindow {
+				j++
+			}
+			if j-i > bestCount {
+				bestCount = j - i
+				bestStartIdx = i
+			}
 		}
+		start := matches[bestStartIdx][0]
 		end := start + ownershipFallbackWindow
 		if end > len(text) {
 			end = len(text)
@@ -275,28 +295,40 @@ func newOwnershipCmd(flags *rootFlags) *cobra.Command {
 			rec := subs.Filings.Recent
 			n := len(rec.Form)
 			for i := 0; i < n; i++ {
-				if strings.EqualFold(strings.TrimSpace(rec.Form[i]), "DEF 14A") {
-					p := proxyRef{}
-					if i < len(rec.AccessionNumber) {
-						p.accession = rec.AccessionNumber[i]
-					}
-					if i < len(rec.FilingDate) {
-						p.date = rec.FilingDate[i]
-					}
-					if i < len(rec.PrimaryDocument) {
-						p.doc = rec.PrimaryDocument[i]
-					}
-					proxies = append(proxies, p)
+				if !strings.EqualFold(strings.TrimSpace(rec.Form[i]), "DEF 14A") {
+					continue
 				}
+				p := proxyRef{}
+				if i < len(rec.AccessionNumber) {
+					p.accession = rec.AccessionNumber[i]
+				}
+				if i < len(rec.FilingDate) {
+					p.date = rec.FilingDate[i]
+				}
+				if i < len(rec.PrimaryDocument) {
+					p.doc = rec.PrimaryDocument[i]
+				}
+				// Skip entries missing the fields needed to build a document
+				// URL — a short or mismatched parallel array would otherwise
+				// yield an invalid archive URL that fails opaquely downstream.
+				if p.accession == "" || p.doc == "" {
+					continue
+				}
+				proxies = append(proxies, p)
 			}
 			if len(proxies) == 0 {
-				return notFoundErr(fmt.Errorf("no DEF 14A proxy statement found for %s (CIK %s) in recent filings", title, cik))
+				msg := fmt.Sprintf("no DEF 14A proxy statement found for %s (CIK %s) in the recent-filings window", title, cik)
+				// filings.recent holds only ~400 of the most recent filings; a
+				// high-frequency filer's DEF 14A can sit in the older
+				// filings.files pages. Surface that so the result isn't
+				// mistaken for "this company never filed a proxy".
+				if older := len(subs.Filings.Files); older > 0 {
+					msg += fmt.Sprintf(" (%d older filing page(s) exist beyond the recent window and were not searched)", older)
+				}
+				return notFoundErr(fmt.Errorf("%s", msg))
 			}
 			sort.SliceStable(proxies, func(i, j int) bool { return proxies[i].date > proxies[j].date })
 			latest := proxies[0]
-			if latest.doc == "" {
-				return classifyAPIError(fmt.Errorf("latest DEF 14A for %s has no primary document listed", title), flags)
-			}
 
 			docURL := archiveBase(cik, latest.accession) + latest.doc
 			body, err := fetchSECRaw(c, docURL)

--- a/library/developer-tools/sec-edgar/internal/cli/ownership.go
+++ b/library/developer-tools/sec-edgar/internal/cli/ownership.go
@@ -1,0 +1,348 @@
+// Copyright 2026 ChrisDrit and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// ownership pulls a company's latest DEF 14A proxy statement and extracts the
+// "Security Ownership of Certain Beneficial Owners" section as readable text.
+// It is the one disclosure every proxy carries under a near-identical heading,
+// and the only one that requires chaining submissions -> document fetch ->
+// HTML section extraction, which no single SEC endpoint provides.
+
+// ---- HTML -> text -----------------------------------------------------------
+
+var (
+	ownReScriptStyle = regexp.MustCompile(`(?is)<(script|style)\b[^>]*>.*?</(script|style)>`)
+	ownReBlockTag    = regexp.MustCompile(`(?is)</?(p|div|tr|br|h[1-6]|li|table|thead|tbody)\b[^>]*>`)
+	ownReTag         = regexp.MustCompile(`(?s)<[^>]+>`)
+	ownReWS          = regexp.MustCompile(`[ \t]+`)
+	ownReBlankLines  = regexp.MustCompile(`\n{3,}`)
+	ownReNumericEnt  = regexp.MustCompile(`&#?[0-9a-zA-Z]+;`)
+)
+
+var ownHTMLEntities = map[string]string{
+	"&nbsp;": " ", "&#160;": " ", "&#xa0;": " ",
+	"&amp;": "&", "&#38;": "&",
+	"&lt;": "<", "&gt;": ">",
+	"&quot;": "\"", "&#34;": "\"",
+	"&apos;": "'", "&#39;": "'", "&rsquo;": "'", "&lsquo;": "'",
+	"&ldquo;": "\"", "&rdquo;": "\"",
+	"&mdash;": "—", "&ndash;": "–", "&#8217;": "'", "&#8211;": "–", "&#8212;": "—",
+}
+
+// ownershipHTMLToText converts an HTML document to readable plain text:
+// scripts/styles removed, block-level tags turned into line breaks, remaining
+// tags stripped, entities decoded, and whitespace collapsed.
+func ownershipHTMLToText(html string) string {
+	s := ownReScriptStyle.ReplaceAllString(html, " ")
+	s = ownReBlockTag.ReplaceAllString(s, "\n")
+	s = ownReTag.ReplaceAllString(s, " ")
+	for ent, rep := range ownHTMLEntities {
+		s = strings.ReplaceAll(s, ent, rep)
+	}
+	s = ownReNumericEnt.ReplaceAllString(s, " ")
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimSpace(ownReWS.ReplaceAllString(ln, " "))
+	}
+	s = strings.Join(lines, "\n")
+	s = ownReBlankLines.ReplaceAllString(s, "\n\n")
+	return strings.TrimSpace(s)
+}
+
+// ---- Ownership section extraction ------------------------------------------
+
+// ownershipHeadings are the canonical and common alternate section titles for
+// the beneficial-ownership disclosure across issuers. The first entry is the
+// canonical phrase; the rest are observed variants (e.g. some issuers use
+// "Principal Shareholders").
+var ownershipHeadings = []string{
+	"security ownership of certain beneficial owners",
+	"security ownership of certain beneficial owners and management",
+	"security ownership of management and certain beneficial owners",
+	"security ownership",
+	"beneficial ownership of",
+	"ownership of securities",
+	"principal shareholders",
+	"principal stockholders",
+	"beneficial owners",
+}
+
+// ownershipNextHeadingRe matches the start of a plausible following section,
+// used to bound the extracted ownership text.
+var ownershipNextHeadingRe = regexp.MustCompile(`(?im)^\s*(item\s+\d+|proposal\s+\d+|equity compensation plan|executive compensation|section 16|certain relationships|related party transactions|audit committee|report of the|annex [a-z]|general information)\b`)
+
+// ownershipTokenRe scores how "ownership-ish" a span of text is.
+var ownershipTokenRe = regexp.MustCompile(`(?i)\b(shares?|beneficial|percent|stock|vanguard|blackrock|state street|holdings?|trustee)\b|%|\d{3,}`)
+
+const (
+	ownershipMaxSectionLen  = 18000
+	ownershipScoreWindow    = 2500
+	ownershipFallbackWindow = 4000
+)
+
+// OwnershipResult is the outcome of extracting the ownership section.
+type OwnershipResult struct {
+	Text     string // extracted readable text
+	Heading  string // the heading phrase that matched
+	Fallback bool   // true if no heading matched and a fuzzy fallback was used
+}
+
+// ExtractOwnershipSection finds and returns the beneficial-ownership section of
+// a proxy statement's plain text. It scores every occurrence of a known heading
+// by the density of ownership tokens in the bounded span that follows (up to
+// the next major heading, capped by ownershipScoreWindow) and returns the
+// densest one. Scoring the bounded span — not a fixed forward window — keeps a
+// table-of-contents mention of the heading from spuriously winning over the
+// real, token-dense section. If no heading matches, it falls back to a window
+// around the densest ownership-token cluster and sets Fallback=true. It never
+// returns empty text when the input is non-empty.
+func ExtractOwnershipSection(text string) OwnershipResult {
+	low := strings.ToLower(text)
+
+	bestScore := -1
+	bestStart := -1
+	bestHeading := ""
+	for _, hd := range ownershipHeadings {
+		from := 0
+		for {
+			idx := strings.Index(low[from:], hd)
+			if idx < 0 {
+				break
+			}
+			pos := from + idx
+			from = pos + len(hd)
+			spanEnd := pos + ownershipScoreWindow
+			if spanEnd > len(text) {
+				spanEnd = len(text)
+			}
+			searchFrom := pos + len(hd)
+			if searchFrom < spanEnd {
+				if loc := ownershipNextHeadingRe.FindStringIndex(text[searchFrom:spanEnd]); loc != nil {
+					spanEnd = searchFrom + loc[0]
+				}
+			}
+			score := len(ownershipTokenRe.FindAllStringIndex(text[pos:spanEnd], -1))
+			if score > bestScore {
+				bestScore = score
+				bestStart = pos
+				bestHeading = hd
+			}
+		}
+	}
+
+	if bestStart >= 0 {
+		end := bestStart + ownershipMaxSectionLen
+		if end > len(text) {
+			end = len(text)
+		}
+		searchFrom := bestStart + len(bestHeading)
+		if loc := ownershipNextHeadingRe.FindStringIndex(text[searchFrom:end]); loc != nil {
+			end = searchFrom + loc[0]
+		}
+		section := strings.TrimSpace(text[bestStart:end])
+		if section != "" {
+			return OwnershipResult{Text: section, Heading: bestHeading}
+		}
+	}
+
+	matches := ownershipTokenRe.FindAllStringIndex(text, -1)
+	if len(matches) > 0 {
+		bestCenter := matches[len(matches)/2][0]
+		start := bestCenter - ownershipFallbackWindow/2
+		if start < 0 {
+			start = 0
+		}
+		end := start + ownershipFallbackWindow
+		if end > len(text) {
+			end = len(text)
+		}
+		return OwnershipResult{Text: strings.TrimSpace(text[start:end]), Fallback: true}
+	}
+
+	end := ownershipFallbackWindow
+	if end > len(text) {
+		end = len(text)
+	}
+	return OwnershipResult{Text: strings.TrimSpace(text[:end]), Fallback: true}
+}
+
+// ---- command ----------------------------------------------------------------
+
+// resolveOwnershipCIK turns a ticker, company name fragment, or raw CIK into a
+// 10-digit zero-padded CIK. Raw all-digit input is padded directly; otherwise
+// the ticker map is consulted (exact ticker match first, then a case-insensitive
+// title substring match).
+func resolveOwnershipCIK(c clientLike, input string) (cik, title string, err error) {
+	in := strings.TrimSpace(input)
+	if in == "" {
+		return "", "", fmt.Errorf("empty company reference")
+	}
+	allDigits := true
+	for _, r := range in {
+		if r < '0' || r > '9' {
+			allDigits = false
+			break
+		}
+	}
+	if allDigits {
+		p, perr := padCIK(in)
+		if perr != nil {
+			return "", "", perr
+		}
+		return p, "", nil
+	}
+	rows, ferr := fetchTickerMap(c)
+	if ferr != nil {
+		return "", "", ferr
+	}
+	upper := strings.ToUpper(in)
+	for _, r := range rows {
+		if strings.ToUpper(r.Ticker) == upper {
+			return r.Padded, r.Title, nil
+		}
+	}
+	low := strings.ToLower(in)
+	for _, r := range rows {
+		if strings.Contains(strings.ToLower(r.Title), low) {
+			return r.Padded, r.Title, nil
+		}
+	}
+	return "", "", fmt.Errorf("no company found matching %q (try an exact ticker like AAPL, a 10-digit CIK, or a name fragment)", input)
+}
+
+func newOwnershipCmd(flags *rootFlags) *cobra.Command {
+	var savePath string
+
+	cmd := &cobra.Command{
+		Use:   "ownership <ticker-or-cik>",
+		Short: "Extract the Security Ownership of Certain Beneficial Owners section from a company's latest DEF 14A.",
+		Long: "Resolve a ticker, name, or CIK to a company, find its most recent DEF 14A\n" +
+			"proxy statement, fetch the document, and extract the \"Security Ownership of\n" +
+			"Certain Beneficial Owners\" section as readable text. This is the disclosure\n" +
+			"that lists who beneficially owns the company, present under a near-identical\n" +
+			"heading in every proxy statement filed before an annual shareholder meeting.",
+		Example: "  sec-edgar-pp-cli ownership MSFT\n" +
+			"  sec-edgar-pp-cli ownership AAPL --json\n" +
+			"  sec-edgar-pp-cli ownership 0000320193 --save apple-ownership.txt",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 && !flags.dryRun {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+			if len(args) == 0 {
+				return usageErr(fmt.Errorf("ownership requires a ticker, name, or CIK argument"))
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			cik, title, err := resolveOwnershipCIK(c, args[0])
+			if err != nil {
+				return notFoundErr(err)
+			}
+
+			subs, err := fetchSubmissions(c, cik)
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+			if title == "" {
+				title = subs.Name
+			}
+
+			// Find the most recent DEF 14A. filings.recent is reverse-chronological,
+			// but sort defensively in case ordering ever changes.
+			type proxyRef struct {
+				accession string
+				date      string
+				doc       string
+			}
+			var proxies []proxyRef
+			rec := subs.Filings.Recent
+			n := len(rec.Form)
+			for i := 0; i < n; i++ {
+				if strings.EqualFold(strings.TrimSpace(rec.Form[i]), "DEF 14A") {
+					p := proxyRef{}
+					if i < len(rec.AccessionNumber) {
+						p.accession = rec.AccessionNumber[i]
+					}
+					if i < len(rec.FilingDate) {
+						p.date = rec.FilingDate[i]
+					}
+					if i < len(rec.PrimaryDocument) {
+						p.doc = rec.PrimaryDocument[i]
+					}
+					proxies = append(proxies, p)
+				}
+			}
+			if len(proxies) == 0 {
+				return notFoundErr(fmt.Errorf("no DEF 14A proxy statement found for %s (CIK %s) in recent filings", title, cik))
+			}
+			sort.SliceStable(proxies, func(i, j int) bool { return proxies[i].date > proxies[j].date })
+			latest := proxies[0]
+			if latest.doc == "" {
+				return classifyAPIError(fmt.Errorf("latest DEF 14A for %s has no primary document listed", title), flags)
+			}
+
+			docURL := archiveBase(cik, latest.accession) + latest.doc
+			body, err := fetchSECRaw(c, docURL)
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+			text := ownershipHTMLToText(string(body))
+			res := ExtractOwnershipSection(text)
+
+			if savePath != "" {
+				if werr := os.WriteFile(savePath, []byte(res.Text), 0o644); werr != nil {
+					return fmt.Errorf("writing --save file: %w", werr)
+				}
+			}
+
+			if flags.asJSON || !wantsHumanTable(cmd.OutOrStdout(), flags) {
+				out := map[string]any{
+					"company":     title,
+					"cik":         cik,
+					"accession":   latest.accession,
+					"filing_date": latest.date,
+					"source_url":  docURL,
+					"heading":     res.Heading,
+					"fallback":    res.Fallback,
+					"section":     res.Text,
+				}
+				if savePath != "" {
+					out["saved_to"] = savePath
+				}
+				return flags.printJSON(cmd, out)
+			}
+
+			w := cmd.OutOrStdout()
+			fmt.Fprintf(w, "Security Ownership — %s (CIK %s)\n", title, cik)
+			fmt.Fprintf(w, "DEF 14A filed %s · %s\n", latest.date, docURL)
+			if res.Fallback {
+				fmt.Fprintln(w, "(heading not matched exactly — showing the densest ownership passage)")
+			}
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, res.Text)
+			if savePath != "" {
+				fmt.Fprintf(w, "\n(saved to %s)\n", savePath)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&savePath, "save", "", "Write the extracted section to this file path")
+	return cmd
+}

--- a/library/developer-tools/sec-edgar/internal/cli/ownership_test.go
+++ b/library/developer-tools/sec-edgar/internal/cli/ownership_test.go
@@ -31,6 +31,17 @@ func TestOwnershipHTMLToText(t *testing.T) {
 			in:   `<div>State Street &amp; Co.</div>`,
 			want: []string{"State Street & Co."},
 		},
+		{
+			name: "numeric and hex entities decoded not dropped",
+			in:   `<p>owns 5&#37; (or 5&#x25;) of&#160;shares</p>`,
+			want: []string{"owns 5%", "5%", "of shares"},
+		},
+		{
+			name: "mismatched script/style tags do not over-strip",
+			in:   `<script>JS_GONE</script>KEEP_ONE<style>CSS_GONE</style>KEEP_TWO A<script>STILL_HERE</style>B`,
+			want: []string{"KEEP_ONE", "KEEP_TWO", "STILL_HERE"},
+			not:  []string{"JS_GONE", "CSS_GONE"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/library/developer-tools/sec-edgar/internal/cli/ownership_test.go
+++ b/library/developer-tools/sec-edgar/internal/cli/ownership_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 ChrisDrit and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOwnershipHTMLToText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string // substrings that must be present
+		not  []string // substrings that must NOT be present
+	}{
+		{
+			name: "strips tags and decodes entities",
+			in:   `<p>Apple&nbsp;Inc. owns 5&#37; of shares</p><script>var x=1;</script>`,
+			want: []string{"Apple Inc. owns 5"},
+			not:  []string{"<p>", "<script>", "var x=1"},
+		},
+		{
+			name: "block tags become line breaks",
+			in:   `<tr><td>Name</td></tr><tr><td>Value</td></tr>`,
+			want: []string{"Name", "Value"},
+			not:  []string{"<tr>", "<td>"},
+		},
+		{
+			name: "ampersand entity decoded",
+			in:   `<div>State Street &amp; Co.</div>`,
+			want: []string{"State Street & Co."},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ownershipHTMLToText(tc.in)
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("want substring %q in:\n%s", w, got)
+				}
+			}
+			for _, n := range tc.not {
+				if strings.Contains(got, n) {
+					t.Errorf("unwanted substring %q in:\n%s", n, got)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractOwnershipSection(t *testing.T) {
+	tests := []struct {
+		name         string
+		text         string
+		wantContains string
+		wantHeading  string
+		wantFallback bool
+	}{
+		{
+			name: "canonical heading wins over table-of-contents mention",
+			text: "Table of Contents\n\nSecurity Ownership of Certain Beneficial Owners\n\nProposal 1\n\n" +
+				strings.Repeat("filler ", 50) +
+				"\n\nSecurity Ownership of Certain Beneficial Owners\n\n" +
+				"Vanguard 12,345,678 shares 8% beneficial BlackRock 9,000,000 shares 6% State Street holdings\n\n" +
+				"Item 12 Other Matters",
+			wantContains: "Vanguard",
+			wantHeading:  "security ownership of certain beneficial owners",
+			wantFallback: false,
+		},
+		{
+			name: "bounded by next major heading",
+			text: "Security Ownership\n\nName Shares Percent\nJohn Doe 1,000,000 5%\n\n" +
+				"Item 13 Certain Relationships\n\nUnrelated text that must not appear here.",
+			wantContains: "John Doe",
+			wantFallback: false,
+		},
+		{
+			name:         "fallback when no heading present",
+			text:         "Random preamble. " + strings.Repeat("holdings 1,000 shares percent beneficial stock ", 20),
+			wantContains: "shares",
+			wantFallback: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := ExtractOwnershipSection(tc.text)
+			if res.Text == "" {
+				t.Fatal("expected non-empty section")
+			}
+			if !strings.Contains(res.Text, tc.wantContains) {
+				t.Errorf("want %q in section:\n%s", tc.wantContains, res.Text)
+			}
+			if tc.wantHeading != "" && res.Heading != tc.wantHeading {
+				t.Errorf("heading: got %q want %q", res.Heading, tc.wantHeading)
+			}
+			if res.Fallback != tc.wantFallback {
+				t.Errorf("fallback: got %v want %v", res.Fallback, tc.wantFallback)
+			}
+			if tc.name == "bounded by next major heading" && strings.Contains(res.Text, "must not appear") {
+				t.Errorf("section bled past the next heading:\n%s", res.Text)
+			}
+		})
+	}
+}
+
+func TestExtractOwnershipSectionNeverEmptyOnNonEmptyInput(t *testing.T) {
+	res := ExtractOwnershipSection("a short document with no ownership tokens at all")
+	if res.Text == "" {
+		t.Fatal("must never return empty text for non-empty input")
+	}
+}

--- a/library/developer-tools/sec-edgar/internal/cli/root.go
+++ b/library/developer-tools/sec-edgar/internal/cli/root.go
@@ -208,6 +208,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newRestatementsCmd(flags))
 	rootCmd.AddCommand(newLateFilersCmd(flags))
 	rootCmd.AddCommand(newHoldingsCmd(flags))
+	rootCmd.AddCommand(newOwnershipCmd(flags))
 
 	return rootCmd
 }


### PR DESCRIPTION
## Add `ownership` to sec-edgar — beneficial-ownership extraction from DEF 14A

This adds one new command, `ownership`, to the existing `developer-tools/sec-edgar` CLI. It resolves a ticker, name, or CIK, finds the company's **latest DEF 14A** proxy statement, fetches the document, and extracts the **"Security Ownership of Certain Beneficial Owners"** section as readable text.

### Why

That section is the one disclosure every proxy statement carries under a near-identical heading — who beneficially owns the company, filed before each annual shareholder meeting. No single SEC endpoint returns it: reaching it means chaining `submissions` → document fetch → HTML section extraction. The existing CLI has the breadth (insider clustering, 13F deltas, peer benchmarks) but no command that walks search → document → section. This fills that gap.

```bash
sec-edgar-pp-cli ownership MSFT --json
sec-edgar-pp-cli ownership AAPL --save apple-ownership.txt
```

### How

The command reuses the CLI's existing helpers — `padCIK`, `fetchTickerMap`, `fetchSubmissions`, `archiveBase`, `fetchSECRaw` — and adds only the new logic it needs:

- `ownershipHTMLToText` — HTML → readable text (scripts/styles dropped, block tags → newlines, entities decoded).
- `ExtractOwnershipSection` — scores every occurrence of a known ownership heading by the density of ownership tokens in the **bounded span** up to the next major heading, so a table-of-contents mention does not win over the real, token-dense section. Falls back to the densest cluster if no heading matches; never returns empty on non-empty input.

It honors the same conventions as the other commands: `--json`/`--save`, `mcp:read-only`, `dryRunOK` short-circuit, help-on-no-args, and the shared `SEC_EDGAR_USER_AGENT` client.

### Files

| File | Change |
|---|---|
| `internal/cli/ownership.go` | new — command + extraction logic |
| `internal/cli/ownership_test.go` | new — table-driven tests (HTML→text, extraction, TOC-vs-real, bounding, never-empty) |
| `internal/cli/root.go` | register `newOwnershipCmd` |
| `.printing-press.json` | add `ownership` to `novel_features` |
| `.printing-press-patches.json` | new — records the customization |
| `README.md` / `SKILL.md` | document `ownership` under a new "Proxy & ownership" group |

### Validation

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS (incl. new ownership tests) |
| `govulncheck ./...` (go 1.26.4) | PASS — 0 reachable |
| `verify-skill` (flag-names, flag-commands, positional-args, shell-var-quotes, unknown-command) | PASS |
| Live `ownership MSFT` | Extracts Microsoft's real beneficial-ownership table from its latest DEF 14A (2025-10-21): Nadella, Hood, full board with percentages |

### Notes

- This builds on @ChrisDrit's sec-edgar CLI; happy to adjust naming, grouping, or scope to fit the CLI's direction.
- `verify-skill` also reports a pre-existing `canonical-sections` "install section drift" on this CLI that is **not introduced by this PR** (it reproduces on `main` without these changes, and the install section is generator-owned — the fix is a `sweep-canonical` regen, not a hand-edit). I left that section untouched.
