### PR TITLE
fix(amazon-seller): make account health resilient

### DIFF
--- a/library/commerce/amazon-seller/.printing-press-patches/amazon-seller-account-health-resilience.json
+++ b/library/commerce/amazon-seller/.printing-press-patches/amazon-seller-account-health-resilience.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "amazon-seller-account-health-resilience",
+  "applied_at": "2026-06-09",
+  "base_run_id": "2026-05-06T17:12:38.566433Z",
+  "base_printing_press_version": "3.10.0",
+  "summary": "Make the Amazon Seller account-health dashboard resolve a default marketplace and tolerate unavailable optional report slices.",
+  "reason": "Amazon Health should work for agents without hand-supplying marketplaceIds, and one CANCELLED or otherwise unavailable SP-API report should not fail the whole dashboard when cached or partial health data can still be returned.",
+  "files": [
+    "internal/cli/novel_account.go",
+    "internal/cli/novel_report_helpers.go",
+    "internal/cli/novel_amazon_seller_test.go"
+  ],
+  "validated_outcome": "go test ./internal/cli -run 'Test(PreferredMarketplaceIDPrefersParticipatingAmazonUS|EnsureReportsResolvesMarketplaceFromSellerParticipations|OptionalReportCancellationDoesNotFailBatch)' -count=1; go test ./internal/cli -count=1"
+}

--- a/library/commerce/amazon-seller/internal/cli/novel_account.go
+++ b/library/commerce/amazon-seller/internal/cli/novel_account.go
@@ -18,10 +18,10 @@ func newAccountHealthCmd(flags *rootFlags) *cobra.Command {
 	dashboard := &cobra.Command{Use: "dashboard", Short: "Show account health summary", RunE: func(cmd *cobra.Command, args []string) error {
 		return runNovelCommand(cmd, flags, novelRunOptions{DBPath: dbPath, MarketplaceID: marketplaceID, ReportTimeout: reportTimeout}, func(ctx context.Context, r *novelCommandRunner) (any, error) {
 			if err := r.ensureReports(ctx,
-				marketSpec("GET_MERCHANTS_LISTINGS_FYP_REPORT", marketplaceID, 1),
-				marketSpec("GET_STRANDED_INVENTORY_UI_DATA", marketplaceID, 1),
-				marketSpec("GET_FBA_FULFILLMENT_CUSTOMER_RETURNS_DATA", marketplaceID, 30),
-				marketSpec("GET_FBA_REIMBURSEMENTS_DATA", marketplaceID, 30),
+				optionalMarketSpec("GET_MERCHANTS_LISTINGS_FYP_REPORT", marketplaceID, 1),
+				optionalMarketSpec("GET_STRANDED_INVENTORY_UI_DATA", marketplaceID, 1),
+				optionalMarketSpec("GET_FBA_FULFILLMENT_CUSTOMER_RETURNS_DATA", marketplaceID, 30),
+				optionalMarketSpec("GET_FBA_REIMBURSEMENTS_DATA", marketplaceID, 30),
 			); err != nil {
 				return nil, err
 			}

--- a/library/commerce/amazon-seller/internal/cli/novel_amazon_seller_test.go
+++ b/library/commerce/amazon-seller/internal/cli/novel_amazon_seller_test.go
@@ -18,15 +18,23 @@ import (
 )
 
 type mockReportAPI struct {
-	postResponse json.RawMessage
-	getResponses []json.RawMessage
-	getErr       error
-	postErr      error
+	postResponse  json.RawMessage
+	postResponses []json.RawMessage
+	postBodies    []any
+	getResponses  []json.RawMessage
+	getErr        error
+	postErr       error
 }
 
 func (m *mockReportAPI) Post(path string, body any) (json.RawMessage, int, error) {
+	m.postBodies = append(m.postBodies, body)
 	if m.postErr != nil {
 		return nil, 0, m.postErr
+	}
+	if len(m.postResponses) > 0 {
+		raw := m.postResponses[0]
+		m.postResponses = m.postResponses[1:]
+		return raw, http.StatusAccepted, nil
 	}
 	if len(m.postResponse) == 0 {
 		return json.RawMessage(`{"reportId":"r1"}`), http.StatusAccepted, nil
@@ -258,6 +266,69 @@ func TestPollReportStatus(t *testing.T) {
 	}
 	if doc != "d1" {
 		t.Fatalf("doc = %q", doc)
+	}
+}
+
+func TestPreferredMarketplaceIDPrefersParticipatingAmazonUS(t *testing.T) {
+	raw := json.RawMessage(`{"payload":[
+		{"marketplace":{"id":"A2ZV50J4W1RKNI","countryCode":"US","domainName":"sim1.stores.amazon.com","name":"Non-Amazon US"},"participation":{"isParticipating":true}},
+		{"marketplace":{"id":"ATVPDKIKX0DER","countryCode":"US","domainName":"www.amazon.com","name":"Amazon.com"},"participation":{"isParticipating":true}},
+		{"marketplace":{"id":"A2EUQ1WTGCTBG2","countryCode":"CA","domainName":"www.amazon.ca","name":"Amazon.ca"},"participation":{"isParticipating":true}}
+	]}`)
+	if got := preferredMarketplaceID(raw); got != defaultAmazonSellerMarketplaceID {
+		t.Fatalf("marketplace = %q, want %q", got, defaultAmazonSellerMarketplaceID)
+	}
+}
+
+func TestEnsureReportsResolvesMarketplaceFromSellerParticipations(t *testing.T) {
+	db := openNovelTestDB(t)
+	api := &mockReportAPI{
+		getResponses: []json.RawMessage{
+			json.RawMessage(`{"payload":[{"marketplace":{"id":"ATVPDKIKX0DER","countryCode":"US","domainName":"www.amazon.com","name":"Amazon.com"},"participation":{"isParticipating":true}}]}`),
+			json.RawMessage(`{"processingStatus":"CANCELLED"}`),
+			json.RawMessage(`{"reports":[]}`),
+		},
+	}
+	o := newReportOrchestrator(api, nil, nil)
+	o.createMinGap = 0
+	o.pollInterval = 0
+	o.sleep = func(context.Context, time.Duration) error { return nil }
+	runner := &novelCommandRunner{
+		flags:        &rootFlags{dataSource: "live"},
+		sqlDB:        db,
+		orchestrator: o,
+		timeout:      time.Minute,
+	}
+	if err := runner.ensureReports(context.Background(), optionalMarketSpec("GET_FBA_REIMBURSEMENTS_DATA", "", 30)); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.postBodies) != 1 {
+		t.Fatalf("post bodies = %d, want 1", len(api.postBodies))
+	}
+	body, ok := api.postBodies[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected body type %T", api.postBodies[0])
+	}
+	marketplaces, ok := body["marketplaceIds"].([]string)
+	if !ok || len(marketplaces) != 1 || marketplaces[0] != defaultAmazonSellerMarketplaceID {
+		t.Fatalf("marketplaceIds = %#v, want [%s]", body["marketplaceIds"], defaultAmazonSellerMarketplaceID)
+	}
+}
+
+func TestOptionalReportCancellationDoesNotFailBatch(t *testing.T) {
+	api := &mockReportAPI{getResponses: []json.RawMessage{
+		json.RawMessage(`{"processingStatus":"CANCELLED"}`),
+		json.RawMessage(`{"reports":[]}`),
+	}}
+	o := newReportOrchestrator(api, nil, nil)
+	o.pollInterval = 0
+	o.sleep = func(context.Context, time.Duration) error { return nil }
+	results, err := o.RequestBatchAndDownload(context.Background(), []reportSpec{{Type: "GET_FBA_REIMBURSEMENTS_DATA", MarketplaceID: "ATVPDKIKX0DER", Optional: true}}, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0] != nil {
+		t.Fatalf("optional cancelled report should produce nil partial result, got %#v", results)
 	}
 }
 

--- a/library/commerce/amazon-seller/internal/cli/novel_report_helpers.go
+++ b/library/commerce/amazon-seller/internal/cli/novel_report_helpers.go
@@ -179,9 +179,6 @@ func (r *novelCommandRunner) ensureReports(ctx context.Context, specs ...reportS
 			}
 			spec.MarketplaceID = marketplaceID
 		}
-		if spec.MarketplaceID == "" {
-			spec.MarketplaceID = r.marketplace
-		}
 		if spec.MaxAge <= 0 {
 			spec.MaxAge = 24 * time.Hour
 		}
@@ -254,11 +251,7 @@ func preferredMarketplaceID(raw json.RawMessage) string {
 	items := marketplaceParticipationItems(raw)
 	var firstParticipating, firstRetailAmazon, firstUS string
 	for _, item := range items {
-		marketplace, _ := item["marketplace"].(map[string]any)
 		id := nestedString(item, "marketplace", "id")
-		if id == "" {
-			id = stringValue(marketplace["id"])
-		}
 		if id == "" || !isParticipatingMarketplace(item) {
 			continue
 		}

--- a/library/commerce/amazon-seller/internal/cli/novel_report_helpers.go
+++ b/library/commerce/amazon-seller/internal/cli/novel_report_helpers.go
@@ -26,10 +26,11 @@ import (
 )
 
 const (
-	reportCreateMinGap     = 60 * time.Second
-	defaultReportTimeout   = 15 * time.Minute
-	defaultReportPollEvery = 15 * time.Second
-	maxReportDownloadBytes = 50 << 20
+	defaultAmazonSellerMarketplaceID = "ATVPDKIKX0DER"
+	reportCreateMinGap               = 60 * time.Second
+	defaultReportTimeout             = 15 * time.Minute
+	defaultReportPollEvery           = 15 * time.Second
+	maxReportDownloadBytes           = 50 << 20
 )
 
 type reportAPIClient interface {
@@ -68,6 +69,7 @@ type reportSpec struct {
 	EndTime       string
 	Options       map[string]any
 	ListOnly      bool
+	Optional      bool
 	MaxAge        time.Duration
 }
 
@@ -149,7 +151,7 @@ func runNovelCommand(cmd *cobra.Command, flags *rootFlags, opts novelRunOptions,
 		sqlDB:        db.DB(),
 		orchestrator: o,
 		timeout:      opts.ReportTimeout,
-		marketplace:  opts.MarketplaceID,
+		marketplace:  strings.TrimSpace(opts.MarketplaceID),
 	}
 	result, err := fn(cmd.Context(), runner)
 	if err != nil {
@@ -169,6 +171,13 @@ func (r *novelCommandRunner) ensureReports(ctx context.Context, specs ...reportS
 	for _, spec := range specs {
 		if spec.Type == "" {
 			continue
+		}
+		if spec.MarketplaceID == "" {
+			marketplaceID, err := r.resolveMarketplaceID(ctx)
+			if err != nil {
+				return err
+			}
+			spec.MarketplaceID = marketplaceID
 		}
 		if spec.MarketplaceID == "" {
 			spec.MarketplaceID = r.marketplace
@@ -206,11 +215,151 @@ func (r *novelCommandRunner) ensureReports(ctx context.Context, specs ...reportS
 	}
 	for i, rows := range results {
 		spec := pending[i]
+		if rows == nil {
+			continue
+		}
 		if err := cacheReportData(r.sqlDB, spec.Type, spec.MarketplaceID, spec.StartTime, spec.EndTime, rows); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (r *novelCommandRunner) resolveMarketplaceID(ctx context.Context) (string, error) {
+	if marketplaceID := strings.TrimSpace(r.marketplace); marketplaceID != "" {
+		return marketplaceID, nil
+	}
+	if r.flags == nil || r.flags.dataSource == "local" || r.orchestrator == nil {
+		r.marketplace = defaultAmazonSellerMarketplaceID
+		return r.marketplace, nil
+	}
+	raw, err := r.orchestrator.api.Get("/sellers/v1/marketplaceParticipations", nil)
+	if err != nil {
+		if r.flags.dataSource == "auto" {
+			fmt.Fprintf(os.Stderr, "warning: could not resolve marketplace from Seller participations; defaulting to %s: %v\n", defaultAmazonSellerMarketplaceID, err)
+			r.marketplace = defaultAmazonSellerMarketplaceID
+			return r.marketplace, nil
+		}
+		return "", classifyAPIError(err, r.flags)
+	}
+	if marketplaceID := preferredMarketplaceID(raw); marketplaceID != "" {
+		r.marketplace = marketplaceID
+		return marketplaceID, nil
+	}
+	r.marketplace = defaultAmazonSellerMarketplaceID
+	return r.marketplace, nil
+}
+
+func preferredMarketplaceID(raw json.RawMessage) string {
+	items := marketplaceParticipationItems(raw)
+	var firstParticipating, firstRetailAmazon, firstUS string
+	for _, item := range items {
+		marketplace, _ := item["marketplace"].(map[string]any)
+		id := nestedString(item, "marketplace", "id")
+		if id == "" {
+			id = stringValue(marketplace["id"])
+		}
+		if id == "" || !isParticipatingMarketplace(item) {
+			continue
+		}
+		if id == defaultAmazonSellerMarketplaceID {
+			return id
+		}
+		name := strings.ToLower(nestedString(item, "marketplace", "name"))
+		domain := strings.ToLower(nestedString(item, "marketplace", "domainName"))
+		country := strings.ToUpper(nestedString(item, "marketplace", "countryCode"))
+		if firstParticipating == "" {
+			firstParticipating = id
+		}
+		if firstRetailAmazon == "" && strings.HasPrefix(name, "amazon.") && strings.Contains(domain, "amazon.") {
+			firstRetailAmazon = id
+		}
+		if firstUS == "" && country == "US" {
+			firstUS = id
+		}
+	}
+	return firstNonEmpty(firstRetailAmazon, firstUS, firstParticipating)
+}
+
+func marketplaceParticipationItems(raw json.RawMessage) []map[string]any {
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil
+	}
+	return marketplaceParticipationItemsFromAny(decoded)
+}
+
+func marketplaceParticipationItemsFromAny(value any) []map[string]any {
+	switch typed := value.(type) {
+	case []any:
+		items := make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			if obj, ok := item.(map[string]any); ok {
+				items = append(items, obj)
+			}
+		}
+		return items
+	case map[string]any:
+		for _, key := range []string{"payload", "data", "items", "results"} {
+			if nested, ok := typed[key]; ok {
+				if items := marketplaceParticipationItemsFromAny(nested); len(items) > 0 {
+					return items
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func isParticipatingMarketplace(item map[string]any) bool {
+	participation, ok := item["participation"].(map[string]any)
+	if !ok {
+		return true
+	}
+	if value, ok := participation["isParticipating"]; ok {
+		return boolValue(value, true)
+	}
+	return true
+}
+
+func nestedString(item map[string]any, path ...string) string {
+	var current any = item
+	for _, part := range path {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = obj[part]
+	}
+	return stringValue(current)
+}
+
+func stringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case nil:
+		return ""
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func boolValue(value any, fallback bool) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		switch strings.ToLower(strings.TrimSpace(typed)) {
+		case "true", "yes", "1":
+			return true
+		case "false", "no", "0":
+			return false
+		}
+	}
+	return fallback
 }
 
 func (r *novelCommandRunner) handleReportFetchError(reportType string, err error) error {
@@ -233,15 +382,18 @@ func (o *ReportOrchestrator) RequestBatchAndDownload(ctx context.Context, specs 
 		spec     reportSpec
 		reportID string
 	}
+	results := make([][]map[string]string, len(specs))
 	created := make([]createdReport, 0, len(specs))
 	for i, spec := range specs {
 		reportID, err := o.createReport(ctx, spec)
 		if err != nil {
+			if o.handleOptionalReport(ctx, spec, err, results, i) {
+				continue
+			}
 			return nil, err
 		}
 		created = append(created, createdReport{index: i, spec: spec, reportID: reportID})
 	}
-	results := make([][]map[string]string, len(specs))
 	errCh := make(chan error, len(created))
 	var wg sync.WaitGroup
 	for _, item := range created {
@@ -251,19 +403,17 @@ func (o *ReportOrchestrator) RequestBatchAndDownload(ctx context.Context, specs 
 			defer wg.Done()
 			documentID, err := o.pollUntilDone(ctx, item.reportID, timeout)
 			if err != nil {
-				if isLatestReportFallbackType(item.spec.Type) {
-					o.progress("report %s failed; trying latest completed %s report", item.reportID, item.spec.Type)
-					rows, fallbackErr := o.FindLatestReportRows(ctx, item.spec.Type, []string{item.spec.MarketplaceID}, 1)
-					if fallbackErr == nil {
-						results[item.index] = rows
-						return
-					}
+				if o.handleOptionalReport(ctx, item.spec, err, results, item.index) {
+					return
 				}
 				errCh <- err
 				return
 			}
 			data, err := o.DownloadReportDocument(ctx, documentID)
 			if err != nil {
+				if o.handleOptionalReport(ctx, item.spec, err, results, item.index) {
+					return
+				}
 				errCh <- err
 				return
 			}
@@ -274,6 +424,9 @@ func (o *ReportOrchestrator) RequestBatchAndDownload(ctx context.Context, specs 
 				rows, err = parseTSV(data)
 			}
 			if err != nil {
+				if o.handleOptionalReport(ctx, item.spec, err, results, item.index) {
+					return
+				}
 				errCh <- err
 				return
 			}
@@ -288,6 +441,23 @@ func (o *ReportOrchestrator) RequestBatchAndDownload(ctx context.Context, specs 
 		}
 	}
 	return results, nil
+}
+
+func (o *ReportOrchestrator) handleOptionalReport(ctx context.Context, spec reportSpec, cause error, results [][]map[string]string, index int) bool {
+	if !spec.Optional && !isLatestReportFallbackType(spec.Type) {
+		return false
+	}
+	o.progress("report %s unavailable; trying latest completed %s report", spec.Type, spec.Type)
+	rows, fallbackErr := o.FindLatestReportRows(ctx, spec.Type, []string{spec.MarketplaceID}, 1)
+	if fallbackErr == nil {
+		results[index] = rows
+		return true
+	}
+	if spec.Optional {
+		o.progress("warning: optional report %s unavailable; continuing with cached/local data if present: %v", spec.Type, cause)
+		return true
+	}
+	return false
 }
 
 func isLatestReportFallbackType(reportType string) bool {
@@ -719,6 +889,12 @@ func novelSinceDate(days int) string {
 func marketSpec(reportType, marketplaceID string, days int) reportSpec {
 	start, end := reportDateRange(days)
 	return reportSpec{Type: reportType, MarketplaceID: marketplaceID, StartTime: start, EndTime: end}
+}
+
+func optionalMarketSpec(reportType, marketplaceID string, days int) reportSpec {
+	spec := marketSpec(reportType, marketplaceID, days)
+	spec.Optional = true
+	return spec
 }
 
 func salesTrafficSpecs(marketplaceID string, days int) []reportSpec {


### PR DESCRIPTION
## Summary
- resolve a default marketplace for Amazon Seller account-health when --marketplace-id is omitted
- treat account-health report slices as optional so one CANCELLED/unavailable SP-API report does not fail the whole dashboard
- add focused coverage for marketplace selection, no-flag report creation, and optional report cancellation

## Validation
- go test ./internal/cli -run "Test(PreferredMarketplaceIDPrefersParticipatingAmazonUS|EnsureReportsResolvesMarketplaceFromSellerParticipations|OptionalReportCancellationDoesNotFailBatch)" -count=1
- go test ./... -count=1
- go build -o /tmp/amazon-seller-pp-cli-public-pr ./cmd/amazon-seller-pp-cli
- /tmp/amazon-seller-pp-cli-public-pr account-health dashboard --help >/dev/null

## Live check on knox
- patched binary ran `account-health dashboard --agent --data-source live --report-timeout 30s --timeout 45s` without --marketplace-id
- it created SP-API reports, handled a CANCELLED optional report via fallback/partial data, and returned account-health JSON instead of exiting nonzero
