### PR TITLE
fix(eu-tenders): resolve descriptive titles for BE notices with reference-only title-lot

### DIFF
--- a/library/sales-and-crm/eu-tenders/.printing-press-patches/bel-descriptive-title-fallback.json
+++ b/library/sales-and-crm/eu-tenders/.printing-press-patches/bel-descriptive-title-fallback.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 2,
+  "id": "bel-descriptive-title-fallback",
+  "applied_at": "2026-06-09",
+  "base_run_id": "20260508-143927",
+  "base_printing_press_version": "4.0.6",
+  "summary": "Resolve descriptive notice titles for buyers whose title-lot holds only a lot reference code.",
+  "reason": "Two compounding bugs produced reference-shaped titles like 'EPV/2026/03/TP - 1' for many BE notices: (1) extractNotice preferred title-lot over title-proc, and many buyers fill title-lot with '<reference> - <lotnum>' instead of a subject; (2) ResolveMultilingual only unwrapped map[lang] -> []string and silently returned '' for map[lang] -> string fields like title-proc, so even reordering the chain would skip title-proc. Fix reorders the fallback to title-proc > title-lot > contract-title and teaches ResolveMultilingual to handle scalar-string language values.",
+  "files": [
+    "internal/cli/sync.go",
+    "internal/store/store.go",
+    "internal/store/multilingual_test.go"
+  ],
+  "validated_outcome": "go test ./... passes (new TestResolveMultilingual covers both shapes). Live re-sync of BE notices 375174-2026, 350076-2026, 339972-2026, 339994-2026 now stores descriptive titles (e.g. 'Installation temporaire de signalisation routière verticale') instead of '<reference> - 1'.",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator title-extraction template should prefer the descriptive procedure title over the lot-reference title field, and the multilingual resolver should handle both scalar-string and array language-value shapes for any TED-style API.",
+      "reason": "Both fixes generalize to every printed CLI over the TED v3 API (and any API returning per-language scalar strings), not just eu-tenders-pp-cli."
+    }
+  ]
+}

--- a/library/sales-and-crm/eu-tenders/internal/cli/sync.go
+++ b/library/sales-and-crm/eu-tenders/internal/cli/sync.go
@@ -283,19 +283,19 @@ func extractNotice(raw map[string]interface{}, syncedAt string) store.Notice {
 	if v, ok := raw["deadline-receipt-tender-date-lot"]; ok {
 		n.SubmissionDeadline = store.ResolveMultilingual(v)
 	}
-	// title-lot is the most reliable title field in TED v3 (works for both
-	// cn-standard and can-standard). Fall back through title-proc then the
-	// legacy contract-title field for older eForms notices.
-	if v, ok := raw["title-lot"]; ok {
-		n.Title = store.ResolveMultilingual(v)
-	}
-	if n.Title == "" {
-		if v, ok := raw["title-proc"]; ok {
-			n.Title = store.ResolveMultilingual(v)
+	// PATCH(amend-2026-06-09: prefer title-proc over title-lot) — many buyers
+	// (notably BE/Wallonia/Brussels) fill title-lot with the lot reference code
+	// plus lot number (e.g. "EPV/2026/03/TP - 1"), not a human-readable subject.
+	// title-proc carries the descriptive procedure title in those cases, so it is
+	// the more reliable first choice. Fall back to title-lot (still descriptive
+	// for notices that omit title-proc), then the legacy contract-title field for
+	// older eForms notices. Reference-shaped lot titles are dropped in favor of a
+	// real subject when one exists.
+	for _, field := range []string{"title-proc", "title-lot", "contract-title"} {
+		if n.Title != "" {
+			break
 		}
-	}
-	if n.Title == "" {
-		if v, ok := raw["contract-title"]; ok {
+		if v, ok := raw[field]; ok {
 			n.Title = store.ResolveMultilingual(v)
 		}
 	}

--- a/library/sales-and-crm/eu-tenders/internal/store/multilingual_test.go
+++ b/library/sales-and-crm/eu-tenders/internal/store/multilingual_test.go
@@ -1,0 +1,65 @@
+package store
+
+import "testing"
+
+// TestResolveMultilingual covers both TED v3 multilingual shapes: language
+// values that are arrays (e.g. title-lot) and language values that are scalar
+// strings (e.g. title-proc). Regression for the 2026-06-09 amend: scalar-string
+// language values previously resolved to "" and were silently skipped.
+func TestResolveMultilingual(t *testing.T) {
+	cases := []struct {
+		name string
+		in   interface{}
+		want string
+	}{
+		{
+			name: "array language values (title-lot shape)",
+			in:   map[string]interface{}{"nld": []interface{}{"EPV/2026/03/TP - 1"}},
+			want: "EPV/2026/03/TP - 1",
+		},
+		{
+			name: "scalar string language values (title-proc shape)",
+			in:   map[string]interface{}{"nld": "Het tijdelijk plaatsen van verplaatsbare verticale wegsignalisatie"},
+			want: "Het tijdelijk plaatsen van verplaatsbare verticale wegsignalisatie",
+		},
+		{
+			name: "language preference order prefers eng over nld",
+			in: map[string]interface{}{
+				"nld": "Nederlandse titel",
+				"eng": "English title",
+			},
+			want: "English title",
+		},
+		{
+			name: "scalar empty string falls through to next language",
+			in: map[string]interface{}{
+				"eng": "",
+				"nld": "Nederlandse titel",
+			},
+			want: "Nederlandse titel",
+		},
+		{
+			name: "top-level array",
+			in:   []interface{}{"plain array title"},
+			want: "plain array title",
+		},
+		{
+			name: "top-level string",
+			in:   "plain string title",
+			want: "plain string title",
+		},
+		{
+			name: "nil",
+			in:   nil,
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveMultilingual(tc.in); got != tc.want {
+				t.Errorf("ResolveMultilingual() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/library/sales-and-crm/eu-tenders/internal/store/multilingual_test.go
+++ b/library/sales-and-crm/eu-tenders/internal/store/multilingual_test.go
@@ -31,6 +31,14 @@ func TestResolveMultilingual(t *testing.T) {
 			want: "English title",
 		},
 		{
+			name: "array empty string falls through to next language",
+			in: map[string]interface{}{
+				"eng": []interface{}{""},
+				"nld": "Nederlandse titel",
+			},
+			want: "Nederlandse titel",
+		},
+		{
 			name: "scalar empty string falls through to next language",
 			in: map[string]interface{}{
 				"eng": "",

--- a/library/sales-and-crm/eu-tenders/internal/store/store.go
+++ b/library/sales-and-crm/eu-tenders/internal/store/store.go
@@ -240,10 +240,23 @@ func scanNotices(rows *sql.Rows) ([]Notice, error) {
 func ResolveMultilingual(v interface{}) string {
 	switch t := v.(type) {
 	case map[string]interface{}:
+		// PATCH(amend-2026-06-09: handle scalar-string language values) — TED v3
+		// returns some multilingual fields as map[lang] -> []string (e.g.
+		// title-lot) and others as map[lang] -> string (e.g. title-proc). The
+		// original code only unwrapped the array shape, so scalar fields like
+		// title-proc silently resolved to "" and the title fallback chain skipped
+		// them. Handle both shapes per language.
 		for _, lang := range []string{"eng", "deu", "fra", "nld"} {
-			if arr, ok := t[lang].([]interface{}); ok && len(arr) > 0 {
-				if s, ok := arr[0].(string); ok {
-					return s
+			switch lv := t[lang].(type) {
+			case []interface{}:
+				if len(lv) > 0 {
+					if s, ok := lv[0].(string); ok {
+						return s
+					}
+				}
+			case string:
+				if lv != "" {
+					return lv
 				}
 			}
 		}

--- a/library/sales-and-crm/eu-tenders/internal/store/store.go
+++ b/library/sales-and-crm/eu-tenders/internal/store/store.go
@@ -250,7 +250,7 @@ func ResolveMultilingual(v interface{}) string {
 			switch lv := t[lang].(type) {
 			case []interface{}:
 				if len(lv) > 0 {
-					if s, ok := lv[0].(string); ok {
+					if s, ok := lv[0].(string); ok && s != "" {
 						return s
 					}
 				}


### PR DESCRIPTION
## Summary

Many TED notices — notably BE / Wallonia / Brussels buyers — were stored with reference-shaped titles like `EPV/2026/03/TP - 1` instead of a human-readable subject. This is two compounding bugs in the sync path; this PR fixes both and adds a regression test.

## Findings

| ID | Category | Type | Rationale |
|----|----------|------|-----------|
| F1 | title-extraction | bug | `extractNotice` preferred `title-lot` over `title-proc`. For these buyers `title-lot` contains the lot reference code + lot number (`<reference> - <lotnum>`), not a subject; `title-proc` carries the real descriptive title. |
| F2 | multilingual-resolver | bug | `ResolveMultilingual` only unwrapped `map[lang] -> []string` and silently returned `""` for `map[lang] -> string` fields like `title-proc`. So even reordering the fallback chain alone would still skip `title-proc`. |

Both bugs had to be fixed together: reordering the chain (F1) is a no-op until the resolver (F2) can actually read `title-proc`.

## Changes

- `internal/cli/sync.go` — title fallback chain reordered to `title-proc` > `title-lot` > `contract-title` (descriptive procedure title first, lot title second, legacy field last).
- `internal/store/store.go` — `ResolveMultilingual` now handles both per-language value shapes: `[]string` (e.g. `title-lot`) and scalar `string` (e.g. `title-proc`).
- `internal/store/multilingual_test.go` — new `TestResolveMultilingual` covering both shapes, language-preference order, empty-string fall-through, and top-level array/string/nil.
- `.printing-press-patches/bel-descriptive-title-fallback.json` — patch manifest entry (schema_version 2) with `deferred_to_upstream` note (both fixes generalize to the generator).

```
 .../bel-descriptive-title-fallback.json            | 21 +++++++
 .../sales-and-crm/eu-tenders/internal/cli/sync.go  | 24 ++++----
 .../eu-tenders/internal/store/multilingual_test.go | 65 ++++++++++++++++++++++
 .../eu-tenders/internal/store/store.go             | 19 ++++++-
 4 files changed, 114 insertions(+), 15 deletions(-)
```

## Verification

- `go build ./...` — PASS
- `go vet ./...` — PASS
- `go test ./...` — PASS (new `TestResolveMultilingual` green)
- **Live re-sync** of BE notices via the patched binary (`--data-source local` after sync):

| Notice | Before | After |
|--------|--------|-------|
| 375174-2026 | `TO/OND/2025/2 - 1` | `TO/OND/2025/2 - Leveringen en werken voor het onderhoud, de herstelling en de vernieuwing van elektromechanische uitrustingen aanwezig in tunnels en vijzelstations` |
| 350076-2026 | `WA/OND/D112/2026/1 - 1` | `GLADHEIDBESTRIJDING IN DISTRICT PUURS VAN DE PROVINCIE ANTWERPEN - Perceel 1: ...` |
| 339972-2026 | `EPV/2026/03/TP - 1` | `Installation temporaire de signalisation routière verticale` |
| 339994-2026 | `FIN/PRO/2026/08 - 1` | `Chèques voyage` |

Reproduced originally with `eu-tenders-pp-cli deadline --country BEL --cpv 63 --agent`.

## Note for maintainers

The patch carries a `deferred_to_upstream` item: both fixes generalize to any printed CLI over the TED v3 API (and any API returning per-language scalar strings), so the generator's title-extraction template and multilingual resolver are the proper long-term home.
