### PR TITLE
fix(dice-fm): harden entity-normalization subsystem (2026-06-08 audit)

### DIFF
--- a/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-normalization-audit-fixes.json
+++ b/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-normalization-audit-fixes.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 2,
+  "id": "dice-fm-normalization-audit-fixes",
+  "date": "2026-06-08",
+  "amend_run_id": "amend-2026-06-08-normalization-audit",
+  "summary": "fix(dice-fm): harden entity-normalization subsystem from the 2026-06-08 audit — validate rule regexes at load, transactional ClearNormalization, immutable entity_type on conflict, compile-once rule cache, --fuzzy-threshold, and wire `normalize promote-rules` (the LLM-tail learn step)",
+  "reason": "An architectural audit of the hand-authored entity-normalization subsystem surfaced three Medium correctness/UX defects, several Low debt items, and one capability gap (the rule-promotion half of the LLM-tail loop was built but unwired). These fixes are CLI-specific hardening of the API-specific normalization value-add, not generator gaps.",
+  "files": [
+    "internal/normalizecfg/config.go",
+    "internal/cli/normalize_rules.go",
+    "internal/cli/normalize_engine.go",
+    "internal/cli/normalize_classify.go",
+    "internal/cli/normalize_pipeline.go",
+    "internal/cli/normalize_cmd.go",
+    "internal/cli/normalize_recommend.go",
+    "internal/cli/normalize_axes.go",
+    "internal/cli/normalize_import.go",
+    "internal/cli/normalize_promote.go",
+    "internal/store/normalization.go"
+  ],
+  "findings_addressed": ["F1", "F2", "F3", "F4", "F5", "F6", "F8", "F9", "F10"],
+  "validated_outcome": "go build ./... && go vet ./... clean; full go test ./... green (all packages); -race clean on store + normalize tests; new tests cover rule-match load validation, compile-once warn-on-skip, fuzzy-threshold clamping, transactional clear, immutable entity_type on conflict, and the promote-rules learn step. Live-verified: `normalize promote-rules` emits validated rules and merges with --write; an invalid operator rule now fails load with exit 1 instead of silently disabling itself. `publish validate` in-scope checks pass (phase5, go mod tidy, go vet, go build, --help, --version, manuscripts); two failing checks (govulncheck stdlib go1.26.3 net/textproto+crypto/x509 advisories, fixed in go1.26.4; SKILL.md generator-owned install-section drift) are PRE-EXISTING on pristine origin/main and unrelated to this diff (no touched file is implicated) — repo-level toolchain-bump + SKILL regen, out of scope for this PR.",
+  "notes": "F1: normalizecfg.validate now compiles every Rule.Match at load (rejecting empty/uncompilable patterns) and compileRules warns-and-skips as defense-in-depth. F2: candidateSources now mirrors the full starter (adds price_tier + ticket_pool) so `normalize recommend` profiles every wireable entity. F3: ClearNormalization wraps its multi-table deletes in one transaction. F4: UpsertEntityAttribute no longer rewrites entity_type on conflict (the canonical_id is type-prefixed and owns one type for life). F5: importMapping uses the methodManual const. F6: new --fuzzy-threshold flag (default 0.92, clamped to (0,1]). F8: new `normalize promote-rules` command graduates the method=manual corpus into validated regex rules (read-only print by default; --write merges into the operator config) — wiring the previously-unused promoteRules/validateRule primitives. F9: attribute rules are compiled once per run instead of per source value. F10: methodRule stored value kept as \"regex\" for back-compat (changing it is a data migration); the const doc now states the migration path explicitly. All findings from docs/audits/2026-06-08-dice-fm-normalization-subsystem-audit.md; F7 (recommend writes by default — deliberate) and F11 (axis values unenforced at DB layer — info) intentionally excluded."
+}

--- a/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-promote-rules-f8-peer-review.json
+++ b/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-promote-rules-f8-peer-review.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "dice-fm-promote-rules-f8-peer-review",
+  "applied_at": "2026-06-08",
+  "base_run_id": "20260511-193451",
+  "base_printing_press_version": "4.12.0",
+  "summary": "Preserve promote-rules safety guarantees by avoiding read-only MCP advertising, operator-config freezing, unstripped cache keys, single-example promotions, and non-atomic writes.",
+  "reason": "The normalize promote-rules command can write operator config and derives reusable rules from manual labels, so it must not be auto-approved as read-only, persist starter entities, learn from classify-inconsistent names, or promote fragile one-off tokens.",
+  "files": [
+    "internal/cli/normalize_promote.go",
+    "internal/cli/normalize_promote_test.go",
+    "internal/cli/normalize_cmd_test.go"
+  ],
+  "validated_outcome": "go build ./... && go vet ./... && go test ./..."
+}

--- a/library/media-and-entertainment/dice-fm/README.md
+++ b/library/media-and-entertainment/dice-fm/README.md
@@ -271,7 +271,7 @@ Run `dice-fm-pp-cli <command> --help` for the full flag list on any command.
 | Command | What it does |
 | --- | --- |
 | `sync` | Sync your DICE data to local SQLite — complete by default; `--since` bounds a window, `--latest-only` grabs the newest, plus `--full`, `--resources` |
-| `normalize` | Normalize raw ticket-type & venue names into canonical, structured axes; writes a parallel lookup and leaves raw data untouched (re-runnable). `--export-unmatched` + `--export-format prompt` (default) bundles the rubric + import schema + names for LLM classification; `--import` writes the result back with method=manual; `normalize stats` shows the distribution; `normalize recommend` profiles the store and emits a starter config |
+| `normalize` | Normalize raw ticket-type & venue names into canonical, structured axes; writes a parallel lookup and leaves raw data untouched (re-runnable). `--tiers`, `--venues`, `--all`, `--entity`, `--fuzzy`, and `--fuzzy-threshold` choose the scope and fuzzy clustering; `--export-unmatched` + `--export-format prompt` (default) bundles the rubric + import schema + names for LLM classification; `--import` writes the result back with method=manual; `normalize stats` shows the distribution; `normalize recommend` profiles the store and emits a starter config; `normalize promote-rules` graduates the method=manual corpus into validated regex rules (the learn step) |
 | `search <query>` | Full-text search across synced data or the live API |
 | `analytics` | Run analytics queries on locally synced data |
 | `tail` | Stream live changes by polling the API at intervals |
@@ -359,6 +359,9 @@ dice-fm-pp-cli normalize --tiers --venues --fuzzy
 # Preview a starter normalization config without writing it
 dice-fm-pp-cli normalize recommend --print
 
+# Graduate your manual classifications into reusable regex rules (the learn step)
+dice-fm-pp-cli normalize promote-rules --entity ticket_type --write
+
 # Verify normalized coverage before grouping a report by axis
 dice-fm-pp-cli normalize stats --entity ticket_type --json
 ```
@@ -375,7 +378,7 @@ Install `dice-fm-pp-mcp` (see **MCP Server Installation** in `SKILL.md`), then c
 | Price-tier sales mix | `tier_performance` | `{ "limit": 20 }` |
 | Normalized coverage by axis | `normalize_stats` | `{ "entity": "ticket_type" }` |
 
-`normalize` itself writes the local store, so it is exposed as a write tool (no read-only hint) — run it from the CLI or invoke it deliberately. Custom SQL is intentionally out of scope for this cookbook.
+`normalize` itself writes the local store, so it is exposed as a write tool (no read-only hint) — run it from the CLI or invoke it deliberately. `normalize_recommend` and `normalize_promote_rules` are likewise write tools; run them deliberately or from the CLI. Custom SQL is intentionally out of scope for this cookbook.
 
 ## Agent Usage
 

--- a/library/media-and-entertainment/dice-fm/SKILL.md
+++ b/library/media-and-entertainment/dice-fm/SKILL.md
@@ -115,7 +115,7 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   dice-fm-pp-cli tier-performance --limit 20 --json
   ```
-- **`normalize`** — Canonicalize free-text ticket-type and venue names into structured axes (parallel, re-runnable, local-only); `normalize recommend` emits a starter config and `normalize stats` shows coverage.
+- **`normalize`** — Canonicalize free-text ticket-type and venue names into structured axes (parallel, re-runnable, local-only); `normalize recommend` emits a starter config, `normalize stats` shows coverage, and `normalize promote-rules` learns reusable regex rules from manual classifications.
 
   ```bash
   dice-fm-pp-cli normalize --tiers --fuzzy
@@ -154,9 +154,10 @@ These capabilities aren't available in any other tool for this API.
 
 **normalize** — Canonicalize manually-entered ticket-type and venue names into structured axes (parallel and re-runnable; raw synced data is never modified)
 
-- `dice-fm-pp-cli normalize` — Resolve raw names → canonical entities + axes (`--tiers`, `--venues`, `--all`, `--entity`, `--fuzzy`, `--export-unmatched <file>`, `--export-format prompt|names`, `--import <file.csv|.json>`)
+- `dice-fm-pp-cli normalize` — Resolve raw names → canonical entities + axes (`--tiers`, `--venues`, `--all`, `--entity`, `--fuzzy`, `--fuzzy-threshold <float>`, `--export-unmatched <file>`, `--export-format prompt|names`, `--import <file.csv|.json>`)
 - `dice-fm-pp-cli normalize stats` — Show the normalized axis distribution (`--entity`)
 - `dice-fm-pp-cli normalize recommend` — Profile the store and emit a starter normalization config (`--print` previews without writing)
+- `dice-fm-pp-cli normalize promote-rules` — Graduate method=manual classifications into validated regex rules (`--entity <type>`, `--write`, `--min-support <int>` default `2`)
 
   Query the normalized view via `revenue summary --by-axis <access_class|sales_stage|entry_window_type|group_size|comp_flag>`. Raw is the default; `--by-axis` falls back to raw (with a warning) if `normalize` has not been run. Normalization is local-only — resolved name mappings never leave your machine.
 
@@ -244,10 +245,15 @@ Per price-tier redemptions and each tier's share of total sales — which price 
 
 ```bash
 dice-fm-pp-cli normalize --tiers --venues --fuzzy
+dice-fm-pp-cli normalize --export-unmatched unmatched.json
+# classify externally, then import the result as method=manual
+dice-fm-pp-cli normalize --import classified.json
+dice-fm-pp-cli normalize promote-rules --entity ticket_type --write
+dice-fm-pp-cli normalize --tiers --venues --fuzzy
 dice-fm-pp-cli revenue summary --from 2026-01-01 --by-axis access_class --json
 ```
 
-Canonicalizes free-text ticket-type and venue names into structured axes (parallel and local-only; raw data untouched), then groups a revenue report on a clean axis. Run `normalize recommend --print` first to preview a starter config.
+Canonicalizes free-text ticket-type and venue names into structured axes (parallel and local-only; raw data untouched), then groups a revenue report on a clean axis. Run `normalize recommend --print` first to preview a starter config; after importing manual classifications, `normalize promote-rules --entity <type> --write` promotes repeat tokens into deterministic regex rules.
 
 ### Via the MCP server
 
@@ -258,7 +264,7 @@ After installing `dice-fm-pp-mcp` (see **MCP Server Installation** below), call 
 - `tier_performance` with `{ "limit": 20 }` — price-tier sales mix
 - `normalize_stats` with `{ "entity": "ticket_type" }` — normalized coverage by axis
 
-These (plus the eight typed `*_list` / `events_get` resource tools) are read-only. `normalize` writes the local store, so call it from the CLI. Custom SQL is out of scope here.
+These (plus the eight typed `*_list` / `events_get` resource tools) are read-only. `normalize` writes the local store, and `normalize_promote_rules` is a write tool when writing promoted rules, so call them from the CLI or invoke them deliberately. Custom SQL is out of scope here.
 
 ## Auth Setup
 

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_axes.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_axes.go
@@ -22,10 +22,17 @@ const (
 // Crosswalk/attribute method labels. These are categorical strings stamped onto
 // crosswalk and typed-attribute rows to record how a row was classified.
 const (
-	// methodRule labels rows classified by a config-driven rule. The value is
-	// historically "regex"; the rule-based mechanism replaced the compiled regex
-	// but the stored label is kept to avoid churning existing fixtures/data.
-	// Change this single const to rename the label everywhere.
+	// methodRule labels rows classified by a config-driven rule. The Go-side
+	// name is methodRule (the accurate name for the rule-engine mechanism), but
+	// the STORED value is deliberately kept as "regex" for backward
+	// compatibility: that string is already persisted in every existing local
+	// store and is asserted by the analytics test fixtures, so changing it now
+	// would be a data migration, not a rename. The code never compares the raw
+	// literal — every read/write routes through this const — so the eventual
+	// value change to "rule" is a one-line edit here plus a store migration
+	// (rewrite existing method='regex' rows) whenever a schema-version bump
+	// lands. Until then, anyone reading method values in SQL should treat
+	// "regex" as "config-driven rule".
 	methodRule      = "regex"
 	methodUnmatched = "unmatched"
 	methodCanonical = "canonical"

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_classify.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_classify.go
@@ -4,6 +4,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -88,6 +89,12 @@ func classifyEntity(ctx context.Context, s *store.Store, entityType string, ent 
 		}
 	}
 
+	// Compile the entity's attribute rules ONCE for reuse across every source
+	// value, rather than recompiling each rule's regexp per value in the inner
+	// loop. Uncompilable rules are warned-and-skipped (config-load validation
+	// already rejects them; this is the defense-in-depth diagnostic).
+	crules := compileRules(entityType, ent.Rules, os.Stderr)
+
 	for _, raw := range raws {
 		if manual[raw] {
 			continue
@@ -112,7 +119,7 @@ func classifyEntity(ctx context.Context, s *store.Store, entityType string, ent 
 			// attributes and the empty shape ("", alias-core) both run the
 			// attribute overlay; with empty rules every value resolves
 			// unmatched until rules are promoted or the LLM-tail fills them.
-			if err := classifyAttributesValue(s, entityType, ent, raw, cid, canon, opts, &res); err != nil {
+			if err := classifyAttributesValue(s, entityType, crules, raw, cid, canon, opts, &res); err != nil {
 				return classifyResult{}, err
 			}
 		}
@@ -156,11 +163,11 @@ func writeCrosswalk(s *store.Store, entityType, raw, cid, method string, opts cl
 	})
 }
 
-// classifyAttributesValue applies the entity's attribute rules to one
-// canonicalized value and writes the matched/unmatched outcome. On a match it
-// writes the typed attribute row routed by entityType.
-func classifyAttributesValue(s *store.Store, entityType string, ent normalizecfg.Entity, raw, cid, canon string, opts classifyOpts, res *classifyResult) error {
-	axisMap := applyAttributesOverlay(canon, ent)
+// classifyAttributesValue applies the entity's precompiled attribute rules to
+// one canonicalized value and writes the matched/unmatched outcome. On a match
+// it writes the typed attribute row routed by entityType.
+func classifyAttributesValue(s *store.Store, entityType string, rules []compiledRule, raw, cid, canon string, opts classifyOpts, res *classifyResult) error {
+	axisMap := applyAttributesOverlay(canon, rules)
 	if len(axisMap) == 0 {
 		if err := writeCrosswalk(s, entityType, raw, cid, methodUnmatched, opts); err != nil {
 			return fmt.Errorf("upsert crosswalk (unmatched): %w", err)
@@ -280,7 +287,7 @@ func fuzzyRemap(s *store.Store, entityType string, canonToID map[string]string, 
 	// Sort before clustering so the representative (cluster[0]) is chosen
 	// deterministically regardless of map iteration order.
 	sort.Strings(canonNames)
-	clusters := clusterNames(canonNames, 0.92)
+	clusters := clusterNames(canonNames, opts.fuzzyThreshold())
 
 	// Hoist a single ListCrosswalk call and build an index keyed by
 	// canonical_id so we remap in O(n) instead of O(k×n).

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_cmd.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_cmd.go
@@ -35,6 +35,9 @@ type normalizeOpts struct {
 	// Fuzzy enables a second-pass Jaro-Winkler clustering of near-duplicate
 	// canonical names.
 	Fuzzy bool
+	// FuzzyThreshold is the Jaro-Winkler similarity bar for the fuzzy pass.
+	// Zero (unset) resolves to the default (0.92) in classifyOpts.fuzzyThreshold.
+	FuzzyThreshold float64
 	// ClassifierVersion is stamped on every written row.
 	ClassifierVersion int
 	// ExportUnmatched, when non-empty, is the file path to write unmatched
@@ -104,6 +107,7 @@ func runNormalize(ctx context.Context, s *store.Store, opts normalizeOpts, w io.
 	classOpts := classifyOpts{
 		ClassifierVersion: opts.ClassifierVersion,
 		Fuzzy:             opts.Fuzzy,
+		FuzzyThreshold:    opts.FuzzyThreshold,
 	}
 
 	// Load the active normalize config once so both target resolution and the
@@ -387,6 +391,7 @@ func newNormalizeCmd(flags *rootFlags) *cobra.Command {
 		doAll             bool
 		entities          []string
 		fuzzy             bool
+		fuzzyThreshold    float64
 		classifierVersion int
 		exportUnmatched   string
 		exportFormat      string
@@ -448,6 +453,7 @@ func newNormalizeCmd(flags *rootFlags) *cobra.Command {
 				All:               doAll,
 				Entities:          entities,
 				Fuzzy:             fuzzy,
+				FuzzyThreshold:    fuzzyThreshold,
 				ClassifierVersion: classifierVersion,
 				ExportUnmatched:   exportUnmatched,
 				ExportFormat:      exportFormat,
@@ -464,6 +470,7 @@ func newNormalizeCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&doAll, "all", false, "Classify every entity declared in the normalize config (ticket_type, venue, artist, genre, ticket_pool, …)")
 	cmd.Flags().StringSliceVar(&entities, "entity", nil, "Classify only these declared entities by name (e.g. --entity artist,genre). Repeatable/comma-separated.")
 	cmd.Flags().BoolVar(&fuzzy, "fuzzy", false, "Enable Jaro-Winkler clustering of near-duplicate canonical names (default false; deterministic without it)")
+	cmd.Flags().Float64Var(&fuzzyThreshold, "fuzzy-threshold", defaultFuzzyThreshold, "Jaro-Winkler similarity bar for --fuzzy clustering, in (0,1]; higher is stricter (default 0.92). Ignored unless --fuzzy is set")
 	cmd.Flags().IntVar(&classifierVersion, "classifier-version", 1, "Classifier version stamped on written rows (default 1)")
 	cmd.Flags().StringVar(&exportUnmatched, "export-unmatched", "", "Write unmatched source values to this CSV file path for external classification")
 	cmd.Flags().StringVar(&exportFormat, "export-format", "prompt", `Format for --export-unmatched: "prompt" (default) writes a self-describing classification request with tier-axis rubric; "names" writes only the source_value CSV`)
@@ -472,6 +479,7 @@ func newNormalizeCmd(flags *rootFlags) *cobra.Command {
 
 	cmd.AddCommand(newNormalizeStatsCmd(flags))
 	cmd.AddCommand(newNormalizeRecommendCmd(flags))
+	cmd.AddCommand(newNormalizePromoteRulesCmd(flags))
 	return cmd
 }
 

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_cmd_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_cmd_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/store"
+	"github.com/spf13/cobra"
 )
 
 // TestNormalizeCommandSummaryTiers verifies that runNormalize over a seeded
@@ -129,6 +130,29 @@ func TestNormalizeStatsCobraWiring(t *testing.T) {
 	}
 	if !found {
 		t.Error("normalize stats subcommand not registered")
+	}
+}
+
+func TestNormalizePromoteRulesCobraWiring(t *testing.T) {
+	flags := &rootFlags{}
+	cmd := newNormalizeCmd(flags)
+	var promote *cobra.Command
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "promote-rules" {
+			promote = sub
+			break
+		}
+	}
+	if promote == nil {
+		t.Fatal("normalize promote-rules subcommand not registered")
+	}
+	for _, flagName := range []string{"entity", "write", "min-support"} {
+		if promote.Flags().Lookup(flagName) == nil {
+			t.Errorf("normalize promote-rules: flag --%s not registered", flagName)
+		}
+	}
+	if promote.Annotations["mcp:read-only"] == "true" {
+		t.Error("normalize promote-rules must not advertise mcp:read-only because --write mutates the operator config")
 	}
 }
 

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_engine.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_engine.go
@@ -1,16 +1,13 @@
 // Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
 package cli
 
-import (
-	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/normalizecfg"
-)
-
-// applyAttributesOverlay runs an entity's promoted attribute rules over an
+// applyAttributesOverlay runs an entity's precompiled attribute rules over an
 // already-canonicalized value and returns the resulting axis map. Axes left
 // unset by the rules are simply absent from the map, which is what marks them
-// as candidates for the LLM-tail classifier.
-func applyAttributesOverlay(canon string, ent normalizecfg.Entity) map[string]string {
-	return applyAttributeRules(canon, ent.Rules)
+// as candidates for the LLM-tail classifier. Rules are compiled once per run by
+// the caller (classifyEntity) so the regexps are not recompiled per value.
+func applyAttributesOverlay(canon string, rules []compiledRule) map[string]string {
+	return applyCompiledRules(canon, rules)
 }
 
 // mapVocab tests whether raw matches any member of set under Layer-A

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_engine_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_engine_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/store"
 )
 
-// TestApplyAttributesOverlay verifies the overlay delegates to the entity's
-// rules: a single rule on the entity sets the corresponding axis.
+// TestApplyAttributesOverlay verifies the overlay applies the entity's
+// precompiled rules: a single rule on the entity sets the corresponding axis.
 func TestApplyAttributesOverlay(t *testing.T) {
 	ent := normalizecfg.Entity{
 		Shape: normalizecfg.ShapeAttributes,
@@ -22,12 +22,12 @@ func TestApplyAttributesOverlay(t *testing.T) {
 			{Match: `(?i)\bvip\b`, Set: map[string]string{"access_class": "vip"}},
 		},
 	}
-	got := applyAttributesOverlay("vip experience", ent)
+	got := applyAttributesOverlay("vip experience", compileRules("ticket_type", ent.Rules, nil))
 	if got["access_class"] != "vip" {
 		t.Errorf("got %v, want access_class=vip", got)
 	}
 	// No rules -> empty overlay.
-	none := applyAttributesOverlay("vip experience", normalizecfg.Entity{})
+	none := applyAttributesOverlay("vip experience", compileRules("ticket_type", normalizecfg.Entity{}.Rules, nil))
 	if len(none) != 0 {
 		t.Errorf("got %v, want empty overlay for entity without rules", none)
 	}

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_import.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_import.go
@@ -145,7 +145,7 @@ func importMapping(s *store.Store, sourceSystem, entityType string, data []byte,
 			SourceSystem:      sourceSystem,
 			SourceValue:       r.SourceValue,
 			CanonicalID:       cid,
-			Method:            "manual",
+			Method:            methodManual,
 			ClassifierVersion: currentClassifierVersion,
 		}); err != nil {
 			return 0, fmt.Errorf("upsert crosswalk for %q: %w", r.SourceValue, err)
@@ -167,7 +167,7 @@ func importMapping(s *store.Store, sourceSystem, entityType string, data []byte,
 				GroupSize:         int(r.GroupSize),
 				CompFlag:          bool(r.CompFlag),
 				ClassifierVersion: currentClassifierVersion,
-				Method:            "manual",
+				Method:            methodManual,
 			}); err != nil {
 				return 0, fmt.Errorf("upsert tier attributes for %q: %w", r.SourceValue, err)
 			}

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_pipeline.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_pipeline.go
@@ -11,6 +11,11 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/store"
 )
 
+// defaultFuzzyThreshold is the Jaro-Winkler similarity bar used by the fuzzy
+// clustering pass when --fuzzy-threshold is not set. Two canonical names cluster
+// together only when their similarity is >= this value.
+const defaultFuzzyThreshold = 0.92
+
 // classifyOpts controls the classify pipeline run.
 type classifyOpts struct {
 	// ClassifierVersion is stamped onto every row written by this run.
@@ -19,6 +24,20 @@ type classifyOpts struct {
 	// canonical names into a shared canonical ID. Off by default so the
 	// primary path is fully deterministic.
 	Fuzzy bool
+	// FuzzyThreshold is the Jaro-Winkler similarity bar for the fuzzy pass. A
+	// zero (unset) value resolves to defaultFuzzyThreshold via fuzzyThreshold().
+	FuzzyThreshold float64
+}
+
+// fuzzyThreshold returns the effective clustering threshold: the configured
+// value when set to a positive number, otherwise defaultFuzzyThreshold. A value
+// outside (0,1] is treated as unset so a stray 0 or a nonsensical bound cannot
+// silently collapse every name into one cluster or disable clustering.
+func (o classifyOpts) fuzzyThreshold() float64 {
+	if o.FuzzyThreshold > 0 && o.FuzzyThreshold <= 1 {
+		return o.FuzzyThreshold
+	}
+	return defaultFuzzyThreshold
 }
 
 // classifyResult summarises what the classify pipeline produced.

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_promote.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_promote.go
@@ -1,0 +1,444 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored `normalize promote-rules` command: the "learn" step of the
+// LLM-tail loop. It reads the method="manual" corpus (operator/agent decisions
+// imported via `normalize --import`), proposes deterministic regex rules whose
+// token consistently predicts an axis value, validates each candidate against
+// the same corpus (promoteRules rejects any false positive), and emits the
+// survivors as a normalize-config fragment. This graduates recurring manual
+// classifications into reusable rules so the next `normalize` run resolves them
+// deterministically instead of re-exporting them as unmatched.
+// This file is NOT generated and survives `generate --force`.
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/cliutil"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/normalizecfg"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/store"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// promoteToken is a candidate-rule token: a single canonicalized word that, in
+// the manual corpus, co-occurs with exactly one value for a given axis.
+type promoteToken struct {
+	Token string
+	Axis  string
+	Value string
+}
+
+// tokenWordRE splits a canonicalized name into word tokens for candidate-rule
+// generation. Canonicalization already lowercased and collapsed whitespace, so
+// a simple word-character run is sufficient.
+var tokenWordRE = regexp.MustCompile(`[a-z0-9]+`)
+
+// buildManualAxisCache reads the method="manual" corpus for entityType and
+// returns a cache keyed by the canonicalized source value, mapping each name to
+// the axis values a human/agent assigned it. This is the exact shape consumed by
+// validateRule/promoteRules. ticket_type axes come from the typed tier_attributes
+// table; every other entity's axes come from the generic entity_attributes table.
+// Only manual rows contribute, so promotion learns from operator decisions, never
+// from machine-derived classifications.
+func buildManualAxisCache(s *store.Store, entityType string) (map[string]map[string]string, int, error) {
+	var stripRE *regexp.Regexp
+	if cfg, err := loadNormalizeConfig(); err != nil {
+		return nil, 0, fmt.Errorf("loading normalize config: %w", err)
+	} else if ent, ok := cfg.Entities[entityType]; ok && ent.StripPattern != "" {
+		stripRE, err = regexp.Compile(ent.StripPattern)
+		if err != nil {
+			return nil, 0, fmt.Errorf("compiling %s strip_pattern %q: %w", entityType, ent.StripPattern, err)
+		}
+	}
+
+	// Manual crosswalk rows give us the (source_value → canonical_id) pairs that
+	// a human/agent classified. canonical_id ties them to their axis rows.
+	cw, err := s.ListCrosswalk(entityType, "dice")
+	if err != nil {
+		return nil, 0, fmt.Errorf("listing crosswalk for %s: %w", entityType, err)
+	}
+	canonNameByID := map[string]string{}
+	for _, r := range cw {
+		if r.Method != methodManual {
+			continue
+		}
+		// Key the cache by the stripped+canonicalized source value — the same
+		// form the rule engine matches against at classify time.
+		canonNameByID[r.CanonicalID] = effectiveCanon(r.SourceValue, stripRE)
+	}
+	manualCrosswalkCount := len(canonNameByID)
+	if len(canonNameByID) == 0 {
+		return map[string]map[string]string{}, manualCrosswalkCount, nil
+	}
+
+	cache := map[string]map[string]string{}
+	ensure := func(name string) map[string]string {
+		if cache[name] == nil {
+			cache[name] = map[string]string{}
+		}
+		return cache[name]
+	}
+
+	if entityType == "ticket_type" {
+		tiers, err := s.ListTierAttributes(entityType)
+		if err != nil {
+			return nil, 0, fmt.Errorf("listing tier attributes for %s: %w", entityType, err)
+		}
+		for _, t := range tiers {
+			if t.Method != methodManual {
+				continue
+			}
+			name, ok := canonNameByID[t.CanonicalID]
+			if !ok {
+				continue
+			}
+			ax := ensure(name)
+			setIfNonEmpty(ax, axisAccessClass, t.AccessClass)
+			setIfNonEmpty(ax, axisSalesStage, t.SalesStage)
+			setIfNonEmpty(ax, axisEntryWindowType, t.EntryWindowType)
+			setIfNonEmpty(ax, axisEntryWindowTime, t.EntryWindowTime)
+			if t.GroupSize > 0 {
+				ax[axisGroupSize] = fmt.Sprintf("%d", t.GroupSize)
+			}
+			if t.CompFlag {
+				ax[axisCompFlag] = "true"
+			}
+		}
+		return cache, manualCrosswalkCount, nil
+	}
+
+	// Generic entity: axes live in entity_attributes (one row per key).
+	attrs, err := s.ListEntityAttributes(entityType)
+	if err != nil {
+		return nil, 0, fmt.Errorf("listing entity attributes for %s: %w", entityType, err)
+	}
+	for _, a := range attrs {
+		if a.Method != methodManual {
+			continue
+		}
+		name, ok := canonNameByID[a.CanonicalID]
+		if !ok {
+			continue
+		}
+		setIfNonEmpty(ensure(name), a.AttrKey, a.AttrValue)
+	}
+	return cache, manualCrosswalkCount, nil
+}
+
+// setIfNonEmpty assigns m[k]=v only when v is non-empty, so empty axes do not
+// pollute the cache (and so a candidate rule is never proposed for an empty
+// value, which would be a no-op assignment).
+func setIfNonEmpty(m map[string]string, k, v string) {
+	if v != "" {
+		m[k] = v
+	}
+}
+
+// proposeCandidateRules derives candidate rules from the manual axis cache. For
+// each (axis, value) pair, it finds tokens that, across every cached name
+// CONTAINING the token, co-occur with exactly that one value for that axis (no
+// conflicting assignment). Each surviving token becomes a candidate rule
+// matching a word-boundary occurrence of the token and setting the axis value.
+// Single-character and purely-numeric tokens are skipped as too generic. The
+// result is deterministically ordered (by axis, value, token).
+func proposeCandidateRules(cache map[string]map[string]string, minSupport int) []normalizecfg.Rule {
+	if minSupport < 1 {
+		minSupport = 1
+	}
+	// For each axis, for each token, collect the set of values it co-occurs with.
+	// token → axis → set(values).
+	type axisVals map[string]map[string]bool
+	tokenAxisVals := map[string]axisVals{}
+	tokenSupport := map[string]int{}
+
+	for name, axes := range cache {
+		seen := map[string]bool{}
+		for _, tok := range tokenWordRE.FindAllString(name, -1) {
+			if len(tok) < 2 || isAllDigits(tok) {
+				continue
+			}
+			if seen[tok] {
+				continue
+			}
+			seen[tok] = true
+			tokenSupport[tok]++
+			for axis, val := range axes {
+				if val == "" {
+					continue
+				}
+				if tokenAxisVals[tok] == nil {
+					tokenAxisVals[tok] = axisVals{}
+				}
+				if tokenAxisVals[tok][axis] == nil {
+					tokenAxisVals[tok][axis] = map[string]bool{}
+				}
+				tokenAxisVals[tok][axis][val] = true
+			}
+		}
+	}
+
+	var tokens []promoteToken
+	for tok, av := range tokenAxisVals {
+		if tokenSupport[tok] < minSupport {
+			continue
+		}
+		for axis, vals := range av {
+			// A token is a clean predictor only when it co-occurs with exactly
+			// one value for the axis. Multiple values → ambiguous → drop.
+			if len(vals) != 1 {
+				continue
+			}
+			for v := range vals {
+				tokens = append(tokens, promoteToken{Token: tok, Axis: axis, Value: v})
+			}
+		}
+	}
+
+	// Deterministic ordering so the emitted config (and tests) are stable.
+	sort.Slice(tokens, func(i, j int) bool {
+		if tokens[i].Axis != tokens[j].Axis {
+			return tokens[i].Axis < tokens[j].Axis
+		}
+		if tokens[i].Value != tokens[j].Value {
+			return tokens[i].Value < tokens[j].Value
+		}
+		return tokens[i].Token < tokens[j].Token
+	})
+
+	rules := make([]normalizecfg.Rule, 0, len(tokens))
+	for _, t := range tokens {
+		rules = append(rules, normalizecfg.Rule{
+			Match: `\b` + regexp.QuoteMeta(t.Token) + `\b`,
+			Set:   map[string]string{t.Axis: t.Value},
+		})
+	}
+	return rules
+}
+
+// isAllDigits reports whether s consists only of ASCII digits.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// promoteRulesForEntity is the testable core of `normalize promote-rules`: it
+// builds the manual axis cache, proposes candidate rules, and returns only those
+// that pass validation against the same cache (promoteRules rejects any rule with
+// a false positive). The returned rules are deterministically ordered.
+func promoteRulesForEntity(s *store.Store, entityType string, minSupport int) ([]normalizecfg.Rule, int, int, error) {
+	cache, manualCrosswalkCount, err := buildManualAxisCache(s, entityType)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	candidates := proposeCandidateRules(cache, minSupport)
+	validated := promoteRules(candidates, cache)
+	return validated, len(cache), manualCrosswalkCount, nil
+}
+
+// newNormalizePromoteRulesCmd returns the `normalize promote-rules` subcommand.
+// Default behavior is read-only: it prints a normalize-config fragment of the
+// promoted rules to stdout for the operator to review and paste into their
+// config. `--write` merges the promoted rules into the entity's existing config
+// (the operator config at the default path), which is the only mutating path and
+// is CLI-only (skipped under verify, like `normalize recommend`'s default write).
+func newNormalizePromoteRulesCmd(flags *rootFlags) *cobra.Command {
+	var (
+		entity     string
+		write      bool
+		minSupport int
+	)
+	cmd := &cobra.Command{
+		Use:   "promote-rules",
+		Short: "Propose deterministic rules from the method=manual corpus (LLM-tail learn step)",
+		Long: "Reads the method=manual classifications for an entity (operator/agent " +
+			"decisions imported via `normalize --import`), proposes regex rules whose " +
+			"token consistently predicts an axis value, validates each candidate against " +
+			"the same corpus (false positives are rejected), and emits the survivors as a " +
+			"normalize-config fragment. This graduates recurring manual classifications " +
+			"into reusable rules so subsequent `normalize` runs resolve them deterministically.\n\n" +
+			"Default is read-only (prints the fragment to stdout). Use --write to merge the " +
+			"promoted rules into the operator config at the default path. The entity source_value " +
+			"should be an event/ticket descriptor, not free text containing personal data.",
+		Example: "  dice-fm-pp-cli normalize promote-rules --entity ticket_type\n" +
+			"  dice-fm-pp-cli normalize promote-rules --entity ticket_type --write",
+		// No mcp:read-only: the optional --write path writes the operator
+		// config file to disk, so the tool must not advertise readOnlyHint and
+		// have hosts auto-approve a filesystem write.
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+
+			s, err := openStoreForRead(cmd.Context(), diceCLIName)
+			if err != nil {
+				return fmt.Errorf("opening store: %w", err)
+			}
+			if s == nil {
+				// No sync/import yet — emit an empty fragment rather than error.
+				return writePromotedRules(cmd, entity, nil, write)
+			}
+			defer s.Close()
+
+			rules, corpusSize, manualCrosswalkCount, err := promoteRulesForEntity(s, entity, minSupport)
+			if err != nil {
+				return err
+			}
+			if corpusSize == 0 {
+				if manualCrosswalkCount == 0 {
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"note: no method=manual rows for %q — import classified mappings with `normalize --import` first\n", entity)
+				} else {
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"note: found method=manual crosswalk rows for %q but no axis attributes to learn from — promote-rules needs imported axis values (tier/entity attributes)\n", entity)
+				}
+			}
+			return writePromotedRules(cmd, entity, rules, write)
+		},
+	}
+	cmd.Flags().StringVar(&entity, "entity", "ticket_type", "Entity whose manual corpus to learn rules from (default ticket_type)")
+	cmd.Flags().BoolVar(&write, "write", false, "Merge the promoted rules into the operator config at the default path (default: print to stdout only)")
+	cmd.Flags().IntVar(&minSupport, "min-support", 2, "Minimum distinct manual source values a token must appear in before it can be promoted")
+	return cmd
+}
+
+// writePromotedRules renders the promoted rules as a single-entity config
+// fragment. When write is false (default) it prints the fragment to stdout. When
+// write is true it merges the rules into the operator config at the default path
+// (skipped under verify, which prints instead). Merge semantics mirror the
+// whole-entity replace used elsewhere: the entity's rules are replaced by the
+// promoted set; other fields and other entities are preserved.
+func writePromotedRules(cmd *cobra.Command, entity string, rules []normalizecfg.Rule, write bool) error {
+	fragment := &normalizecfg.Config{
+		Version: 1,
+		Entities: map[string]normalizecfg.Entity{
+			entity: {
+				// Carry the entity's declared source/shape from the active config
+				// so the emitted fragment is a valid standalone config the
+				// operator can merge or write directly.
+				Rules: rules,
+			},
+		},
+	}
+	// Backfill source/shape from the active config so the fragment validates and
+	// is directly usable.
+	if cfg, err := loadNormalizeConfig(); err == nil {
+		if ent, ok := cfg.Entities[entity]; ok {
+			merged := fragment.Entities[entity]
+			merged.Source = ent.Source
+			merged.Shape = ent.Shape
+			merged.Attributes = ent.Attributes
+			merged.Vocab = ent.Vocab
+			merged.StripPattern = ent.StripPattern
+			fragment.Entities[entity] = merged
+		}
+	}
+
+	out, err := yaml.Marshal(fragment)
+	if err != nil {
+		return fmt.Errorf("marshaling promoted rules: %w", err)
+	}
+
+	if !write || cliutil.IsVerifyEnv() {
+		_, err = cmd.OutOrStdout().Write(out)
+		return err
+	}
+
+	// --write: merge the promoted rules into the operator config on disk.
+	cfgPath := defaultConfigPath(diceCLIName)
+	if err := mergePromotedRulesToConfig(cfgPath, entity, rules); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "merged %d promoted rule(s) for %q into %s\n", len(rules), entity, cfgPath)
+	return nil
+}
+
+// mergePromotedRulesToConfig loads the operator config at cfgPath (or starts
+// from an empty operator config when no file exists yet), replaces/adds the
+// named entity's rules with the promoted set, and writes the result back. The
+// whole entity is preserved except its rules, matching the whole-entity replace
+// semantics of the config loader. Starter entities the operator never
+// customized are not persisted.
+func mergePromotedRulesToConfig(cfgPath, entity string, rules []normalizecfg.Rule) error {
+	cfg := &normalizecfg.Config{Version: 1, Entities: map[string]normalizecfg.Entity{}}
+	opData, err := os.ReadFile(cfgPath)
+	if err == nil {
+		cfg, err = normalizecfg.Parse(opData)
+		if err != nil {
+			return fmt.Errorf("parsing operator config %q: %w", cfgPath, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("reading operator config %q: %w", cfgPath, err)
+	}
+
+	ent, ok := cfg.Entities[entity]
+	if !ok {
+		active, err := loadNormalizeConfig()
+		if err != nil {
+			return fmt.Errorf("loading active config: %w", err)
+		}
+		ent, ok = active.Entities[entity]
+		if !ok {
+			return fmt.Errorf("entity %q is not declared in the normalize config", entity)
+		}
+	}
+	ent.Rules = rules
+	cfg.Entities[entity] = ent
+
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling merged config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o700); err != nil {
+		return fmt.Errorf("creating config dir: %w", err)
+	}
+	if err := atomicWriteFile(cfgPath, out, 0o600); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	return nil
+}
+
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".normalize-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_promote_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_promote_test.go
@@ -1,0 +1,316 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Tests for `normalize promote-rules` (the LLM-tail learn step). All fixtures
+// are synthetic — no real tenant ticket-type names.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/normalizecfg"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/store"
+)
+
+// TestBuildManualAxisCacheTicketType verifies the manual corpus is read into the
+// validateRule-shaped cache keyed by canonicalized source value, with axes drawn
+// from the manual tier_attributes rows only.
+func TestBuildManualAxisCacheTicketType(t *testing.T) {
+	s := openSeededStoreForImport(t)
+	csvData := "source_value,access_class,sales_stage\n" +
+		"VIP Lounge,vip,early_bird\n" +
+		"VIP Experience,vip,final_release\n" +
+		"General Admission,ga,early_bird\n"
+	if _, err := importMapping(s, "dice", "ticket_type", []byte(csvData), "csv"); err != nil {
+		t.Fatalf("seed import: %v", err)
+	}
+
+	cache, manualCrosswalks, err := buildManualAxisCache(s, "ticket_type")
+	if err != nil {
+		t.Fatalf("buildManualAxisCache: %v", err)
+	}
+	if manualCrosswalks != 3 {
+		t.Fatalf("want 3 manual crosswalks, got %d", manualCrosswalks)
+	}
+	if len(cache) != 3 {
+		t.Fatalf("want 3 cached names, got %d: %+v", len(cache), cache)
+	}
+	// Keys are canonicalized (lowercased).
+	if cache["vip lounge"]["access_class"] != "vip" {
+		t.Errorf("vip lounge access_class = %q, want vip", cache["vip lounge"]["access_class"])
+	}
+	if cache["general admission"]["access_class"] != "ga" {
+		t.Errorf("general admission access_class = %q, want ga", cache["general admission"]["access_class"])
+	}
+}
+
+// TestPromoteRulesForEntity verifies the full learn step: a token that cleanly
+// predicts an axis value across the manual corpus is promoted, while a token
+// that co-occurs with conflicting values for the same axis is NOT promoted.
+func TestPromoteRulesForEntity(t *testing.T) {
+	s := openSeededStoreForImport(t)
+	// "vip" cleanly predicts access_class=vip; "early" co-occurs with both
+	// early_bird (good) — but here we make sales_stage ambiguous for the shared
+	// token "admission" by giving the two GA rows different sales stages, so no
+	// sales_stage rule should be promoted from "admission".
+	csvData := "source_value,access_class,sales_stage\n" +
+		"VIP Lounge,vip,early_bird\n" +
+		"VIP Balcony,vip,early_bird\n" +
+		"General Admission,ga,early_bird\n" +
+		"Standard Admission,ga,final_release\n"
+	if _, err := importMapping(s, "dice", "ticket_type", []byte(csvData), "csv"); err != nil {
+		t.Fatalf("seed import: %v", err)
+	}
+
+	rules, corpus, manualCrosswalks, err := promoteRulesForEntity(s, "ticket_type", 2)
+	if err != nil {
+		t.Fatalf("promoteRulesForEntity: %v", err)
+	}
+	if corpus != 4 {
+		t.Errorf("corpus size = %d, want 4", corpus)
+	}
+	if manualCrosswalks != 4 {
+		t.Errorf("manual crosswalk count = %d, want 4", manualCrosswalks)
+	}
+
+	// Collect (axis,value) pairs that were promoted.
+	byAxis := map[string]map[string]bool{}
+	for _, r := range rules {
+		for k, v := range r.Set {
+			if byAxis[k] == nil {
+				byAxis[k] = map[string]bool{}
+			}
+			byAxis[k][v] = true
+		}
+	}
+
+	// "vip" → access_class=vip must be promoted.
+	if !byAxis["access_class"]["vip"] {
+		t.Errorf("expected an access_class=vip rule promoted; rules=%+v", rules)
+	}
+	// "admission" predicts access_class=ga cleanly (both admission rows are ga),
+	// so an access_class=ga rule SHOULD be promoted.
+	if !byAxis["access_class"]["ga"] {
+		t.Errorf("expected an access_class=ga rule promoted; rules=%+v", rules)
+	}
+	// No rule should set access_class to both vip and ga from the same token —
+	// validation (promoteRules) guarantees each promoted rule is a clean
+	// predictor. Verify every promoted rule, applied to its own corpus, has no
+	// false positive by re-running validation.
+	cache, _, err := buildManualAxisCache(s, "ticket_type")
+	if err != nil {
+		t.Fatalf("rebuild cache: %v", err)
+	}
+	for _, r := range rules {
+		if !validateRule(r, cache) {
+			t.Errorf("promoted rule failed re-validation (should be impossible): %+v", r)
+		}
+	}
+}
+
+// TestPromoteRulesForEntityEmptyCorpus verifies an entity with no manual rows
+// yields zero promoted rules and a zero corpus size (no panic, no error).
+func TestPromoteRulesForEntityEmptyCorpus(t *testing.T) {
+	s := openSeededStoreForImport(t)
+	rules, corpus, manualCrosswalks, err := promoteRulesForEntity(s, "ticket_type", 2)
+	if err != nil {
+		t.Fatalf("promoteRulesForEntity on empty store: %v", err)
+	}
+	if corpus != 0 || manualCrosswalks != 0 || len(rules) != 0 {
+		t.Errorf("empty corpus: got %d rules / corpus %d / manual crosswalks %d, want 0/0/0", len(rules), corpus, manualCrosswalks)
+	}
+}
+
+func TestPromoteRulesWarnsWhenManualCrosswalksHaveNoAxisAttributes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dbPath := defaultDBPath(diceCLIName)
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	s, err := store.OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	csvData := "source_value,canonical_name\n" +
+		"VIP Lounge,VIP Lounge\n"
+	if _, err := importMapping(s, "dice", "ticket_type", []byte(csvData), "csv"); err != nil {
+		t.Fatalf("seed import: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close seeded store: %v", err)
+	}
+
+	flags := &rootFlags{}
+	cmd := newNormalizeCmd(flags)
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"promote-rules", "--entity", "ticket_type"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("promote-rules: %v", err)
+	}
+
+	stderr := errBuf.String()
+	if !strings.Contains(stderr, "found method=manual crosswalk rows for \"ticket_type\" but no axis attributes to learn from") {
+		t.Fatalf("missing distinct no-axis warning; stderr=%q", stderr)
+	}
+	if strings.Contains(stderr, "no method=manual rows") {
+		t.Fatalf("used no-manual-rows warning for manual rows without axes; stderr=%q", stderr)
+	}
+}
+
+// TestProposeCandidateRulesSkipsGenericTokens verifies single-character and
+// purely-numeric tokens are not proposed as rules (too generic).
+func TestProposeCandidateRulesSkipsGenericTokens(t *testing.T) {
+	cache := map[string]map[string]string{
+		"a 1 vip": {"access_class": "vip"},
+		"b 2 vip": {"access_class": "vip"},
+	}
+	rules := proposeCandidateRules(cache, 2)
+	for _, r := range rules {
+		// The match wraps a token in \b...\b; the only acceptable token here is
+		// "vip" (len>=2, not all-digits).
+		if !strings.Contains(r.Match, "vip") {
+			t.Errorf("unexpected candidate from a generic token: %q", r.Match)
+		}
+	}
+	if len(rules) == 0 {
+		t.Error("expected at least the vip rule to be proposed")
+	}
+}
+
+func TestProposeCandidateRulesMinimumSupport(t *testing.T) {
+	cache := map[string]map[string]string{
+		"vip lounge":     {"access_class": "vip"},
+		"vip experience": {"access_class": "vip"},
+		"solo balcony":   {"access_class": "vip"},
+	}
+
+	defaultRules := proposeCandidateRules(cache, 2)
+	if !hasRuleMatch(defaultRules, `\bvip\b`) {
+		t.Fatalf("token with support 2 should be promoted: %+v", defaultRules)
+	}
+	if hasRuleMatch(defaultRules, `\bsolo\b`) {
+		t.Fatalf("token with support 1 should not be promoted by default: %+v", defaultRules)
+	}
+
+	legacyRules := proposeCandidateRules(cache, 1)
+	if !hasRuleMatch(legacyRules, `\bsolo\b`) {
+		t.Fatalf("--min-support 1 should allow single-example tokens: %+v", legacyRules)
+	}
+}
+
+func TestBuildManualAxisCacheAppliesStripPattern(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfgPath := defaultConfigPath(diceCLIName)
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	operator := []byte(`version: 1
+entities:
+  price_tier:
+    source: tickets.priceTier.name
+    shape: attributes
+    attributes: [price_band]
+    strip_pattern: '^[^:]+:\s*'
+`)
+	if err := os.WriteFile(cfgPath, operator, 0o600); err != nil {
+		t.Fatalf("write operator config: %v", err)
+	}
+
+	s := openSeededStoreForImport(t)
+	csvData := "source_value,price_band\n" +
+		"Currency: Premium Alpha,high\n" +
+		"Currency: Premium Beta,high\n"
+	if _, err := importMapping(s, "dice", "price_tier", []byte(csvData), "csv"); err != nil {
+		t.Fatalf("seed generic import: %v", err)
+	}
+
+	cache, _, err := buildManualAxisCache(s, "price_tier")
+	if err != nil {
+		t.Fatalf("buildManualAxisCache: %v", err)
+	}
+	if _, ok := cache["premium alpha"]; !ok {
+		t.Fatalf("stripped canonical key missing; cache=%+v", cache)
+	}
+	if _, ok := cache["currency premium alpha"]; ok {
+		t.Fatalf("unstripped canonical key should not be present; cache=%+v", cache)
+	}
+
+	rules, _, _, err := promoteRulesForEntity(s, "price_tier", 2)
+	if err != nil {
+		t.Fatalf("promoteRulesForEntity: %v", err)
+	}
+	if !hasRuleMatch(rules, `\bpremium\b`) {
+		t.Fatalf("expected stripped token to promote: %+v", rules)
+	}
+	if hasRuleMatch(rules, `\bcurrency\b`) {
+		t.Fatalf("prefix token removed by strip_pattern must not promote: %+v", rules)
+	}
+}
+
+func TestMergePromotedRulesToConfigDoesNotPersistStarterEntities(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfgPath := filepath.Join(t.TempDir(), "normalize.yaml")
+	rules := []normalizecfg.Rule{{Match: `\bvip\b`, Set: map[string]string{"access_class": "vip"}}}
+
+	if err := mergePromotedRulesToConfig(cfgPath, "ticket_type", rules); err != nil {
+		t.Fatalf("mergePromotedRulesToConfig absent operator: %v", err)
+	}
+	cfg := readNormalizeConfigFile(t, cfgPath)
+	if len(cfg.Entities) != 1 {
+		t.Fatalf("absent operator write should contain only promoted entity, got %d: %+v", len(cfg.Entities), cfg.Entities)
+	}
+	if cfg.Entities["ticket_type"].Source != "tickets.ticketType.name" {
+		t.Fatalf("promoted entity should be backfilled from active config: %+v", cfg.Entities["ticket_type"])
+	}
+
+	operator := []byte(`version: 1
+entities:
+  genre:
+    source: events.genres
+    shape: vocab
+    vocab: [house]
+`)
+	if err := os.WriteFile(cfgPath, operator, 0o600); err != nil {
+		t.Fatalf("replace operator config: %v", err)
+	}
+	if err := mergePromotedRulesToConfig(cfgPath, "ticket_type", rules); err != nil {
+		t.Fatalf("mergePromotedRulesToConfig existing operator: %v", err)
+	}
+	cfg = readNormalizeConfigFile(t, cfgPath)
+	if len(cfg.Entities) != 2 {
+		t.Fatalf("existing operator write should preserve only operator entities plus promoted entity, got %d: %+v", len(cfg.Entities), cfg.Entities)
+	}
+	if _, ok := cfg.Entities["genre"]; !ok {
+		t.Fatal("existing operator entity was not preserved")
+	}
+	if _, ok := cfg.Entities["venue"]; ok {
+		t.Fatalf("starter-only venue should not be frozen into operator config: %+v", cfg.Entities)
+	}
+}
+
+func hasRuleMatch(rules []normalizecfg.Rule, match string) bool {
+	for _, r := range rules {
+		if r.Match == match {
+			return true
+		}
+	}
+	return false
+}
+
+func readNormalizeConfigFile(t *testing.T, path string) *normalizecfg.Config {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfg, err := normalizecfg.Parse(data)
+	if err != nil {
+		t.Fatalf("parse config: %v\n%s", err, data)
+	}
+	return cfg
+}

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_recommend.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_recommend.go
@@ -214,13 +214,19 @@ func splitArrayPath(path string) (arrayField, leafField string) {
 	return path[:dot], path[dot+1:]
 }
 
-// candidateSources maps entity names to source paths for the dice-fm CLI.
-// These mirror the source paths used by classifyTiers / classifyVenues.
+// candidateSources maps entity names to source paths for the dice-fm CLI. The
+// set mirrors the entities declared in the embedded starter config
+// (normalize_starter.yaml) so `normalize recommend` profiles every entity the
+// operator can wire — including price_tier and ticket_pool, which were
+// previously absent here and so were invisible to the recommend→classify
+// bootstrap.
 var candidateSources = map[string]string{
 	"ticket_type": "tickets.ticketType.name",
+	"price_tier":  "tickets.ticketType.price",
 	"venue":       "events.venues[*].name",
 	"genre":       "events.genres[*]",
 	"artist":      "events.artists[*].name",
+	"ticket_pool": "events.ticketPools[*].name",
 }
 
 // runRecommend profiles each candidate source against the store and returns a

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_rules.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_rules.go
@@ -2,31 +2,69 @@
 package cli
 
 import (
+	"fmt"
+	"io"
 	"regexp"
 	"strings"
 
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/normalizecfg"
 )
 
-// applyAttributeRules runs an ordered set of match→set rules over an
-// already-canonicalized value and returns the merged axis assignments. Rules
-// are applied in order; a later matching rule overrides an earlier one for the
-// same key. A rule whose Match does not compile is skipped (never panics). The
-// returned map may be empty when no rule matches.
-func applyAttributeRules(canon string, rules []normalizecfg.Rule) map[string]string {
-	out := map[string]string{}
-	for _, r := range rules {
+// compiledRule pairs an entity rule's match pattern, compiled once, with its
+// axis assignments so the regexp is not recompiled per source value in the
+// classify inner loop.
+type compiledRule struct {
+	re  *regexp.Regexp
+	set map[string]string
+}
+
+// compileRules compiles each rule's match pattern exactly once for reuse across
+// every source value. A rule whose Match does not compile is skipped with a
+// warning written to warn (never panics). Config-load validation
+// (normalizecfg.validate) already rejects an uncompilable rule, so a skip here
+// is a defense-in-depth diagnostic for any rule that reaches classify without
+// passing through Parse — it makes a silently-disabled rule visible instead of
+// matching nothing with no signal. Pass entityType for the warning context; a
+// nil warn writer silences the diagnostic.
+func compileRules(entityType string, rules []normalizecfg.Rule, warn io.Writer) []compiledRule {
+	out := make([]compiledRule, 0, len(rules))
+	for i, r := range rules {
 		re, err := regexp.Compile(r.Match)
 		if err != nil {
+			if warn != nil {
+				fmt.Fprintf(warn, "warning: %s rule %d: skipping uncompilable match %q: %v\n", entityType, i, r.Match, err)
+			}
 			continue
 		}
-		if re.MatchString(canon) {
-			for k, v := range r.Set {
+		out = append(out, compiledRule{re: re, set: r.Set})
+	}
+	return out
+}
+
+// applyCompiledRules runs an ordered set of precompiled match→set rules over an
+// already-canonicalized value and returns the merged axis assignments. Rules
+// are applied in order; a later matching rule overrides an earlier one for the
+// same key. The returned map may be empty when no rule matches.
+func applyCompiledRules(canon string, rules []compiledRule) map[string]string {
+	out := map[string]string{}
+	for _, r := range rules {
+		if r.re.MatchString(canon) {
+			for k, v := range r.set {
 				out[k] = v
 			}
 		}
 	}
 	return out
+}
+
+// applyAttributeRules compiles the rules and runs them over canon in a single
+// call. It is a convenience wrapper retained for callers (and tests) that do not
+// hold a precompiled rule set; the classify hot path uses compileRules +
+// applyCompiledRules so the patterns are compiled once per run, not per value.
+// Uncompilable rules are silently skipped here (the warn path lives in
+// compileRules); this preserves the original never-panics contract.
+func applyAttributeRules(canon string, rules []normalizecfg.Rule) map[string]string {
+	return applyCompiledRules(canon, compileRules("", rules, nil))
 }
 
 // validateRule checks a candidate rule against a cache of already-classified

--- a/library/media-and-entertainment/dice-fm/internal/cli/normalize_rules_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/normalize_rules_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/normalizecfg"
@@ -80,6 +82,63 @@ func TestValidateRuleBadRegexFails(t *testing.T) {
 	r := normalizecfg.Rule{Match: `(unclosed`, Set: map[string]string{"access_class": "vip"}}
 	if validateRule(r, cached) {
 		t.Error("rule with uncompilable regex must not validate")
+	}
+}
+
+// TestCompileRulesWarnsAndSkips verifies the compile-once cache skips an
+// uncompilable rule, writes a diagnostic to the warn writer, and still applies
+// the good rules — the defense-in-depth half of the silent-skip fix (F1/F9).
+func TestCompileRulesWarnsAndSkips(t *testing.T) {
+	var warn bytes.Buffer
+	rules := []normalizecfg.Rule{
+		{Match: `(unclosed`, Set: map[string]string{"access_class": "vip"}},
+		{Match: `(?i)\bvip\b`, Set: map[string]string{"access_class": "vip"}},
+	}
+	crules := compileRules("ticket_type", rules, &warn)
+	if len(crules) != 1 {
+		t.Fatalf("want 1 compiled rule (bad one skipped), got %d", len(crules))
+	}
+	if !strings.Contains(warn.String(), "skipping uncompilable match") {
+		t.Errorf("expected a warning about the skipped rule, got %q", warn.String())
+	}
+	if got := applyCompiledRules("vip experience", crules); got["access_class"] != "vip" {
+		t.Errorf("good rule should still apply, got %v", got)
+	}
+}
+
+// TestCompileRulesNilWarnSilent verifies a nil warn writer silences the
+// diagnostic without panicking (the applyAttributeRules convenience path).
+func TestCompileRulesNilWarnSilent(t *testing.T) {
+	rules := []normalizecfg.Rule{{Match: `(unclosed`, Set: map[string]string{"access_class": "vip"}}}
+	crules := compileRules("", rules, nil)
+	if len(crules) != 0 {
+		t.Errorf("uncompilable rule should be skipped, got %d compiled", len(crules))
+	}
+}
+
+// TestFuzzyThresholdResolution verifies the configurable fuzzy threshold (F6):
+// an unset/zero value falls back to the default, an in-range value is used
+// verbatim, and an out-of-range value is treated as unset (clamped to default)
+// so a stray 0 or >1 cannot collapse or disable clustering.
+func TestFuzzyThresholdResolution(t *testing.T) {
+	cases := []struct {
+		name string
+		in   float64
+		want float64
+	}{
+		{"unset zero -> default", 0, defaultFuzzyThreshold},
+		{"in range used verbatim", 0.85, 0.85},
+		{"upper bound 1 allowed", 1.0, 1.0},
+		{"above 1 -> default", 1.5, defaultFuzzyThreshold},
+		{"negative -> default", -0.5, defaultFuzzyThreshold},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := classifyOpts{FuzzyThreshold: c.in}.fuzzyThreshold()
+			if got != c.want {
+				t.Errorf("fuzzyThreshold(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
 	}
 }
 

--- a/library/media-and-entertainment/dice-fm/internal/normalizecfg/config.go
+++ b/library/media-and-entertainment/dice-fm/internal/normalizecfg/config.go
@@ -45,7 +45,11 @@ type Config struct {
 	Entities map[string]Entity `yaml:"entities"`
 }
 
-// validate checks that all entities in c have a known shape and a non-empty source.
+// validate checks that all entities in c have a known shape and a non-empty
+// source, and that every regexp in the entity (strip_pattern and each rule's
+// match) compiles. Validating rule.match at load time (alongside strip_pattern)
+// turns a typo'd promoted rule into a clear load-time error instead of a rule
+// that silently disables itself and matches nothing at classify time.
 func validate(c *Config) error {
 	for name, e := range c.Entities {
 		switch e.Shape {
@@ -59,6 +63,14 @@ func validate(c *Config) error {
 		if e.StripPattern != "" {
 			if _, err := regexp.Compile(e.StripPattern); err != nil {
 				return fmt.Errorf("entity %q: invalid strip_pattern %q: %w", name, e.StripPattern, err)
+			}
+		}
+		for i, r := range e.Rules {
+			if r.Match == "" {
+				return fmt.Errorf("entity %q: rule %d has an empty match pattern", name, i)
+			}
+			if _, err := regexp.Compile(r.Match); err != nil {
+				return fmt.Errorf("entity %q: invalid rule match %q: %w", name, r.Match, err)
 			}
 		}
 	}

--- a/library/media-and-entertainment/dice-fm/internal/normalizecfg/config_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/normalizecfg/config_test.go
@@ -71,6 +71,50 @@ entities:
 	}
 }
 
+// TestValidateRuleMatch verifies that a rule's match pattern is validated at
+// parse time: a valid pattern parses, an uncompilable pattern fails the load
+// (instead of silently disabling itself at classify time), and an empty match
+// is rejected.
+func TestValidateRuleMatch(t *testing.T) {
+	good := `version: 1
+entities:
+  ticket_type:
+    source: tickets.ticketType.name
+    shape: attributes
+    rules:
+      - match: '(?i)\bvip\b'
+        set: {access_class: vip}
+`
+	if _, err := Parse([]byte(good)); err != nil {
+		t.Fatalf("valid rule match should parse: %v", err)
+	}
+
+	badRegexp := `version: 1
+entities:
+  ticket_type:
+    source: tickets.ticketType.name
+    shape: attributes
+    rules:
+      - match: '([unclosed'
+        set: {access_class: vip}
+`
+	if _, err := Parse([]byte(badRegexp)); err == nil {
+		t.Fatal("expected error for uncompilable rule match")
+	}
+
+	emptyMatch := `version: 1
+entities:
+  ticket_type:
+    source: tickets.ticketType.name
+    shape: attributes
+    rules:
+      - set: {access_class: vip}
+`
+	if _, err := Parse([]byte(emptyMatch)); err == nil {
+		t.Fatal("expected error for empty rule match")
+	}
+}
+
 func mustParse(t *testing.T, b []byte) *Config {
 	t.Helper()
 	c, err := Parse(b)

--- a/library/media-and-entertainment/dice-fm/internal/store/normalization.go
+++ b/library/media-and-entertainment/dice-fm/internal/store/normalization.go
@@ -345,6 +345,14 @@ func (s *Store) ListVenueAttributes(entityType string) ([]VenueAttributesRow, er
 
 // UpsertEntityAttribute inserts or replaces a single generic attribute row
 // keyed by (canonical_id, attr_key). All writes are serialized through writeMu.
+//
+// entity_type is intentionally NOT updated on conflict: the canonical_id is a
+// type-prefixed SHA1 ("<entity_type>:<hash>"), so a given canonical_id belongs
+// to exactly one entity type for its whole life. Rewriting entity_type on
+// conflict could only do harm — in the (astronomically unlikely) event of a
+// minting collision across two types it would silently relabel the row's type
+// rather than surfacing the clash — so the column is set once at insert and
+// left immutable thereafter.
 func (s *Store) UpsertEntityAttribute(canonicalID, entityType, key, value, method string, classifierVersion int) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
@@ -353,7 +361,6 @@ func (s *Store) UpsertEntityAttribute(canonicalID, entityType, key, value, metho
 			(canonical_id, entity_type, attr_key, attr_value, method, classifier_version)
 		 VALUES (?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(canonical_id, attr_key) DO UPDATE SET
-			entity_type        = excluded.entity_type,
 			attr_value         = excluded.attr_value,
 			method             = excluded.method,
 			classifier_version = excluded.classifier_version`,
@@ -398,13 +405,25 @@ func (s *Store) ListEntityAttributes(entityType string) ([]EntityAttrRow, error)
 // entity type from entity_crosswalk and the corresponding attribute tables.
 // Rows with method='manual' are preserved so operator overrides survive a
 // re-classification run.
+//
+// The whole multi-table clear runs inside a single transaction so the store is
+// never observed in a half-cleared state (e.g. crosswalk rows gone but attribute
+// rows still present): either every non-manual row is removed or none is. Writes
+// are also serialized through writeMu, matching the locking contract of the
+// other store mutators.
 func (s *Store) ClearNormalization(entityType string) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin clear normalization: %w", err)
+	}
+	defer tx.Rollback()
+
 	// Collect canonical IDs that are exclusively non-manual before deleting,
 	// so we can clean up the attribute tables without touching manual entries.
-	rows, err := s.db.Query(
+	rows, err := tx.Query(
 		`SELECT DISTINCT canonical_id FROM entity_crosswalk
 		 WHERE entity_type = ? AND method <> 'manual'
 		   AND canonical_id NOT IN (
@@ -432,7 +451,7 @@ func (s *Store) ClearNormalization(entityType string) error {
 	rows.Close()
 
 	// Delete non-manual crosswalk rows.
-	if _, err := s.db.Exec(
+	if _, err := tx.Exec(
 		`DELETE FROM entity_crosswalk WHERE entity_type = ? AND method <> 'manual'`,
 		entityType,
 	); err != nil {
@@ -442,12 +461,12 @@ func (s *Store) ClearNormalization(entityType string) error {
 	// Delete tier/venue attributes only for canonical IDs that had no manual
 	// crosswalk row (collected above).
 	for _, id := range ids {
-		if _, err := s.db.Exec(
+		if _, err := tx.Exec(
 			`DELETE FROM tier_attributes WHERE canonical_id = ?`, id,
 		); err != nil {
 			return fmt.Errorf("clear tier attributes for %s: %w", id, err)
 		}
-		if _, err := s.db.Exec(
+		if _, err := tx.Exec(
 			`DELETE FROM venue_attributes WHERE canonical_id = ?`, id,
 		); err != nil {
 			return fmt.Errorf("clear venue attributes for %s: %w", id, err)
@@ -458,11 +477,15 @@ func (s *Store) ClearNormalization(entityType string) error {
 	// typed tier/venue tables (which key manual-preservation off the crosswalk
 	// method), entity_attributes carries its own per-row method, so manual rows
 	// are identified directly and left in place.
-	if _, err := s.db.Exec(
+	if _, err := tx.Exec(
 		`DELETE FROM entity_attributes WHERE entity_type = ? AND method <> 'manual'`,
 		entityType,
 	); err != nil {
 		return fmt.Errorf("clear entity attributes: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit clear normalization: %w", err)
 	}
 	return nil
 }

--- a/library/media-and-entertainment/dice-fm/internal/store/normalization_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/store/normalization_test.go
@@ -253,6 +253,97 @@ func TestEntityAttributesRoundTrip(t *testing.T) {
 	}
 }
 
+// TestEntityAttributeTypeImmutableOnConflict verifies that re-upserting the same
+// (canonical_id, attr_key) with a different entity_type does NOT change the
+// stored entity_type (F4): the canonical_id is type-prefixed and owns exactly
+// one entity type for life, so the ON CONFLICT path must not relabel it.
+func TestEntityAttributeTypeImmutableOnConflict(t *testing.T) {
+	s := openTestStore(t)
+
+	if err := s.UpsertEntityAttribute("price_tier:aa", "price_tier", "price_band", "mid", "regex", 1); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+	// Re-upsert the same key but with a (wrong) different entity_type. The value
+	// should update; the entity_type must stay price_tier.
+	if err := s.UpsertEntityAttribute("price_tier:aa", "genre", "price_band", "high", "manual", 2); err != nil {
+		t.Fatalf("conflicting-type upsert: %v", err)
+	}
+
+	rows, err := s.ListEntityAttributes("price_tier")
+	if err != nil {
+		t.Fatalf("list price_tier: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 price_tier row, got %d: %+v", len(rows), rows)
+	}
+	if rows[0].EntityType != "price_tier" {
+		t.Errorf("entity_type = %q, want price_tier (must be immutable on conflict)", rows[0].EntityType)
+	}
+	if rows[0].AttrValue != "high" {
+		t.Errorf("attr_value = %q, want high (value should still update)", rows[0].AttrValue)
+	}
+	// The row must NOT have moved into the "genre" listing.
+	genreRows, err := s.ListEntityAttributes("genre")
+	if err != nil {
+		t.Fatalf("list genre: %v", err)
+	}
+	if len(genreRows) != 0 {
+		t.Errorf("genre listing should be empty; the row must not have been relabeled: %+v", genreRows)
+	}
+}
+
+// TestClearNormalizationAtomicClearsAllTables verifies the transactional clear
+// (F3) removes non-manual rows from the crosswalk AND the typed/generic
+// attribute tables in one shot, leaving manual rows intact.
+func TestClearNormalizationAtomicClearsAllTables(t *testing.T) {
+	s := openTestStore(t)
+
+	// A non-manual ticket_type: crosswalk + tier_attributes.
+	if err := s.UpsertCrosswalk(CrosswalkRow{
+		EntityType: "ticket_type", SourceSystem: "dice", SourceValue: "vip lounge",
+		CanonicalID: "ticket_type:vip", Method: "regex", ClassifierVersion: 1,
+	}); err != nil {
+		t.Fatalf("upsert non-manual crosswalk: %v", err)
+	}
+	if err := s.UpsertTierAttributes("ticket_type:vip", TierAttributesRow{
+		CanonicalID: "ticket_type:vip", AccessClass: "vip", ClassifierVersion: 1, Method: "regex",
+	}); err != nil {
+		t.Fatalf("upsert tier attrs: %v", err)
+	}
+	// A manual ticket_type that must survive.
+	if err := s.UpsertCrosswalk(CrosswalkRow{
+		EntityType: "ticket_type", SourceSystem: "dice", SourceValue: "comp guest",
+		CanonicalID: "ticket_type:comp", Method: "manual", ClassifierVersion: 1,
+	}); err != nil {
+		t.Fatalf("upsert manual crosswalk: %v", err)
+	}
+	if err := s.UpsertTierAttributes("ticket_type:comp", TierAttributesRow{
+		CanonicalID: "ticket_type:comp", CompFlag: true, ClassifierVersion: 1, Method: "manual",
+	}); err != nil {
+		t.Fatalf("upsert manual tier attrs: %v", err)
+	}
+
+	if err := s.ClearNormalization("ticket_type"); err != nil {
+		t.Fatalf("ClearNormalization: %v", err)
+	}
+
+	cw, err := s.ListCrosswalk("ticket_type", "dice")
+	if err != nil {
+		t.Fatalf("list crosswalk: %v", err)
+	}
+	if len(cw) != 1 || cw[0].CanonicalID != "ticket_type:comp" {
+		t.Fatalf("want only the manual crosswalk row left, got %+v", cw)
+	}
+
+	tiers, err := s.ListTierAttributes("ticket_type")
+	if err != nil {
+		t.Fatalf("list tier attrs: %v", err)
+	}
+	if len(tiers) != 1 || tiers[0].CanonicalID != "ticket_type:comp" {
+		t.Fatalf("want only the manual tier_attributes row left, got %+v", tiers)
+	}
+}
+
 // TestClearNormalizationPreservesManualEntityAttributes verifies that
 // ClearNormalization deletes non-manual entity_attributes rows for the entity
 // type while preserving rows whose own method is "manual". Synthetic fixtures.


### PR DESCRIPTION
## Summary

Addresses the actionable findings from a 2026-06-08 architectural audit of dice-fm's hand-authored
entity-normalization subsystem. Three Medium correctness/UX defects, several Low debt items, and one
capability gap (the rule-promotion half of the LLM-tail loop was built but never wired to a command).
No data-loss or injection risk was found; these are hardening + a new "learn" step. The new
`normalize promote-rules` command was additionally hardened by an independent code/security/privacy
review pass before this PR.

## Findings addressed

| ID | Sev | Fix |
|----|-----|-----|
| F1 | Med | Validate every `Rule.Match` regexp at config load (reject empty/uncompilable); `compileRules` warns-and-skips as defense-in-depth. A typo'd promoted rule now fails fast instead of silently disabling itself. |
| F2 | Med | `candidateSources` mirrors the full embedded starter (adds `price_tier` + `ticket_pool`) so `normalize recommend` profiles every wireable entity. |
| F3 | Med | Wrap `ClearNormalization`'s multi-table deletes in a single transaction (never observed half-cleared). |
| F4 | Med (latent) | Stop rewriting `entity_type` on `entity_attributes` ON CONFLICT (canonical_id is type-prefixed and owns one type for life). |
| F5 | Low | `importMapping` uses the `methodManual` const instead of a `"manual"` literal. |
| F6 | Low | Add `--fuzzy-threshold` (default 0.92, clamped to (0,1]) to the previously-hardcoded Jaro-Winkler bar. |
| F8 | Low (capability) | Wire `normalize promote-rules` — graduates the `method=manual` corpus into validated regex rules (read-only print by default; `--write` merges into the operator config). The LLM-tail "learn" step. |
| F9 | Nit | Compile each entity's attribute rules once per run instead of per source value. |
| F10 | Nit | Keep `methodRule`'s stored value `"regex"` for back-compat (changing it is a data migration); document the migration path on the const. |

Excluded as non-bugs per the audit: **F7** (`recommend` writes by default — deliberate; `--print` is the safe path) and **F11** (axis values unenforced at the DB layer — informational).

## Hardening of the new `promote-rules` command (pre-merge review)

- Dropped a misleading `mcp:read-only` hint from `promote-rules` — it has a mutating `--write` path,
  so it now matches the `recommend` convention (an MCP host won't auto-approve a filesystem write
  under a read-only annotation). A Cobra-wiring test guards the regression.
- `--write` now persists only the operator's own entities plus the promoted one, instead of freezing
  verbatim copies of every starter entity into the operator config.
- `buildManualAxisCache` applies the entity's `strip_pattern` before canonicalizing, so promoted
  rules round-trip against the classify path.
- New `--min-support` (default 2): a token must appear in ≥2 distinct manual source values before
  promotion, so a one-off token can't become a rule.
- Atomic operator-config write (temp file + rename) to avoid a torn YAML on a crash mid-write.

## Verification

- `go build ./...` + `go vet ./...` clean; full `go test ./...` green; `-race` clean on store + normalize tests.
- New tests cover: rule-match load validation, compile-once warn-on-skip, fuzzy-threshold clamping,
  transactional clear, immutable entity_type on conflict, the promote-rules learn step, min-support,
  strip_pattern round-trip, and a `promote-rules` Cobra-wiring test asserting it is **not** `mcp:read-only`.

## Documentation

README.md and SKILL.md updated: `normalize promote-rules` added to the Commands table, command list,
and both cookbooks (the export-unmatched → import → **promote-rules** → re-run learn loop is now
discoverable); `--fuzzy-threshold` and `--min-support` documented; MCP sections note
`normalize_promote_rules` / `normalize_recommend` are write tools (not read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
