### PR TITLE
fix(x-twitter): clarify bearer token auth

### DIFF
--- a/library/social-and-messaging/x-twitter/.printing-press-patches/x-twitter-auth-command-clarity.json
+++ b/library/social-and-messaging/x-twitter/.printing-press-patches/x-twitter-auth-command-clarity.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "x-twitter-auth-command-clarity",
+  "applied_at": "2026-06-08",
+  "base_run_id": "20260603-230951",
+  "base_printing_press_version": "4.20.1",
+  "summary": "Add explicit auth set-bearer-token command, deprecate ambiguous auth set-token, and clarify X auth lanes in README/SKILL.",
+  "reason": "X has three distinct auth lanes: app-only Bearer token, OAuth2 user-context token, and X Articles browser cookies. The prior auth set-token command wrote to access_token while app-only diagnostics expected bearer_token, making both humans and agents think bearer auth was configured when doctor still reported app_only_api missing.",
+  "files": [
+    "README.md",
+    "SKILL.md",
+    "internal/config/config.go",
+    "internal/cli/auth.go",
+    "internal/cli/auth_test.go"
+  ],
+  "validated_outcome": "Focused auth tests cover set-bearer-token storing bearer_token, deprecated set-token alias storing the same app-only field, preservation of OAuth2 user-context tokens, and JSON lane reporting."
+}

--- a/library/social-and-messaging/x-twitter/README.md
+++ b/library/social-and-messaging/x-twitter/README.md
@@ -127,17 +127,19 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 X auth has three separate lanes. Run `x-twitter-pp-cli doctor --json` and inspect `auth_lanes` before choosing a command; do not assume one credential can stand in for another.
 
-- `auth_lanes.app_only_api`: `X_BEARER_TOKEN`, the app-only bearer token from the X developer console. Use this for public reads such as post/user lookup, recent search, lists, and spaces.
-- `auth_lanes.oauth2_user_context`: `X_OAUTH2_USER_TOKEN` or a stored OAuth2 access token. Required for `/2/users/me`, writes, bookmarks, personal reads, DMs, follows, likes, reposts, and user-context analytics. If this lane is missing or invalid, do not retry with `X_BEARER_TOKEN`; get a real OAuth2 authorization-code + PKCE user token and set/import it explicitly.
+- `auth_lanes.app_only_api`: an app-only X API Bearer token from the X developer console. Use this for public read-only API access such as post/user lookup, recent search, lists, and spaces. Store it with `x-twitter-pp-cli auth set-bearer-token <token>` or export `X_BEARER_TOKEN`.
+- `auth_lanes.oauth2_user_context`: `X_OAUTH2_USER_TOKEN` or a stored OAuth2 access token imported with `x-twitter-pp-cli auth import-oauth2`. Required for `/2/users/me`, writes, bookmarks, personal reads, DMs, follows, likes, reposts, and user-context analytics. If this lane is missing or invalid, do not retry with the app-only bearer token; get a real OAuth2 authorization-code + PKCE user token and import it explicitly.
 - `auth_lanes.x_articles_cookie`: logged-in x.com browser cookies captured by `x-twitter-pp-cli auth login --chrome`. This lane is only for X Articles / x.com browser-session endpoints. It does not create `X_OAUTH2_USER_TOKEN` and does not authenticate v2 API user-context commands.
 
 Setup sequence:
 
 1. Attach the app to a Project in the X developer console (`console.x.com`). Any environment, including Development, unlocks v2 API access; standalone-app tokens are rejected.
 2. Set app permissions to Read and write when you need posting or other mutations.
-3. Copy the app Bearer Token into `X_BEARER_TOKEN` for app-only public reads.
-4. Enable OAuth2 with suitable scopes such as `tweet.read`, `tweet.write`, `users.read`, `offline.access`, and `bookmark.read` (required if you intend to sync or search bookmarks), complete the authorization-code + PKCE flow, and set the resulting user-context token in `X_OAUTH2_USER_TOKEN` or import it with `x-twitter-pp-cli auth import-oauth2 --access-token <token> --refresh-token <token> --scopes tweet.read,tweet.write,users.read,offline.access,bookmark.read`.
+3. Copy the app Bearer Token and run `x-twitter-pp-cli auth set-bearer-token <bearer-token>` for app-only public reads. Environment alternative: `export X_BEARER_TOKEN="<bearer-token>"`.
+4. Enable OAuth2 with suitable scopes such as `tweet.read`, `tweet.write`, `users.read`, `offline.access`, `bookmark.read`, `like.read`, `like.write`, `follows.read`, and `follows.write`, complete the authorization-code + PKCE flow, and import the resulting user-context token with `x-twitter-pp-cli auth import-oauth2 --access-token <oauth2-access-token> --refresh-token <oauth2-refresh-token> --scopes tweet.read,tweet.write,users.read,offline.access,bookmark.read,like.read,like.write,follows.read,follows.write`. Environment alternative: `export X_OAUTH2_USER_TOKEN="<oauth2-access-token>"`.
 5. Separately run `x-twitter-pp-cli auth login --chrome` only when using X Articles commands such as `articles-publish-md` or `articles ...` (needs `pycookiecheat` or `press-auth`; manual DevTools fallback is available).
+
+`auth set-token` is deprecated because “token” is ambiguous for X. It remains as a compatibility alias for `auth set-bearer-token` and must not be used for OAuth2 user-context tokens. Use `auth import-oauth2` for OAuth2.
 
 `doctor --json` is the machine-readable preflight. It reports `selected_profile`, per-lane status, `/2/users/me` probe results, authenticated user identity when returned, stored scopes, missing workflow scopes, token expiry, refresh-token presence, and X Articles cookie status without printing secrets.
 

--- a/library/social-and-messaging/x-twitter/SKILL.md
+++ b/library/social-and-messaging/x-twitter/SKILL.md
@@ -369,17 +369,19 @@ Splits the markdown into a numbered 280-char-packed self-reply thread and prints
 
 X auth has three separate lanes. Do not infer one lane from another; run `x-twitter-pp-cli doctor --json` and inspect `auth_lanes` before choosing a command.
 
-- `auth_lanes.app_only_api`: `X_BEARER_TOKEN`, the app-only bearer token from the X developer console. Use this for public reads such as tweet/user lookup, recent search, lists, and spaces.
-- `auth_lanes.oauth2_user_context`: `X_OAUTH2_USER_TOKEN` or a stored OAuth2 access token. Required for `/2/users/me`, writes, bookmarks, personal reads, DMs, follows, likes, reposts, and user-context analytics. If this lane is `missing` or `invalid`, do not retry with `X_BEARER_TOKEN`; get a real OAuth2 authorization-code + PKCE user token and set/import it explicitly.
+- `auth_lanes.app_only_api`: an app-only X API Bearer token from the X developer console. Use this for public read-only API access such as tweet/user lookup, recent search, lists, and spaces. Store it with `x-twitter-pp-cli auth set-bearer-token <token>` or export `X_BEARER_TOKEN`.
+- `auth_lanes.oauth2_user_context`: `X_OAUTH2_USER_TOKEN` or a stored OAuth2 access token imported with `x-twitter-pp-cli auth import-oauth2`. Required for `/2/users/me`, writes, bookmarks, personal reads, DMs, follows, likes, reposts, and user-context analytics. If this lane is `missing` or `invalid`, do not retry with the app-only bearer token; get a real OAuth2 authorization-code + PKCE user token and import it explicitly.
 - `auth_lanes.x_articles_cookie`: browser cookies captured by `x-twitter-pp-cli auth login --chrome`. This lane is only for X Articles / x.com browser-session endpoints. It does not create `X_OAUTH2_USER_TOKEN` and does not authenticate v2 API user-context commands.
 
 Setup sequence:
 
 1. Attach the app to a Project in the X developer console.
 2. Set app permissions to Read and write when you need posting or other mutations.
-3. Copy the app Bearer Token into `X_BEARER_TOKEN` for app-only public reads.
-4. Enable OAuth2 with suitable scopes such as `tweet.read`, `tweet.write`, `users.read`, `offline.access`, and `bookmark.read` (required if you intend to sync or search bookmarks), complete the authorization-code + PKCE flow, and set the resulting user-context token in `X_OAUTH2_USER_TOKEN` or import it with `x-twitter-pp-cli auth import-oauth2 --access-token <token> --refresh-token <token> --scopes tweet.read,tweet.write,users.read,offline.access,bookmark.read`.
+3. Copy the app Bearer Token and run `x-twitter-pp-cli auth set-bearer-token <bearer-token>` for app-only public reads. Environment alternative: set `X_BEARER_TOKEN` in your shell or runtime secret manager.
+4. Enable OAuth2 with suitable scopes such as `tweet.read`, `tweet.write`, `users.read`, `offline.access`, `bookmark.read`, `like.read`, `like.write`, `follows.read`, and `follows.write`, complete the authorization-code + PKCE flow, and import the resulting user-context token with `x-twitter-pp-cli auth import-oauth2 --access-token <oauth2-access-token> --refresh-token <oauth2-refresh-token> --scopes tweet.read,tweet.write,users.read,offline.access,bookmark.read,like.read,like.write,follows.read,follows.write`. Environment alternative: set `X_OAUTH2_USER_TOKEN` in your shell or runtime secret manager.
 5. Separately run `x-twitter-pp-cli auth login --chrome` only when using `articles ...` commands.
+
+`auth set-token` is deprecated because “token” is ambiguous for X. It remains as a compatibility alias for `auth set-bearer-token` and must not be used for OAuth2 user-context tokens. Use `auth import-oauth2` for OAuth2.
 
 `doctor --json` is the machine-readable preflight. It reports `selected_profile`, per-lane status, `/2/users/me` probe results, authenticated user identity when returned, stored scopes, missing workflow scopes, token expiry, refresh-token presence, and X Articles cookie status without printing secrets.
 

--- a/library/social-and-messaging/x-twitter/internal/cli/auth.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/auth.go
@@ -26,6 +26,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newXAuthLoginCmd(flags))
 	cmd.AddCommand(newAuthSetupCmd(flags))
 	cmd.AddCommand(newAuthStatusCmd(flags))
+	cmd.AddCommand(newAuthSetBearerTokenCmd(flags))
 	cmd.AddCommand(newAuthSetTokenCmd(flags))
 	cmd.AddCommand(newAuthImportOAuth2Cmd(flags))
 	cmd.AddCommand(newAuthLogoutCmd(flags))
@@ -138,13 +139,20 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 		Example: "  x-twitter-pp-cli auth setup\n  x-twitter-pp-cli auth setup --launch",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
-			fmt.Fprintln(w, "Get a key at: https://console.x.com/")
-			fmt.Fprintln(w, "  Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.")
+			fmt.Fprintln(w, "Get credentials at: https://console.x.com/")
 			fmt.Fprintln(w, "")
-			fmt.Fprintln(w, "Then set:")
-			fmt.Fprintln(w, "  export X_BEARER_TOKEN=\"<your-token>\"")
-			fmt.Fprintln(w, "  export X_OAUTH2_USER_TOKEN=\"<your-token>\"")
-			fmt.Fprintln(w, "  x-twitter-pp-cli auth set-token <token>")
+			fmt.Fprintln(w, "Auth lanes:")
+			fmt.Fprintln(w, "  1. App-only Bearer token: public read-only API access such as tweet/user lookup, recent search, lists, and spaces. Store it with `auth set-bearer-token` or set X_BEARER_TOKEN.")
+			fmt.Fprintln(w, "  2. OAuth2 user-context token: personal reads and writes such as /2/users/me, bookmarks, likes, follows, posting, replies, and owned metrics. Import it with `auth import-oauth2`.")
+			fmt.Fprintln(w, "  3. X Articles cookies: browser-cookie lane captured with `auth login --chrome` for article authoring workflows.")
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Recommended setup order:")
+			fmt.Fprintln(w, "  x-twitter-pp-cli auth set-bearer-token <bearer-token>")
+			fmt.Fprintln(w, "  x-twitter-pp-cli auth import-oauth2 --access-token <oauth2-access-token> --refresh-token <oauth2-refresh-token> --scopes tweet.read,tweet.write,users.read,offline.access,bookmark.read,like.read,like.write,follows.read,follows.write")
+			fmt.Fprintln(w, "  x-twitter-pp-cli auth login --chrome")
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Deprecated: `auth set-token` is kept as an alias for `auth set-bearer-token` only. Do not use it for OAuth2 user-context tokens.")
+			fmt.Fprintln(w, "Run `x-twitter-pp-cli doctor --json` to verify which lanes are configured and what each enables.")
 			if !launch {
 				return nil
 			}
@@ -215,10 +223,11 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			if !authed {
 				fmt.Fprintln(w, red("Not authenticated"))
 				fmt.Fprintln(w, "")
-				fmt.Fprintln(w, "Set your token:")
-				fmt.Fprintln(w, "  export X_BEARER_TOKEN=\"your-token-here\" # App-only Bearer token for public reads (tweet/user lookup, recent search, lists, spaces). Required minimum - nothing works without it. Get one at https://console.x.com/ (app, then Keys and Tokens, then Bearer Token).")
-				fmt.Fprintln(w, "  export X_OAUTH2_USER_TOKEN=\"your-token-here\" # OAuth2 user-context token for v2 writes and personal reads. Obtain via OAuth2 authorization-code + PKCE and set/import explicitly; auth login --chrome is cookie-only for X Articles.")
-				fmt.Fprintf(w, "  x-twitter-pp-cli auth set-token <token>\n")
+				fmt.Fprintln(w, "Set credentials:")
+				fmt.Fprintln(w, "  x-twitter-pp-cli auth set-bearer-token <bearer-token> # App-only Bearer token for public read-only API access: tweet/user lookup, recent search, lists, spaces. Alternative: export X_BEARER_TOKEN=\"your-token-here\".")
+				fmt.Fprintln(w, "  x-twitter-pp-cli auth import-oauth2 --access-token <oauth2-access-token> --refresh-token <oauth2-refresh-token> --scopes tweet.read,tweet.write,users.read,offline.access,bookmark.read,like.read,like.write,follows.read,follows.write # OAuth2 user-context for /2/users/me, bookmarks, likes, follows, writes, and owned metrics.")
+				fmt.Fprintln(w, "  x-twitter-pp-cli auth login --chrome # Optional browser-cookie lane for X Articles.")
+				fmt.Fprintln(w, "  x-twitter-pp-cli auth set-token <bearer-token> # Deprecated alias for set-bearer-token; do not use for OAuth2 user-context tokens.")
 				return authErr(fmt.Errorf("no credentials configured"))
 			}
 
@@ -230,38 +239,54 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 	}
 }
 
+func saveBearerToken(cmd *cobra.Command, flags *rootFlags, token string, deprecatedAlias bool) error {
+	cfg, err := config.Load(flags.configPath)
+	if err != nil {
+		return configErr(err)
+	}
+	if err := cfg.SaveBearerToken(token); err != nil {
+		return configErr(fmt.Errorf("saving bearer token: %w", err))
+	}
+
+	out := map[string]any{
+		"saved":       true,
+		"auth_lane":   "app_only_bearer",
+		"config_path": cfg.Path,
+	}
+	if deprecatedAlias {
+		out["deprecated_alias"] = "auth set-token is deprecated; use auth set-bearer-token for app-only Bearer tokens and auth import-oauth2 for user-context tokens"
+	}
+	if flags.asJSON {
+		return printJSONFiltered(cmd.OutOrStdout(), out, flags)
+	}
+	if deprecatedAlias {
+		fmt.Fprintln(cmd.OutOrStdout(), "Warning: `auth set-token` is deprecated. Use `auth set-bearer-token` for app-only Bearer tokens; use `auth import-oauth2` for OAuth2 user-context tokens.")
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Bearer token saved to %s\n", cfg.Path)
+	fmt.Fprintln(cmd.OutOrStdout(), "Run `x-twitter-pp-cli doctor --json` to verify the app-only API lane.")
+	return nil
+}
+
+func newAuthSetBearerTokenCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:     "set-bearer-token <token>",
+		Short:   "Save an app-only X API Bearer token for public read-only API access",
+		Example: "  x-twitter-pp-cli auth set-bearer-token YOUR_BEARER_TOKEN_HERE",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return saveBearerToken(cmd, flags, args[0], false)
+		},
+	}
+}
+
 func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "set-token <token>",
-		Short:   "Save an API token to the config file",
-		Example: "  x-twitter-pp-cli auth set-token YOUR_TOKEN_HERE",
+		Short:   "Deprecated alias for set-bearer-token; do not use for OAuth2 user-context tokens",
+		Example: "  x-twitter-pp-cli auth set-token YOUR_BEARER_TOKEN_HERE\n  # Deprecated: prefer `x-twitter-pp-cli auth set-bearer-token YOUR_BEARER_TOKEN_HERE`",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(flags.configPath)
-			if err != nil {
-				return configErr(err)
-			}
-
-			// Clear any legacy auth_header so AuthHeader() falls through to
-			// the newly-saved credential. Without this, a pre-existing
-			// auth_header value (common after regenerate) shadows the saved
-			// token and set-token silently has no effect. Silent clear (no
-			// log line): a masked-tail variant could leak token bytes through
-			// scripted dogfood that captures stderr.
-			cfg.AuthHeaderVal = ""
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
-				return configErr(fmt.Errorf("saving token: %w", err))
-			}
-
-			// JSON envelope: {saved, config_path}.
-			if flags.asJSON {
-				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
-					"saved":       true,
-					"config_path": cfg.Path,
-				}, flags)
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Token saved to %s\n", cfg.Path)
-			return nil
+			return saveBearerToken(cmd, flags, args[0], true)
 		},
 	}
 }

--- a/library/social-and-messaging/x-twitter/internal/cli/auth_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/auth_test.go
@@ -13,6 +13,117 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/internal/config"
 )
 
+func TestAuthSetBearerTokenStoresAppOnlyBearerField(t *testing.T) {
+	t.Setenv("X_BEARER_TOKEN", "")
+	t.Setenv("X_OAUTH2_USER_TOKEN", "")
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("access_token = \"old-ambiguous-token\"\noauth2_user_token = \"user-token\"\n"), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"auth", "set-bearer-token", "bearer-token",
+		"--json",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth set-bearer-token failed: %v\noutput: %s", err, out.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if payload["auth_lane"] != "app_only_bearer" || payload["saved"] != true {
+		t.Fatalf("payload = %#v", payload)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.XBearerToken != "bearer-token" {
+		t.Fatalf("bearer token not stored in bearer_token: %+v", cfg)
+	}
+	if cfg.AccessToken != "" {
+		t.Fatalf("ambiguous access_token should be cleared, got %q", cfg.AccessToken)
+	}
+	if cfg.XOauth2UserToken != "user-token" {
+		t.Fatalf("user-context token should be preserved, got %q", cfg.XOauth2UserToken)
+	}
+	if got := cfg.AppOnlyAuthHeader(); got != "Bearer bearer-token" {
+		t.Fatalf("AppOnlyAuthHeader() = %q", got)
+	}
+}
+
+func TestAuthSetTokenDeprecatedAliasStoresBearerField(t *testing.T) {
+	t.Setenv("X_BEARER_TOKEN", "")
+	t.Setenv("X_OAUTH2_USER_TOKEN", "")
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"auth", "set-token", "bearer-token",
+		"--json",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth set-token alias failed: %v\noutput: %s", err, out.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	msg, ok := payload["deprecated_alias"].(string)
+	if payload["auth_lane"] != "app_only_bearer" || !ok || msg == "" {
+		t.Fatalf("payload should identify app-only lane and deprecation: %#v", payload)
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.XBearerToken != "bearer-token" || cfg.AccessToken != "" {
+		t.Fatalf("set-token alias should write bearer_token, not access_token: %+v", cfg)
+	}
+}
+
+func TestAuthSetBearerTokenRejectsEmptyToken(t *testing.T) {
+	t.Setenv("X_BEARER_TOKEN", "")
+	t.Setenv("X_OAUTH2_USER_TOKEN", "")
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"auth", "set-bearer-token", "   ",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected whitespace-only bearer token to fail")
+	}
+	if !strings.Contains(err.Error(), "bearer token must not be empty") {
+		t.Fatalf("expected empty-token error, got %v", err)
+	}
+	if _, statErr := os.Stat(configPath); !os.IsNotExist(statErr) {
+		t.Fatalf("empty token should not write config file, stat err = %v", statErr)
+	}
+}
+
 func TestAuthImportOAuth2StoresUserContextMetadata(t *testing.T) {
 	t.Setenv("X_BEARER_TOKEN", "")
 	t.Setenv("X_OAUTH2_USER_TOKEN", "")

--- a/library/social-and-messaging/x-twitter/internal/config/config.go
+++ b/library/social-and-messaging/x-twitter/internal/config/config.go
@@ -208,6 +208,20 @@ func (c *Config) SaveOAuth2UserContext(accessToken, refreshToken string, expiry 
 	return c.save()
 }
 
+func (c *Config) SaveBearerToken(token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return fmt.Errorf("bearer token must not be empty")
+	}
+	c.AuthHeaderVal = ""
+	c.XBearerToken = token
+	// access_token is the legacy ambiguous field. Keep it empty so app-only
+	// doctor/status checks read the same bearer_token field AuthHeader() and
+	// AppOnlyAuthHeader() use for public app-only API reads.
+	c.AccessToken = ""
+	return c.save()
+}
+
 func (c *Config) ClearTokens() error {
 	// AuthHeader() falls back to the env-var-derived fields when AuthHeaderVal
 	// and AccessToken are empty, so dropping the working credential requires


### PR DESCRIPTION
## What

Fixes the confusing X auth setup path we just hit in dogfood:

- add explicit `x-twitter-pp-cli auth set-bearer-token <token>` for the app-only X API Bearer token
- make deprecated `auth set-token` a compatibility alias for `set-bearer-token`
- stop writing app-only bearer tokens into the ambiguous `access_token` field
- keep OAuth2 user-context setup on `auth import-oauth2`
- clarify README + SKILL auth guidance across the three X auth lanes:
  - app-only Bearer token: public read-only API access
  - OAuth2 user-context token: `/2/users/me`, bookmarks, likes/follows, writes, owned metrics
  - X Articles browser cookies: article/x.com browser-session workflows only
- record the generated-tree patch in `.printing-press-patches/`

## Why

`auth set-token <token>` was too ambiguous for X. In practice it wrote the Bearer token into `access_token`, while `doctor` checks the app-only lane through `bearer_token` / `X_BEARER_TOKEN`. Result: humans and agents could follow the CLI help and still see `app_only_api: missing`.

This PR makes the auth surface explicit and teaches agents which credential enables which lane, in which order, and why.

## Verification

From `library/social-and-messaging/x-twitter`:

```bash
go test ./internal/config ./internal/cli -run 'TestAuth(SetBearerToken|SetTokenDeprecatedAlias|ImportOAuth2)' -count=1
go test ./...
go build ./cmd/x-twitter-pp-cli
```

Smoke tested local binary with temp configs:

```bash
./x-twitter-pp-cli --config "$tmp/config.toml" auth set-bearer-token tk_bearer --json
# verified bearer_token=tk_bearer and access_token empty

./x-twitter-pp-cli --config "$tmp2/config.toml" auth set-token tk_alias --json
# verified deprecated alias writes bearer_token=tk_alias and access_token empty
```

Also checked:

```bash
git diff --check
./x-twitter-pp-cli auth set-bearer-token --help
./x-twitter-pp-cli auth set-token --help
```
