### PR TITLE
fix(dice-fm): consolidated 2026-06-08 whole-project review hardening

### DIFF
--- a/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-critical-pseudonymization-hardening.json
+++ b/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-critical-pseudonymization-hardening.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 2,
+  "id": "dice-fm-critical-pseudonymization-hardening",
+  "applied_at": "2026-06-09",
+  "base_run_id": "20260511-193451",
+  "base_printing_press_version": "4.12.0",
+  "summary": "MCP PII pseudonymization must cover flat mirrored command rows, keep the salt outside the queryable SQLite database, and omit dob even when raw PII is explicitly requested.",
+  "reason": "DICE's mirrored fan and door commands emit top-level identifier fields rather than nested fan/holder containers, and the sql tool can query local SQLite metadata; without these guards, raw identifiers or the pseudonymization salt can enter model context.",
+  "files": [
+    "internal/mcp/pseudonymize.go",
+    "internal/mcp/tools.go",
+    "internal/mcp/cobratree/postprocess.go",
+    "internal/mcp/cobratree/shellout.go",
+    "internal/mcp/mirrored_pii_test.go",
+    "internal/mcp/pseudonymize_test.go",
+    "internal/mcp/sql_scrub_test.go",
+    "internal/mcp/tools_test.go",
+    "internal/mcp/cobratree/shellout_test.go"
+  ],
+  "validated_outcome": "Flat door/fan JSON rows are pseudonymized by default, include_pii omits dob, SQL metadata exfiltration queries are rejected, and PII mirrored shell-outs are forced to JSON before post-processing."
+}

--- a/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-extras-mcp-pseudonymization.json
+++ b/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-extras-mcp-pseudonymization.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "dice-fm-extras-mcp-pseudonymization",
+  "applied_at": "2026-06-09",
+  "base_run_id": "20260511-193451",
+  "base_printing_press_version": "4.12.0",
+  "summary": "extras_list must use MCP-boundary pseudonymization by default with an include_pii opt-in because its GraphQL selection includes holder PII.",
+  "reason": "DICE extra payloads embed holder firstName, lastName, email, and phoneNumber via extraSelection; without wrapping this typed MCP tool, raw holder PII can enter MCP host/model context by default.",
+  "files": [
+    "internal/mcp/tools.go",
+    "internal/mcp/scrub_handler_test.go",
+    "README.md",
+    "SKILL.md"
+  ],
+  "validated_outcome": "extras_list GraphQL-shaped fixtures are scrubbed by default through pseudonymizeHandler, retain fan_ref tokens and non-PII extra fields, and return raw identifiers only with include_pii:true."
+}

--- a/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-greptile-pseudonymization-followups.json
+++ b/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-greptile-pseudonymization-followups.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "id": "dice-fm-greptile-pseudonymization-followups",
+  "applied_at": "2026-06-09",
+  "base_run_id": "20260511-193451",
+  "base_printing_press_version": "4.12.0",
+  "summary": "MCP pseudonymization tokens use 64 bits of HMAC output, flat person-name redaction is documented accurately, and salt lookup reads the sidecar without opening or migrating SQLite.",
+  "reason": "DICE-scale fan bases need a wider ephemeral fan_ref token to avoid collisions, and pseudonymized MCP read paths should not pay store migration cost just to resolve the per-store salt.",
+  "files": [
+    "internal/mcp/pseudonymize.go",
+    "internal/mcp/tools.go",
+    "internal/mcp/pseudonymize_test.go",
+    "internal/mcp/tools_test.go",
+    "internal/mcp/mirrored_pii_test.go",
+    "README.md",
+    "SKILL.md"
+  ],
+  "validated_outcome": "go build ./... && go vet ./... && go test ./... && go test -race ./... all pass."
+}

--- a/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-greptile-pseudonymize-review-fixes.json
+++ b/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-greptile-pseudonymize-review-fixes.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "dice-fm-greptile-pseudonymize-review-fixes",
+  "applied_at": "2026-06-09",
+  "base_run_id": "20260511-193451",
+  "base_printing_press_version": "4.12.0",
+  "summary": "Keep MCP pseudonymization fan_ref tokens stable across nested fan/holder containers and flat rows, and refuse malformed salt sidecars instead of silently rotating tokens.",
+  "reason": "Greptile found that nested fan containers could seed fan_ref from a different key than flat PII rows and that wrong-length salt files were overwritten without warning. Both failures break the MCP privacy boundary's stable-linking guarantee for DICE fan data.",
+  "files": [
+    "internal/mcp/pseudonymize.go",
+    "internal/mcp/tools.go",
+    "internal/mcp/pseudonymize_test.go"
+  ],
+  "validated_outcome": "go build ./..., go vet ./..., go test ./..., and go test -race ./... all pass locally."
+}

--- a/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-residual-pii-leak-hardening.json
+++ b/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-residual-pii-leak-hardening.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "dice-fm-residual-pii-leak-hardening",
+  "applied_at": "2026-06-09",
+  "base_run_id": "20260511-193451",
+  "base_printing_press_version": "4.12.0",
+  "summary": "MCP pseudonymization must fail closed on non-JSON mirrored PII output, ignore inherited format overrides for mirrored PII commands, and redact direct identifier columns even when email/id token seeds are absent.",
+  "reason": "MCP clients can pass inherited csv/plain/quiet flags to mirrored commands, and DICE door/search/sql rows can contain only names or phones; without layered guards those default paths can emit raw identifiers into model context.",
+  "files": [
+    "internal/cli/helpers.go",
+    "internal/mcp/tools.go",
+    "internal/mcp/pseudonymize.go",
+    "internal/mcp/cobratree/shellout.go"
+  ]
+}

--- a/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-returns-transfers-mcp-pseudonymization.json
+++ b/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-returns-transfers-mcp-pseudonymization.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "dice-fm-returns-transfers-mcp-pseudonymization",
+  "applied_at": "2026-06-09",
+  "base_run_id": "20260511-193451",
+  "base_printing_press_version": "4.12.0",
+  "summary": "returns_list and transfers_list must use the same MCP-boundary pseudonymization defaults and include_pii opt-in as the other PII-bearing typed tools.",
+  "reason": "DICE return and transfer payloads can carry linked ticket holder and order fan identifiers; without wrapping these tools, holder and buyer PII can enter MCP host/model context by default.",
+  "files": [
+    "internal/mcp/tools.go",
+    "internal/mcp/scrub_handler_test.go",
+    "README.md",
+    "SKILL.md"
+  ],
+  "validated_outcome": "returns_list and transfers_list GraphQL-shaped fixtures are scrubbed by default through pseudonymizeHandler, retain fan_ref tokens, and return raw identifiers only with include_pii:true."
+}

--- a/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-review-hardening.json
+++ b/library/media-and-entertainment/dice-fm/.printing-press-patches/dice-fm-review-hardening.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 2,
+  "id": "dice-fm-review-hardening",
+  "date": "2026-06-08",
+  "amend_run_id": "amend-2026-06-08-review-hardening",
+  "summary": "fix(dice-fm): consolidated 2026-06-08 whole-project review hardening — correctness (race-safe test isolation + output flags, revenue paid-total basis, sync fan-loss gate), an FTS rework (content minimization + collision-free key + v3 rebuild), data minimization (drop dob), an MCP-boundary pseudonymization layer (salted HMAC fan_ref token with include_pii opt-in), and egress/perms hardening (deliver webhook https-only + SSRF deny, least-privilege file/db/cache perms, feedback https-only, MCP canonical config path), plus nits",
+  "reason": "An all-three (code/security/privacy) whole-project peer review of dice-fm at post-#1109 main surfaced a P0 test-integrity issue, several correctness defects, a privacy gap (raw fan PII reaching the MCP/model context — dice-fm is frequently agent-driven), and egress/perms hardening items. These are CLI-specific hardening of an API-specific value-add (DICE fan/ticket/revenue analytics + the local store + the MCP surface), not generator gaps. The headline is a pseudonymization layer applied at the MCP output boundary only: the human CLI stays raw, but agent/MCP use replaces buyer/holder email/phone/name with a deterministic salted HMAC fan_ref token (include_pii opts back in to raw).",
+  "files": [
+    "internal/cli/root.go",
+    "internal/cli/helpers.go",
+    "internal/cli/sync.go",
+    "internal/cli/dice_revenue.go",
+    "internal/cli/dice_query.go",
+    "internal/cli/dice_capacity.go",
+    "internal/cli/analytics.go",
+    "internal/cli/deliver.go",
+    "internal/cli/feedback.go",
+    "internal/cli/import.go",
+    "internal/store/store.go",
+    "internal/client/client.go",
+    "internal/cache/cache.go",
+    "internal/mcp/tools.go",
+    "internal/mcp/pseudonymize.go",
+    "internal/mcp/cobratree/postprocess.go",
+    "internal/mcp/cobratree/shellout.go",
+    "internal/mcp/cobratree/walker.go",
+    "scripts/test-race.sh",
+    "README.md",
+    "SKILL.md"
+  ],
+  "findings_addressed": ["P0-1", "P1-2", "P1-3", "P1-4", "P1-5", "P1-6", "P1-7", "P2-8", "P2-10", "P3-12", "P3-13", "P3-14", "P3-15", "P3-16", "P3-17", "P3-18", "P3-19"],
+  "validated_outcome": "go build ./... && go vet ./... clean; full go test ./... green; FULL go test -race ./... green across all packages in ~12s (was a 600s timeout on origin/main — the P0). The -race timeout was diagnosed (verify-the-reviewer) NOT as a literal data race but as a test (TestRevenueSummaryByAxisWithFiltersSucceeds) opening the operator's real ~70k-row default-path store; isolated to a temp store. The package-global output flags (--no-color/--human-friendly) were additionally moved off mutable package state onto rootFlags + atomics as defense against a latent race. New tests cover: store isolation, parallel-Execute output-flag race regression, revenue paid-total basis (scoped == unscoped), sync fan-write error surfacing + cursor gating, meta table round-trip, FTS content-PII exclusion + collision-free key + v2->v3 rebuild, the pseudonymizer (token determinism/salt isolation/scrub default+include_pii/nested/blob), tickets_list/orders_list/search/sql/mirrored-fans scrubbing, deliver webhook https+SSRF+perms, feedback https, MCP config.json resolution, import hidden, analytics dotted group-by. `publish validate` in-scope checks pass (manifest, transcendence, phase5, go mod tidy, go vet, go build, --help, --version, manuscripts); two failing checks are PRE-EXISTING on pristine origin/main and unrelated to this diff: (1) govulncheck flags two go1.26.3 stdlib advisories (net/textproto GO-2026-5039, crypto/x509 GO-2026-5037, both fixed in go1.26.4) reached via cliutil/probe.go + store.ResolveByName — neither file/line is in this diff; (2) verify-skill reports SKILL.md install-section drift in a GENERATOR-OWNED section this diff does not touch (this diff edits only the MCP cookbook, Output Delivery, and feedback sections). Both are repo-level toolchain-bump + SKILL-regen items, out of scope for this PR (trust CI per the #1109 lesson).",
+  "notes": "Schema bumped to v3 (meta table + FTS rebuild) in the existing pinned-conn BEGIN IMMEDIATE migration. Pseudonymization is MCP-boundary only (cobratree gained a generic output post-processor + extra-tool-option + description-suffix registry so the mcp package can register the scrubber without cobratree importing it); the CLI command surface is unchanged (no redaction flag added to commands — redaction is an MCP-output concern). dob removed from fanSelection (existing stores keep stale dob in resources.data until re-sync; the v3 FTS rebuild drops it from the index immediately). sql scrubbing is best-effort (flat known-PII columns + recursive JSON-cell scrub) with a description warning that aliased/computed PII may slip through. --deliver webhook is https-only + denies RFC-1918/loopback/link-local/metadata IPs unless --allow-private-webhook, with a stderr audit; deliver is MCP-blocked (added allow-private-webhook to cobratree blockedRootFlags too). OUT OF SCOPE by design: #9 erasure/retention (fans forget / age-out) — a feature, deliberately deferred. Source findings: docs/agent-reviews/2026-06-08-dice-fm-whole-project-peer-reviews.md; spec: dice-fm-review-hardening-design.md (foundry 0eccf2eb); plan: 2026-06-08-dice-fm-review-hardening.md.",
+  "deferred_to_upstream": [
+    {
+      "feature": "A `go test -race ./...` CI gate for printed CLIs (and a test convention that command-executing tests must use an isolated --db/$HOME, never the real default-path store).",
+      "reason": "The public library CI is generator/library-owned; a per-CLI -race step can't be added, so this CLI ships a local scripts/test-race.sh as the equivalent. The default-path-store test-isolation pitfall is a generator-template-shaped issue (the transcendence-command test scaffold should isolate the store)."
+    }
+  ]
+}

--- a/library/media-and-entertainment/dice-fm/README.md
+++ b/library/media-and-entertainment/dice-fm/README.md
@@ -276,7 +276,6 @@ Run `dice-fm-pp-cli <command> --help` for the full flag list on any command.
 | `analytics` | Run analytics queries on locally synced data |
 | `tail` | Stream live changes by polling the API at intervals |
 | `doctor` | Check auth, config, and connectivity |
-| `import` | Import data from a JSONL file via API create/upsert calls |
 
 ## Output Formats
 
@@ -305,6 +304,24 @@ dice-fm-pp-cli events list --dry-run
 # Agent mode — JSON + compact + no prompts in one flag
 dice-fm-pp-cli events list --agent
 ```
+
+### Routing output with `--deliver`
+
+Any command's output can be routed to a sink instead of (alongside) stdout:
+
+```bash
+# Write to a file (atomically; created dirs are 0700, file 0600)
+dice-fm-pp-cli revenue summary --json --deliver file:/tmp/revenue.json
+
+# POST to a webhook (https only)
+dice-fm-pp-cli revenue summary --json --deliver webhook:https://hooks.example.com/dice
+```
+
+Webhook delivery is hardened because command output can contain personal data:
+
+- **https only** — cleartext `http://` is refused.
+- **SSRF guard** — a webhook host that resolves to a private (RFC-1918), loopback, link-local, or cloud-metadata (`169.254.169.254`) address is refused. Pass **`--allow-private-webhook`** to opt in for a trusted internal endpoint.
+- **Audit** — a one-line `delivered N bytes to <host>` is written to stderr on success.
 
 ## Cookbook
 
@@ -379,6 +396,12 @@ Install `dice-fm-pp-mcp` (see **MCP Server Installation** in `SKILL.md`), then c
 | Normalized coverage by axis | `normalize_stats` | `{ "entity": "ticket_type" }` |
 
 `normalize` itself writes the local store, so it is exposed as a write tool (no read-only hint) — run it from the CLI or invoke it deliberately. `normalize_recommend` and `normalize_promote_rules` are likewise write tools; run them deliberately or from the CLI. Custom SQL is intentionally out of scope for this cookbook.
+
+#### Personal data is pseudonymized in MCP output
+
+The MCP surface is privacy-aware. Tools that can return fan/holder personal data — `tickets_list`, `orders_list`, `returns_list`, `transfers_list`, `extras_list`, `search`, `sql`, and the mirrored `fans *` / `door list` tools — **pseudonymize by default**: buyer/holder `email`, `phone`, and name fields are replaced with a stable `fan_ref` token (e.g. `"fan_ref": "fan:1a2b3c4d5e6f708192"`) and `dob` is omitted. The token is deterministic per fan, so an agent can still dedup and correlate the same person across calls without ever pulling a raw identifier into the model context. Each of these tools accepts **`include_pii: true`** to return the raw values *and* the token when an operator explicitly needs them. Each tool's description carries a "returns personal data" notice so an MCP host can gate auto-approval.
+
+> The **CLI stays raw** — this is your own terminal. Pseudonymization applies only at the MCP boundary, where output flows into an agent/model context. `sql` scrubbing is best-effort (known PII columns + JSON `data` cells); PII surfaced through a column alias or computed expression may slip through — prefer the typed tools or `search`.
 
 ## Agent Usage
 

--- a/library/media-and-entertainment/dice-fm/SKILL.md
+++ b/library/media-and-entertainment/dice-fm/SKILL.md
@@ -266,6 +266,8 @@ After installing `dice-fm-pp-mcp` (see **MCP Server Installation** below), call 
 
 These (plus the eight typed `*_list` / `events_get` resource tools) are read-only. `normalize` writes the local store, and `normalize_promote_rules` is a write tool when writing promoted rules, so call them from the CLI or invoke them deliberately. Custom SQL is out of scope here.
 
+**Personal data is pseudonymized by default.** Tools that can return fan/holder PII — `tickets_list`, `orders_list`, `returns_list`, `transfers_list`, `extras_list`, `search`, `sql`, and the mirrored `fans_top` / `fans_profile` / `fans_optin` / `fans_repeat` / `fans_segment` / `door_list` — replace buyer/holder `email`, `phone`, and name with a stable `fan_ref` token (e.g. `fan:1a2b3c4d5e6f708192`) and omit `dob`. The token is deterministic per fan, so you can dedup/correlate the same person across calls without raw identifiers entering the model context. Pass `include_pii: true` on any of these to get raw values **plus** the token. The plain CLI is unaffected — it always emits raw output to the operator's terminal. `sql` redaction is best-effort (known PII columns + nested JSON `data` cells); a column alias or computed expression can slip past it, so prefer the typed tools or `search` when you need a guarantee.
+
 ## Auth Setup
 
 Requires a Bearer token from MIO (DICE.FM AMP). Set DICE_FM_TOKEN in your environment. All commands are read-only — no writes to the DICE platform.
@@ -310,7 +312,7 @@ dice-fm-pp-cli feedback --stdin < notes.txt
 dice-fm-pp-cli feedback list --json --limit 10
 ```
 
-Entries are stored locally at `~/.dice-fm-pp-cli/feedback.jsonl`. They are never POSTed unless `DICE_FM_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `DICE_FM_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+Entries are stored locally at `~/.dice-fm-pp-cli/feedback.jsonl`. They are never POSTed unless `DICE_FM_FEEDBACK_ENDPOINT` is set (must be `https://`) AND either `--send` is passed or `DICE_FM_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
 
 Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
 
@@ -321,10 +323,18 @@ Every command accepts `--deliver <sink>`. The output goes to the named sink in a
 | Sink | Effect |
 |------|--------|
 | `stdout` | Default; write to stdout only |
-| `file:<path>` | Atomically write output to `<path>` (tmp + rename) |
+| `file:<path>` | Atomically write output to `<path>` (tmp + rename; created dirs `0700`, file `0600`) |
 | `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
 
 Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
+
+Webhook delivery is hardened because command output can carry personal data:
+
+- **https only** — cleartext `http://` is refused.
+- **SSRF guard** — a host that resolves to a private (RFC-1918), loopback, link-local, or cloud-metadata (`169.254.169.254`) address is refused unless you pass `--allow-private-webhook` (opt-in for a trusted internal endpoint).
+- **Audit** — a `delivered N bytes to <host>` line is written to stderr on success.
+
+`--deliver` is blocked on the MCP surface, so an agent cannot use it to exfiltrate output; it is a human/CLI feature.
 
 ## Named Profiles
 

--- a/library/media-and-entertainment/dice-fm/internal/cache/cache.go
+++ b/library/media-and-entertainment/dice-fm/internal/cache/cache.go
@@ -44,8 +44,10 @@ func (s *Store) Get(key string) (json.RawMessage, bool) {
 
 // Set stores a value in the cache.
 func (s *Store) Set(key string, value json.RawMessage) {
-	_ = os.MkdirAll(s.Dir, 0o755)
-	_ = os.WriteFile(s.path(key), []byte(value), 0o644)
+	// 0700/0600: posture-consistency least-privilege for the CLI's on-disk
+	// footprint (matches the PII store's perms).
+	_ = os.MkdirAll(s.Dir, 0o700)
+	_ = os.WriteFile(s.path(key), []byte(value), 0o600)
 }
 
 // Clear removes all cached entries.

--- a/library/media-and-entertainment/dice-fm/internal/cli/analytics.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/analytics.go
@@ -87,11 +87,37 @@ Data must be synced first with the sync command.`,
 	}
 
 	cmd.Flags().StringVar(&resourceType, "type", "", "Resource type to analyze")
-	cmd.Flags().StringVar(&groupBy, "group-by", "", "Field to group by")
+	cmd.Flags().StringVar(&groupBy, "group-by", "", "Field to group by; supports dotted paths into nested objects (e.g. ticketType.name)")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max groups to show")
 
 	return cmd
+}
+
+// resolveDottedField resolves a possibly-dotted field path against a decoded
+// JSON object, descending through nested objects (e.g. "ticketType.name").
+// Returns nil if any segment is missing or a non-terminal segment is not an
+// object. A field with no dot resolves a top-level key (back-compat).
+func resolveDottedField(obj map[string]any, field string) any {
+	cur := any(obj)
+	start := 0
+	for i := 0; i <= len(field); i++ {
+		if i < len(field) && field[i] != '.' {
+			continue
+		}
+		seg := field[start:i]
+		start = i + 1
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		v, ok := m[seg]
+		if !ok {
+			return nil
+		}
+		cur = v
+	}
+	return cur
 }
 
 func runGroupBy(db *store.Store, resourceType, field string, limit int, flags *rootFlags) error {
@@ -106,7 +132,7 @@ func runGroupBy(db *store.Store, resourceType, field string, limit int, flags *r
 		if err := json.Unmarshal(item, &obj); err != nil {
 			continue
 		}
-		val := fmt.Sprintf("%v", obj[field])
+		val := fmt.Sprintf("%v", resolveDottedField(obj, field))
 		counts[val]++
 	}
 

--- a/library/media-and-entertainment/dice-fm/internal/cli/analytics_groupby_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/analytics_groupby_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Test for analytics --group-by dotted-path support (review nit #15): a dotted
+// field like ticketType.name must resolve the nested value, not bucket all rows
+// under <nil>. Synthetic fixtures only.
+package cli
+
+import "testing"
+
+func TestResolveDottedFieldTopLevel(t *testing.T) {
+	obj := map[string]any{"state": "on_sale", "id": "e1"}
+	if got := resolveDottedField(obj, "state"); got != "on_sale" {
+		t.Errorf("top-level resolve = %v, want on_sale", got)
+	}
+}
+
+func TestResolveDottedFieldNested(t *testing.T) {
+	obj := map[string]any{
+		"id": "tk1",
+		"ticketType": map[string]any{
+			"name":  "General Admission",
+			"price": float64(2500),
+		},
+	}
+	if got := resolveDottedField(obj, "ticketType.name"); got != "General Admission" {
+		t.Errorf("nested resolve = %v, want 'General Admission'", got)
+	}
+	if got := resolveDottedField(obj, "ticketType.price"); got != float64(2500) {
+		t.Errorf("nested numeric resolve = %v, want 2500", got)
+	}
+}
+
+func TestResolveDottedFieldMissing(t *testing.T) {
+	obj := map[string]any{"id": "x"}
+	if got := resolveDottedField(obj, "ticketType.name"); got != nil {
+		t.Errorf("missing nested path = %v, want nil", got)
+	}
+	if got := resolveDottedField(obj, "absent"); got != nil {
+		t.Errorf("missing top-level = %v, want nil", got)
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/cli/deliver.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/deliver.go
@@ -6,7 +6,9 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,8 +47,12 @@ func ParseDeliverSink(spec string) (DeliverSink, error) {
 			return DeliverSink{}, fmt.Errorf("--deliver file:<path> requires a path")
 		}
 	case "webhook":
-		if !strings.HasPrefix(target, "http://") && !strings.HasPrefix(target, "https://") {
-			return DeliverSink{}, fmt.Errorf("--deliver webhook:<url> requires an http:// or https:// URL, got %q", target)
+		// https-only: command output may carry fan PII; refuse cleartext.
+		if strings.HasPrefix(target, "http://") {
+			return DeliverSink{}, fmt.Errorf("--deliver webhook:<url> requires https:// (cleartext http:// is refused — command output may contain personal data), got %q", target)
+		}
+		if !strings.HasPrefix(target, "https://") {
+			return DeliverSink{}, fmt.Errorf("--deliver webhook:<url> requires an https:// URL, got %q", target)
 		}
 	default:
 		return DeliverSink{}, fmt.Errorf("unknown --deliver scheme %q (supported: stdout, file, webhook)", scheme)
@@ -57,14 +63,19 @@ func ParseDeliverSink(spec string) (DeliverSink, error) {
 // Deliver routes a captured output buffer to the configured sink. stdout
 // is a no-op because the buffer has already been streamed to stdout via
 // the MultiWriter set up in root.go.
-func Deliver(sink DeliverSink, body []byte, compact bool) error {
+//
+// allowPrivate gates the webhook SSRF guard: when false (default), a webhook
+// host that resolves to a private/loopback/link-local/metadata address is
+// refused. The operator opts in with --allow-private-webhook for a trusted
+// internal endpoint.
+func Deliver(sink DeliverSink, body []byte, compact bool, allowPrivate bool) error {
 	switch sink.Scheme {
 	case "", "stdout":
 		return nil
 	case "file":
 		return deliverFile(sink.Target, body)
 	case "webhook":
-		return deliverWebhook(sink.Target, body, compact)
+		return deliverWebhook(sink.Target, body, compact, allowPrivate)
 	default:
 		return fmt.Errorf("unsupported deliver sink %q", sink.Scheme)
 	}
@@ -75,7 +86,9 @@ func deliverFile(path string, body []byte) error {
 	// file if the process is interrupted mid-write.
 	dir := filepath.Dir(path)
 	if dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		// 0700: delivered output may contain personal data — don't create
+		// world/group-traversable directories.
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return fmt.Errorf("creating deliver dir: %w", err)
 		}
 	}
@@ -89,12 +102,29 @@ func deliverFile(path string, body []byte) error {
 	return nil
 }
 
-func deliverWebhook(url string, body []byte, compact bool) error {
+func deliverWebhook(rawURL string, body []byte, compact bool, allowPrivate bool) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parsing webhook URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("webhook requires https:// (got %q)", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("webhook URL has no host")
+	}
+	if !allowPrivate {
+		if err := denyPrivateWebhookHost(host); err != nil {
+			return err
+		}
+	}
+
 	contentType := "application/json"
 	if compact {
 		contentType = "application/x-ndjson"
 	}
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, rawURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("building webhook request: %w", err)
 	}
@@ -110,5 +140,47 @@ func deliverWebhook(url string, body []byte, compact bool) error {
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("webhook returned %s", resp.Status)
 	}
+	// One-line stderr audit so an exfil to an unexpected host is observable.
+	fmt.Fprintf(os.Stderr, "delivered %d bytes to %s\n", len(body), host)
 	return nil
+}
+
+// denyPrivateWebhookHost resolves host and rejects it if ANY resolved IP is
+// private (RFC-1918), loopback, link-local (incl. the 169.254.169.254 cloud
+// metadata endpoint), unique-local IPv6, or unspecified. This is an SSRF guard:
+// command output may carry fan PII, so a webhook must not be coaxed into POSTing
+// it to an internal service or the metadata API. Rejecting on ANY private IP
+// (not just the first) blocks DNS-rebinding-style multi-record tricks at
+// validation time. (Note: a TOCTOU window remains between this resolve and the
+// client's own resolve; a full fix would pin the dialer to the validated IP —
+// out of scope here, and --deliver is human-surface only, MCP-blocked.)
+func denyPrivateWebhookHost(host string) error {
+	// A bare IP literal is checked directly.
+	if ip := net.ParseIP(host); ip != nil {
+		if isDisallowedIP(ip) {
+			return fmt.Errorf("webhook host %q resolves to a private/loopback/link-local/metadata address; pass --allow-private-webhook to override", host)
+		}
+		return nil
+	}
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return fmt.Errorf("resolving webhook host %q: %w", host, err)
+	}
+	for _, ip := range ips {
+		if isDisallowedIP(ip) {
+			return fmt.Errorf("webhook host %q resolves to a private/loopback/link-local/metadata address (%s); pass --allow-private-webhook to override", host, ip)
+		}
+	}
+	return nil
+}
+
+// isDisallowedIP reports whether ip is in a range a webhook must not reach by
+// default: loopback, private (RFC-1918 / ULA), link-local (incl. the cloud
+// metadata 169.254.169.254), or the unspecified address.
+func isDisallowedIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified()
 }

--- a/library/media-and-entertainment/dice-fm/internal/cli/deliver_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/deliver_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Tests for --deliver hardening (Task 15/16): webhook https-only + SSRF deny +
+// audit; deliver-file dir perms 0700.
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestParseDeliverSinkRejectsHTTPWebhook(t *testing.T) {
+	if _, err := ParseDeliverSink("webhook:http://example.com/hook"); err == nil {
+		t.Errorf("ParseDeliverSink accepted cleartext http:// webhook; want rejection")
+	}
+	if _, err := ParseDeliverSink("webhook:https://example.com/hook"); err != nil {
+		t.Errorf("ParseDeliverSink rejected a valid https:// webhook: %v", err)
+	}
+}
+
+func TestDenyPrivateWebhookHost(t *testing.T) {
+	denied := []string{
+		"127.0.0.1",       // loopback
+		"10.0.0.1",        // RFC-1918
+		"192.168.1.1",     // RFC-1918
+		"172.16.0.1",      // RFC-1918
+		"169.254.169.254", // link-local / cloud metadata
+		"0.0.0.0",         // unspecified
+		"localhost",       // resolves to loopback
+	}
+	for _, h := range denied {
+		if err := denyPrivateWebhookHost(h); err == nil {
+			t.Errorf("denyPrivateWebhookHost(%q) = nil, want rejection", h)
+		}
+	}
+	// A public IP literal must pass.
+	if err := denyPrivateWebhookHost("93.184.216.34"); err != nil {
+		t.Errorf("denyPrivateWebhookHost(public IP) = %v, want nil", err)
+	}
+}
+
+func TestDeliverWebhookRejectsPrivateUnlessAllowed(t *testing.T) {
+	// Spin a loopback test server; webhook to it must be rejected by default.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	// srv.URL is http://127.0.0.1:PORT — rewrite scheme to https for the
+	// scheme gate, but the host is loopback so SSRF deny fires first.
+	httpsURL := strings.Replace(srv.URL, "http://", "https://", 1)
+
+	if err := deliverWebhook(httpsURL, []byte(`{}`), false, false); err == nil {
+		t.Errorf("deliverWebhook to loopback (allowPrivate=false) = nil, want SSRF rejection")
+	}
+}
+
+func TestDeliverWebhookAcceptsPublicAndAudits(t *testing.T) {
+	// allowPrivate=true lets the loopback test server through so we can verify
+	// the success path emits the stderr audit line.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	httpsURL := strings.Replace(srv.URL, "http://", "https://", 1)
+
+	// Capture stderr.
+	oldStderr := os.Stderr
+	rPipe, wPipe, _ := os.Pipe()
+	os.Stderr = wPipe
+
+	// httptest server is plain HTTP; force the client to accept by using the
+	// http scheme via allowPrivate path won't validate TLS. Since deliverWebhook
+	// hard-requires https scheme, point at the https-rewritten URL but the
+	// underlying server is http — the POST will fail TLS. So instead assert the
+	// audit by exercising denyPrivateWebhookHost passing + scheme gate via a
+	// public-shaped hostname is impractical in a unit test. We instead assert
+	// that with allowPrivate=true the SSRF guard is bypassed (no "private
+	// address" error), accepting a transport error.
+	err := deliverWebhook(httpsURL, []byte(`{}`), false, true)
+
+	wPipe.Close()
+	os.Stderr = oldStderr
+	buf := make([]byte, 4096)
+	n, _ := rPipe.Read(buf)
+	stderr := string(buf[:n])
+
+	if err != nil && strings.Contains(err.Error(), "private/loopback") {
+		t.Errorf("allowPrivate=true should bypass the SSRF guard, got: %v", err)
+	}
+	// On a successful (or TLS-failed) call the audit line only prints on success;
+	// just assert no SSRF rejection leaked into stderr.
+	if strings.Contains(stderr, "private/loopback") {
+		t.Errorf("unexpected SSRF rejection in stderr: %q", stderr)
+	}
+}
+
+func TestDeliverFileDirPerms0700(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX perms not applicable on Windows")
+	}
+	base := t.TempDir()
+	nested := filepath.Join(base, "deliver-out", "sub")
+	target := filepath.Join(nested, "data.json")
+
+	if err := deliverFile(target, []byte(`{"ok":true}`)); err != nil {
+		t.Fatalf("deliverFile: %v", err)
+	}
+	info, err := os.Stat(nested)
+	if err != nil {
+		t.Fatalf("stat created dir: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("created deliver dir perm = %o, want 0700", perm)
+	}
+	// File itself is 0600.
+	finfo, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if perm := finfo.Mode().Perm(); perm != 0o600 {
+		t.Errorf("deliver file perm = %o, want 0600", perm)
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/cli/dice_capacity.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/dice_capacity.go
@@ -50,6 +50,11 @@ type storeTicketPool struct {
 // the [from, to] inclusive show-date window (YYYY-MM-DD). The second return is
 // false when no window is set (both bounds empty), meaning "do not filter by
 // date". Comparison is on the date prefix, correct for ISO-8601 timestamps.
+//
+// NOTE — bound semantics differ from sync by design: the analytics --to here is
+// INCLUSIVE ("shows on or before <to>"), whereas sync's --events-to is EXCLUSIVE
+// (it maps to the API's date filter). Both are documented in their respective
+// --help; keep them in sync if either changes.
 func eligibleEventsByDate(ctx context.Context, db *sql.DB, from, to string) (map[string]bool, bool, error) {
 	if from == "" && to == "" {
 		return nil, false, nil

--- a/library/media-and-entertainment/dice-fm/internal/cli/dice_fans_segment_axis_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/dice_fans_segment_axis_test.go
@@ -297,7 +297,12 @@ func TestFansSegmentAxisNoopWhenNoCrosswalk(t *testing.T) {
 // TestFansSegmentAxisNoCrosswalkWarnOnCmd verifies the newFansSegmentCmd warns
 // to stderr when axis flags are used but normalization has not been run.
 func TestFansSegmentAxisNoCrosswalkWarnOnCmd(t *testing.T) {
-	// Use dry-run to bypass the store open, so we just test flag acceptance.
+	// Isolate from the operator's real default-path store. The --dry-run flag is
+	// never actually passed in SetArgs below, so without a $HOME override the
+	// command would open ~/.local/share/dice-fm-pp-cli/data.db. A temp $HOME
+	// yields no data.db, so the store open is a graceful no-op and this stays a
+	// pure flag-acceptance test.
+	t.Setenv("HOME", t.TempDir())
 	flags := &rootFlags{dryRun: true}
 	root := newRootCmd(flags)
 	var outBuf, errBuf bytes.Buffer

--- a/library/media-and-entertainment/dice-fm/internal/cli/dice_query.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/dice_query.go
@@ -30,7 +30,10 @@ const (
 		ticketPools { id name allocation }
 		socialLinks { campaign default url }`
 
-	fanSelection = `id firstName lastName email dob phoneNumber optInPartners`
+	// dob intentionally NOT selected: it was collected + stored but never read
+	// by any command/analytic/MCP tool (data minimization — GDPR Art. 5(1)(c)).
+	// Existing stores keep stale dob in resources.data until re-sync ages it out.
+	fanSelection = `id firstName lastName email phoneNumber optInPartners`
 
 	ticketSelection = `id code fullPrice commission diceCommission total claimedAt
 		holder { ` + fanSelection + ` }
@@ -123,11 +126,14 @@ func buildConnectionQuery(cs connectionSpec, latest bool) string {
 		whereArg = ", where: $where"
 	}
 	if latest {
+		// No pageInfo selection: viewerConnectionPage only parses the forward
+		// hasNextPage/endCursor fields, and --latest-only caps at a single
+		// backward page, so a backward pageInfo { hasPreviousPage startCursor }
+		// was dead — selected but never read. Drop it.
 		return fmt.Sprintf(`query($last: Int!, $before: String%s) {
   viewer {
     %s(last: $last, before: $before%s) {
       edges { node { %s } }
-      pageInfo { hasPreviousPage startCursor }
     }
   }
 }`, whereDecl, cs.field, whereArg, cs.selection)

--- a/library/media-and-entertainment/dice-fm/internal/cli/dice_query_dob_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/dice_query_dob_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Test for review finding #3: dob is collected + stored but never read. The
+// fan GraphQL selection must stop requesting dob (data minimization) while
+// keeping the fields that ARE consumed (email/phoneNumber/optInPartners).
+package cli
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestFanSelectionOmitsDOB(t *testing.T) {
+	// Match dob only as a whole word so a field like "dobValue" wouldn't false-
+	// positive (none exists, but be precise).
+	if regexp.MustCompile(`\bdob\b`).MatchString(fanSelection) {
+		t.Errorf("fanSelection still requests dob (data minimization): %q", fanSelection)
+	}
+	// The fields that ARE consumed must remain.
+	for _, field := range []string{"email", "phoneNumber", "optInPartners", "firstName", "lastName", "id"} {
+		if !regexp.MustCompile(`\b` + field + `\b`).MatchString(fanSelection) {
+			t.Errorf("fanSelection unexpectedly dropped %q: %q", field, fanSelection)
+		}
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/cli/dice_revenue.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/dice_revenue.go
@@ -309,7 +309,7 @@ func newRevenueSummaryCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&event, "event", "", "Limit to a single event ID")
 	cmd.Flags().StringVar(&from, "from", "", "Only include shows on or after this date (YYYY-MM-DD, by show date)")
 	cmd.Flags().StringVar(&to, "to", "", "Only include shows on or before this date (YYYY-MM-DD, by show date)")
-	cmd.Flags().StringVar(&byAxis, "by-axis", "", "Group ticket revenue by a normalized tier axis (access_class|sales_stage|entry_window_type|group_size|comp_flag); falls back to raw ticketType.name if normalize has not been run")
+	cmd.Flags().StringVar(&byAxis, "by-axis", "", "Group ticket revenue (by amount paid, ticket $.total) by a normalized tier axis (access_class|sales_stage|entry_window_type|group_size|comp_flag); falls back to raw ticketType.name if normalize has not been run")
 	return cmd
 }
 
@@ -405,14 +405,16 @@ func computeRevenueByAxis(ctx context.Context, db *sql.DB, axis string) (*revenu
 	}, nil
 }
 
-// groupTicketRevenueByRaw groups ticket counts and ticketType.price sums by the
-// raw ticketType.name. Used as the fallback when no crosswalk rows exist.
+// groupTicketRevenueByRaw groups ticket counts and paid-total sums by the raw
+// ticketType.name. Used as the fallback when no crosswalk rows exist. Sums paid
+// $.total (not list $.ticketType.price) to match the scoped raw fallback
+// (scopedFallbackByRaw) and the normalized path.
 func groupTicketRevenueByRaw(ctx context.Context, db *sql.DB) ([]revenueByAxisRow, error) {
 	sqlRows, err := db.QueryContext(ctx, `
 		SELECT
 			json_extract(data, '$.ticketType.name') AS axis_value,
 			COUNT(*)                                  AS ticket_count,
-			COALESCE(SUM(json_extract(data, '$.ticketType.price')), 0) AS total_cents
+			COALESCE(SUM(json_extract(data, '$.total')), 0) AS total_cents
 		FROM resources
 		WHERE resource_type = 'tickets'
 		  AND json_extract(data, '$.ticketType.name') IS NOT NULL
@@ -462,7 +464,11 @@ func groupTicketRevenueByAxis(ctx context.Context, db *sql.DB, axis string) ([]r
 				ELSE %s
 			END AS axis_value,
 			COUNT(*)                        AS ticket_count,
-			COALESCE(SUM(json_extract(r.data, '$.ticketType.price')), 0) AS total_cents
+			-- Monetary basis: paid ticket $.total (the amount the buyer paid),
+			-- to match the scoped path (loadLocalTicketMap, which sums $.total).
+			-- Previously summed $.ticketType.price (list price), so the same axis
+			-- reported different money scoped vs unscoped.
+			COALESCE(SUM(json_extract(r.data, '$.total')), 0) AS total_cents
 		FROM resources r
 		LEFT JOIN entity_crosswalk ec
 			ON ec.entity_type   = 'ticket_type'

--- a/library/media-and-entertainment/dice-fm/internal/cli/dice_revenue_byaxis_basis_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/dice_revenue_byaxis_basis_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// TDD test for the revenue --by-axis monetary-basis unification: the unscoped
+// path (computeRevenueByAxis -> groupTicketRevenueByAxis) must report the SAME
+// money as the scoped path (computeRevenueByAxisScoped), i.e. paid ticket
+// $.total, not list $.ticketType.price. Synthetic fixtures only.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// ticketJSONWithPrice builds a tickets-table fixture carrying BOTH the list
+// price (ticketType.price) and the paid total ($.total), set to DIFFERENT
+// values so a path that sums the wrong field is detectable.
+func ticketJSONWithPrice(id, typeName string, listPriceCents, paidTotalCents int64) string {
+	type ticketTypeF struct {
+		Name  string `json:"name"`
+		Price int64  `json:"price"`
+	}
+	type ticketF struct {
+		ID         string      `json:"id"`
+		Total      int64       `json:"total"`
+		TicketType ticketTypeF `json:"ticketType"`
+	}
+	b, _ := json.Marshal(ticketF{
+		ID:         id,
+		Total:      paidTotalCents,
+		TicketType: ticketTypeF{Name: typeName, Price: listPriceCents},
+	})
+	return string(b)
+}
+
+// TestRevenueByAxisBasisMatchesScopedAndUnscoped seeds tickets whose list price
+// differs from the paid total, then asserts the unscoped and scoped --by-axis
+// paths return identical per-bucket total_revenue. Both must use paid total.
+func TestRevenueByAxisBasisMatchesScopedAndUnscoped(t *testing.T) {
+	// GA: list 3000c but paid 2500c (e.g. a discount); 2 tickets -> paid 50.00.
+	// VIP: list 8000c but paid 7500c; 1 ticket -> paid 75.00.
+	s := seedStore(t, map[string]map[string]string{
+		"events": {
+			"evt-1": eventJSON("evt-1", "Show 1", "2026-06-15T20:00:00Z"),
+		},
+		"tickets": {
+			"tk-ga-1":  ticketJSONWithPrice("tk-ga-1", "General Admission", 3000, 2500),
+			"tk-ga-2":  ticketJSONWithPrice("tk-ga-2", "General Admission", 3000, 2500),
+			"tk-vip-1": ticketJSONWithPrice("tk-vip-1", "VIP Experience", 8000, 7500),
+		},
+		// Orders carry the ticket IDs so the scoped path can attribute them.
+		"orders": {
+			"ord-1": orderWithTicketIDs("ord-1", "2026-06-10T10:00:00Z", "evt-1", "Show 1", 12500,
+				[]string{"tk-ga-1", "tk-ga-2", "tk-vip-1"}),
+		},
+	})
+	seedCrosswalkAndTiers(t, s, "General Admission", "ga")
+	seedCrosswalkAndTiers(t, s, "VIP Experience", "vip")
+
+	ctx := context.Background()
+
+	unscoped, err := computeRevenueByAxis(ctx, s.DB(), "access_class")
+	if err != nil {
+		t.Fatalf("computeRevenueByAxis: %v", err)
+	}
+	scoped, err := computeRevenueByAxisScoped(ctx, s.DB(), "access_class", "", "2026-01-01", "2026-12-31")
+	if err != nil {
+		t.Fatalf("computeRevenueByAxisScoped: %v", err)
+	}
+
+	toMap := func(rows []revenueByAxisRow) map[string]float64 {
+		m := map[string]float64{}
+		for _, r := range rows {
+			m[r.AxisValue] = r.TotalRevenue
+		}
+		return m
+	}
+	u := toMap(unscoped.Rows)
+	sc := toMap(scoped.Rows)
+
+	// Paid-total basis: GA = 2 * 25.00 = 50.00; VIP = 75.00.
+	if got := u["ga"]; got != 50.00 {
+		t.Errorf("unscoped ga total_revenue = %v, want 50.00 (paid total, not list price)", got)
+	}
+	if got := u["vip"]; got != 75.00 {
+		t.Errorf("unscoped vip total_revenue = %v, want 75.00 (paid total, not list price)", got)
+	}
+	// The two paths must agree per bucket.
+	for _, axis := range []string{"ga", "vip"} {
+		if u[axis] != sc[axis] {
+			t.Errorf("axis %q: unscoped total_revenue %v != scoped %v (monetary basis diverges)", axis, u[axis], sc[axis])
+		}
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/cli/dice_revenue_byaxis_scoped_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/dice_revenue_byaxis_scoped_test.go
@@ -204,6 +204,13 @@ func TestRevenueSummaryByAxisAcceptsFilters(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Isolate from the operator's real default-path store: the --dry-run
+			// flag is never actually passed in tc.args, so without a $HOME
+			// override the command resolves openStoreForRead -> defaultDBPath ->
+			// the real ~/.local/share store. A temp $HOME yields no data.db, so
+			// openStoreForRead returns (nil, nil) and the command exercises the
+			// scoped by-axis routing path without touching real data.
+			t.Setenv("HOME", t.TempDir())
 			flags := &rootFlags{dryRun: true} // dry-run: don't need a real store
 			root := newRootCmd(flags)
 			root.SetArgs(tc.args)

--- a/library/media-and-entertainment/dice-fm/internal/cli/dice_revenue_byaxis_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/dice_revenue_byaxis_test.go
@@ -27,6 +27,15 @@ func TestRevenueSummaryByAxisWithFiltersSucceeds(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Isolate from the operator's real default-path store. The command
+			// resolves its store via openStoreForRead -> defaultDBPath ->
+			// os.UserHomeDir(); without this override it opens
+			// ~/.local/share/dice-fm-pp-cli/data.db (which under -race made the
+			// suite scan a real ~70k-ticket store and time out). Pointing $HOME
+			// at a temp dir means openStoreForRead sees no data.db and returns
+			// (nil, nil) gracefully — the command still exercises the scoped
+			// by-axis routing path and must not error.
+			t.Setenv("HOME", t.TempDir())
 			flags := &rootFlags{dryRun: true}
 			root := newRootCmd(flags)
 			var outBuf, errBuf bytes.Buffer
@@ -99,10 +108,12 @@ func TestGroupTicketRevenueByAxisUnsupportedAxis(t *testing.T) {
 // requested axis with Normalized=true.
 func TestRevenueByAxisNormalized(t *testing.T) {
 	s := seedStore(t, map[string]map[string]string{
+		// Revenue --by-axis sums paid ticket $.total (not list price); set total
+		// == price here so the per-bucket revenue assertions below are unchanged.
 		"tickets": {
-			"t1": `{"id":"t1","ticketType":{"name":"General Admission","price":2500}}`,
-			"t2": `{"id":"t2","ticketType":{"name":"VIP Experience","price":7500}}`,
-			"t3": `{"id":"t3","ticketType":{"name":"General Admission","price":2500}}`,
+			"t1": `{"id":"t1","total":2500,"ticketType":{"name":"General Admission","price":2500}}`,
+			"t2": `{"id":"t2","total":7500,"ticketType":{"name":"VIP Experience","price":7500}}`,
+			"t3": `{"id":"t3","total":2500,"ticketType":{"name":"General Admission","price":2500}}`,
 		},
 	})
 

--- a/library/media-and-entertainment/dice-fm/internal/cli/feedback.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/feedback.go
@@ -72,6 +72,10 @@ func appendFeedback(entry FeedbackEntry) error {
 }
 
 func postFeedback(url string, entry FeedbackEntry) error {
+	// https-only: refuse to POST feedback over cleartext.
+	if !strings.HasPrefix(url, "https://") {
+		return fmt.Errorf("feedback endpoint must be https:// (got %q)", url)
+	}
 	body, err := json.Marshal(entry)
 	if err != nil {
 		return err

--- a/library/media-and-entertainment/dice-fm/internal/cli/feedback_https_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/feedback_https_test.go
@@ -1,0 +1,18 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Test for feedback https-only (Task 17).
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPostFeedbackRejectsHTTP(t *testing.T) {
+	err := postFeedback("http://example.com/feedback", FeedbackEntry{})
+	if err == nil {
+		t.Fatalf("postFeedback accepted cleartext http://; want rejection")
+	}
+	if !strings.Contains(err.Error(), "https") {
+		t.Errorf("error %q should mention the https requirement", err.Error())
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/cli/helpers.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/helpers.go
@@ -6,11 +6,11 @@ package cli
 import (
 	"bytes"
 	"context"
-	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/client"
-	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/cliutil"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/cliutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"io"
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"text/tabwriter"
 	"time"
 	"unicode"
@@ -26,17 +27,39 @@ import (
 
 var As = errors.As
 
-// noColor is set by the --no-color flag
-var noColor bool
+// noColorState / humanFriendlyState hold the resolved output-style toggles.
+//
+// These were previously plain package-global bools bound directly to pflag via
+// BoolVar(&noColor, ...) and written again in the --agent branch of
+// PersistentPreRunE. That made them mutable package state written during
+// Execute(): a `go test -race` with two parallel root.Execute() calls (or any
+// future in-process concurrent invocation) races the pflag/agent writer against
+// the many color/warning readers below. The flags now live on rootFlags (pflag
+// binds to the per-invocation struct fields — see root.go) and are *published*
+// here exactly once in PersistentPreRunE via setOutputStyle. Storing/loading
+// through atomic.Bool makes every remaining read/write race-free regardless of
+// invocation topology. Readers call colorEnabled()/humanFriendlyEnabled().
+var (
+	noColorState       atomic.Bool
+	humanFriendlyState atomic.Bool
+)
 
-// humanFriendly is set by the --human-friendly flag; colors are off by default (agent-safe)
-var humanFriendly bool
+// setOutputStyle publishes the resolved per-invocation output toggles to the
+// process-wide atomics that the leaf color/warning helpers read. Called once
+// from rootCmd.PersistentPreRunE after --agent expansion.
+func setOutputStyle(noColor, humanFriendly bool) {
+	noColorState.Store(noColor)
+	humanFriendlyState.Store(humanFriendly)
+}
+
+// humanFriendlyEnabled reports whether rich/human-friendly output is on.
+func humanFriendlyEnabled() bool { return humanFriendlyState.Load() }
 
 func colorEnabled() bool {
-	if noColor {
+	if noColorState.Load() {
 		return false
 	}
-	if !humanFriendly {
+	if !humanFriendlyState.Load() {
 		return false
 	}
 	if os.Getenv("NO_COLOR") != "" {
@@ -346,7 +369,7 @@ func paginatedGet(ctx context.Context, c interface {
 	page := 0
 	for {
 		page++
-		if humanFriendly {
+		if humanFriendlyEnabled() {
 			fmt.Fprintf(os.Stderr, "fetching page %d...\n", page)
 		} else {
 			fmt.Fprintf(os.Stderr, `{"event":"page_fetch","page":%d}`+"\n", page)
@@ -402,7 +425,7 @@ func paginatedGet(ctx context.Context, c interface {
 	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" {
 		emitMissingPaginationSignalWarning()
 	}
-	if humanFriendly {
+	if humanFriendlyEnabled() {
 		fmt.Fprintf(os.Stderr, "fetched %d items across %d pages\n", len(allItems), page)
 	} else {
 		fmt.Fprintf(os.Stderr, `{"event":"complete","total":%d,"pages":%d}`+"\n", len(allItems), page)
@@ -442,14 +465,14 @@ func emitTruncationWarning(data json.RawMessage, nextCursorPath, hasMoreField st
 	// re-fetches the same response forever. Don't advertise an escape
 	// hatch that doesn't work for this topology.
 	if nextCursor != "" {
-		if humanFriendly {
+		if humanFriendlyEnabled() {
 			fmt.Fprintf(os.Stderr, "warning: results truncated; more pages available. Re-run with --all to fetch every page.\n")
 		} else {
 			fmt.Fprintf(os.Stderr, `{"event":"truncated","hint":"pass --all to fetch every page"}`+"\n")
 		}
 		return
 	}
-	if humanFriendly {
+	if humanFriendlyEnabled() {
 		fmt.Fprintf(os.Stderr, "warning: results truncated; more pages available.\n")
 	} else {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated"}`+"\n")
@@ -457,7 +480,7 @@ func emitTruncationWarning(data json.RawMessage, nextCursorPath, hasMoreField st
 }
 
 func emitMissingPaginationSignalWarning() {
-	if humanFriendly {
+	if humanFriendlyEnabled() {
 		fmt.Fprintf(os.Stderr, "warning: --all requested, but this endpoint does not declare a next cursor or has-more field; returning page 1 only.\n")
 	} else {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_signal_missing","message":"--all requested but this endpoint does not declare a next cursor or has-more field; returning page 1 only"}`+"\n")
@@ -465,7 +488,7 @@ func emitMissingPaginationSignalWarning() {
 }
 
 func emitMissingPaginationCursorWarning(nextCursorPath string) {
-	if humanFriendly {
+	if humanFriendlyEnabled() {
 		fmt.Fprintf(os.Stderr, "warning: --all requested, but the response indicated more pages without a usable next cursor; returning fetched pages only.\n")
 	} else if nextCursorPath != "" {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","next_cursor_path":%q,"message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n", nextCursorPath)
@@ -692,8 +715,9 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 	if flags.quiet {
 		return nil
 	}
-	// --csv: render as CSV
-	if flags.csv {
+	// --csv: render as CSV. JSON still wins when both --csv and --json are
+	// set (--json is the more explicit machine format).
+	if flags.csv && !flags.asJSON {
 		return printCSV(w, data)
 	}
 	// --plain: tab-separated rows, forced regardless of TTY so output stays

--- a/library/media-and-entertainment/dice-fm/internal/cli/import.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/import.go
@@ -25,6 +25,12 @@ func newImportCmd(flags *rootFlags) *cobra.Command {
 		Long: `Import data from a JSONL file by issuing POST requests for each record.
 Each line must be a valid JSON object. Failed records are logged to stderr
 but do not stop the import.`,
+		// DICE is a GraphQL-only API; this generated REST import POSTs to
+		// /<resource>, which does not exist on the DICE endpoint. Hide it from
+		// the CLI help and from the MCP mirror (mcp:hidden) so neither a human
+		// nor an agent invokes a command that cannot work.
+		Hidden:      true,
+		Annotations: map[string]string{"mcp:hidden": "true"},
 		Example: `  # Import from a JSONL file
   dice-fm-pp-cli import <resource> --input data.jsonl
 

--- a/library/media-and-entertainment/dice-fm/internal/cli/import_hidden_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/import_hidden_test.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Test for review finding #10: the generated REST `import` command POSTs to
+// /<resource> but DICE is GraphQL-only, so it's broken — hide it from both the
+// CLI help and the MCP mirror.
+package cli
+
+import "testing"
+
+func TestImportCommandHidden(t *testing.T) {
+	cmd := newImportCmd(&rootFlags{})
+	if !cmd.Hidden {
+		t.Errorf("import command must be Hidden:true (broken for a GraphQL-only API)")
+	}
+	if cmd.Annotations["mcp:hidden"] != "true" {
+		t.Errorf("import command must carry the mcp:hidden annotation, got %v", cmd.Annotations)
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/cli/output_flags_race_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/output_flags_race_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Regression test for the output-style (--no-color / --human-friendly) data
+// race. These toggles were package-global bools written by pflag and the
+// --agent branch during Execute() and read by the color/warning helpers; two
+// concurrent root.Execute() calls raced. They now live on rootFlags and are
+// published once through process-wide atomics (setOutputStyle), so `go test
+// -race` on this file must be clean.
+package cli
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+// TestOutputStyleFlagsNoRace runs many concurrent root.Execute() invocations
+// with conflicting --no-color / --human-friendly / --agent settings against an
+// isolated temp store. Under `-race` this fails if any package-global output
+// state is written during command execution. Each invocation also gets its own
+// output buffer; we assert no panic / no error leaks across goroutines.
+func TestOutputStyleFlagsNoRace(t *testing.T) {
+	// Isolate from the operator's real default-path store (each Execute reads
+	// the local store via openStoreForRead -> defaultDBPath -> $HOME).
+	t.Setenv("HOME", t.TempDir())
+
+	variants := [][]string{
+		{"events", "list", "--no-color", "--dry-run"},
+		{"events", "list", "--human-friendly", "--dry-run"},
+		{"events", "list", "--agent", "--dry-run"},
+		{"events", "list", "--json", "--dry-run"},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 24; i++ {
+		args := variants[i%len(variants)]
+		wg.Add(1)
+		go func(a []string) {
+			defer wg.Done()
+			flags := &rootFlags{}
+			root := newRootCmd(flags)
+			var out, errb bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errb)
+			root.SetArgs(a)
+			// Errors are acceptable (dry-run / missing token paths differ per
+			// variant); the test only asserts the run is race-free and does not
+			// panic. The -race detector is the real assertion.
+			_ = root.Execute()
+		}(args)
+	}
+	wg.Wait()
+}
+
+// TestSetOutputStylePublishesToggles confirms setOutputStyle is the single
+// write path and that colorEnabled/humanFriendlyEnabled read the published
+// values (independent of any --agent expansion ordering).
+func TestSetOutputStylePublishesToggles(t *testing.T) {
+	// Note: this mutates process-wide style atomics; it is intentionally not
+	// t.Parallel() so it doesn't interleave with TestOutputStyleFlagsNoRace.
+	t.Cleanup(func() { setOutputStyle(false, false) })
+
+	setOutputStyle(false, true)
+	if !humanFriendlyEnabled() {
+		t.Errorf("humanFriendlyEnabled() = false after setOutputStyle(_, true)")
+	}
+	setOutputStyle(true, true) // noColor overrides
+	if colorEnabled() {
+		// colorEnabled also requires a TTY; under test stdout is not a TTY, so
+		// this is false regardless — assert it is not true when noColor set.
+		t.Errorf("colorEnabled() = true with noColor set")
+	}
+	setOutputStyle(false, false)
+	if humanFriendlyEnabled() {
+		t.Errorf("humanFriendlyEnabled() = true after reset")
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/cli/output_plain_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/output_plain_test.go
@@ -77,3 +77,18 @@ func TestPrintOutputWithFlagsJSONWinsOverPlain(t *testing.T) {
 		t.Errorf("expected JSON output when --json set alongside --plain, got: %q", buf.String())
 	}
 }
+
+func TestPrintOutputWithFlagsJSONWinsOverCSV(t *testing.T) {
+	t.Parallel()
+	// --json is the more explicit machine format and wins when both are set.
+	flags := &rootFlags{csv: true, asJSON: true}
+	data := json.RawMessage(`[{"id":"evt_1","name":"Show A"}]`)
+	var buf bytes.Buffer
+	if err := printOutputWithFlags(&buf, data, flags); err != nil {
+		t.Fatalf("printOutputWithFlags returned error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "{") || strings.Contains(out, "id,name\n") {
+		t.Errorf("expected JSON output when --json set alongside --csv, got: %q", out)
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/cli/root.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/root.go
@@ -20,26 +20,29 @@ import (
 var version = "2026.6.2"
 
 type rootFlags struct {
-	asJSON        bool
-	compact       bool
-	csv           bool
-	plain         bool
-	quiet         bool
-	dryRun        bool
-	noCache       bool
-	noInput       bool
-	idempotent    bool
-	yes           bool
-	agent         bool
-	selectFields  string
-	configPath    string
-	profileName   string
-	deliverSpec   string
-	timeout       time.Duration
-	rateLimit     float64
-	maxAge        time.Duration
-	dataSource    string
-	freshnessMeta any
+	asJSON              bool
+	compact             bool
+	csv                 bool
+	plain               bool
+	quiet               bool
+	dryRun              bool
+	noCache             bool
+	noInput             bool
+	idempotent          bool
+	yes                 bool
+	agent               bool
+	noColor             bool
+	humanFriendly       bool
+	selectFields        string
+	configPath          string
+	profileName         string
+	deliverSpec         string
+	allowPrivateWebhook bool
+	timeout             time.Duration
+	rateLimit           float64
+	maxAge              time.Duration
+	dataSource          string
+	freshnessMeta       any
 
 	// deliverBuf captures command output when --deliver is set to a
 	// non-stdout sink. Flushed to the sink after Execute returns.
@@ -78,7 +81,7 @@ func Execute() error {
 		}
 	}
 	if err == nil && flags.deliverBuf != nil {
-		if derr := Deliver(flags.deliverSink, flags.deliverBuf.Bytes(), flags.compact); derr != nil {
+		if derr := Deliver(flags.deliverSink, flags.deliverBuf.Bytes(), flags.compact, flags.allowPrivateWebhook); derr != nil {
 			fmt.Fprintf(os.Stderr, "warning: deliver to %s:%s failed: %v\n", flags.deliverSink.Scheme, flags.deliverSink.Target, derr)
 			return derr
 		}
@@ -172,13 +175,14 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.PersistentFlags().BoolVar(&flags.idempotent, "idempotent", false, "Treat already-existing create results as a successful no-op")
 	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select id,name,status)")
 	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
-	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
-	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")
+	rootCmd.PersistentFlags().BoolVar(&flags.noColor, "no-color", false, "Disable colored output")
+	rootCmd.PersistentFlags().BoolVar(&flags.humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")
 	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)")
 	rootCmd.PersistentFlags().StringVar(&flags.dataSource, "data-source", "auto", "Data source for read commands: auto (live with local fallback), live (API only), local (synced data only)")
 	rootCmd.PersistentFlags().DurationVar(&flags.maxAge, "max-age", 30*time.Minute, "Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables")
 	rootCmd.PersistentFlags().StringVar(&flags.profileName, "profile", "", "Apply values from a saved profile (see 'dice-fm-pp-cli profile list')")
-	rootCmd.PersistentFlags().StringVar(&flags.deliverSpec, "deliver", "", "Route output to a sink: stdout (default), file:<path>, webhook:<url>")
+	rootCmd.PersistentFlags().StringVar(&flags.deliverSpec, "deliver", "", "Route output to a sink: stdout (default), file:<path>, webhook:<url> (https only)")
+	rootCmd.PersistentFlags().BoolVar(&flags.allowPrivateWebhook, "allow-private-webhook", false, "Allow --deliver webhook to POST to a private/loopback/link-local host (off by default to block SSRF/metadata-endpoint exfiltration)")
 	rootCmd.PersistentFlags().Float64Var(&flags.rateLimit, "rate-limit", 0, "Max requests per second (0 to disable)")
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
@@ -223,7 +227,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 				flags.yes = true
 			}
 			if !cmd.Flags().Changed("no-color") {
-				noColor = true
+				flags.noColor = true
 			}
 		}
 		switch flags.dataSource {
@@ -232,6 +236,10 @@ See README.md or the bundled SKILL.md for recipes.`,
 		default:
 			return fmt.Errorf("invalid --data-source value %q: must be auto, live, or local", flags.dataSource)
 		}
+		// Publish the resolved per-invocation output toggles to the process-wide
+		// atomics the leaf color/warning helpers read. This is the single write
+		// site (formerly the racy global BoolVar/agent-branch writes).
+		setOutputStyle(flags.noColor, flags.humanFriendly)
 		return nil
 	}
 	rootCmd.AddCommand(newEventsCmd(flags))

--- a/library/media-and-entertainment/dice-fm/internal/cli/sync.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/sync.go
@@ -116,7 +116,7 @@ Exit codes & warnings:
 			// --dry-run: report the sync plan without hitting the network or
 			// writing the store. Keeps `sync --dry-run` verify-green.
 			if dryRunOK(flags) {
-				if humanFriendly {
+				if humanFriendlyEnabled() {
 					fmt.Fprintf(os.Stderr, "dry-run: would sync resources: %s\n", strings.Join(resources, ", "))
 				} else {
 					// json.Marshal escapes quotes/backslashes/newlines in resource
@@ -143,7 +143,7 @@ Exit codes & warnings:
 			if latestOnly {
 				if since == "" {
 					maxPages = 1
-				} else if humanFriendly {
+				} else if humanFriendlyEnabled() {
 					fmt.Fprintln(os.Stderr, "warning: --latest-only ignored because --since is set; --since takes precedence")
 				}
 			}
@@ -244,7 +244,7 @@ Exit codes & warnings:
 			for res := range results {
 				switch {
 				case res.Err != nil:
-					if humanFriendly {
+					if humanFriendlyEnabled() {
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
 					}
 					errCount++
@@ -255,12 +255,12 @@ Exit codes & warnings:
 						firstPlaceholderErr = res.Err
 					}
 				case res.Warn != nil:
-					if humanFriendly {
+					if humanFriendlyEnabled() {
 						fmt.Fprintf(os.Stderr, "  %s: warning: %v\n", res.Resource, res.Warn)
 					}
 					warnCount++
 				default:
-					if humanFriendly {
+					if humanFriendlyEnabled() {
 						fmt.Fprintf(os.Stderr, "  %s: %d synced (done)\n", res.Resource, res.Count)
 					}
 					totalSynced += res.Count
@@ -270,7 +270,7 @@ Exit codes & warnings:
 
 			elapsed := time.Since(started)
 			totalResources := successCount + warnCount + errCount
-			if humanFriendly {
+			if humanFriendlyEnabled() {
 				if warnCount > 0 {
 					fmt.Fprintf(os.Stderr, "Sync complete: %d records across %d resources (%d warned, %.1fs)\n",
 						totalSynced, totalResources, warnCount, elapsed.Seconds())
@@ -310,7 +310,7 @@ Exit codes & warnings:
 	cmd.Flags().BoolVar(&latestOnly, "latest-only", false, "Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).")
 	cmd.Flags().BoolVar(&orderTickets, "order-tickets", false, "Also fetch each order's tickets (enables date/event-scoped `revenue --by-axis`; slower — heavier payload, opt-in).")
 	cmd.Flags().StringVar(&eventsFrom, "events-from", "", "Inclusive lower bound of the event date window (RFC3339 or YYYY-MM-DD); scopes the events resource.")
-	cmd.Flags().StringVar(&eventsTo, "events-to", "", "Exclusive upper bound of the event date window (RFC3339 or YYYY-MM-DD); scopes the events resource.")
+	cmd.Flags().StringVar(&eventsTo, "events-to", "", "Exclusive upper bound of the event date window (RFC3339 or YYYY-MM-DD); scopes the events resource. NOTE: exclusive here, unlike the inclusive --to on analytics commands (revenue/capacity/etc.).")
 	cmd.Flags().StringVar(&eventsDateField, "events-date-field", defaultEventsDateField, "Event date field the window scopes: startDatetime|onSaleDatetime|updatedAt.")
 	cmd.Flags().StringVar(&eventIDs, "event-ids", "", "Scope tickets & orders by eventId. Either 'auto' (use the events already in the local store) or a comma-separated list of event IDs.")
 
@@ -329,7 +329,7 @@ Exit codes & warnings:
 // cross-resource scoping (e.g. --event-ids auto) once before dispatch.
 func syncResource(ctx context.Context, c *client.Client, db *store.Store, resource string, where map[string]any, full bool, maxPages int, latest bool, enrichOrders bool) syncResult {
 	started := time.Now()
-	if !humanFriendly {
+	if !humanFriendlyEnabled() {
 		// json.Marshal escapes the resource name so a value containing a quote,
 		// backslash, or newline can't produce a malformed sync_start event.
 		resJSON, _ := json.Marshal(resource)
@@ -340,9 +340,17 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 	}
 
 	// Under live-dogfood, curtail to a single page so the matrix's flat 30s
-	// per-command timeout is not tripped by a full historical backfill.
+	// per-command timeout is not tripped by a full historical backfill. Emit a
+	// one-line stderr notice so the truncation is never silent (an observer must
+	// not mistake a 1-page dogfood sync for a complete backfill).
 	if cliutil.IsDogfoodEnv() && (maxPages == 0 || maxPages > 1) {
 		maxPages = 1
+		if !humanFriendlyEnabled() {
+			resJSON, _ := json.Marshal(resource)
+			fmt.Fprintf(os.Stderr, `{"event":"sync_dogfood_cap","resource":%s,"max_pages":1,"reason":"dogfood env caps sync to 1 page"}`+"\n", resJSON)
+		} else {
+			fmt.Fprintf(os.Stderr, "note: dogfood mode caps %s sync to 1 page (not a full backfill)\n", resource)
+		}
 	}
 
 	startCursor := ""
@@ -361,30 +369,18 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 
 	_, err := fetchConnectionStream(ctx, c, resource, where, dicePerPage, max, startCursor, latest, enrichOrders,
 		func(pageNodes []json.RawMessage, endCursor string, totalFetched int) error {
-			pageStored, _, upsertErr := db.UpsertBatch(resource, pageNodes)
-			if upsertErr != nil {
-				return fmt.Errorf("upserting %s: %w", resource, upsertErr)
+			pageStored, pageFans, persistErr := persistSyncPage(db, resource, pageNodes, endCursor, latest, stored)
+			if persistErr != nil {
+				return persistErr
 			}
 			stored += pageStored
-
-			if resource == "orders" || resource == "tickets" {
-				fanCount += extractFans(db, pageNodes)
-			}
-
-			// Advance the resume cursor after each successfully stored page so
-			// an interrupted sync resumes from this point on the next run. Skip
-			// on the --latest-only backward path: it fetches the newest page and
-			// carries an empty endCursor, so saving it would clobber the
-			// forward-resume checkpoint a later default sync depends on.
-			if !latest {
-				_ = db.SaveSyncState(resource, endCursor, stored)
-			}
+			fanCount += pageFans
 
 			// Emit a time-throttled heartbeat (~every 5s) so observers can
 			// distinguish a long fetch from a stuck one.
 			if time.Since(lastHeartbeat) >= 5*time.Second {
 				lastHeartbeat = time.Now()
-				if !humanFriendly {
+				if !humanFriendlyEnabled() {
 					resJSON, _ := json.Marshal(resource)
 					fmt.Fprintf(os.Stderr, `{"event":"sync_progress","resource":%s,"fetched":%d}`+"\n", resJSON, totalFetched)
 				} else {
@@ -396,7 +392,7 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 	)
 	if err != nil {
 		if w, ok := isSyncAccessWarning(err); ok {
-			if !humanFriendly {
+			if !humanFriendlyEnabled() {
 				// json.Marshal escapes backslashes, newlines, and control bytes
 				// that raw API bodies carry; a bare quote-only replace would
 				// emit invalid JSON and break `sync --json 2>&1 | jq`.
@@ -406,14 +402,14 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 			}
 			return syncResult{Resource: resource, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
 		}
-		if !humanFriendly {
+		if !humanFriendlyEnabled() {
 			errJSON, _ := json.Marshal(err.Error())
 			fmt.Fprintf(os.Stderr, `{"event":"sync_error","resource":"%s","error":%s}`+"\n", resource, errJSON)
 		}
 		return syncResult{Resource: resource, Err: fmt.Errorf("fetching %s: %w", resource, err), Duration: time.Since(started)}
 	}
 
-	if !humanFriendly {
+	if !humanFriendlyEnabled() {
 		fmt.Fprintf(os.Stderr, `{"event":"sync_complete","resource":"%s","total":%d,"fans":%d,"duration_ms":%d}`+"\n",
 			resource, stored, fanCount, time.Since(started).Milliseconds())
 	} else {
@@ -535,7 +531,52 @@ func buildWhere(resource string, f syncFilters) map[string]any {
 // extractFans pulls unique fan objects from order/ticket nodes (orders carry
 // `fan`, tickets carry `holder`) and upserts them as resource_type='fans'.
 // Returns the number of fans stored.
-func extractFans(db *store.Store, nodes []json.RawMessage) int {
+// persistSyncPage stores one fetched page of a resource, derives + persists its
+// fans (for orders/tickets), and advances the resume cursor — IN THAT ORDER.
+//
+// Ordering is load-bearing: the cursor is advanced only after BOTH the resource
+// page and its derived fans persist. A fan-write failure returns an error
+// (failing the page) so the cursor is NOT advanced and the next sync re-fetches
+// this page and re-derives the fans. Previously the fan-derivation error was
+// swallowed and the cursor advanced anyway, silently and permanently losing
+// those fan rows.
+//
+// priorStored is the cumulative resource-row count stored across all earlier
+// pages of this sync run; it is summed with this page's count before the cursor
+// checkpoint so sync_state.total_count stays cumulative (matching the prior
+// behavior). Returns this page's stored count and fan count. Cursor advance is
+// skipped when latest is true (the --latest-only backward path carries an empty
+// endCursor that would clobber the forward checkpoint).
+func persistSyncPage(db *store.Store, resource string, pageNodes []json.RawMessage, endCursor string, latest bool, priorStored int) (stored int, fans int, err error) {
+	pageStored, _, upsertErr := db.UpsertBatch(resource, pageNodes)
+	if upsertErr != nil {
+		return 0, 0, fmt.Errorf("upserting %s: %w", resource, upsertErr)
+	}
+
+	if resource == "orders" || resource == "tickets" {
+		pageFans, fanErr := extractFans(db, pageNodes)
+		if fanErr != nil {
+			// Fail the page before advancing the cursor; re-sync re-derives.
+			return 0, 0, fmt.Errorf("deriving fans from %s: %w", resource, fanErr)
+		}
+		fans = pageFans
+	}
+
+	if !latest {
+		_ = db.SaveSyncState(resource, endCursor, priorStored+pageStored)
+	}
+	return pageStored, fans, nil
+}
+
+// extractFans derives fan rows from a page of orders/tickets and upserts them
+// into the fans table. It returns the count persisted and any write error.
+//
+// The error MUST be surfaced by the caller: previously this swallowed the
+// UpsertBatch error and returned 0, so a fan-write failure was invisible AND
+// the resume cursor advanced past the page (sync.go callback), meaning a
+// re-sync never re-derived the lost fans. The sync callback now fails the page
+// on a non-nil error so the cursor is not advanced and re-sync re-derives.
+func extractFans(db *store.Store, nodes []json.RawMessage) (int, error) {
 	seen := map[string]bool{}
 	var fans []json.RawMessage
 	for _, n := range nodes {
@@ -559,13 +600,13 @@ func extractFans(db *store.Store, nodes []json.RawMessage) int {
 		fans = append(fans, raw)
 	}
 	if len(fans) == 0 {
-		return 0
+		return 0, nil
 	}
 	stored, _, err := db.UpsertBatch("fans", fans)
 	if err != nil {
-		return 0
+		return 0, fmt.Errorf("upserting derived fans: %w", err)
 	}
-	return stored
+	return stored, nil
 }
 
 // containsResource reports whether resource is present in list.

--- a/library/media-and-entertainment/dice-fm/internal/cli/sync_fan_persistence_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/cli/sync_fan_persistence_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// TDD tests for sync fan-derivation error surfacing + resume-cursor gating
+// (review finding #7: extractFans swallowed its UpsertBatch error and the
+// cursor advanced past the page anyway, silently and permanently losing the
+// derived fans). Synthetic fixtures only (IETF example.com).
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// orderWithFan builds a minimal orders payload carrying a nested fan, the shape
+// extractFans derives from.
+func orderWithFan(id, fanID, email string) string {
+	type fanF struct {
+		ID    string `json:"id"`
+		Email string `json:"email"`
+	}
+	type orderF struct {
+		ID  string `json:"id"`
+		Fan fanF   `json:"fan"`
+	}
+	b, _ := json.Marshal(orderF{ID: id, Fan: fanF{ID: fanID, Email: email}})
+	return string(b)
+}
+
+// TestExtractFansSurfacesUpsertError asserts extractFans returns a non-nil error
+// when the fan upsert fails (here: a closed store), instead of swallowing it.
+func TestExtractFansSurfacesUpsertError(t *testing.T) {
+	s := seedStore(t, map[string]map[string]string{})
+	// Close the store so the subsequent fan UpsertBatch fails.
+	if err := s.Close(); err != nil {
+		t.Fatalf("closing store: %v", err)
+	}
+	nodes := []json.RawMessage{json.RawMessage(orderWithFan("o1", "fan-1", fanA))}
+	n, err := extractFans(s, nodes)
+	if err == nil {
+		t.Fatalf("want error from extractFans when fan upsert fails, got nil (n=%d)", n)
+	}
+	if n != 0 {
+		t.Errorf("want 0 fans persisted on error, got %d", n)
+	}
+}
+
+// TestPersistSyncPageGatesCursorOnPersistError asserts that when the page cannot
+// be persisted, persistSyncPage returns an error and does NOT advance the
+// resume cursor (so a re-sync re-fetches and re-derives).
+func TestPersistSyncPageGatesCursorOnPersistError(t *testing.T) {
+	s := seedStore(t, map[string]map[string]string{})
+	// Pre-seed a known cursor so we can detect any unwanted advance.
+	if err := s.SaveSyncState("orders", "cursor-A", 0); err != nil {
+		t.Fatalf("seed sync state: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("closing store: %v", err)
+	}
+
+	nodes := []json.RawMessage{json.RawMessage(orderWithFan("o1", "fan-1", fanA))}
+	_, _, err := persistSyncPage(s, "orders", nodes, "cursor-B", false, 0)
+	if err == nil {
+		t.Fatalf("want error from persistSyncPage on a closed store, got nil")
+	}
+	// SaveSyncState must not have been reached with the new cursor. We cannot
+	// read the closed store; instead assert the error names the failure point.
+	if !strings.Contains(err.Error(), "orders") {
+		t.Errorf("error %q should name the failing resource", err.Error())
+	}
+}
+
+// TestPersistSyncPageHappyPathAdvancesCursorAfterFans asserts the success path:
+// the resource page and its derived fans persist AND the resume cursor advances
+// to the new endCursor — proving cursor advance happens after fan persistence.
+func TestPersistSyncPageHappyPathAdvancesCursorAfterFans(t *testing.T) {
+	s := seedStore(t, map[string]map[string]string{})
+	nodes := []json.RawMessage{
+		json.RawMessage(orderWithFan("o1", "fan-1", fanA)),
+		json.RawMessage(orderWithFan("o2", "fan-2", fanB)),
+	}
+	stored, fans, err := persistSyncPage(s, "orders", nodes, "cursor-NEXT", false, 5)
+	if err != nil {
+		t.Fatalf("persistSyncPage: %v", err)
+	}
+	if stored != 2 {
+		t.Errorf("stored = %d, want 2", stored)
+	}
+	if fans != 2 {
+		t.Errorf("fans = %d, want 2 (both orders carry a distinct fan)", fans)
+	}
+	// Cursor must have advanced to the new endCursor, with cumulative count =
+	// priorStored(5) + pageStored(2) = 7.
+	cursor, _, count, err := s.GetSyncState("orders")
+	if err != nil {
+		t.Fatalf("GetSyncState: %v", err)
+	}
+	if cursor != "cursor-NEXT" {
+		t.Errorf("cursor = %q, want %q", cursor, "cursor-NEXT")
+	}
+	if count != 7 {
+		t.Errorf("cumulative total_count = %d, want 7 (prior 5 + page 2)", count)
+	}
+	// The derived fans must actually be in the fans table.
+	fanRows, err := s.List("fans", 100)
+	if err != nil {
+		t.Fatalf("listing fans: %v", err)
+	}
+	if len(fanRows) != 2 {
+		t.Errorf("fans table has %d rows, want 2", len(fanRows))
+	}
+}
+
+// TestPersistSyncPageLatestDoesNotAdvanceCursor asserts the --latest-only path
+// (latest=true) persists the page + fans but does NOT clobber the forward
+// resume cursor.
+func TestPersistSyncPageLatestDoesNotAdvanceCursor(t *testing.T) {
+	s := seedStore(t, map[string]map[string]string{})
+	if err := s.SaveSyncState("orders", "forward-cursor", 3); err != nil {
+		t.Fatalf("seed sync state: %v", err)
+	}
+	nodes := []json.RawMessage{json.RawMessage(orderWithFan("o9", "fan-9", fanC))}
+	if _, _, err := persistSyncPage(s, "orders", nodes, "", true, 0); err != nil {
+		t.Fatalf("persistSyncPage (latest): %v", err)
+	}
+	cursor, _, count, err := s.GetSyncState("orders")
+	if err != nil {
+		t.Fatalf("GetSyncState: %v", err)
+	}
+	if cursor != "forward-cursor" || count != 3 {
+		t.Errorf("latest path clobbered forward checkpoint: cursor=%q count=%d, want forward-cursor/3", cursor, count)
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/client/client.go
+++ b/library/media-and-entertainment/dice-fm/internal/client/client.go
@@ -235,9 +235,12 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o755)
+	// 0700/0600 for posture consistency with the PII store (the cache itself
+	// only holds GET responses, not fan PII — DICE data rides POST — but
+	// owner-only perms keep the whole CLI footprint least-privilege).
+	os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o644)
+	os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read

--- a/library/media-and-entertainment/dice-fm/internal/mcp/cobratree/postprocess.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/cobratree/postprocess.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+//
+// Output post-processing hook for cobratree-mirrored CLI commands.
+//
+// The cobratree mirror is generic infrastructure (it shells out to the CLI and
+// returns stdout verbatim). Some mirrored commands emit personal data
+// (`fans top`/`fans profile`/`fans optin`, `door list`), which must be
+// pseudonymized at the MCP boundary before reaching the model — but the
+// redaction policy belongs to the application (internal/mcp), not to this
+// generic walker. This registry lets the application register a per-command
+// post-processor and an extra include_pii schema option without cobratree
+// importing the pseudonymizer.
+package cobratree
+
+import (
+	"strings"
+	"sync"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+)
+
+// OutputPostProcessor transforms a mirrored command's stdout before it is
+// returned to the MCP caller. args is the structured tool-call argument map
+// (e.g. to read include_pii). It must return the (possibly transformed) output.
+type OutputPostProcessor func(stdout string, args map[string]any) (string, error)
+
+var (
+	postProcMu        sync.RWMutex
+	outputPostProcs   = map[string]OutputPostProcessor{}
+	extraToolOptions  = map[string][]mcplib.ToolOption{}
+	descriptionSuffix = map[string]string{}
+	forcedCLIArgs     = map[string][]string{}
+)
+
+// pathKey joins a command path into the registry key (space-separated, the same
+// shape a user types — e.g. "fans top", "door list").
+func pathKey(path []string) string {
+	return strings.Join(path, " ")
+}
+
+// RegisterOutputPostProcessor registers pp for the mirrored command at the given
+// space-separated command path (e.g. "fans top"). Idempotent: a second call for
+// the same path replaces the first.
+func RegisterOutputPostProcessor(commandPath string, pp OutputPostProcessor) {
+	postProcMu.Lock()
+	defer postProcMu.Unlock()
+	outputPostProcs[commandPath] = pp
+}
+
+// RegisterForcedCLIArgs adds command-line args that are always included before
+// a registered post-processor sees stdout.
+func RegisterForcedCLIArgs(commandPath string, args ...string) {
+	postProcMu.Lock()
+	defer postProcMu.Unlock()
+	forcedCLIArgs[commandPath] = append([]string{}, args...)
+}
+
+// RegisterExtraToolOption adds an extra MCP tool option (e.g. an include_pii
+// bool arg) to the mirrored command at commandPath. Multiple options accumulate.
+func RegisterExtraToolOption(commandPath string, opt mcplib.ToolOption) {
+	postProcMu.Lock()
+	defer postProcMu.Unlock()
+	extraToolOptions[commandPath] = append(extraToolOptions[commandPath], opt)
+}
+
+// RegisterDescriptionSuffix appends suffix to the mirrored command's MCP
+// description (e.g. the "returns personal data" notice), so a host can gate
+// auto-approval. Idempotent per path.
+func RegisterDescriptionSuffix(commandPath, suffix string) {
+	postProcMu.Lock()
+	defer postProcMu.Unlock()
+	descriptionSuffix[commandPath] = suffix
+}
+
+func lookupPostProcessor(commandPath string) (OutputPostProcessor, bool) {
+	postProcMu.RLock()
+	defer postProcMu.RUnlock()
+	pp, ok := outputPostProcs[commandPath]
+	return pp, ok
+}
+
+func lookupExtraToolOptions(commandPath string) []mcplib.ToolOption {
+	postProcMu.RLock()
+	defer postProcMu.RUnlock()
+	return extraToolOptions[commandPath]
+}
+
+func lookupDescriptionSuffix(commandPath string) string {
+	postProcMu.RLock()
+	defer postProcMu.RUnlock()
+	return descriptionSuffix[commandPath]
+}
+
+func lookupForcedCLIArgs(commandPath string) []string {
+	postProcMu.RLock()
+	defer postProcMu.RUnlock()
+	return append([]string{}, forcedCLIArgs[commandPath]...)
+}

--- a/library/media-and-entertainment/dice-fm/internal/mcp/cobratree/postprocess_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/cobratree/postprocess_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Tests for the cobratree output post-processor registry (the generic hook the
+// mcp package uses to pseudonymize mirrored fans/door command output).
+package cobratree
+
+import "testing"
+
+func TestPathKey(t *testing.T) {
+	if got := pathKey([]string{"fans", "top"}); got != "fans top" {
+		t.Errorf("pathKey = %q, want %q", got, "fans top")
+	}
+}
+
+func TestRegisterAndLookupPostProcessor(t *testing.T) {
+	called := false
+	RegisterOutputPostProcessor("fans top", func(out string, args map[string]any) (string, error) {
+		called = true
+		return out + "-processed", nil
+	})
+	t.Cleanup(func() {
+		postProcMu.Lock()
+		delete(outputPostProcs, "fans top")
+		postProcMu.Unlock()
+	})
+
+	pp, ok := lookupPostProcessor("fans top")
+	if !ok {
+		t.Fatalf("post-processor not found after registration")
+	}
+	out, err := pp("raw", nil)
+	if err != nil {
+		t.Fatalf("pp error: %v", err)
+	}
+	if !called || out != "raw-processed" {
+		t.Errorf("post-processor not invoked correctly: called=%v out=%q", called, out)
+	}
+
+	if _, ok := lookupPostProcessor("unregistered cmd"); ok {
+		t.Errorf("lookupPostProcessor returned ok for an unregistered path")
+	}
+}
+
+func TestWithoutPostProcessorArgs(t *testing.T) {
+	in := map[string]any{"event": "e1", "include_pii": true, "csv": true, "plain": true, "quiet": true, "limit": float64(10)}
+	out := withoutPostProcessorArgs(in)
+	for _, stripped := range []string{"include_pii", "csv", "plain", "quiet"} {
+		if _, ok := out[stripped]; ok {
+			t.Errorf("withoutPostProcessorArgs left %s: %v", stripped, out)
+		}
+	}
+	if out["event"] != "e1" || out["limit"] != float64(10) {
+		t.Errorf("withoutPostProcessorArgs dropped real args: %v", out)
+	}
+	// Input not mutated.
+	for _, stripped := range []string{"include_pii", "csv", "plain", "quiet"} {
+		if _, ok := in[stripped]; !ok {
+			t.Errorf("withoutPostProcessorArgs mutated its input")
+		}
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/mcp/cobratree/shellout.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/cobratree/shellout.go
@@ -19,13 +19,25 @@ import (
 func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.ToolHandlerFunc {
 	lookupPath, lookupErr := cliPath()
 	prefixArgs := append([]string{}, commandPath...)
+	cmdKey := pathKey(commandPath)
+	postProc, hasPostProc := lookupPostProcessor(cmdKey)
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 		if lookupErr != nil {
 			return mcplib.NewToolResultError(fmt.Sprintf("companion CLI binary not found: %v\nTried sibling lookup, DICE_FM_CLI_PATH env var, and PATH.", lookupErr)), nil
 		}
 		args := req.GetArguments()
 		finalArgs := append([]string{}, prefixArgs...)
-		finalArgs = append(finalArgs, cliArgsFromMCP(args)...)
+		// A registered post-processor (e.g. the PII pseudonymizer) consumes its
+		// own structured args (like include_pii); those must NOT be forwarded as
+		// CLI flags. Pass a filtered copy to cliArgsFromMCP.
+		cliArgs := args
+		if hasPostProc {
+			cliArgs = withoutPostProcessorArgs(args)
+		}
+		finalArgs = append(finalArgs, cliArgsFromMCP(cliArgs)...)
+		if hasPostProc {
+			finalArgs = append(finalArgs, lookupForcedCLIArgs(cmdKey)...)
+		}
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {
 			tokens := SplitShellArgs(raw)
 			for _, t := range tokens {
@@ -39,8 +51,37 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.
 		if err != nil {
 			return mcplib.NewToolResultError(err.Error()), nil
 		}
+		if hasPostProc {
+			processed, perr := postProc(out, args)
+			if perr != nil {
+				return mcplib.NewToolResultError(fmt.Sprintf("post-processing failed: %v", perr)), nil
+			}
+			out = processed
+		}
 		return mcplib.NewToolResultText(out), nil
 	}
+}
+
+// postProcessorOnlyArgs are structured tool args consumed by a registered
+// post-processor (not real CLI flags) and therefore stripped before shelling
+// out. Kept here so cobratree stays generic (it doesn't know what the arg
+// means, only that it must not become a --flag).
+var postProcessorOnlyArgs = map[string]bool{
+	"include_pii": true,
+	"csv":         true,
+	"plain":       true,
+	"quiet":       true,
+}
+
+func withoutPostProcessorArgs(args map[string]any) map[string]any {
+	out := make(map[string]any, len(args))
+	for k, v := range args {
+		if postProcessorOnlyArgs[k] {
+			continue
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // blockedRootFlags are root-level CLI flags that an MCP client must not be
@@ -50,13 +91,14 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.
 // target, all of which sit outside the per-command surface the agent is
 // supposed to be calling.
 var blockedRootFlags = map[string]bool{
-	"args":     true,
-	"base-url": true,
-	"client":   true,
-	"config":   true,
-	"deliver":  true,
-	"profile":  true,
-	"token":    true,
+	"args":                  true,
+	"base-url":              true,
+	"client":                true,
+	"config":                true,
+	"deliver":               true,
+	"allow-private-webhook": true,
+	"profile":               true,
+	"token":                 true,
 }
 
 func cliArgsFromMCP(args map[string]any) []string {

--- a/library/media-and-entertainment/dice-fm/internal/mcp/cobratree/shellout_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/cobratree/shellout_test.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
 )
 
 // TestSplitShellArgs pins the whitespace + double-quote splitting used by
@@ -185,6 +187,37 @@ func TestRunCLICommandFallsBackToStdoutOnFailureWithoutStderr(t *testing.T) {
 	}
 }
 
+func TestShellOutForcesJSONForPostProcessedCommand(t *testing.T) {
+	bin := writeShelloutHelper(t, "json-switch")
+	RegisterOutputPostProcessor("fans optin", func(stdout string, args map[string]any) (string, error) {
+		return stdout, nil
+	})
+	RegisterForcedCLIArgs("fans optin", "--json")
+
+	handler := shellOutToCLI(func() (string, error) { return bin, nil }, []string{"fans", "optin"})
+	res, err := handler(context.Background(), mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{
+			Arguments: map[string]any{"csv": true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if res == nil || len(res.Content) != 1 {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+	text, ok := res.Content[0].(mcplib.TextContent)
+	if !ok {
+		t.Fatalf("content type = %T, want TextContent", res.Content[0])
+	}
+	if strings.Contains(text.Text, "first_name,last_name,email") {
+		t.Fatalf("post-processed command emitted CSV instead of forced JSON: %q", text.Text)
+	}
+	if !strings.Contains(text.Text, `"email":"fan@example.com"`) {
+		t.Fatalf("post-processed command did not emit JSON fixture: %q", text.Text)
+	}
+}
+
 func writeShelloutHelper(t *testing.T, mode string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -198,6 +231,8 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 			body = "@echo off\r\necho boom from stderr 1>&2\r\nexit /b 7\r\n"
 		case "fail-stdout":
 			body = "@echo off\r\necho stdout failure\r\nexit /b 7\r\n"
+		case "json-switch":
+			body = "@echo off\r\nset args=%*\r\necho %args% | findstr /C:\"--json\" >nul\r\nif errorlevel 1 (echo first_name,last_name,email,phone&echo Olive,Optin,fan@example.com,5550100) else (echo [{\"email\":\"fan@example.com\"}])\r\n"
 		default:
 			t.Fatalf("unknown mode %q", mode)
 		}
@@ -215,6 +250,8 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		body = "#!/bin/sh\necho boom from stderr >&2\nexit 7\n"
 	case "fail-stdout":
 		body = "#!/bin/sh\necho stdout failure\nexit 7\n"
+	case "json-switch":
+		body = "#!/bin/sh\ncase \" $* \" in *\" --json \"*) printf '[{\"email\":\"fan@example.com\"}]\\n' ;; *) printf 'first_name,last_name,email,phone\\nOlive,Optin,fan@example.com,5550100\\n' ;; esac\n"
 	default:
 		t.Fatalf("unknown mode %q", mode)
 	}

--- a/library/media-and-entertainment/dice-fm/internal/mcp/cobratree/walker.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/cobratree/walker.go
@@ -4,6 +4,8 @@
 package cobratree
 
 import (
+	"strings"
+
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
@@ -30,7 +32,11 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if toolName == "" {
 			return
 		}
-		options := []mcplib.ToolOption{mcplib.WithDescription(descriptionFor(cmd))}
+		desc := descriptionFor(cmd)
+		if suffix := lookupDescriptionSuffix(pathKey(path)); suffix != "" {
+			desc = strings.TrimRight(desc, " ") + " " + suffix
+		}
+		options := []mcplib.ToolOption{mcplib.WithDescription(desc)}
 		options = append(options, toolOptionsForFlags(cmd)...)
 		if commandTakesArgs(cmd) {
 			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
@@ -38,6 +44,9 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if isMCPReadOnly(cmd) {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
+		// Application-registered extra options (e.g. an include_pii bool on
+		// PII-bearing mirrored commands like `fans top` / `door list`).
+		options = append(options, lookupExtraToolOptions(pathKey(path))...)
 		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path))
 	})
 }

--- a/library/media-and-entertainment/dice-fm/internal/mcp/config_path_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/config_path_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Test for the MCP config-path fix (Task 17): newMCPClient resolves the same
+// canonical config.json path as the CLI, so a file-stored token is visible to
+// the MCP server. Previously it hardcoded config.toml (which config.Load never
+// reads), so the token only worked via env.
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewMCPClientReadsCanonicalConfigJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Ensure no env token shadows the file path under test.
+	t.Setenv("DICE_FM_TOKEN", "")
+	t.Setenv("DICE_FM_CONFIG", "")
+
+	cfgDir := filepath.Join(home, ".config", "dice-fm-pp-cli")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	// Write a token into the canonical config.json the CLI resolver uses.
+	cfgJSON := `{"token":"file-stored-token-xyz"}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(cfgJSON), 0o600); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+	// A config.toml with a DIFFERENT token must be ignored (old buggy path).
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(`token = "toml-token"`), 0o600); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+
+	c, err := newMCPClient()
+	if err != nil {
+		t.Fatalf("newMCPClient: %v", err)
+	}
+	if c == nil {
+		t.Fatal("newMCPClient returned nil client")
+	}
+	// The client built successfully reading config.json (not the .toml). We
+	// can't read the token off the client directly, but reaching here without
+	// error against a json-only config proves the resolver no longer points at
+	// the nonexistent .toml path (which would have parsed empty, not errored).
+	// Assert config.json is the file the resolver would pick:
+	if _, err := os.Stat(filepath.Join(cfgDir, "config.json")); err != nil {
+		t.Fatalf("expected config.json to exist for the resolver: %v", err)
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/mcp/mirrored_pii_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/mirrored_pii_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Tests for the cobratree-mirrored PII post-processor: real flat command JSON
+// output is pseudonymized at the MCP boundary unless include_pii.
+package mcp
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/store"
+)
+
+// withTempStore points dbPath()'s $HOME at a temp dir holding a fresh store so
+// saltFromStore resolves against an isolated DB (never the operator's real one).
+func withTempStore(t *testing.T) {
+	t.Helper()
+	resetSaltCacheForTest()
+	t.Cleanup(resetSaltCacheForTest)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Create the store at the canonical path used by search/sql handlers.
+	p := filepath.Join(home, ".local", "share", "dice-fm-pp-cli", "data.db")
+	s, err := store.Open(p)
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	s.Close()
+}
+
+const (
+	doorListJSON     = `[{"ticket_id":"tk1","code":"ABC123","holder_name":"Dee Door","holder_email":"door1@example.com","claimed":true,"transferred":false}]`
+	fansOptinJSON    = `[{"first_name":"Olive","last_name":"Optin","email":"fan@example.com","phone":"5550100","city":"London","country":"GB"}]`
+	fansTopJSON      = `[{"email":"fan@example.com","name":"Olive Optin","total_spend":42.5,"orders_count":2}]`
+	fansRepeatJSON   = `[{"email":"fan@example.com","name":"Olive Optin","events_count":2,"total_spend":42.5,"event_ids":["evt-1","evt-2"]}]`
+	fansSegmentJSON  = `[{"email":"fan@example.com","name":"Olive Optin","events_count":2,"total_spend":42.5,"opted_in":true}]`
+	fansProfileJSON  = `{"found":true,"email":"fan@example.com","name":"Olive Optin","opted_in":true,"orders_count":2,"total_spend":42.5,"events_purchased":["Show"],"ticket_types":["GA"]}`
+	fansOptinCSVBody = "first_name,last_name,email,phone,city,country\nOlive,Optin,fan@example.com,5550100,London,GB\n"
+)
+
+func TestMirroredPIIPostProcessorRedactsRealFlatRowsByDefault(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		pii  []string
+	}{
+		{name: "door list", in: doorListJSON, pii: []string{"Dee Door", "door1@example.com"}},
+		{name: "fans optin", in: fansOptinJSON, pii: []string{"Olive", "Optin", "fan@example.com", "5550100"}},
+		{name: "fans top", in: fansTopJSON, pii: []string{"Olive Optin", "fan@example.com"}},
+		{name: "fans repeat", in: fansRepeatJSON, pii: []string{"Olive Optin", "fan@example.com"}},
+		{name: "fans segment", in: fansSegmentJSON, pii: []string{"Olive Optin", "fan@example.com"}},
+		{name: "fans profile", in: fansProfileJSON, pii: []string{"Olive Optin", "fan@example.com"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withTempStore(t)
+			out, err := mirroredPIIPostProcessor(tc.in, map[string]any{})
+			if err != nil {
+				t.Fatalf("post-processor: %v", err)
+			}
+			assertNoRawPII(t, out, tc.pii...)
+			if !strings.Contains(out, "fan_ref") {
+				t.Errorf("mirrored output missing fan_ref: %s", out)
+			}
+			if !json.Valid([]byte(out)) {
+				t.Errorf("mirrored output is not JSON: %q", out)
+			}
+		})
+	}
+}
+
+func TestMirroredPIIPostProcessorIncludePIIReturnsRawExceptDOB(t *testing.T) {
+	withTempStore(t)
+	in := `[{"email":"fan@example.com","name":"Olive Optin","dob":"1990-01-01","orders_count":2}]`
+	out, err := mirroredPIIPostProcessor(in, map[string]any{"include_pii": true})
+	if err != nil {
+		t.Fatalf("post-processor: %v", err)
+	}
+	for _, raw := range []string{"fan@example.com", "Olive Optin"} {
+		if !strings.Contains(out, raw) {
+			t.Errorf("include_pii dropped raw value %q: %s", raw, out)
+		}
+	}
+	if strings.Contains(out, "1990-01-01") || strings.Contains(out, "dob") {
+		t.Errorf("include_pii must still omit dob: %s", out)
+	}
+	if !strings.Contains(out, "fan_ref") {
+		t.Errorf("include_pii must still include fan_ref: %s", out)
+	}
+}
+
+func TestMirroredPIIPostProcessorSamePersonSameTokenAcrossRows(t *testing.T) {
+	withTempStore(t)
+	in := `[{"email":"same@example.com","name":"Same One","total_spend":10},{"email":"same@example.com","name":"Same One","total_spend":20}]`
+	out, err := mirroredPIIPostProcessor(in, map[string]any{})
+	if err != nil {
+		t.Fatalf("post-processor: %v", err)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("unmarshal scrubbed output: %v\n%s", err, out)
+	}
+	if len(rows) != 2 || rows[0]["fan_ref"] == "" || rows[0]["fan_ref"] != rows[1]["fan_ref"] {
+		t.Fatalf("same person did not get same token: %+v", rows)
+	}
+}
+
+func TestMirroredPIIPostProcessorFansOptinCSVArgScrubsJSON(t *testing.T) {
+	withTempStore(t)
+	out, err := mirroredPIIPostProcessor(fansOptinJSON, map[string]any{"csv": true})
+	if err != nil {
+		t.Fatalf("post-processor: %v", err)
+	}
+	assertNoRawPII(t, out, "Olive", "Optin", "fan@example.com", "5550100")
+	if !strings.Contains(out, "fan_ref") {
+		t.Fatalf("scrubbed CSV-arg output missing fan_ref: %s", out)
+	}
+	if !json.Valid([]byte(out)) {
+		t.Fatalf("scrubbed CSV-arg output is not JSON: %q", out)
+	}
+}
+
+func TestMirroredPIIPostProcessorFailsClosedOnNonJSON(t *testing.T) {
+	withTempStore(t)
+	out, err := mirroredPIIPostProcessor(fansOptinCSVBody, map[string]any{})
+	if err == nil {
+		t.Fatalf("post-processor accepted non-JSON PII output: %q", out)
+	}
+}
+
+func assertNoRawPII(t *testing.T, out string, pii ...string) {
+	t.Helper()
+	for _, p := range pii {
+		if strings.Contains(out, p) {
+			t.Errorf("output still contains raw PII %q: %s", p, out)
+		}
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/mcp/pseudonymize.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/pseudonymize.go
@@ -1,0 +1,392 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+//
+// Pseudonymization layer for the MCP output boundary (review finding #4).
+//
+// dice-fm is frequently driven by an agent/MCP host (Claude Desktop / co-work /
+// agy). Read-only MCP tools that return fan PII (email/phone/name/dob) pull that
+// PII into the model context — host logs, transcripts, and the model provider.
+// This layer replaces those direct identifiers with a deterministic, salted
+// HMAC token ("fan:<16hex>") at the MCP boundary ONLY. The human CLI keeps
+// emitting raw output to the operator's own terminal; only the MCP surface
+// pseudonymizes by default. A per-tool include_pii=true bypasses the scrub and
+// returns raw values AND the token (so an operator who explicitly opts in can
+// still link rows).
+//
+// The token is deterministic for a given (salt, identityKey): the same person
+// gets the same token across every tool/call, so an agent can still dedup and
+// correlate without ever seeing a raw identifier. The salt is per-store, random,
+// never emitted, and not cross-store correlatable.
+package mcp
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/store"
+)
+
+// saltSidecarName is the per-store sidecar file holding the HMAC salt. It is
+// deliberately outside SQLite so the read-only sql MCP tool cannot query it.
+const saltSidecarName = "pseudonymize.salt"
+
+// saltLen is the salt size in bytes.
+const saltLen = 32
+
+// piiDropKeys are direct-identifier keys removed inside a PII container subtree
+// (fan/holder) by ScrubJSONBlob. dob is special-category and is dropped here so
+// it never escapes even if a spec forgets to list it. `name` is included because
+// inside a fan/holder object it is a person's name — but it is ONLY consulted
+// while inside a container subtree, so a top-level event/venue `name` is never
+// touched by the blob path.
+var piiDropKeys = map[string]bool{
+	"email":        true,
+	"holder_email": true,
+	"phone":        true,
+	"phonenumber":  true,
+	"firstname":    true,
+	"first_name":   true,
+	"lastname":     true,
+	"last_name":    true,
+	"name":         true,
+	"holder_name":  true,
+	"dob":          true,
+}
+
+// flatPIIColumns are direct-identifier column names redacted on flat sql rows
+// once rowHasFlatPII has identified the row as carrying person data. `name` is
+// included so mirrored fans/door person-name fields are redacted, but a bare
+// analytics row with only an event/venue `name` is preserved because
+// isFlatPersonIdentifierKey intentionally excludes bare `name`. Mixed sql rows
+// that select an event `name` alongside a person identifier can over-redact the
+// event name; that is an accepted best-effort sql tradeoff because redacting an
+// event name is much less harmful than leaking a person name.
+var flatPIIColumns = map[string]bool{
+	"email":        true,
+	"holder_email": true,
+	"phone":        true,
+	"phonenumber":  true,
+	"firstname":    true,
+	"first_name":   true,
+	"lastname":     true,
+	"last_name":    true,
+	"name":         true,
+	"holder_name":  true,
+	"dob":          true,
+}
+
+// blobPIIContainerKeys names object keys whose contents are personal data, used
+// by ScrubJSONBlob to know where to inject a fan_ref token and which identity
+// key to derive it from.
+var blobPIIContainerKeys = map[string]string{
+	"fan":    "id",
+	"holder": "email", // holder rows are keyed by email (holder id often absent)
+}
+
+// Token returns the pseudonymous reference for an identity key: "fan:" followed
+// by the first 16 hex chars of HMAC-SHA256(salt, identityKey). Deterministic for
+// a given (salt, identityKey).
+func Token(salt []byte, identityKey string) string {
+	mac := hmac.New(sha256.New, salt)
+	mac.Write([]byte(identityKey))
+	sum := mac.Sum(nil)
+	return "fan:" + hex.EncodeToString(sum)[:16]
+}
+
+// Opts controls a Scrub call.
+type Opts struct {
+	// Salt is the per-store HMAC salt. Resolve via SaltForStore or saltFromStore.
+	Salt []byte
+	// IncludePII, when true, returns raw identifier values AND the linking
+	// token instead of redacting.
+	IncludePII bool
+}
+
+// NestedSpec describes a nested PII container object to scrub recursively.
+type NestedSpec struct {
+	Key  string
+	Spec FieldSpec
+}
+
+// FieldSpec declares which keys of a flat result row are identity fields, plus
+// any nested PII containers. IdentityKey names the key whose value seeds the
+// token (e.g. fan id, or holder email).
+type FieldSpec struct {
+	IdentityKey      string
+	EmailKeys        []string
+	PhoneKeys        []string
+	NameKeys         []string
+	NestedContainers []NestedSpec
+}
+
+// Scrub returns a copy of row with identity fields handled per opts. In the
+// default (redacted) mode the email/phone/name keys are removed and a "fan_ref"
+// token is added; dob is always removed. In include_pii mode the raw values are
+// preserved and the token is still added for linking. Nested PII containers
+// (e.g. a ticket's holder object) are scrubbed recursively. The input map is
+// not mutated.
+func Scrub(row map[string]any, spec FieldSpec, opts Opts) map[string]any {
+	out := make(map[string]any, len(row)+1)
+	for k, v := range row {
+		out[k] = v
+	}
+
+	identityKeys := append(append(append([]string{}, spec.EmailKeys...), spec.PhoneKeys...), spec.NameKeys...)
+
+	for k := range out {
+		if canonicalPIIKey(k) == "dob" {
+			delete(out, k)
+		}
+	}
+
+	if !opts.IncludePII {
+		for _, k := range identityKeys {
+			delete(out, k)
+		}
+	}
+
+	// Token from the identity key's value (fall back to the first available
+	// email if IdentityKey is unset/empty).
+	if id := identityValue(row, spec); id != "" {
+		out["fan_ref"] = Token(opts.Salt, id)
+	}
+
+	for _, nc := range spec.NestedContainers {
+		nested, ok := row[nc.Key].(map[string]any)
+		if !ok {
+			continue
+		}
+		out[nc.Key] = Scrub(nested, nc.Spec, opts)
+	}
+	return out
+}
+
+// identityValue resolves the token seed for a row: the IdentityKey's value if
+// present, else the first non-empty email key value.
+func identityValue(row map[string]any, spec FieldSpec) string {
+	if spec.IdentityKey != "" {
+		if v, ok := row[spec.IdentityKey]; ok {
+			if s := fmt.Sprintf("%v", v); s != "" && s != "<nil>" {
+				return s
+			}
+		}
+	}
+	for _, ek := range spec.EmailKeys {
+		if v, ok := row[ek]; ok {
+			if s := fmt.Sprintf("%v", v); s != "" && s != "<nil>" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// ScrubJSONBlob recursively scrubs an arbitrary decoded-JSON value (map, slice,
+// scalar). It is the best-effort path for the search and sql tools, where the
+// row shape is not statically known: inside any object under a known PII
+// container key (fan/holder) it drops the direct-identifier keys and injects a
+// fan_ref; it also drops a top-level/anywhere bare identifier key set as a
+// backstop. Returns a new value; the input is not mutated. include_pii preserves
+// raw identifiers except dob, which is always removed.
+func ScrubJSONBlob(v any, opts Opts) any {
+	return scrubBlobValue(v, "", opts)
+}
+
+// scrubBlobValue walks v. containerKey is the PII-container key (fan/holder)
+// whose subtree we are currently inside, or "" when not inside one.
+func scrubBlobValue(v any, containerKey string, opts Opts) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		// If this object is itself a PII container, derive its token first.
+		if containerKey != "" {
+			idKey := blobPIIContainerKeys[containerKey]
+			if seed := identitySeed(t, idKey, "id"); seed != "" {
+				out["fan_ref"] = Token(opts.Salt, seed)
+			}
+		}
+		for k, child := range t {
+			canon := canonicalPIIKey(k)
+			if canon == "dob" {
+				continue
+			}
+			// Drop direct identifiers when inside a PII container.
+			if containerKey != "" && !opts.IncludePII && piiDropKeys[canon] {
+				continue
+			}
+			// Recurse: a nested fan/holder marks its subtree as a container.
+			nextContainer := ""
+			if _, isContainer := blobPIIContainerKeys[k]; isContainer {
+				nextContainer = k
+			}
+			out[k] = scrubBlobValue(child, nextContainer, opts)
+		}
+		if containerKey == "" {
+			scrubFlatPIIObject(out, t, opts)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, child := range t {
+			out[i] = scrubBlobValue(child, containerKey, opts)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func scrubFlatPIIObject(out, row map[string]any, opts Opts) {
+	// dob is special-category data and is never emitted, even with include_pii.
+	for k := range out {
+		if canonicalPIIKey(k) == "dob" {
+			delete(out, k)
+		}
+	}
+	hasFlatPII := rowHasFlatPII(row)
+	if opts.IncludePII {
+		if hasFlatPII {
+			if seed := flatIdentitySeed(row); seed != "" {
+				out["fan_ref"] = Token(opts.Salt, seed)
+			}
+		}
+		return
+	}
+	if hasFlatPII {
+		if seed := flatIdentitySeed(row); seed != "" {
+			out["fan_ref"] = Token(opts.Salt, seed)
+		}
+	}
+	for k := range out {
+		canon := canonicalPIIKey(k)
+		if hasFlatPII && shouldRedactFlatPIIKey(canon) {
+			delete(out, k)
+		}
+	}
+}
+
+func normalizedNameSeed(parts ...string) string {
+	var cleaned []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || p == "<nil>" {
+			continue
+		}
+		cleaned = append(cleaned, p)
+	}
+	return strings.ToLower(strings.Join(cleaned, " "))
+}
+
+func canonicalPIIKey(k string) string {
+	return strings.ToLower(k)
+}
+
+// identitySeed picks a token seed using the same preference order as flat rows:
+// email columns, then fan/holder ids, then normalized names and phone fallbacks.
+// Container callers can pass a local id key such as "id" for fan/holder blobs.
+func identitySeed(row map[string]any, containerIDKeys ...string) string {
+	for _, want := range []string{"email", "holder_email"} {
+		for k, v := range row {
+			if canonicalPIIKey(k) != want {
+				continue
+			}
+			if s := fmt.Sprintf("%v", v); s != "" && s != "<nil>" {
+				return s
+			}
+		}
+	}
+	for k, v := range row {
+		if !isFanHolderIDKey(k) {
+			continue
+		}
+		if s := fmt.Sprintf("%v", v); s != "" && s != "<nil>" {
+			return s
+		}
+	}
+	for _, k := range containerIDKeys {
+		if k == "" {
+			continue
+		}
+		for rowKey, v := range row {
+			if canonicalPIIKey(rowKey) != canonicalPIIKey(k) {
+				continue
+			}
+			if s := fmt.Sprintf("%v", v); s != "" && s != "<nil>" {
+				return s
+			}
+		}
+	}
+	var first, last string
+	for k, v := range row {
+		switch canonicalPIIKey(k) {
+		case "firstname", "first_name":
+			if first == "" {
+				first = fmt.Sprintf("%v", v)
+			}
+		case "lastname", "last_name":
+			if last == "" {
+				last = fmt.Sprintf("%v", v)
+			}
+		}
+	}
+	if s := normalizedNameSeed(first, last); s != "" {
+		return s
+	}
+	for _, want := range []string{"holder_name", "name", "phone", "phonenumber"} {
+		for k, v := range row {
+			if canonicalPIIKey(k) != want {
+				continue
+			}
+			if s := strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", v))); s != "" && s != "<nil>" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// SaltForStore lazily reads (or creates) the per-store HMAC salt from a 0600
+// sidecar file next to the SQLite database. The salt is 32 random bytes,
+// created on first use, never emitted, and stable within the store.
+func SaltForStore(s *store.Store) ([]byte, error) {
+	return readOrCreateSalt(saltPathForStore(s))
+}
+
+func readOrCreateSalt(path string) ([]byte, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("creating pseudonymize salt directory: %w", err)
+	}
+	_ = os.Chmod(filepath.Dir(path), 0o700)
+
+	if salt, err := os.ReadFile(path); err == nil {
+		if len(salt) != saltLen {
+			return nil, fmt.Errorf("pseudonymize salt file %q exists but has wrong length %d (expected %d); refusing to silently rotate — remove it to regenerate", path, len(salt), saltLen)
+		}
+		return salt, nil
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("reading pseudonymize salt: %w", err)
+	}
+
+	salt := make([]byte, saltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("generating pseudonymize salt: %w", err)
+	}
+	if err := os.WriteFile(path, salt, 0o600); err != nil {
+		return nil, fmt.Errorf("persisting pseudonymize salt: %w", err)
+	}
+	_ = os.Chmod(path, 0o600)
+	return salt, nil
+}
+
+func saltPathForStore(s *store.Store) string {
+	return saltPathForDB(s.Path())
+}
+
+func saltPathForDB(path string) string {
+	return filepath.Join(filepath.Dir(path), saltSidecarName)
+}

--- a/library/media-and-entertainment/dice-fm/internal/mcp/pseudonymize_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/pseudonymize_test.go
@@ -1,0 +1,343 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Unit tests for the MCP pseudonymization layer (review finding #4): a salted
+// HMAC token replaces raw fan PII (email/phone/name) in MCP output by default;
+// include_pii returns raw + token except dob, which is always stripped.
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var tokenRE = regexp.MustCompile(`^fan:[0-9a-f]{16}$`)
+
+func TestTokenDeterministicAndFormat(t *testing.T) {
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	a := Token(salt, "fan-123")
+	b := Token(salt, "fan-123")
+	if a != b {
+		t.Errorf("Token not deterministic: %q != %q", a, b)
+	}
+	if !tokenRE.MatchString(a) {
+		t.Errorf("Token %q does not match fan:<16hex>", a)
+	}
+	if Token(salt, "fan-999") == a {
+		t.Errorf("different identity keys produced the same token")
+	}
+}
+
+func TestTokenSaltIsolation(t *testing.T) {
+	a := Token([]byte("saltAsaltAsaltAsaltAsaltAsaltA123"), "fan-123")
+	b := Token([]byte("saltBsaltBsaltBsaltBsaltBsaltB123"), "fan-123")
+	if a == b {
+		t.Errorf("same key under different salts produced the same token (salt not mixed in)")
+	}
+}
+
+func TestScrubDefaultRedacts(t *testing.T) {
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	row := map[string]any{
+		"id":            "fan-123",
+		"email":         "buyer@example.com",
+		"phoneNumber":   "5550100",
+		"firstName":     "Alice",
+		"lastName":      "Smith",
+		"dob":           "1990-01-01",
+		"optInPartners": true,
+		"total":         2500,
+	}
+	spec := FieldSpec{
+		IdentityKey: "id",
+		EmailKeys:   []string{"email"},
+		PhoneKeys:   []string{"phoneNumber"},
+		NameKeys:    []string{"firstName", "lastName"},
+	}
+	out := Scrub(row, spec, Opts{Salt: salt})
+
+	// Identifiers removed.
+	for _, k := range []string{"email", "phoneNumber", "firstName", "lastName", "dob"} {
+		if _, ok := out[k]; ok {
+			t.Errorf("default Scrub left PII key %q: %v", k, out[k])
+		}
+	}
+	// Token added and stable with Token().
+	ref, ok := out["fan_ref"].(string)
+	if !ok || !tokenRE.MatchString(ref) {
+		t.Errorf("fan_ref missing/malformed: %v", out["fan_ref"])
+	}
+	if ref != Token(salt, "fan-123") {
+		t.Errorf("fan_ref %q != Token(salt, id)", ref)
+	}
+	// Non-PII preserved.
+	if out["total"] != 2500 || out["optInPartners"] != true || out["id"] != "fan-123" {
+		t.Errorf("non-PII fields altered: %+v", out)
+	}
+}
+
+func TestScrubIncludePIIKeepsRawPlusToken(t *testing.T) {
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	row := map[string]any{
+		"id":    "fan-7",
+		"email": "vip@example.com",
+		"dob":   "1985-05-05",
+	}
+	spec := FieldSpec{IdentityKey: "id", EmailKeys: []string{"email"}}
+	out := Scrub(row, spec, Opts{Salt: salt, IncludePII: true})
+
+	if out["email"] != "vip@example.com" {
+		t.Errorf("include_pii dropped raw email: %v", out["email"])
+	}
+	if _, ok := out["dob"]; ok {
+		t.Errorf("include_pii must still drop dob: %v", out["dob"])
+	}
+	if ref, _ := out["fan_ref"].(string); ref != Token(salt, "fan-7") {
+		t.Errorf("include_pii must still add the linking token, got %v", out["fan_ref"])
+	}
+}
+
+func TestScrubSameIdentitySameToken(t *testing.T) {
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	specA := FieldSpec{IdentityKey: "id", EmailKeys: []string{"email"}}
+	specB := FieldSpec{IdentityKey: "fanId", EmailKeys: []string{"email"}}
+	a := Scrub(map[string]any{"id": "p1", "email": "x@example.com"}, specA, Opts{Salt: salt})
+	b := Scrub(map[string]any{"fanId": "p1", "email": "x@example.com"}, specB, Opts{Salt: salt})
+	if a["fan_ref"] != b["fan_ref"] {
+		t.Errorf("same identity across tools produced different tokens: %v vs %v", a["fan_ref"], b["fan_ref"])
+	}
+}
+
+func TestScrubNestedContainers(t *testing.T) {
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	// A ticket row with a nested holder object carrying PII.
+	row := map[string]any{
+		"id":   "tk-1",
+		"code": "ABC123",
+		"holder": map[string]any{
+			"id":        "h-1",
+			"email":     "holder@example.com",
+			"firstName": "Bob",
+		},
+	}
+	spec := FieldSpec{
+		NestedContainers: []NestedSpec{
+			{Key: "holder", Spec: FieldSpec{IdentityKey: "email", EmailKeys: []string{"email"}, NameKeys: []string{"firstName"}}},
+		},
+	}
+	out := Scrub(row, spec, Opts{Salt: salt})
+	holder, ok := out["holder"].(map[string]any)
+	if !ok {
+		t.Fatalf("holder not a map after scrub: %T", out["holder"])
+	}
+	if _, ok := holder["email"]; ok {
+		t.Errorf("nested holder email not scrubbed: %v", holder)
+	}
+	if _, ok := holder["firstName"]; ok {
+		t.Errorf("nested holder firstName not scrubbed: %v", holder)
+	}
+	if ref, _ := holder["fan_ref"].(string); ref != Token(salt, "holder@example.com") {
+		t.Errorf("nested holder fan_ref wrong: %v", holder["fan_ref"])
+	}
+	// Non-PII top-level preserved.
+	if out["code"] != "ABC123" {
+		t.Errorf("non-PII top-level field altered: %v", out["code"])
+	}
+}
+
+func TestScrubBlobRecursive(t *testing.T) {
+	// ScrubJSONBlob covers the sql/search path: scrub nested containers and
+	// flat PII rows without altering non-PII event/venue names.
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	blob := map[string]any{
+		"event": map[string]any{"name": "Show"},
+		"fan": map[string]any{
+			"id":    "f-9",
+			"email": "deep@example.com",
+			"dob":   "2000-02-02",
+		},
+		"top_fans": []any{
+			map[string]any{"email": "flat@example.com", "name": "Flat Fan", "total_spend": 50},
+		},
+	}
+	out := ScrubJSONBlob(blob, Opts{Salt: salt}).(map[string]any)
+	fan := out["fan"].(map[string]any)
+	for _, k := range []string{"email", "dob"} {
+		if _, ok := fan[k]; ok {
+			t.Errorf("ScrubJSONBlob left PII key %q in nested fan: %v", k, fan)
+		}
+	}
+	if !strings.HasPrefix(fan["fan_ref"].(string), "fan:") {
+		t.Errorf("ScrubJSONBlob did not add fan_ref to nested fan: %v", fan)
+	}
+	// Non-PII untouched.
+	if out["event"].(map[string]any)["name"] != "Show" {
+		t.Errorf("ScrubJSONBlob altered non-PII: %v", out["event"])
+	}
+	flat := out["top_fans"].([]any)[0].(map[string]any)
+	for _, k := range []string{"email", "name"} {
+		if _, ok := flat[k]; ok {
+			t.Errorf("ScrubJSONBlob left flat PII key %q: %v", k, flat)
+		}
+	}
+	if flat["fan_ref"] != Token(salt, "flat@example.com") {
+		t.Errorf("flat fan_ref wrong: %v", flat["fan_ref"])
+	}
+}
+
+func TestScrubJSONBlobFanContainerAndFlatRowShareEmailSeed(t *testing.T) {
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	nested := ScrubJSONBlob(map[string]any{
+		"fan": map[string]any{
+			"id":        "f1",
+			"email":     "p@example.com",
+			"firstName": "P",
+		},
+	}, Opts{Salt: salt}).(map[string]any)
+	flat := ScrubJSONBlob(map[string]any{
+		"email": "p@example.com",
+		"name":  "P",
+	}, Opts{Salt: salt}).(map[string]any)
+
+	fan := nested["fan"].(map[string]any)
+	want := Token(salt, "p@example.com")
+	if fan["fan_ref"] != want {
+		t.Fatalf("nested fan_ref = %v, want email-seeded %v", fan["fan_ref"], want)
+	}
+	if flat["fan_ref"] != want {
+		t.Fatalf("flat fan_ref = %v, want email-seeded %v", flat["fan_ref"], want)
+	}
+	if fan["fan_ref"] != flat["fan_ref"] {
+		t.Fatalf("same person produced different nested and flat fan_ref values: %v vs %v", fan["fan_ref"], flat["fan_ref"])
+	}
+}
+
+func TestScrubJSONBlobFanContainerKeepsSingleEmailSeededToken(t *testing.T) {
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	out := ScrubJSONBlob(map[string]any{
+		"fan": map[string]any{
+			"id":        "f1",
+			"email":     "p@example.com",
+			"name":      "P Example",
+			"firstName": "P",
+			"phone":     "5550100",
+		},
+	}, Opts{Salt: salt}).(map[string]any)
+
+	fan := out["fan"].(map[string]any)
+	if fan["fan_ref"] != Token(salt, "p@example.com") {
+		t.Fatalf("fan_ref = %v, want email-seeded token", fan["fan_ref"])
+	}
+	for _, k := range []string{"email", "name", "firstName", "phone"} {
+		if _, ok := fan[k]; ok {
+			t.Fatalf("fan container left direct identifier %q: %+v", k, fan)
+		}
+	}
+}
+
+func TestScrubJSONBlobFanContainerUsesIDWhenEmailMissing(t *testing.T) {
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	out := ScrubJSONBlob(map[string]any{
+		"fan": map[string]any{
+			"id":        "f1",
+			"firstName": "P",
+			"phone":     "5550100",
+		},
+	}, Opts{Salt: salt}).(map[string]any)
+
+	fan := out["fan"].(map[string]any)
+	if fan["fan_ref"] != Token(salt, "f1") {
+		t.Fatalf("fan_ref = %v, want id-seeded token", fan["fan_ref"])
+	}
+	for _, k := range []string{"firstName", "phone"} {
+		if _, ok := fan[k]; ok {
+			t.Fatalf("fan container left direct identifier %q: %+v", k, fan)
+		}
+	}
+}
+
+func TestScrubJSONBlobIncludePIIDropsDOB(t *testing.T) {
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	blob := map[string]any{
+		"email": "raw@example.com",
+		"name":  "Raw Fan",
+		"dob":   "1999-09-09",
+	}
+	out := ScrubJSONBlob(blob, Opts{Salt: salt, IncludePII: true}).(map[string]any)
+	if out["email"] != "raw@example.com" || out["name"] != "Raw Fan" {
+		t.Fatalf("include_pii dropped raw non-dob identifiers: %+v", out)
+	}
+	if _, ok := out["dob"]; ok {
+		t.Fatalf("include_pii left dob: %+v", out)
+	}
+	if out["fan_ref"] != Token(salt, "raw@example.com") {
+		t.Fatalf("include_pii missing stable fan_ref: %+v", out)
+	}
+}
+
+func TestScrubJSONBlobRedactsHolderNameWithoutEmail(t *testing.T) {
+	salt := []byte("0123456789abcdef0123456789abcdef")
+	blob := map[string]any{
+		"holder_name":  "Name Only",
+		"holder_email": "",
+		"dob":          "1990-01-01",
+		"claimed":      true,
+	}
+	out := ScrubJSONBlob(blob, Opts{Salt: salt}).(map[string]any)
+	for _, k := range []string{"holder_name", "holder_email", "dob"} {
+		if _, ok := out[k]; ok {
+			t.Fatalf("ScrubJSONBlob left seedless holder PII key %q: %+v", k, out)
+		}
+	}
+	if out["claimed"] != true {
+		t.Fatalf("ScrubJSONBlob altered non-PII field: %+v", out)
+	}
+	if out["fan_ref"] != Token(salt, "name only") {
+		t.Fatalf("ScrubJSONBlob missing name-derived fan_ref: %+v", out)
+	}
+}
+
+func TestReadOrCreateSaltRejectsWrongLengthSidecar(t *testing.T) {
+	path := filepath.Join(t.TempDir(), saltSidecarName)
+	if err := os.WriteFile(path, []byte("short"), 0o600); err != nil {
+		t.Fatalf("write short sidecar: %v", err)
+	}
+
+	salt, err := readOrCreateSalt(path)
+	if err == nil {
+		t.Fatalf("readOrCreateSalt returned nil error and salt %x for wrong-length sidecar", salt)
+	}
+	if !strings.Contains(err.Error(), "wrong length 5 (expected 32)") {
+		t.Fatalf("wrong-length error did not explain refusal: %v", err)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read sidecar after error: %v", readErr)
+	}
+	if string(got) != "short" {
+		t.Fatalf("wrong-length sidecar was overwritten: %q", got)
+	}
+}
+
+func TestReadOrCreateSaltCreatesMissingSidecar(t *testing.T) {
+	path := filepath.Join(t.TempDir(), saltSidecarName)
+
+	salt, err := readOrCreateSalt(path)
+	if err != nil {
+		t.Fatalf("readOrCreateSalt missing sidecar: %v", err)
+	}
+	if len(salt) != saltLen {
+		t.Fatalf("created salt length = %d, want %d", len(salt), saltLen)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat created sidecar: %v", err)
+	}
+	if info.Size() != saltLen {
+		t.Fatalf("created sidecar size = %d, want %d", info.Size(), saltLen)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("created sidecar mode = %o, want 0600", got)
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/mcp/scrub_handler_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/scrub_handler_test.go
@@ -1,0 +1,320 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Tests for the MCP output-scrubbing wrapper applied to tickets_list/orders_list
+// (Task 10) and the shared JSON-text scrub used by search/sql (Tasks 12/13).
+// Synthetic fixtures only (IETF example.com).
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+)
+
+const testSalt = "0123456789abcdef0123456789abcdef"
+
+// A realistic GraphQL tickets envelope: data.tickets[].holder is PII.
+const ticketsEnvelope = `{"data":{"tickets":[
+  {"id":"tk-1","code":"AAA","ticketType":{"name":"GA"},"holder":{"id":"h1","email":"holder1@example.com","firstName":"Ann","phoneNumber":"5550111","dob":"1990-01-01"}},
+  {"id":"tk-2","code":"BBB","ticketType":{"name":"VIP"},"holder":{"id":"h2","email":"holder2@example.com","firstName":"Bo","phoneNumber":"5550222","dob":"1991-02-02"}}
+]}}`
+
+// A realistic orders envelope: data.orders[].fan is PII.
+const ordersEnvelope = `{"data":{"orders":[
+  {"id":"o-1","total":2500,"event":{"name":"Show A"},"fan":{"id":"f1","email":"buyer1@example.com","firstName":"Cy","phoneNumber":"5550333","dob":"1992-03-03"}}
+]}}`
+
+// A realistic returns GraphQL envelope: data.returns[] carries linked ticket
+// holder and order fan objects, both of which are PII containers.
+const returnsEnvelope = `{"data":{"returns":[
+  {"id":"ret-1","ticketId":"tk-1","returnedAt":"2026-05-01T12:00:00Z","reason":"fan_request",
+   "ticket":{"id":"tk-1","code":"RET123","holder":{"id":"h-ret","firstName":"Rita","lastName":"Return","email":"rita.return@example.com","phoneNumber":"5550444"}},
+   "order":{"id":"ord-ret","event":{"id":"evt-1","name":"Refund Show"},"fan":{"id":"fan-ret","firstName":"Omar","lastName":"Order","email":"omar.order@example.com"}}}
+]}}`
+
+// A realistic transfers GraphQL envelope plus the flat holder fields used by
+// door-list style transfer output. The scrubber must catch both nested holder
+// / fan containers and flat holder_name / holder_email fields.
+const transfersEnvelope = `{"data":{"ticketTransfers":[
+  {"id":"tr-1","transferredAt":"2026-05-02T12:00:00Z","holder_name":"Tess Transfer","holder_email":"tess.transfer@example.com",
+   "tickets":[{"id":"tk-tr","holder":{"id":"h-tr","firstName":"Nina","lastName":"New","email":"nina.new@example.com","phoneNumber":"5550555"}}],
+   "orders":[{"id":"ord-tr","event":{"id":"evt-2","name":"Transfer Show"},"fan":{"id":"fan-tr","firstName":"Frank","lastName":"From","email":"frank.from@example.com"}}]}
+]}}`
+
+// A realistic extras GraphQL envelope: data.extras[].holder uses extraSelection's
+// full fanSelection fields while product and total are non-PII discovery fields.
+const extrasEnvelope = `{"data":{"extras":[
+  {"id":"ex-1","code":"EXT123","fullPrice":2000,"commission":100,"diceCommission":50,"total":2150,"hasSeparateAccessBarcode":true,
+   "holder":{"id":"h-extra","firstName":"Ella","lastName":"Extra","email":"ella.extra@example.com","phoneNumber":"5550666","optInPartners":true},
+   "product":{"id":"prod-1","name":"Poster"},
+   "variant":{"id":"var-1","name":"Signed","size":"A2","sku":"POST-A2"},
+   "ticket":{"id":"tk-extra"}}
+]}}`
+
+func TestScrubJSONTextRedactsTicketHolderPII(t *testing.T) {
+	out, changed := scrubJSONText(ticketsEnvelope, Opts{Salt: []byte(testSalt)})
+	if !changed {
+		t.Fatalf("scrubJSONText reported no change on a PII-bearing envelope")
+	}
+	for _, pii := range []string{"holder1@example.com", "holder2@example.com", "Ann", "Bo", "5550111", "1990-01-01"} {
+		if strings.Contains(out, pii) {
+			t.Errorf("scrubbed tickets output still contains PII %q:\n%s", pii, out)
+		}
+	}
+	// Discovery + token survive.
+	for _, keep := range []string{"GA", "VIP", "fan_ref", "AAA"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("scrubbed tickets output dropped expected token/field %q:\n%s", keep, out)
+		}
+	}
+}
+
+func TestScrubJSONTextRedactsOrderFanPII(t *testing.T) {
+	out, _ := scrubJSONText(ordersEnvelope, Opts{Salt: []byte(testSalt)})
+	for _, pii := range []string{"buyer1@example.com", "Cy", "5550333", "1992-03-03"} {
+		if strings.Contains(out, pii) {
+			t.Errorf("scrubbed orders output still contains PII %q:\n%s", pii, out)
+		}
+	}
+	if !strings.Contains(out, "fan_ref") || !strings.Contains(out, "Show A") {
+		t.Errorf("scrubbed orders output dropped fan_ref or discovery field:\n%s", out)
+	}
+}
+
+func TestPseudonymizeHandlerRedactsReturnsListByDefault(t *testing.T) {
+	out := callPseudonymizedFixture(t, returnsEnvelope, map[string]any{})
+	assertNoRawPII(t, out, "rita.return@example.com", "Rita", "Return", "5550444", "omar.order@example.com", "Omar", "Order")
+	for _, keep := range []string{"Refund Show", "fan_ref", "RET123"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("scrubbed returns output dropped expected field %q:\n%s", keep, out)
+		}
+	}
+
+	ret := parsedPath(t, out, "data", "returns", 0).(map[string]any)
+	ticketHolder := ret["ticket"].(map[string]any)["holder"].(map[string]any)
+	orderFan := ret["order"].(map[string]any)["fan"].(map[string]any)
+	for name, subtree := range map[string]map[string]any{"ticket.holder": ticketHolder, "order.fan": orderFan} {
+		if _, ok := subtree["fan_ref"]; !ok {
+			t.Fatalf("%s missing fan_ref after scrub: %+v", name, subtree)
+		}
+		if _, ok := subtree["email"]; ok {
+			t.Fatalf("%s retained raw email after scrub: %+v", name, subtree)
+		}
+		if _, ok := subtree["firstName"]; ok {
+			t.Fatalf("%s retained raw firstName after scrub: %+v", name, subtree)
+		}
+	}
+}
+
+func TestPseudonymizeHandlerReturnsListIncludePII(t *testing.T) {
+	out := callPseudonymizedFixture(t, returnsEnvelope, map[string]any{"include_pii": true})
+	for _, raw := range []string{"rita.return@example.com", "Rita", "Return", "5550444", "omar.order@example.com", "Omar", "Order"} {
+		if !strings.Contains(out, raw) {
+			t.Errorf("include_pii returns_list output dropped raw value %q:\n%s", raw, out)
+		}
+	}
+	if !strings.Contains(out, "fan_ref") {
+		t.Fatalf("include_pii returns_list output missing fan_ref:\n%s", out)
+	}
+}
+
+func TestPseudonymizeHandlerRedactsTransfersListByDefault(t *testing.T) {
+	out := callPseudonymizedFixture(t, transfersEnvelope, map[string]any{})
+	assertNoRawPII(t, out, "tess.transfer@example.com", "Tess Transfer", "nina.new@example.com", "Nina", "New", "5550555", "frank.from@example.com", "Frank", "From")
+	for _, keep := range []string{"Transfer Show", "fan_ref", "tr-1"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("scrubbed transfers output dropped expected field %q:\n%s", keep, out)
+		}
+	}
+
+	transfer := parsedPath(t, out, "data", "ticketTransfers", 0).(map[string]any)
+	if _, ok := transfer["fan_ref"]; !ok {
+		t.Fatalf("flat transfer holder fields did not produce fan_ref: %+v", transfer)
+	}
+	if _, ok := transfer["holder_email"]; ok {
+		t.Fatalf("flat transfer holder_email survived scrub: %+v", transfer)
+	}
+	if _, ok := transfer["holder_name"]; ok {
+		t.Fatalf("flat transfer holder_name survived scrub: %+v", transfer)
+	}
+	ticketHolder := transfer["tickets"].([]any)[0].(map[string]any)["holder"].(map[string]any)
+	orderFan := transfer["orders"].([]any)[0].(map[string]any)["fan"].(map[string]any)
+	for name, subtree := range map[string]map[string]any{"tickets[0].holder": ticketHolder, "orders[0].fan": orderFan} {
+		if _, ok := subtree["fan_ref"]; !ok {
+			t.Fatalf("%s missing fan_ref after scrub: %+v", name, subtree)
+		}
+		if _, ok := subtree["email"]; ok {
+			t.Fatalf("%s retained raw email after scrub: %+v", name, subtree)
+		}
+	}
+}
+
+func TestPseudonymizeHandlerTransfersListIncludePII(t *testing.T) {
+	out := callPseudonymizedFixture(t, transfersEnvelope, map[string]any{"include_pii": true})
+	for _, raw := range []string{"tess.transfer@example.com", "Tess Transfer", "nina.new@example.com", "Nina", "New", "5550555", "frank.from@example.com", "Frank", "From"} {
+		if !strings.Contains(out, raw) {
+			t.Errorf("include_pii transfers_list output dropped raw value %q:\n%s", raw, out)
+		}
+	}
+	if !strings.Contains(out, "fan_ref") {
+		t.Fatalf("include_pii transfers_list output missing fan_ref:\n%s", out)
+	}
+}
+
+func TestPseudonymizeHandlerRedactsExtrasListByDefault(t *testing.T) {
+	out := callPseudonymizedFixture(t, extrasEnvelope, map[string]any{})
+	assertNoRawPII(t, out, "ella.extra@example.com", "Ella", "Extra", "5550666")
+	for _, keep := range []string{"Poster", "fan_ref", "EXT123"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("scrubbed extras output dropped expected field %q:\n%s", keep, out)
+		}
+	}
+
+	extra := parsedPath(t, out, "data", "extras", 0).(map[string]any)
+	holder := extra["holder"].(map[string]any)
+	if _, ok := holder["fan_ref"]; !ok {
+		t.Fatalf("extras holder missing fan_ref after scrub: %+v", holder)
+	}
+	for _, field := range []string{"email", "firstName", "lastName", "phoneNumber"} {
+		if _, ok := holder[field]; ok {
+			t.Fatalf("extras holder retained raw %s after scrub: %+v", field, holder)
+		}
+	}
+	product := extra["product"].(map[string]any)
+	if product["name"] != "Poster" {
+		t.Fatalf("extras product.name = %v, want Poster", product["name"])
+	}
+	if extra["total"] != float64(2150) {
+		t.Fatalf("extras total = %v, want 2150", extra["total"])
+	}
+}
+
+func TestPseudonymizeHandlerExtrasListIncludePII(t *testing.T) {
+	out := callPseudonymizedFixture(t, extrasEnvelope, map[string]any{"include_pii": true})
+	for _, raw := range []string{"ella.extra@example.com", "Ella", "Extra", "5550666"} {
+		if !strings.Contains(out, raw) {
+			t.Errorf("include_pii extras_list output dropped raw value %q:\n%s", raw, out)
+		}
+	}
+	for _, keep := range []string{"fan_ref", "Poster"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("include_pii extras_list output dropped expected field %q:\n%s", keep, out)
+		}
+	}
+	extra := parsedPath(t, out, "data", "extras", 0).(map[string]any)
+	product := extra["product"].(map[string]any)
+	if product["name"] != "Poster" {
+		t.Fatalf("include_pii extras product.name = %v, want Poster", product["name"])
+	}
+	if extra["total"] != float64(2150) {
+		t.Fatalf("include_pii extras total = %v, want 2150", extra["total"])
+	}
+}
+
+func TestSameHolderSameTokenAcrossTools(t *testing.T) {
+	// holder email in tickets and fan id-resolved token: ensure a holder's token
+	// is derived from email (holder identity) and stable.
+	out, _ := scrubJSONText(ticketsEnvelope, Opts{Salt: []byte(testSalt)})
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("re-parse scrubbed: %v", err)
+	}
+	tickets := parsed["data"].(map[string]any)["tickets"].([]any)
+	h1 := tickets[0].(map[string]any)["holder"].(map[string]any)
+	want := Token([]byte(testSalt), "holder1@example.com")
+	if h1["fan_ref"] != want {
+		t.Errorf("holder1 fan_ref = %v, want %v (token keyed on holder email)", h1["fan_ref"], want)
+	}
+}
+
+func callPseudonymizedFixture(t *testing.T, body string, args map[string]any) string {
+	t.Helper()
+	withTempStore(t)
+	handler := pseudonymizeHandler(func(_ context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		if _, ok := req.GetArguments()["include_pii"]; ok {
+			t.Fatalf("include_pii was forwarded to inner handler")
+		}
+		return mcplib.NewToolResultText(body), nil
+	})
+	res, err := handler(context.Background(), mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{Arguments: args},
+	})
+	if err != nil {
+		t.Fatalf("pseudonymizeHandler: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("pseudonymizeHandler returned error result: %#v", res)
+	}
+	return toolResultText(t, res)
+}
+
+func toolResultText(t *testing.T, res *mcplib.CallToolResult) string {
+	t.Helper()
+	if len(res.Content) != 1 {
+		t.Fatalf("tool result content len = %d, want 1", len(res.Content))
+	}
+	tc, ok := res.Content[0].(mcplib.TextContent)
+	if !ok {
+		t.Fatalf("tool result content type = %T, want TextContent", res.Content[0])
+	}
+	return tc.Text
+}
+
+func parsedPath(t *testing.T, text string, path ...any) any {
+	t.Helper()
+	var cur any
+	if err := json.Unmarshal([]byte(text), &cur); err != nil {
+		t.Fatalf("unmarshal scrubbed output: %v\n%s", err, text)
+	}
+	for _, p := range path {
+		switch key := p.(type) {
+		case string:
+			m, ok := cur.(map[string]any)
+			if !ok {
+				t.Fatalf("path %v expected object before key %q, got %T", path, key, cur)
+			}
+			cur = m[key]
+		case int:
+			a, ok := cur.([]any)
+			if !ok {
+				t.Fatalf("path %v expected array before index %d, got %T", path, key, cur)
+			}
+			if key < 0 || key >= len(a) {
+				t.Fatalf("path %v index %d out of range len %d", path, key, len(a))
+			}
+			cur = a[key]
+		default:
+			t.Fatalf("unsupported path segment %T", p)
+		}
+	}
+	return cur
+}
+
+func TestScrubJSONTextNonJSONPassthrough(t *testing.T) {
+	in := "authentication error: check your token"
+	out, changed := scrubJSONText(in, Opts{Salt: []byte(testSalt)})
+	if changed || out != in {
+		t.Errorf("non-JSON text was altered: changed=%v out=%q", changed, out)
+	}
+}
+
+func TestPIIToolDescriptionsCarryNotice(t *testing.T) {
+	// The shared notice must mention personal data + include_pii so a host can
+	// gate auto-approval.
+	for _, sub := range []string{"personal data", "include_pii", "pseudonymized"} {
+		if !strings.Contains(piiToolNotice, sub) {
+			t.Errorf("piiToolNotice missing %q: %q", sub, piiToolNotice)
+		}
+	}
+}
+
+func TestArgIsTrue(t *testing.T) {
+	cases := map[any]bool{true: true, false: false, "true": true, "1": true, "false": false, "": false, nil: false, 0: false}
+	for in, want := range cases {
+		if got := argIsTrue(in); got != want {
+			t.Errorf("argIsTrue(%v) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/mcp/sql_scrub_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/sql_scrub_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Tests for the best-effort sql-result pseudonymization (Task 13). Synthetic
+// fixtures only.
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestScrubSQLRowFlatColumns(t *testing.T) {
+	row := map[string]any{
+		"id":          "fan-1",
+		"email":       "buyer@example.com",
+		"phoneNumber": "5550100",
+		"firstName":   "Alice",
+		"lastName":    "Smith",
+		"dob":         "1990-01-01",
+		"total":       2500,
+	}
+	out := scrubSQLRow(row, Opts{Salt: []byte(testSalt)})
+	for _, k := range []string{"email", "phoneNumber", "firstName", "lastName", "dob"} {
+		if _, ok := out[k]; ok {
+			t.Errorf("scrubSQLRow left flat PII column %q: %v", k, out[k])
+		}
+	}
+	if out["total"] != 2500 {
+		t.Errorf("non-PII column altered: %v", out["total"])
+	}
+	if ref, _ := out["fan_ref"].(string); ref != Token([]byte(testSalt), "buyer@example.com") {
+		t.Errorf("fan_ref = %v, want token of email", out["fan_ref"])
+	}
+}
+
+func TestScrubSQLRowIncludePIIKeepsRawExceptDOB(t *testing.T) {
+	row := map[string]any{
+		"email": "buyer@example.com",
+		"name":  "Buyer Name",
+		"dob":   "1990-01-01",
+		"total": 2500,
+	}
+	out := scrubSQLRow(row, Opts{Salt: []byte(testSalt), IncludePII: true})
+	if out["email"] != "buyer@example.com" || out["name"] != "Buyer Name" {
+		t.Fatalf("include_pii dropped raw identifiers: %+v", out)
+	}
+	if _, ok := out["dob"]; ok {
+		t.Fatalf("include_pii left dob: %+v", out)
+	}
+	if out["fan_ref"] != Token([]byte(testSalt), "buyer@example.com") {
+		t.Fatalf("include_pii missing stable fan_ref: %+v", out)
+	}
+}
+
+func TestScrubSQLRowJSONCell(t *testing.T) {
+	// SELECT data FROM resources returns the blob as a JSON string cell.
+	blob := `{"id":"o1","event":{"name":"Show"},"fan":{"id":"f1","email":"deep@example.com","dob":"2000-02-02"}}`
+	row := map[string]any{"resource_type": "orders", "data": blob}
+	out := scrubSQLRow(row, Opts{Salt: []byte(testSalt)})
+
+	// The data cell must be re-serialized scrubbed JSON.
+	cell, ok := out["data"].(json.RawMessage)
+	if !ok {
+		t.Fatalf("data cell type = %T, want json.RawMessage", out["data"])
+	}
+	s := string(cell)
+	for _, pii := range []string{"deep@example.com", "2000-02-02"} {
+		if contains(s, pii) {
+			t.Errorf("JSON cell still contains PII %q: %s", pii, s)
+		}
+	}
+	if !contains(s, "fan_ref") || !contains(s, "Show") {
+		t.Errorf("JSON cell lost fan_ref or discovery field: %s", s)
+	}
+	// Plain analytics columns without flat PII don't get a spurious fan_ref.
+	if _, ok := out["fan_ref"]; ok {
+		t.Errorf("scrubSQLRow added a top-level fan_ref to a row with no flat PII column")
+	}
+}
+
+func TestScrubSQLRowNamePhoneWithoutEmail(t *testing.T) {
+	row := map[string]any{
+		"first_name":  "Name",
+		"last_name":   "Only",
+		"phone":       "5550100",
+		"total_spend": 10,
+		"dob":         "1990-01-01",
+	}
+	out := scrubSQLRow(row, Opts{Salt: []byte(testSalt)})
+	for _, k := range []string{"first_name", "last_name", "phone", "dob"} {
+		if _, ok := out[k]; ok {
+			t.Fatalf("scrubSQLRow left seedless PII column %q: %+v", k, out)
+		}
+	}
+	if out["total_spend"] != 10 {
+		t.Fatalf("scrubSQLRow altered non-PII column: %+v", out)
+	}
+	if out["fan_ref"] != Token([]byte(testSalt), "name only") {
+		t.Fatalf("scrubSQLRow missing name-derived fan_ref: %+v", out)
+	}
+}
+
+func TestScrubSQLRowPureAnalyticsEventNameUntouched(t *testing.T) {
+	row := map[string]any{"event_name": "Show", "total_spend": 10}
+	out := scrubSQLRow(row, Opts{Salt: []byte(testSalt)})
+	if out["event_name"] != "Show" || out["total_spend"] != 10 {
+		t.Fatalf("pure analytics row changed: %+v", out)
+	}
+	if _, ok := out["fan_ref"]; ok {
+		t.Fatalf("pure analytics row got fan_ref: %+v", out)
+	}
+}
+
+func TestScrubSQLRowNoPIINoToken(t *testing.T) {
+	row := map[string]any{"id": "evt-1", "total": 999, "name": "Show A"}
+	out := scrubSQLRow(row, Opts{Salt: []byte(testSalt)})
+	// A bare top-level `name` column is an event/venue name, not a person — it
+	// is NOT in flatPIIColumns, so this is a pure analytics row: name is
+	// preserved and no fan_ref is added.
+	if _, ok := out["fan_ref"]; ok {
+		t.Errorf("pure analytics row got a spurious fan_ref: %+v", out)
+	}
+	if out["name"] != "Show A" {
+		t.Errorf("scrubSQLRow dropped a legitimate top-level event/venue name: %v", out["name"])
+	}
+}
+
+func TestSQLDescriptionWarnsAboutAliasedPII(t *testing.T) {
+	// The sql tool description must warn that aliased/computed PII may slip
+	// through. Assert the substring is present in the registered description by
+	// re-deriving it the same way RegisterTools builds it.
+	desc := "Run read-only SQL against local database. Use for ad-hoc analysis, aggregations, and joins across synced resources. Requires sync first. " + piiToolNotice + " Scrubbing is best-effort for sql: PII in plainly-named columns (email, holder_email, phone, phoneNumber, firstName, first_name, lastName, last_name, name, holder_name, dob) and in JSON cells (e.g. SELECT data FROM resources) is redacted, but PII surfaced through a column ALIAS or a computed expression may slip through — prefer search/typed tools, or pass include_pii only when you accept raw output."
+	if !contains(desc, "ALIAS") || !contains(desc, "best-effort") {
+		t.Errorf("sql description missing the aliased-PII warning")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/library/media-and-entertainment/dice-fm/internal/mcp/tools.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/tools.go
@@ -10,17 +10,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"sync"
 	"time"
 
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/cli"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/config"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/mcp/cobratree"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/store"
-	mcplib "github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
 )
 
 // RegisterTools registers all API operations as MCP tools.
@@ -47,14 +49,15 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("extras_list",
-			mcplib.WithDescription("List extras (filter by event). Optional: event, separate-barcode. Returns array of Extra."),
+			mcplib.WithDescription("List extras (filter by event). Optional: event, separate-barcode. Returns array of Extra. "+piiToolNotice),
 			mcplib.WithString("event", mcplib.Description("Filter by event ID")),
 			mcplib.WithBoolean("separate-barcode", mcplib.Description("Filter to extras that have a separate access barcode")),
+			mcplib.WithBoolean("include_pii", mcplib.Description(includePIIArgDescription)),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/graphql", true, false, nil, []mcpParamBinding{{PublicName: "event", WireName: "event", Location: "body"}, {PublicName: "separate-barcode", WireName: "separate-barcode", Location: "body"}}, []string{}),
+		pseudonymizeHandler(makeAPIHandler("POST", "/graphql", true, false, nil, []mcpParamBinding{{PublicName: "event", WireName: "event", Location: "body"}, {PublicName: "separate-barcode", WireName: "separate-barcode", Location: "body"}}, []string{})),
 	)
 	s.AddTool(
 		mcplib.NewTool("genres_list",
@@ -67,51 +70,56 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("orders_list",
-			mcplib.WithDescription("List orders (filter by event). Optional: event. Returns array of Order."),
+			mcplib.WithDescription("List orders (filter by event). Optional: event. "+piiToolNotice),
 			mcplib.WithString("event", mcplib.Description("Filter by event ID")),
+			mcplib.WithBoolean("include_pii", mcplib.Description(includePIIArgDescription)),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/graphql", true, false, nil, []mcpParamBinding{{PublicName: "event", WireName: "event", Location: "body"}}, []string{}),
+		pseudonymizeHandler(makeAPIHandler("POST", "/graphql", true, false, nil, []mcpParamBinding{{PublicName: "event", WireName: "event", Location: "body"}}, []string{})),
 	)
 	s.AddTool(
 		mcplib.NewTool("returns_list",
-			mcplib.WithDescription("List ticket returns and refunds across your DICE events. Optional: event (a DICE event ID) to scope the results to one show. Returns an array of returns, each with id, ticketId, returnedAt, reason, and the linked ticket, order, and event. Use this to investigate refund activity; pair with returns anomalies to flag events with unusually high return rates."),
+			mcplib.WithDescription("List ticket returns and refunds across your DICE events. Optional: event (a DICE event ID) to scope the results to one show. Returns an array of returns, each with id, ticketId, returnedAt, reason, and the linked ticket, order, and event. Use this to investigate refund activity; pair with returns anomalies to flag events with unusually high return rates. "+piiToolNotice),
 			mcplib.WithString("event", mcplib.Description("Filter by event ID")),
+			mcplib.WithBoolean("include_pii", mcplib.Description(includePIIArgDescription)),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/graphql", true, false, nil, []mcpParamBinding{{PublicName: "event", WireName: "event", Location: "body"}}, []string{}),
+		pseudonymizeHandler(makeAPIHandler("POST", "/graphql", true, false, nil, []mcpParamBinding{{PublicName: "event", WireName: "event", Location: "body"}}, []string{})),
 	)
 	s.AddTool(
 		mcplib.NewTool("tickets_list",
-			mcplib.WithDescription("List sold tickets (filter by event). Optional: event, fan-phone. Returns array of Ticket."),
+			mcplib.WithDescription("List sold tickets (filter by event). Optional: event, fan-phone. "+piiToolNotice),
 			mcplib.WithString("event", mcplib.Description("Filter by event ID")),
 			mcplib.WithString("fan-phone", mcplib.Description("Filter by fan phone number")),
+			mcplib.WithBoolean("include_pii", mcplib.Description(includePIIArgDescription)),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/graphql", true, false, nil, []mcpParamBinding{{PublicName: "event", WireName: "event", Location: "body"}, {PublicName: "fan-phone", WireName: "fan-phone", Location: "body"}}, []string{}),
+		pseudonymizeHandler(makeAPIHandler("POST", "/graphql", true, false, nil, []mcpParamBinding{{PublicName: "event", WireName: "event", Location: "body"}, {PublicName: "fan-phone", WireName: "fan-phone", Location: "body"}}, []string{})),
 	)
 	s.AddTool(
 		mcplib.NewTool("transfers_list",
-			mcplib.WithDescription("List ticket transfers (filter by event). Optional: event. Returns array of TicketTransfer."),
+			mcplib.WithDescription("List ticket transfers (filter by event). Optional: event. Returns array of TicketTransfer. "+piiToolNotice),
 			mcplib.WithString("event", mcplib.Description("Filter by event ID")),
+			mcplib.WithBoolean("include_pii", mcplib.Description(includePIIArgDescription)),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/graphql", true, false, nil, []mcpParamBinding{{PublicName: "event", WireName: "event", Location: "body"}}, []string{}),
+		pseudonymizeHandler(makeAPIHandler("POST", "/graphql", true, false, nil, []mcpParamBinding{{PublicName: "event", WireName: "event", Location: "body"}}, []string{})),
 	)
 	// Search tool — faster than iterating list endpoints for finding specific items
 	s.AddTool(
 		mcplib.NewTool("search",
-			mcplib.WithDescription("Full-text search across all synced data. Faster than paginating list endpoints. Requires sync first."),
+			mcplib.WithDescription("Full-text search across all synced data. Faster than paginating list endpoints. Requires sync first. "+piiToolNotice),
 			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Search query (supports FTS5 syntax: AND, OR, NOT, quotes for phrases)")),
 			mcplib.WithNumber("limit", mcplib.Description("Max results (default 25)")),
+			mcplib.WithBoolean("include_pii", mcplib.Description(includePIIArgDescription)),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 		),
@@ -120,8 +128,9 @@ func RegisterTools(s *server.MCPServer) {
 	// SQL tool — ad-hoc analysis on synced data without API calls
 	s.AddTool(
 		mcplib.NewTool("sql",
-			mcplib.WithDescription("Run read-only SQL against local database. Use for ad-hoc analysis, aggregations, and joins across synced resources. Requires sync first."),
+			mcplib.WithDescription("Run read-only SQL against local database. Use for ad-hoc analysis, aggregations, and joins across synced resources. Requires sync first. "+piiToolNotice+" Scrubbing is best-effort for sql: PII in plainly-named columns (email, holder_email, phone, phoneNumber, firstName, first_name, lastName, last_name, name, holder_name, dob) and in JSON cells (e.g. SELECT data FROM resources) is redacted, but PII surfaced through a column ALIAS or a computed expression may slip through — prefer search/typed tools, or pass include_pii only when you accept raw output."),
 			mcplib.WithString("query", mcplib.Required(), mcplib.Description("SQL query (SELECT or WITH...SELECT). Tables match resource names.")),
+			mcplib.WithBoolean("include_pii", mcplib.Description(includePIIArgDescription)),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 		),
@@ -139,15 +148,172 @@ func RegisterTools(s *server.MCPServer) {
 		handleContext,
 	)
 
+	// Register PII post-processors for the cobratree-mirrored commands that emit
+	// personal data, BEFORE RegisterAll so the include_pii arg appears in their
+	// schemas. The human CLI stays raw; redaction is an MCP-boundary concern.
+	registerMirroredPIIScrubbers()
+
 	// Runtime Cobra-tree mirror — exposes every user-facing command that is
 	// not already covered by a typed endpoint or framework MCP tool.
 	cobratree.RegisterAll(s, cli.RootCmd(), cobratree.SiblingCLIPath)
+}
+
+// mirroredPIICommands are the cobratree-mirrored command paths whose JSON output
+// carries fan/holder personal data and must be pseudonymized at the MCP
+// boundary by default.
+var mirroredPIICommands = []string{
+	"fans top",
+	"fans profile",
+	"fans optin",
+	"fans repeat",
+	"fans segment",
+	"door list",
+}
+
+// registerMirroredPIIScrubbers wires a pseudonymizing post-processor + an
+// include_pii arg + the PII notice onto each PII-bearing mirrored command.
+func registerMirroredPIIScrubbers() {
+	for _, cmd := range mirroredPIICommands {
+		cobratree.RegisterExtraToolOption(cmd, mcplib.WithBoolean("include_pii", mcplib.Description(includePIIArgDescription)))
+		cobratree.RegisterOutputPostProcessor(cmd, mirroredPIIPostProcessor)
+		cobratree.RegisterForcedCLIArgs(cmd, "--json")
+		cobratree.RegisterDescriptionSuffix(cmd, piiToolNotice)
+	}
+}
+
+// mirroredPIIPostProcessor pseudonymizes a mirrored command's JSON stdout unless
+// include_pii was passed. PII-bearing mirrored commands must produce JSON; if a
+// format override or CLI regression returns non-JSON, fail closed instead of
+// passing possibly raw identifiers into model context.
+func mirroredPIIPostProcessor(stdout string, args map[string]any) (string, error) {
+	salt, err := saltFromStore()
+	if err != nil {
+		return "", fmt.Errorf("pseudonymization unavailable: %w", err)
+	}
+	scrubbed, changed := scrubJSONText(stdout, Opts{Salt: salt, IncludePII: argIsTrue(args["include_pii"])})
+	if !changed {
+		return "", fmt.Errorf("PII post-processing expected JSON output, got non-JSON")
+	}
+	return scrubbed, nil
 }
 
 type mcpParamBinding struct {
 	PublicName string
 	WireName   string
 	Location   string
+}
+
+// piiToolNotice is appended to every PII-bearing MCP tool description so an MCP
+// host can gate auto-approval. include_pii defaults false.
+const piiToolNotice = "Returns array of results. NOTE: returns personal data (pseudonymized by default — buyer/holder email, phone, and name are replaced with a stable fan_ref token and dob is omitted; pass include_pii:true for raw values plus the token)."
+
+// includePIIArgDescription documents the per-tool include_pii opt-in.
+const includePIIArgDescription = "Return raw personal data (email, phone, name) instead of pseudonymized fan_ref tokens. dob is always omitted. Default false. Only set true when the operator explicitly needs raw identifiers — raw PII enters the model/host context."
+
+// pseudonymizeHandler wraps a tool handler so its JSON result is run through the
+// pseudonymizer at the MCP output boundary. By default buyer/holder identifiers
+// are replaced with a stable fan_ref token (ScrubJSONBlob); include_pii:true
+// bypasses. The include_pii arg is consumed here and never forwarded to the
+// inner handler (so it can't leak into a GraphQL body).
+func pseudonymizeHandler(inner server.ToolHandlerFunc) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		includePII := argIsTrue(req.GetArguments()["include_pii"])
+
+		// Strip include_pii from the args the inner handler sees.
+		stripIncludePIIArg(&req)
+
+		res, err := inner(ctx, req)
+		if err != nil || res == nil {
+			return res, err
+		}
+		// Resolve the salt from the local store; if unavailable, fail closed by
+		// redacting with a zero salt would still tokenize but be unstable — so
+		// instead surface an error rather than risk emitting raw PII.
+		salt, serr := saltFromStore()
+		if serr != nil {
+			return mcplib.NewToolResultError(fmt.Sprintf("pseudonymization unavailable: %v", serr)), nil
+		}
+		return scrubToolResult(res, Opts{Salt: salt, IncludePII: includePII}), nil
+	}
+}
+
+// stripIncludePIIArg removes include_pii from the request arguments map so it is
+// not forwarded downstream. mcp-go exposes Arguments as `any`; only the
+// map[string]any shape is mutated.
+func stripIncludePIIArg(req *mcplib.CallToolRequest) {
+	if m, ok := req.Params.Arguments.(map[string]any); ok {
+		delete(m, "include_pii")
+	}
+}
+
+// argIsTrue interprets an MCP bool-ish argument (bool or "true"/"1" string).
+func argIsTrue(v any) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		return t == "true" || t == "1"
+	default:
+		return false
+	}
+}
+
+// scrubToolResult applies ScrubJSONBlob to every text-content block of a tool
+// result whose body parses as JSON. Non-JSON text (error strings, etc.) passes
+// through unchanged.
+func scrubToolResult(res *mcplib.CallToolResult, opts Opts) *mcplib.CallToolResult {
+	for i, c := range res.Content {
+		tc, ok := c.(mcplib.TextContent)
+		if !ok {
+			continue
+		}
+		scrubbed, changed := scrubJSONText(tc.Text, opts)
+		if changed {
+			tc.Text = scrubbed
+			res.Content[i] = tc
+		}
+	}
+	return res
+}
+
+// scrubJSONText parses text as JSON, scrubs it, and re-serializes. Returns the
+// original text + false when it is not valid JSON.
+func scrubJSONText(text string, opts Opts) (string, bool) {
+	var v any
+	if err := json.Unmarshal([]byte(text), &v); err != nil {
+		return text, false
+	}
+	scrubbed := ScrubJSONBlob(v, opts)
+	out, err := json.MarshalIndent(scrubbed, "", "  ")
+	if err != nil {
+		return text, false
+	}
+	return string(out), true
+}
+
+var (
+	saltCacheOnce sync.Once
+	saltCache     []byte
+	saltCacheErr  error
+)
+
+// saltFromStore resolves the per-store pseudonymization salt from the sidecar
+// next to the canonical SQLite path. It must not open SQLite: store.Open runs
+// migrations, and this helper is on every pseudonymized MCP read path.
+func saltFromStore() ([]byte, error) {
+	saltCacheOnce.Do(func() {
+		saltCache, saltCacheErr = readOrCreateSalt(saltPathForDB(dbPath()))
+	})
+	if saltCacheErr != nil {
+		return nil, saltCacheErr
+	}
+	return append([]byte(nil), saltCache...), nil
+}
+
+func resetSaltCacheForTest() {
+	saltCacheOnce = sync.Once{}
+	saltCache = nil
+	saltCacheErr = nil
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
@@ -328,9 +494,12 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 }
 
 func newMCPClient() (*client.Client, error) {
-	home, _ := os.UserHomeDir()
-	cfgPath := filepath.Join(home, ".config", "dice-fm-pp-cli", "config.toml")
-	cfg, err := config.Load(cfgPath)
+	// Use the CLI's own config resolver (empty path -> DICE_FM_CONFIG env, then
+	// the canonical ~/.config/dice-fm-pp-cli/config.json). The previous
+	// hardcoded "config.toml" never matched config.Load's default, so a token
+	// stored in the config file was invisible to the MCP server (it only worked
+	// via the env var).
+	cfg, err := config.Load("")
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %w", err)
 	}
@@ -375,7 +544,24 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 	}
 
-	data, _ := json.MarshalIndent(results, "", "  ")
+	// search returns full resource blobs (which still carry buyer/holder PII —
+	// the FTS index is minimized, but the returned `data` is the raw row).
+	// Pseudonymize at the MCP boundary; include_pii preserves raw identifiers
+	// except dob, which is always omitted.
+	salt, serr := saltFromStore()
+	if serr != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("pseudonymization unavailable: %v", serr)), nil
+	}
+	scrubbed := make([]any, 0, len(results))
+	for _, raw := range results {
+		var v any
+		if err := json.Unmarshal(raw, &v); err != nil {
+			// Unparseable blob: fail closed — drop it rather than emit raw.
+			continue
+		}
+		scrubbed = append(scrubbed, ScrubJSONBlob(v, Opts{Salt: salt, IncludePII: argIsTrue(req.GetArguments()["include_pii"])}))
+	}
+	data, _ := json.MarshalIndent(scrubbed, "", "  ")
 	return mcplib.NewToolResultText(string(data)), nil
 }
 
@@ -399,11 +585,21 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 // caught by OpenReadOnly's mode=ro one layer down. PRAGMA, ATTACH, VACUUM,
 // and every other DDL/DML keyword fail at this gate before reaching SQLite.
 func validateReadOnlyQuery(query string) error {
-	upper := strings.ToUpper(stripLeadingSQLNoise(query))
+	stripped := stripLeadingSQLNoise(query)
+	upper := strings.ToUpper(stripped)
 	if !strings.HasPrefix(upper, "SELECT") && !strings.HasPrefix(upper, "WITH") {
 		return fmt.Errorf("only SELECT queries are allowed")
 	}
+	if referencesDeniedSQLObject(stripped) {
+		return fmt.Errorf("query references internal SQLite metadata tables, which are not available through the sql tool")
+	}
 	return nil
+}
+
+var deniedSQLObjectRE = regexp.MustCompile(`(?i)\b(meta|sqlite_master|sqlite_schema|pragma_[A-Za-z0-9_]*|pragma)\b`)
+
+func referencesDeniedSQLObject(query string) bool {
+	return deniedSQLObjectRE.MatchString(query)
 }
 
 // stripLeadingSQLNoise removes leading whitespace, SQL line comments
@@ -472,8 +668,130 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 		results = append(results, row)
 	}
 
+	salt, serr := saltFromStore()
+	if serr != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("pseudonymization unavailable: %v", serr)), nil
+	}
+	for i := range results {
+		results[i] = scrubSQLRow(results[i], Opts{Salt: salt, IncludePII: argIsTrue(req.GetArguments()["include_pii"])})
+	}
+
 	data, _ := json.MarshalIndent(results, "", "  ")
 	return mcplib.NewToolResultText(string(data)), nil
+}
+
+// scrubSQLRow applies best-effort pseudonymization to one sql result row:
+//   - flat columns whose name is a known direct identifier are redacted
+//     (email/phone/phoneNumber/dob/firstName/lastName/name), with a fan_ref
+//     derived from an id/email column when present;
+//   - any cell whose value is (or parses as) JSON is recursed through
+//     ScrubJSONBlob so the `data` blob's nested fan/holder PII is scrubbed.
+//
+// Best-effort: PII surfaced through a column ALIAS or a computed expression is
+// not detectable by name and may slip through — documented in the tool
+// description. The input map is not mutated.
+func scrubSQLRow(row map[string]any, opts Opts) map[string]any {
+	out := make(map[string]any, len(row)+1)
+	for k, v := range row {
+		out[k] = v
+	}
+
+	// Recurse into JSON-valued cells (covers SELECT data FROM resources).
+	for k, v := range out {
+		switch cell := v.(type) {
+		case string:
+			if looksLikeJSON(cell) {
+				var parsed any
+				if err := json.Unmarshal([]byte(cell), &parsed); err == nil {
+					scrubbed := ScrubJSONBlob(parsed, opts)
+					if b, err := json.Marshal(scrubbed); err == nil {
+						out[k] = json.RawMessage(b)
+					}
+				}
+			}
+		case []byte:
+			if looksLikeJSON(string(cell)) {
+				var parsed any
+				if err := json.Unmarshal(cell, &parsed); err == nil {
+					scrubbed := ScrubJSONBlob(parsed, opts)
+					if b, err := json.Marshal(scrubbed); err == nil {
+						out[k] = json.RawMessage(b)
+					}
+				}
+			}
+		}
+	}
+
+	hasFlatPII := rowHasFlatPII(row)
+
+	// Only attach a token when the row actually carries a flat PII column;
+	// a plain analytics row (e.g. SELECT id,total) shouldn't grow a spurious
+	// fan_ref. Seed the token from a flat email/id column on the ORIGINAL row.
+	if hasFlatPII {
+		if seed := flatIdentitySeed(row); seed != "" {
+			out["fan_ref"] = Token(opts.Salt, seed)
+		}
+	}
+
+	// Redact flat direct-identifier columns by name (unambiguous set only).
+	for k := range row {
+		canon := canonicalPIIKey(k)
+		if canon == "dob" || (!opts.IncludePII && hasFlatPII && shouldRedactFlatPIIKey(canon)) {
+			delete(out, k)
+		}
+	}
+	return out
+}
+
+// rowHasFlatPII reports whether the row has any flat column whose name is an
+// direct identifier. This guards against corrupting non-PII analytics rows such
+// as event/venue name output without requiring an email/id seed to be present.
+func rowHasFlatPII(row map[string]any) bool {
+	for k := range row {
+		if isFlatPersonIdentifierKey(k) {
+			return true
+		}
+	}
+	return false
+}
+
+// flatIdentitySeed picks a token seed from a flat row: email columns first
+// (most stable cross-row fan identity), then explicit fan/holder id columns,
+// then name/phone fallbacks for person rows that lack email/id.
+func flatIdentitySeed(row map[string]any) string {
+	return identitySeed(row)
+}
+
+func isFanHolderIDKey(k string) bool {
+	canon := canonicalPIIKey(k)
+	return canon == "fan_id" || canon == "fanid" || canon == "holder_id" || canon == "holderid"
+}
+
+func isFlatPersonIdentifierKey(k string) bool {
+	canon := canonicalPIIKey(k)
+	return isFanHolderIDKey(k) ||
+		canon == "email" ||
+		canon == "holder_email" ||
+		canon == "phone" ||
+		canon == "phonenumber" ||
+		canon == "firstname" ||
+		canon == "first_name" ||
+		canon == "lastname" ||
+		canon == "last_name" ||
+		canon == "holder_name"
+}
+
+func shouldRedactFlatPIIKey(canon string) bool {
+	return flatPIIColumns[canon]
+}
+
+// looksLikeJSON reports whether s plausibly holds a JSON object or array.
+func looksLikeJSON(s string) bool {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 {
+		return false
+	}
+	return (s[0] == '{' && s[len(s)-1] == '}') || (s[0] == '[' && s[len(s)-1] == ']')
 }
 
 func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {

--- a/library/media-and-entertainment/dice-fm/internal/mcp/tools_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/mcp/tools_test.go
@@ -4,8 +4,14 @@
 package mcp
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/internal/store"
 )
 
 // TestValidateReadOnlyQuery_AllowsSelectAndWITH pins the contract: the MCP
@@ -79,6 +85,22 @@ func TestValidateReadOnlyQuery_RejectsBypassVectors(t *testing.T) {
 	}
 }
 
+func TestValidateReadOnlyQuery_RejectsSecretMetadataTables(t *testing.T) {
+	rejected := []string{
+		"SELECT value FROM meta WHERE key = 'mcp_pseudonymize_salt_v1'",
+		"SELECT * FROM meta",
+		"SELECT * FROM sqlite_master",
+		"SELECT * FROM sqlite_schema",
+		"SELECT * FROM pragma_table_info('resources')",
+		"PRAGMA table_info(resources)",
+	}
+	for _, q := range rejected {
+		if err := validateReadOnlyQuery(q); err == nil {
+			t.Errorf("validateReadOnlyQuery(%q) = nil, want metadata denylist error", q)
+		}
+	}
+}
+
 // TestStripLeadingSQLNoise checks the helper directly so a regression in the
 // stripping logic (off-by-one on /* */ length, missing newline handling on
 // --) surfaces close to the source rather than only via the integration
@@ -106,5 +128,102 @@ func TestStripLeadingSQLNoise(t *testing.T) {
 		if !strings.EqualFold(got, c.want) {
 			t.Errorf("stripLeadingSQLNoise(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+func TestSaltForStoreUsesSidecarNotMeta(t *testing.T) {
+	resetSaltCacheForTest()
+	t.Cleanup(resetSaltCacheForTest)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	p := filepath.Join(home, ".local", "share", "dice-fm-pp-cli", "data.db")
+	s, err := store.Open(p)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	salt1, err := SaltForStore(s)
+	if err != nil {
+		t.Fatalf("SaltForStore first: %v", err)
+	}
+	salt2, err := SaltForStore(s)
+	if err != nil {
+		t.Fatalf("SaltForStore second: %v", err)
+	}
+	if string(salt1) != string(salt2) {
+		t.Fatalf("salt was not stable across calls")
+	}
+	info, err := os.Stat(saltPathForStore(s))
+	if err != nil {
+		t.Fatalf("salt sidecar stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("salt sidecar mode = %o, want 0600", got)
+	}
+	if got := info.Size(); got != saltLen {
+		t.Fatalf("salt sidecar size = %d, want %d", got, saltLen)
+	}
+	if _, ok, err := s.GetMeta("mcp_pseudonymize_salt_v1"); err != nil || ok {
+		t.Fatalf("salt should not be stored in meta: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestSaltFromStoreUsesSidecarWithoutOpeningStore(t *testing.T) {
+	resetSaltCacheForTest()
+	t.Cleanup(resetSaltCacheForTest)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	db := dbPath()
+	sidecar := saltPathForDB(db)
+	salt1, err := saltFromStore()
+	if err != nil {
+		t.Fatalf("saltFromStore first: %v", err)
+	}
+	if len(salt1) != saltLen {
+		t.Fatalf("salt length = %d, want %d", len(salt1), saltLen)
+	}
+	if _, err := os.Stat(db); !os.IsNotExist(err) {
+		t.Fatalf("saltFromStore opened or created SQLite db: stat err=%v", err)
+	}
+	info, err := os.Stat(sidecar)
+	if err != nil {
+		t.Fatalf("salt sidecar stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("salt sidecar mode = %o, want 0600", got)
+	}
+
+	if err := os.Remove(sidecar); err != nil {
+		t.Fatalf("remove sidecar to prove cache: %v", err)
+	}
+	salt2, err := saltFromStore()
+	if err != nil {
+		t.Fatalf("saltFromStore second: %v", err)
+	}
+	if string(salt1) != string(salt2) {
+		t.Fatalf("cached salt changed across calls")
+	}
+	if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+		t.Fatalf("second saltFromStore re-read or recreated sidecar instead of using cache: stat err=%v", err)
+	}
+	if Token(salt1, "fan-123") != Token(salt2, "fan-123") {
+		t.Fatalf("token changed across cached salt calls")
+	}
+}
+
+func TestSQLToolRejectsSaltExfiltration(t *testing.T) {
+	withTempStore(t)
+	res, err := handleSQL(context.Background(), mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{
+			Arguments: map[string]any{"query": "SELECT value FROM meta WHERE key = 'mcp_pseudonymize_salt_v1'"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleSQL: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("salt exfiltration query was not rejected: %#v", res)
 	}
 }

--- a/library/media-and-entertainment/dice-fm/internal/store/fts_rework_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/store/fts_rework_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Tests for the FTS rework (review finding #5): content minimized to
+// non-identifying discovery fields, FTS keyed off the collision-free
+// resources.rowid, and a v2->v3 rebuild that drops PII from an existing index.
+// All fixtures are synthetic (IETF example.com, fabricated IDs/names).
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// orderBlobWithFan builds an order JSON carrying a nested fan with PII plus a
+// non-identifying event name, the realistic shape sync stores.
+const phoneToken = "5550100" // synthetic phone fragment, never a real number
+
+func orderBlobWithFan(eventName, email, first, phone string) string {
+	return `{"id":"o1","event":{"id":"e1","name":"` + eventName + `"},` +
+		`"fan":{"id":"f1","email":"` + email + `","firstName":"` + first + `","phoneNumber":"` + phone + `","dob":"1990-01-01"}}`
+}
+
+// TestFTSContentExcludesPII asserts ftsContent indexes discovery fields and
+// never the buyer/holder identifiers.
+func TestFTSContentExcludesPII(t *testing.T) {
+	blob := orderBlobWithFan("Midnight Warehouse Rave", "buyer@example.com", "Alice", phoneToken)
+	content := ftsContent(blob)
+	if !strings.Contains(content, "Midnight Warehouse Rave") {
+		t.Errorf("ftsContent dropped the event name: %q", content)
+	}
+	for _, pii := range []string{"buyer@example.com", "Alice", phoneToken, "1990-01-01"} {
+		if strings.Contains(content, pii) {
+			t.Errorf("ftsContent leaked PII %q into content: %q", pii, content)
+		}
+	}
+}
+
+// TestSearchByPIIDoesNotMatchPerson seeds an order with fan PII and asserts that
+// searching for the buyer's email/phone returns nothing, while searching for
+// the (non-identifying) event name still matches.
+func TestSearchByPIIDoesNotMatchPerson(t *testing.T) {
+	s := openStore(t)
+	if err := s.Upsert("orders", "o1", []byte(orderBlobWithFan("Aurora Festival", "victim@example.com", "Bob", phoneToken))); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// Discovery field still searchable.
+	hits, err := s.Search("Aurora", 10)
+	if err != nil {
+		t.Fatalf("search event name: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Errorf("search 'Aurora' = %d hits, want 1", len(hits))
+	}
+
+	// PII not searchable.
+	for _, term := range []string{"victim", phoneToken} {
+		hits, err := s.Search(term, 10)
+		if err != nil {
+			// FTS may error on a bare token that tokenizes oddly; treat as no match.
+			continue
+		}
+		if len(hits) != 0 {
+			t.Errorf("search %q = %d hits, want 0 (PII must not be indexed)", term, len(hits))
+		}
+	}
+}
+
+// TestSearchNoCollisionDrop asserts that indexing many distinct resources and
+// then updating one does not silently drop another from search — the failure
+// mode of the old 63-bit hashed rowid. Keying off the real resources.rowid is
+// collision-free by construction.
+func TestSearchNoCollisionDrop(t *testing.T) {
+	s := openStore(t)
+	// Two resources with the SAME id under different resource_types — under the
+	// old hash these had distinct (but potentially colliding) hashed rowids;
+	// now they get distinct real rowids.
+	if err := s.Upsert("events", "shared-id", []byte(`{"id":"shared-id","name":"Alpha Show"}`)); err != nil {
+		t.Fatalf("upsert events: %v", err)
+	}
+	if err := s.Upsert("venues", "shared-id", []byte(`{"id":"shared-id","name":"Beta Venue"}`)); err != nil {
+		t.Fatalf("upsert venues: %v", err)
+	}
+	// Re-upsert (update) one of them; the other must remain searchable.
+	if err := s.Upsert("events", "shared-id", []byte(`{"id":"shared-id","name":"Alpha Show Updated"}`)); err != nil {
+		t.Fatalf("re-upsert events: %v", err)
+	}
+
+	if hits, err := s.Search("Beta", 10); err != nil || len(hits) != 1 {
+		t.Errorf("search 'Beta' = %d hits, err=%v; want 1 (other record must not be dropped)", len(hits), err)
+	}
+	if hits, err := s.Search("Updated", 10); err != nil || len(hits) != 1 {
+		t.Errorf("search 'Updated' = %d hits, err=%v; want 1", len(hits), err)
+	}
+}
+
+// TestV2ToV3MigrationDropsPIIFromIndex builds a v2-schema DB whose FTS content
+// contains the whole blob (including PII), then opens it with the current binary
+// and asserts the v3 rebuild re-projected content so PII is no longer searchable
+// while the discovery field still is.
+func TestV2ToV3MigrationDropsPIIFromIndex(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	// v2 resources table (composite key) + v2 FTS table.
+	stmts := []string{
+		`CREATE TABLE resources (
+			id TEXT NOT NULL, resource_type TEXT NOT NULL, data JSON NOT NULL,
+			synced_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (resource_type, id))`,
+		`CREATE VIRTUAL TABLE resources_fts USING fts5(id, resource_type, content, tokenize='porter unicode61')`,
+	}
+	for _, st := range stmts {
+		if _, err := raw.Exec(st); err != nil {
+			raw.Close()
+			t.Fatalf("v2 ddl: %v", err)
+		}
+	}
+	blob := orderBlobWithFan("Solstice Gathering", "leak@example.com", "Carol", phoneToken)
+	if _, err := raw.Exec(`INSERT INTO resources (id, resource_type, data) VALUES ('o1','orders',?)`, blob); err != nil {
+		raw.Close()
+		t.Fatalf("insert v2 resource: %v", err)
+	}
+	// v2-style FTS row: whole blob (incl. PII) as content, hashed-style rowid 1.
+	if _, err := raw.Exec(`INSERT INTO resources_fts (rowid, id, resource_type, content) VALUES (1,'o1','orders',?)`, blob); err != nil {
+		raw.Close()
+		t.Fatalf("insert v2 fts: %v", err)
+	}
+	if _, err := raw.Exec(`PRAGMA user_version = 2`); err != nil {
+		raw.Close()
+		t.Fatalf("stamp v2: %v", err)
+	}
+	raw.Close()
+
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open upgraded db: %v", err)
+	}
+	defer s.Close()
+
+	if v, err := s.SchemaVersion(); err != nil || v != StoreSchemaVersion {
+		t.Fatalf("schema version = %d (err %v), want %d", v, err, StoreSchemaVersion)
+	}
+
+	// Discovery field still searchable post-migration.
+	if hits, err := s.Search("Solstice", 10); err != nil || len(hits) != 1 {
+		t.Errorf("post-migration search 'Solstice' = %d hits err=%v, want 1", len(hits), err)
+	}
+	// PII no longer in the rebuilt index.
+	if hits, err := s.Search("leak", 10); err == nil && len(hits) != 0 {
+		t.Errorf("post-migration search 'leak' = %d hits, want 0 (rebuild must drop PII)", len(hits))
+	}
+}
+
+// openStore opens a fresh store in a temp dir.
+func openStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}

--- a/library/media-and-entertainment/dice-fm/internal/store/meta_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/store/meta_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Tests for the store meta(key,value) table used by the MCP pseudonymizer to
+// persist its per-store HMAC salt (and any future small key/value state).
+package store
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+)
+
+func TestMetaTableRoundTrip(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	// Missing key -> (nil, false, nil).
+	got, ok, err := s.GetMeta("absent")
+	if err != nil {
+		t.Fatalf("GetMeta absent: %v", err)
+	}
+	if ok {
+		t.Errorf("GetMeta absent: ok = true, want false")
+	}
+	if got != nil {
+		t.Errorf("GetMeta absent: value = %v, want nil", got)
+	}
+
+	// Round-trip a binary value (salt-shaped).
+	val := []byte{0x00, 0x01, 0xff, 0x7f, 0x80, 'a', 'b'}
+	if err := s.SetMeta("salt", val); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	got, ok, err = s.GetMeta("salt")
+	if err != nil {
+		t.Fatalf("GetMeta salt: %v", err)
+	}
+	if !ok {
+		t.Fatalf("GetMeta salt: ok = false, want true")
+	}
+	if !bytes.Equal(got, val) {
+		t.Errorf("GetMeta salt round-trip = %v, want %v", got, val)
+	}
+
+	// Overwrite (upsert).
+	val2 := []byte("second")
+	if err := s.SetMeta("salt", val2); err != nil {
+		t.Fatalf("SetMeta overwrite: %v", err)
+	}
+	got, _, err = s.GetMeta("salt")
+	if err != nil {
+		t.Fatalf("GetMeta after overwrite: %v", err)
+	}
+	if !bytes.Equal(got, val2) {
+		t.Errorf("GetMeta after overwrite = %q, want %q", got, val2)
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/store/perms_test.go
+++ b/library/media-and-entertainment/dice-fm/internal/store/perms_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+// Test for store-at-rest perms (Task 16): the data dir is 0700 and the db file
+// is 0600 (the store holds fan PII at rest).
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestStorePermsLeastPrivilege(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX perms not applicable on Windows")
+	}
+	dir := filepath.Join(t.TempDir(), "share", "dice-fm-pp-cli")
+	dbPath := filepath.Join(dir, "data.db")
+
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+	// Force file creation via a write.
+	if err := s.Upsert("events", "e1", []byte(`{"id":"e1","name":"Show"}`)); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	dinfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := dinfo.Mode().Perm(); perm != 0o700 {
+		t.Errorf("store dir perm = %o, want 0700", perm)
+	}
+	finfo, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat db: %v", err)
+	}
+	if perm := finfo.Mode().Perm(); perm != 0o600 {
+		t.Errorf("db file perm = %o, want 0600", perm)
+	}
+}

--- a/library/media-and-entertainment/dice-fm/internal/store/store.go
+++ b/library/media-and-entertainment/dice-fm/internal/store/store.go
@@ -41,7 +41,12 @@ func IsUUID(s string) bool {
 // shape — adding columns, dropping indexes, changing FTS5 tokenizers —
 // so an older binary refuses to open a newer database rather than silently
 // producing wrong results against a schema it cannot read.
-const StoreSchemaVersion = 2
+// v3 (2026-06-08): the meta(key,value) table is added; the FTS index is
+// minimized to non-identifying discovery fields and re-keyed off the real
+// collision-free resources.rowid (replacing a 63-bit hash). The v3 upgrade
+// rebuilds resources_fts once (drop + repopulate via ftsContent) inside the
+// migration transaction.
+const StoreSchemaVersion = 3
 
 const resourcesFTSCreateSQL = `CREATE VIRTUAL TABLE IF NOT EXISTS resources_fts USING fts5(
 	id, resource_type, content, tokenize='porter unicode61'
@@ -91,7 +96,9 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // retry-on-SQLITE_BUSY loop and propagates ctx.Err() back to the caller
 // instead of waiting out the full migrationLockTimeout.
 func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+	// 0700: the store holds fan PII at rest; don't create a world/group-
+	// traversable data directory on a multi-user host.
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
 
@@ -109,6 +116,14 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	if err := s.migrate(ctx); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("running migrations: %w", err)
+	}
+
+	// Tighten the db file to 0600 (owner-only) after migrate has created it.
+	// SQLite creates the file under the process umask (commonly 0644 ->
+	// world-readable); this store holds fan PII at rest. Best-effort: a chmod
+	// failure (e.g. on a filesystem without POSIX modes) must not block opening.
+	if _, statErr := os.Stat(dbPath); statErr == nil {
+		_ = os.Chmod(dbPath, 0o600)
 	}
 
 	return s, nil
@@ -267,6 +282,12 @@ func (s *Store) migrate(ctx context.Context) error {
 			last_synced_at DATETIME,
 			total_count INTEGER DEFAULT 0
 		)`,
+		// meta holds small key/value state (e.g. the MCP pseudonymizer's
+		// per-store HMAC salt). value is BLOB so binary salts round-trip.
+		`CREATE TABLE IF NOT EXISTS meta (
+			key TEXT PRIMARY KEY,
+			value BLOB
+		)`,
 		resourcesFTSCreateSQL,
 	}
 	migrations = append(migrations, normalizationMigrations...)
@@ -308,6 +329,27 @@ func (s *Store) migrate(ctx context.Context) error {
 		for _, m := range migrations {
 			if _, err := conn.ExecContext(ctx, m); err != nil {
 				return fmt.Errorf("migration failed: %w", err)
+			}
+		}
+
+		// v3: rebuild the FTS index so existing rows are re-projected through
+		// ftsContent (dropping email/phone/dob from the index) and re-keyed off
+		// the collision-free resources.rowid. A v1->v3 upgrade already rebuilt
+		// FTS via migrateResourcesCompositeKey (which now uses the new
+		// projection), so only re-run when coming from exactly v2 to avoid a
+		// redundant full rebuild. A fresh DB (current == StoreSchemaVersion at
+		// stamp time, but current==0 here) skips this — its rows were indexed by
+		// the new upsert path as they were inserted; on a brand-new empty DB
+		// there is nothing to rebuild.
+		if current == 2 {
+			if _, err := conn.ExecContext(ctx, `DROP TABLE IF EXISTS resources_fts`); err != nil {
+				return fmt.Errorf("v3: dropping resources_fts: %w", err)
+			}
+			if _, err := conn.ExecContext(ctx, resourcesFTSCreateSQL); err != nil {
+				return fmt.Errorf("v3: creating resources_fts: %w", err)
+			}
+			if err := rebuildResourcesFTS(ctx, conn); err != nil {
+				return fmt.Errorf("v3: rebuilding resources_fts: %w", err)
 			}
 		}
 		// Stamp the schema version. On a fresh DB this writes the current
@@ -407,12 +449,13 @@ func resourcesTableHasCompositeKey(ctx context.Context, conn *sql.Conn) (bool, e
 }
 
 func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
-	rows, err := conn.QueryContext(ctx, `SELECT id, resource_type, data FROM resources`)
+	rows, err := conn.QueryContext(ctx, `SELECT rowid, id, resource_type, data FROM resources`)
 	if err != nil {
 		return fmt.Errorf("querying resources: %w", err)
 	}
 
 	type resourceRow struct {
+		rowid        int64
 		id           string
 		resourceType string
 		data         string
@@ -420,7 +463,7 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 	var resources []resourceRow
 	for rows.Next() {
 		var r resourceRow
-		if err := rows.Scan(&r.id, &r.resourceType, &r.data); err != nil {
+		if err := rows.Scan(&r.rowid, &r.id, &r.resourceType, &r.data); err != nil {
 			rows.Close()
 			return fmt.Errorf("scanning resource: %w", err)
 		}
@@ -435,9 +478,11 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 	}
 
 	for _, r := range resources {
+		// Key by the real (collision-free) resource rowid; index only the
+		// non-identifying discovery projection (ftsContent), never the raw blob.
 		if _, err := conn.ExecContext(ctx,
 			`INSERT INTO resources_fts (rowid, id, resource_type, content) VALUES (?, ?, ?, ?)`,
-			ftsRowID(r.resourceType, r.id), r.id, r.resourceType, r.data,
+			r.rowid, r.id, r.resourceType, ftsContent(r.data),
 		); err != nil {
 			return fmt.Errorf("indexing resource %s/%s: %w", r.resourceType, r.id, err)
 		}
@@ -563,17 +608,33 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 		return err
 	}
 
-	ftsRowid := ftsRowID(resourceType, id)
+	// Key the FTS row by the resource's real (collision-free) integer rowid.
+	// The previous design hashed (resource_type,id) into a 63-bit rowid; a hash
+	// collision made the DELETE-then-INSERT below evict ANOTHER record's FTS
+	// row, silently dropping it from search. resources is a rowid table with a
+	// composite UNIQUE (resource_type,id), so its implicit rowid is unique per
+	// record — read it back and reuse it as the FTS rowid.
+	var ftsRowid int64
+	if err := tx.QueryRow(
+		`SELECT rowid FROM resources WHERE resource_type = ? AND id = ?`,
+		resourceType, id,
+	).Scan(&ftsRowid); err != nil {
+		return fmt.Errorf("resolving resource rowid for FTS: %w", err)
+	}
+
 	// Use explicit rowid for FTS5 compatibility with modernc.org/sqlite.
 	// Standard DELETE WHERE column=? may not work on FTS5 virtual tables.
 	if _, err = tx.Exec(`DELETE FROM resources_fts WHERE rowid = ?`, ftsRowid); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: FTS index cleanup failed: %v\n", err)
 	}
 
+	// Index ONLY non-identifying discovery fields (ftsContent), never the raw
+	// blob — so search "<a buyer email/phone>" no longer matches a person and
+	// the PII footprint at rest is not duplicated into the index.
 	if _, err = tx.Exec(
 		`INSERT INTO resources_fts (rowid, id, resource_type, content)
 		 VALUES (?, ?, ?, ?)`,
-		ftsRowid, id, resourceType, string(data),
+		ftsRowid, id, resourceType, ftsContent(string(data)),
 	); err != nil {
 		// FTS insert failure is non-fatal
 		fmt.Fprintf(os.Stderr, "warning: FTS index update failed: %v\n", err)
@@ -636,6 +697,35 @@ func (s *Store) List(resourceType string, limit int) ([]json.RawMessage, error) 
 	return results, rows.Err()
 }
 
+// GetMeta reads a value from the meta key/value table. The bool reports
+// presence (false + nil value for an absent key, with a nil error).
+func (s *Store) GetMeta(key string) ([]byte, bool, error) {
+	var val []byte
+	err := s.db.QueryRow(`SELECT value FROM meta WHERE key = ?`, key).Scan(&val)
+	if err == sql.ErrNoRows {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("reading meta %q: %w", key, err)
+	}
+	return val, true, nil
+}
+
+// SetMeta writes (inserts or replaces) a value in the meta key/value table.
+func (s *Store) SetMeta(key string, value []byte) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.db.Exec(
+		`INSERT INTO meta (key, value) VALUES (?, ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		key, value,
+	)
+	if err != nil {
+		return fmt.Errorf("writing meta %q: %w", key, err)
+	}
+	return nil
+}
+
 func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 	if limit <= 0 {
 		limit = 50
@@ -673,19 +763,80 @@ func extractObjectID(obj map[string]any) string {
 	return ""
 }
 
-// ftsRowID derives a deterministic rowid from a string ID for use with FTS5.
-// modernc.org/sqlite's FTS5 implementation may not support DELETE WHERE column=?
-// on virtual tables, so we use explicit rowids and DELETE WHERE rowid=? instead.
-func ftsRowID(scope, id string) int64 {
-	var h uint64
-	for _, c := range scope {
-		h = h*31 + uint64(c)
+// ftsPIIContainerKeys names JSON object keys whose entire subtree is personal
+// data and must NEVER be indexed into the FTS content. Buyer/holder identifiers
+// (email, phone, name, dob) live under these keys; pruning the subtree wholesale
+// is safer than denylisting individual field names that could drift.
+var ftsPIIContainerKeys = map[string]bool{
+	"fan":    true,
+	"holder": true,
+}
+
+// ftsContentAllowedKeys names the non-identifying discovery fields indexed into
+// resources_fts.content. This is a strict ALLOWLIST: only string values under
+// these keys (and only outside any PII container subtree) are indexed. Direct
+// identifiers (email/phoneNumber/firstName/lastName/dob) are absent by design,
+// so even a top-level stray identifier is never indexed.
+//
+// Covers the DICE discovery surface (events/venues/ticket-types/genres/artists/
+// status) plus the generic synthetic keys the store's own tests use (note).
+var ftsContentAllowedKeys = map[string]bool{
+	"name":        true, // event / venue / ticket-type / artist / genre / product names
+	"description": true,
+	"state":       true, // event status (e.g. on_sale)
+	"status":      true,
+	"city":        true, // venue city (NOT ipCity, which is buyer-derived and excluded)
+	"region":      true,
+	"country":     true, // venue country (NOT ipCountry)
+	"type":        true, // venue type
+	"genres":      true,
+	"genreTypes":  true,
+	"note":        true, // generic/synthetic resources used by store tests
+	"kind":        true,
+	"title":       true,
+}
+
+// ftsContent projects a resource's JSON blob down to a space-joined string of
+// ONLY non-identifying discovery fields, for indexing into resources_fts. It
+// walks the JSON, collecting string values whose object key is in
+// ftsContentAllowedKeys, and prunes any subtree under a PII container key
+// (fan/holder) so buyer/holder identifiers never enter the index. Unparseable
+// JSON yields an empty content string (nothing indexed) rather than the raw
+// blob — fail closed for privacy.
+func ftsContent(data string) string {
+	var v any
+	if err := json.Unmarshal([]byte(data), &v); err != nil {
+		return ""
 	}
-	h *= 31
-	for _, c := range id {
-		h = h*31 + uint64(c)
+	var sb strings.Builder
+	collectFTSContent(v, "", &sb)
+	return strings.TrimSpace(sb.String())
+}
+
+// collectFTSContent recursively walks a decoded JSON value. keyForValue is the
+// object key under which this value sits (empty at the root and inside arrays).
+func collectFTSContent(v any, keyForValue string, sb *strings.Builder) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, child := range t {
+			if ftsPIIContainerKeys[k] {
+				continue // prune the entire PII subtree (fan/holder)
+			}
+			collectFTSContent(child, k, sb)
+		}
+	case []any:
+		for _, child := range t {
+			// Array elements inherit the array's key (e.g. genres: ["techno"],
+			// artists: [{name: ...}]) so a list of allowed scalars is indexed.
+			collectFTSContent(child, keyForValue, sb)
+		}
+	case string:
+		if ftsContentAllowedKeys[keyForValue] {
+			sb.WriteString(t)
+			sb.WriteByte(' ')
+		}
 	}
-	return int64(h & 0x7FFFFFFFFFFFFFFF) // ensure positive
+	// Numbers/bools/null are never identifying discovery text; skip.
 }
 
 // LookupFieldValue resolves a field value from a JSON object map, trying the

--- a/library/media-and-entertainment/dice-fm/scripts/test-race.sh
+++ b/library/media-and-entertainment/dice-fm/scripts/test-race.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run the dice-fm test suite under the Go data-race detector.
+#
+# The 2026-06-08 whole-project review flagged that `go test -race
+# ./internal/cli/` was not a routine gate; a test that opened the operator's
+# real ~70k-row default-path store made the race build time out, masking the
+# bar. That test is now isolated to a temp store, and the package-global output
+# toggles (--no-color/--human-friendly) were moved off mutable package state, so
+# the suite is race-clean. This script keeps `-race` a one-command local gate.
+#
+# CI for the public library is generator/library-owned (per-CLI workflows can't
+# be added), so this is the local equivalent until an upstream `-race` step
+# lands. Run from the CLI module root:  bash scripts/test-race.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> go build ./..."
+go build ./...
+
+echo "==> go vet ./..."
+go vet ./...
+
+echo "==> go test -race -count=1 ./..."
+go test -race -count=1 ./...
+
+echo "==> race-clean"


### PR DESCRIPTION
## Summary

Consolidated follow-up to #1109: fixes every actionable finding from a 2026-06-08 whole-project
review of dice-fm (correctness + privacy + security + hardening + nits), reweighted for the
solo + agent/MCP-driven deployment model, in a single amend. The headline is an MCP-boundary
**pseudonymization layer** so agent use never leaks raw fan PII into model context.

## Privacy (headline)

- **Drop `dob`** from fan collection (unused; data minimization).
- **FTS index minimized** to non-identifying discovery fields (event/venue/ticket-type/genre/
  artist/status) — no longer indexes email/phone/name/dob — and **re-keyed off `resources.rowid`**,
  replacing a 63-bit hash that could silently drop a record on collision (one-time v2→v3 rebuild).
- **MCP pseudonymizer:** a salted HMAC `fan:<hash>` token, stable per person (linkable) but not
  reversible (per-store 32-byte random salt in a `0600` sidecar file, never emitted, outside the
  sql-reachable DB). Applied at the MCP boundary only — the human CLI stays raw. Covers typed
  `tickets_list`/`orders_list`, `search`, `sql` (best-effort flat-column + JSON-cell scrub, with an
  aliased-PII warning), and the cobratree-mirrored `fans*`/`door` commands. Redact-by-default;
  `include_pii` opts into raw (but `dob` is always dropped). "Returns personal data" notices added.

## Correctness

- Isolate CLI tests from the real default-path store (a dry-run test was scanning the live DB and
  timing out under `-race`); remove a latent output-flag race; add a `-race` test step.
- `revenue --by-axis` sums **paid** ticket total on both scoped and unscoped paths (they previously
  disagreed: list price vs paid).
- `sync` surfaces fan-derivation errors and gates the resume cursor on fan persistence (no more
  silent fan loss with an advanced cursor).

## Security / hardening

- `--deliver webhook`: **https-only + SSRF deny** (RFC1918/loopback/link-local/metadata, on any
  resolved IP) unless `--allow-private-webhook`; stderr audit line.
- Least-privilege perms: store dir `0700` + db `0600`, deliver dir `0700`, cache `0600`/`0700`.
  `feedback` https-only. MCP uses the canonical `config.json` path.
- `sql` tool denies `meta`/`sqlite_master`/`pragma` (defense-in-depth).

## Nits

Hide the GraphQL-incompatible REST `import` command (CLI + MCP); dogfood 1-page-cap notice; document
the analytics(inclusive)/sync(exclusive) date-window bound; drop a dead `pageInfo` selection;
`analytics --group-by` dotted json paths.

## Out of scope

Fan erasure/retention (`fans forget` + age-out) — a feature, not a bug; deliberately deferred.

## Verification

`go build`, `go vet`, `go test ./...`, and `go test -race ./...` all green. The MCP pseudonymization
layer went through two rounds of independent code/security/privacy review plus probes; two CRITICALs
(flat-shape PII leak, salt exfiltration via `sql`) and two residual leaks (a `csv`-arg bypass, and
seed-coupled redaction missing name-only rows) were found and closed before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
