### PR TITLE
fix(wavespeed): streamline image iteration workflow

### DIFF
--- a/library/ai/wavespeed/.printing-press-patches/wavespeed-daily-image-workflow.json
+++ b/library/ai/wavespeed/.printing-press-patches/wavespeed-daily-image-workflow.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 2,
+  "id": "wavespeed-daily-image-workflow",
+  "applied_at": "2026-06-09",
+  "base_run_id": "20260527-214905",
+  "base_printing_press_version": "4.18.1",
+  "summary": "WaveSpeed image-edit users need one-command model price discovery, enum-rich model help, reusable reference-image profiles, and one-step access to the latest downloaded output.",
+  "reason": "Daily blog-image iteration depends on comparing image-edit models by cost, choosing valid resolution/size values without guessing, reusing style anchors, checking price before submission, and opening the most recent result without parsing paths from command output.",
+  "files": [
+    "internal/cli/promoted_models.go",
+    "internal/cli/profile.go",
+    "internal/cli/root.go",
+    "internal/cli/run.go",
+    "internal/cli/run_test.go",
+    "README.md"
+  ],
+  "validated_outcome": "go test ./... and go vet ./... pass; CLI smoke verified profile save with positional image anchors, run --price-only --dry-run with the profile, models --help exposing --capability, and open --dry-run."
+}

--- a/library/ai/wavespeed/README.md
+++ b/library/ai/wavespeed/README.md
@@ -192,6 +192,7 @@ Manage model pricing
 Model catalog and model metadata
 
 - **`wavespeed-pp-cli models`** - List available WaveSpeed models and their API schemas.
+- **`wavespeed-pp-cli models --capability image-edit`** - List image-editing models as `model_id`, price/base price, pricing formula, and resolution/size enums so you can compare cheaper options without guessing IDs.
 
 ### run
 
@@ -199,6 +200,10 @@ Submit generation tasks to slash-delimited WaveSpeed model paths.
 
 - **`wavespeed-pp-cli run <model-id> --input '<json>'`** - Submit a model run with JSON inputs.
 - **`wavespeed-pp-cli run <model-id> --input-file request.json --price --wait --download`** - Price, submit, poll, and download output URLs.
+- **`wavespeed-pp-cli run <model-id> --help-model`** - Show model inputs, valid enum values such as `resolution`/`size`, and pricing formula/base price guidance.
+- **`wavespeed-pp-cli run <model-id> --price-only`** - Estimate pricing with the same flags/profile as a real run, without submitting a prediction.
+- **`wavespeed-pp-cli profile save littlemight --images @style1.png @style2.png @style3.png`** then **`wavespeed-pp-cli run <model-id> --profile littlemight -p "..."`** - Reuse Little Might reference image anchors without retyping them.
+- **`wavespeed-pp-cli last`** / **`wavespeed-pp-cli open`** - Print or open the most recently downloaded output.
 
 ### prediction_deletions
 

--- a/library/ai/wavespeed/internal/cli/profile.go
+++ b/library/ai/wavespeed/internal/cli/profile.go
@@ -116,9 +116,20 @@ func ApplyProfileToFlags(cmd *cobra.Command, profile *Profile) error {
 		if flag.Changed {
 			continue
 		}
-		if err := flag.Value.Set(value); err != nil {
+		if isProfileArrayFlag(flag) && strings.HasPrefix(strings.TrimSpace(value), "[") {
+			var items []string
+			if err := json.Unmarshal([]byte(value), &items); err != nil {
+				return fmt.Errorf("parsing profile array value %s=%q: %w", name, value, err)
+			}
+			for _, item := range items {
+				if err := flag.Value.Set(item); err != nil {
+					return fmt.Errorf("applying profile value %s=%q: %w", name, item, err)
+				}
+			}
+		} else if err := flag.Value.Set(value); err != nil {
 			return fmt.Errorf("applying profile value %s=%q: %w", name, value, err)
 		}
+		flag.Changed = true
 	}
 	return nil
 }
@@ -165,6 +176,7 @@ Explicit flags override profile values.`,
 
 func newProfileSaveCmd(flags *rootFlags) *cobra.Command {
 	var description string
+	var runDefaults runCommandOptions
 	cmd := &cobra.Command{
 		Use:   "save <name> [--<flag> <value> ...]",
 		Short: "Save the current invocation's non-default flags as a named profile",
@@ -176,9 +188,14 @@ To avoid creating empty profiles, at least one non-default flag must be
 present (other than --profile and --config).`,
 		Example: `  wavespeed-pp-cli profile save my-defaults --json --compact
   wavespeed-pp-cli profile save tonight-defaults --region US`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
+			if len(args) > 1 && cmd.Flags().Changed("images") {
+				runDefaults.images = append(runDefaults.images, args[1:]...)
+			} else if len(args) > 1 {
+				return fmt.Errorf("unexpected extra profile save args: %s", strings.Join(args[1:], ", "))
+			}
 			if strings.ContainsAny(name, `/\: `) {
 				return fmt.Errorf("profile name %q contains reserved characters", name)
 			}
@@ -187,7 +204,13 @@ present (other than --profile and --config).`,
 			skip := map[string]bool{"profile": true, "config": true, "help": true, "description": true}
 			visit := func(fl *pflag.Flag) {
 				if fl.Changed && !skip[fl.Name] {
-					values[fl.Name] = fl.Value.String()
+					if isProfileArrayFlag(fl) {
+						items := profileArrayValues(fl.Value.String())
+						raw, _ := json.Marshal(items)
+						values[fl.Name] = string(raw)
+					} else {
+						values[fl.Name] = fl.Value.String()
+					}
 				}
 			}
 			cmd.InheritedFlags().VisitAll(visit)
@@ -211,7 +234,40 @@ present (other than --profile and --config).`,
 		},
 	}
 	cmd.Flags().StringVar(&description, "description", "", "Short description shown in 'profile list'")
+	addRunInputFlags(cmd, &runDefaults)
 	return cmd
+}
+
+func isProfileArrayFlag(fl *pflag.Flag) bool {
+	if fl == nil {
+		return false
+	}
+	switch fl.Value.Type() {
+	case "stringArray", "stringSlice":
+		return true
+	default:
+		return false
+	}
+}
+
+func profileArrayValues(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "[") && strings.HasSuffix(raw, "]") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(raw, "["), "]")
+		if strings.TrimSpace(inner) == "" {
+			return nil
+		}
+		parts := strings.Split(inner, ",")
+		out := make([]string, 0, len(parts))
+		for _, part := range parts {
+			out = append(out, strings.TrimSpace(part))
+		}
+		return out
+	}
+	if raw == "" {
+		return nil
+	}
+	return []string{raw}
 }
 
 func newProfileUseCmd(flags *rootFlags) *cobra.Command {

--- a/library/ai/wavespeed/internal/cli/profile.go
+++ b/library/ai/wavespeed/internal/cli/profile.go
@@ -252,20 +252,17 @@ func isProfileArrayFlag(fl *pflag.Flag) bool {
 
 func profileArrayValues(raw string) []string {
 	raw = strings.TrimSpace(raw)
-	if strings.HasPrefix(raw, "[") && strings.HasSuffix(raw, "]") {
-		inner := strings.TrimSuffix(strings.TrimPrefix(raw, "["), "]")
-		if strings.TrimSpace(inner) == "" {
-			return nil
-		}
-		parts := strings.Split(inner, ",")
-		out := make([]string, 0, len(parts))
-		for _, part := range parts {
-			out = append(out, strings.TrimSpace(part))
-		}
-		return out
-	}
 	if raw == "" {
 		return nil
+	}
+	if strings.HasPrefix(raw, "[") && strings.HasSuffix(raw, "]") {
+		var items []string
+		if err := json.Unmarshal([]byte(raw), &items); err == nil {
+			if len(items) == 0 {
+				return nil
+			}
+			return items
+		}
 	}
 	return []string{raw}
 }

--- a/library/ai/wavespeed/internal/cli/profile_test.go
+++ b/library/ai/wavespeed/internal/cli/profile_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProfileArrayValuesParsesPflagStringArrayOutput(t *testing.T) {
+	got := profileArrayValues(`["@style1.png","@style2.png","https://example.com/input.png"]`)
+	want := []string{"@style1.png", "@style2.png", "https://example.com/input.png"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("profileArrayValues() = %#v, want %#v", got, want)
+	}
+}
+
+func TestProfileArrayValuesEmptyArray(t *testing.T) {
+	if got := profileArrayValues(`[]`); got != nil {
+		t.Fatalf("profileArrayValues(empty array) = %#v, want nil", got)
+	}
+}
+
+func TestOpenCommandUsesPlatformViewer(t *testing.T) {
+	cases := []struct {
+		goos     string
+		wantName string
+		wantArgs []string
+	}{
+		{goos: "darwin", wantName: "open", wantArgs: []string{"/tmp/out.png"}},
+		{goos: "linux", wantName: "xdg-open", wantArgs: []string{"/tmp/out.png"}},
+		{goos: "windows", wantName: "rundll32", wantArgs: []string{"url.dll,FileProtocolHandler", `/tmp/out.png`}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.goos, func(t *testing.T) {
+			name, args, err := openCommand("/tmp/out.png", tc.goos)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if name != tc.wantName || !reflect.DeepEqual(args, tc.wantArgs) {
+				t.Fatalf("openCommand() = %q %#v, want %q %#v", name, args, tc.wantName, tc.wantArgs)
+			}
+		})
+	}
+}

--- a/library/ai/wavespeed/internal/cli/promoted_models.go
+++ b/library/ai/wavespeed/internal/cli/promoted_models.go
@@ -16,6 +16,7 @@ func newModelsPromotedCmd(flags *rootFlags) *cobra.Command {
 	var category string
 	var popular bool
 	var refresh bool
+	var capability string
 
 	cmd := &cobra.Command{
 		Use:         "models",
@@ -46,6 +47,12 @@ func newModelsPromotedCmd(flags *rootFlags) *cobra.Command {
 			data, err = filterModelsForCLI(data, query, modelType, category, popular)
 			if err != nil {
 				return err
+			}
+			if capability != "" {
+				data, err = summarizeModelsForCapability(data, capability)
+				if err != nil {
+					return err
+				}
 			}
 			// Print provenance to stderr for human-facing output only.
 			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
@@ -97,6 +104,7 @@ func newModelsPromotedCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&category, "category", "", "Alias for --type")
 	cmd.Flags().BoolVar(&popular, "popular", false, "Sort popular models first when sort metadata is available")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Refresh the model catalog instead of using the local HTTP cache")
+	cmd.Flags().StringVar(&capability, "capability", "", "Filter to a workflow capability (for example image-edit) and print model_id + price guidance")
 
 	// Wire sibling endpoints and sub-resources as subcommands
 

--- a/library/ai/wavespeed/internal/cli/root.go
+++ b/library/ai/wavespeed/internal/cli/root.go
@@ -256,6 +256,8 @@ Run 'wavespeed-pp-cli doctor' to verify auth and connectivity.`,
 	rootCmd.AddCommand(newPriceCmd(flags))
 	rootCmd.AddCommand(newUploadCmd(flags))
 	rootCmd.AddCommand(newDownloadCmd(flags))
+	rootCmd.AddCommand(newLastCmd(flags))
+	rootCmd.AddCommand(newOpenCmd(flags))
 	rootCmd.AddCommand(newAliasesCmd(flags))
 	rootCmd.AddCommand(newInitCmd(flags))
 	rootCmd.AddCommand(newAccountBalancePromotedCmd(flags))

--- a/library/ai/wavespeed/internal/cli/run.go
+++ b/library/ai/wavespeed/internal/cli/run.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"sort"
@@ -110,8 +111,11 @@ func newRunCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			if opts.schema || opts.helpModel {
+			if opts.schema {
 				return printModelSchema(cmd, flags, c, modelID)
+			}
+			if opts.helpModel {
+				return printModelHelp(cmd, flags, c, modelID)
 			}
 
 			changed := runChangedFlags(cmd)
@@ -154,6 +158,9 @@ func newRunCmd(flags *rootFlags) *cobra.Command {
 			for _, item := range res.Downloads {
 				fmt.Fprintf(cmd.ErrOrStderr(), "downloaded %s\n", item.Path)
 			}
+			if err := rememberDownloads(res.Downloads); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: recording last download failed: %v\n", err)
+			}
 
 			// run records to the library only when --record is passed (opt-in),
 			// the inverse of novel commands which record by default. A record
@@ -182,6 +189,9 @@ func newRunCmd(flags *rootFlags) *cobra.Command {
 				downloads, err := downloadPlannedRunOutputs(cmd.Context(), c, plannedDownloads)
 				for _, item := range downloads {
 					fmt.Fprintf(cmd.ErrOrStderr(), "downloaded %s\n", item.Path)
+				}
+				if recErr := rememberDownloads(downloads); recErr != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: recording last download failed: %v\n", recErr)
 				}
 				if err != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(), "warning: download failed: %v\n", err)
@@ -290,12 +300,12 @@ func installRunModelHelp(cmd *cobra.Command, flags *rootFlags, opts *runCommandO
 			fmt.Fprintf(helpCmd.ErrOrStderr(), "\nModel schema unavailable: %v\n", err)
 			return
 		}
-		schema, err := requestSchemaForModel(models, modelID)
-		if err != nil {
-			fmt.Fprintf(helpCmd.ErrOrStderr(), "\nModel schema unavailable: %v\n", err)
+		model, ok := findModelObject(models, modelID)
+		if !ok {
+			fmt.Fprintf(helpCmd.ErrOrStderr(), "\nModel schema unavailable: model %q not found in /models response\n", modelID)
 			return
 		}
-		fmt.Fprintf(helpCmd.OutOrStdout(), "\nModel Inputs for %s:\n%s", modelID, schemaHelpText(schema))
+		fmt.Fprintf(helpCmd.OutOrStdout(), "\n%s", modelHelpText(modelID, model))
 	})
 }
 
@@ -382,6 +392,125 @@ func newPriceCmd(flags *rootFlags) *cobra.Command {
 	return cmd
 }
 
+type lastDownloadState struct {
+	UpdatedAt string           `json:"updated_at"`
+	Downloads []downloadedFile `json:"downloads"`
+}
+
+func lastDownloadStatePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home dir: %w", err)
+	}
+	dir := filepath.Join(home, ".wavespeed-pp-cli")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("creating state dir: %w", err)
+	}
+	return filepath.Join(dir, "last-download.json"), nil
+}
+
+func rememberDownloads(downloads []downloadedFile) error {
+	if len(downloads) == 0 {
+		return nil
+	}
+	p, err := lastDownloadStatePath()
+	if err != nil {
+		return err
+	}
+	state := lastDownloadState{UpdatedAt: time.Now().Format(time.RFC3339), Downloads: downloads}
+	raw, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, raw, 0o600)
+}
+
+func loadLastDownloadState() (lastDownloadState, error) {
+	p, err := lastDownloadStatePath()
+	if err != nil {
+		return lastDownloadState{}, err
+	}
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		return lastDownloadState{}, err
+	}
+	var state lastDownloadState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return lastDownloadState{}, err
+	}
+	return state, nil
+}
+
+func lastDownloadedPath() (string, error) {
+	state, err := loadLastDownloadState()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("no downloaded image recorded yet; run with --download first")
+		}
+		return "", err
+	}
+	for i := len(state.Downloads) - 1; i >= 0; i-- {
+		if strings.TrimSpace(state.Downloads[i].Path) != "" {
+			return state.Downloads[i].Path, nil
+		}
+	}
+	return "", fmt.Errorf("last download record contains no local path")
+}
+
+func newLastCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:         "last",
+		Short:       "Print the most recently downloaded WaveSpeed output path",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			state, err := loadLastDownloadState()
+			if err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("no downloaded image recorded yet; run with --download first")
+				}
+				return err
+			}
+			if flags.asJSON {
+				return printJSONFiltered(cmd.OutOrStdout(), state, flags)
+			}
+			p, err := lastDownloadedPath()
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), p)
+			return nil
+		},
+	}
+}
+
+func newOpenCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "open [path]",
+		Short: "Open the most recently downloaded WaveSpeed output (or a supplied path)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p := ""
+			if len(args) > 0 {
+				p = args[0]
+			} else {
+				var err error
+				p, err = lastDownloadedPath()
+				if err != nil {
+					return err
+				}
+			}
+			if _, err := os.Stat(p); err != nil {
+				return fmt.Errorf("opening %s: %w", p, err)
+			}
+			if flags.dryRun {
+				fmt.Fprintf(cmd.OutOrStdout(), "open %s\n", p)
+				return nil
+			}
+			return exec.CommandContext(cmd.Context(), "open", p).Run()
+		},
+	}
+}
+
 func newUploadCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "upload <file>...",
@@ -462,6 +591,9 @@ func newDownloadCmd(flags *rootFlags) *cobra.Command {
 			downloads, err := downloadRunOutputs(cmd.Context(), c, json.RawMessage(raw), spec)
 			if err != nil {
 				return err
+			}
+			if err := rememberDownloads(downloads); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: recording last download failed: %v\n", err)
 			}
 			if flags.quiet {
 				for _, item := range downloads {
@@ -1062,6 +1194,26 @@ func printModelSchema(cmd *cobra.Command, flags *rootFlags, c *client.Client, mo
 	return printOutputWithFlags(cmd.OutOrStdout(), schema, flags)
 }
 
+func printModelHelp(cmd *cobra.Command, flags *rootFlags, c *client.Client, modelID string) error {
+	models, err := c.Get(cmd.Context(), "/models", nil)
+	if err != nil {
+		return classifyAPIError(err, flags)
+	}
+	model, ok := findModelObject(models, modelID)
+	if !ok {
+		return fmt.Errorf("model %q not found in /models response", modelID)
+	}
+	if flags.asJSON {
+		raw, err := json.MarshalIndent(modelHelpSummary(modelID, model), "", "  ")
+		if err != nil {
+			return err
+		}
+		return printOutput(cmd.OutOrStdout(), raw, true)
+	}
+	_, err = fmt.Fprint(cmd.OutOrStdout(), modelHelpText(modelID, model))
+	return err
+}
+
 func requestSchemaForModel(models json.RawMessage, modelID string) (json.RawMessage, error) {
 	model, ok := findModelObject(models, modelID)
 	if !ok {
@@ -1076,6 +1228,188 @@ func requestSchemaForModel(models json.RawMessage, modelID string) (json.RawMess
 		return nil, err
 	}
 	return json.RawMessage(raw), nil
+}
+
+type modelHelpField struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Required    bool     `json:"required"`
+	Default     any      `json:"default,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+	Description string   `json:"description,omitempty"`
+}
+
+type modelHelpInfo struct {
+	ModelID           string              `json:"model_id"`
+	Name              string              `json:"name,omitempty"`
+	Type              string              `json:"type,omitempty"`
+	Price             string              `json:"price"`
+	BasePrice         any                 `json:"base_price,omitempty"`
+	Formula           string              `json:"formula,omitempty"`
+	ResolutionOptions map[string][]string `json:"resolution_options,omitempty"`
+	Fields            []modelHelpField    `json:"fields"`
+}
+
+func modelHelpSummary(modelID string, model map[string]any) modelHelpInfo {
+	schema, _ := schemaFromModelObject(model)
+	fields := schemaFields(schema)
+	info := modelHelpInfo{
+		ModelID:   modelID,
+		Name:      stringFromAny(model["name"]),
+		Type:      stringFromAny(model["type"]),
+		Price:     modelPriceText(model),
+		BasePrice: model["base_price"],
+		Formula:   stringFromAny(model["formula"]),
+		Fields:    fields,
+	}
+	resolution := map[string][]string{}
+	for _, f := range fields {
+		key := strings.ToLower(f.Name)
+		if (strings.Contains(key, "resolution") || strings.Contains(key, "size")) && len(f.Enum) > 0 {
+			resolution[f.Name] = f.Enum
+		}
+	}
+	if len(resolution) > 0 {
+		info.ResolutionOptions = resolution
+	}
+	return info
+}
+
+func modelHelpText(modelID string, model map[string]any) string {
+	info := modelHelpSummary(modelID, model)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Model Inputs for %s:\n", modelID)
+	if info.Name != "" || info.Type != "" {
+		fmt.Fprintf(&b, "  model: %s", info.Name)
+		if info.Type != "" {
+			fmt.Fprintf(&b, " (%s)", info.Type)
+		}
+		b.WriteByte('\n')
+	}
+	fmt.Fprintf(&b, "  price: %s", info.Price)
+	if info.Formula != "" {
+		fmt.Fprintf(&b, " (%s)", info.Formula)
+	}
+	b.WriteString("\n")
+	if len(info.ResolutionOptions) > 0 {
+		b.WriteString("  resolution/size options (affect cost when the formula references them):\n")
+		keys := make([]string, 0, len(info.ResolutionOptions))
+		for k := range info.ResolutionOptions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(&b, "    - %s: %s\n", k, strings.Join(info.ResolutionOptions[k], " | "))
+		}
+	}
+	for _, f := range info.Fields {
+		req := ""
+		if f.Required {
+			req = " required"
+		}
+		fmt.Fprintf(&b, "  - %s (%s%s)", f.Name, f.Type, req)
+		if f.Default != nil {
+			fmt.Fprintf(&b, " default=%v", f.Default)
+		}
+		if len(f.Enum) > 0 {
+			fmt.Fprintf(&b, " enum=%s", strings.Join(f.Enum, "|"))
+		}
+		if f.Description != "" {
+			fmt.Fprintf(&b, " - %s", f.Description)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func schemaFromModelObject(model map[string]any) (json.RawMessage, bool) {
+	schema, ok := nestedValue(model, "api_schema", "api_schemas", "0", "request_schema")
+	if !ok {
+		return nil, false
+	}
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		return nil, false
+	}
+	return json.RawMessage(raw), true
+}
+
+func schemaFields(schema json.RawMessage) []modelHelpField {
+	var root map[string]any
+	if len(schema) == 0 || json.Unmarshal(schema, &root) != nil {
+		return nil
+	}
+	props, _ := root["properties"].(map[string]any)
+	required := map[string]bool{}
+	if items, ok := root["required"].([]any); ok {
+		for _, item := range items {
+			if s, ok := item.(string); ok {
+				required[s] = true
+			}
+		}
+	}
+	names := orderedSchemaPropertyNames(root, props)
+	fields := make([]modelHelpField, 0, len(names))
+	for _, name := range names {
+		prop, _ := props[name].(map[string]any)
+		field := modelHelpField{Name: name, Type: schemaTypeName(prop), Required: required[name], Description: oneline(stringFromAny(prop["description"]))}
+		if def, ok := prop["default"]; ok {
+			field.Default = def
+		}
+		if enum, ok := prop["enum"].([]any); ok {
+			for _, item := range enum {
+				field.Enum = append(field.Enum, fmt.Sprintf("%v", item))
+			}
+		}
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+func modelPriceText(model map[string]any) string {
+	for _, key := range []string{"unit_price", "price", "base_price", "cost"} {
+		if v, ok := model[key]; ok {
+			if s := stringFromAny(v); s != "" && s != "0" {
+				return s
+			}
+			if n, ok := numberFromAny(v); ok {
+				return strconv.FormatFloat(n, 'f', -1, 64)
+			}
+		}
+	}
+	if f := stringFromAny(model["formula"]); f != "" {
+		return f
+	}
+	return "?"
+}
+
+func stringFromAny(v any) string {
+	switch t := v.(type) {
+	case string:
+		return strings.TrimSpace(t)
+	case json.Number:
+		return t.String()
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(t)
+	default:
+		return ""
+	}
+}
+
+func numberFromAny(v any) (float64, bool) {
+	switch t := v.(type) {
+	case json.Number:
+		f, err := t.Float64()
+		return f, err == nil
+	case float64:
+		return t, true
+	case int:
+		return float64(t), true
+	default:
+		return 0, false
+	}
 }
 
 func schemaHelpText(schema json.RawMessage) string {
@@ -1108,7 +1442,7 @@ func schemaHelpText(schema json.RawMessage) string {
 		if def, ok := prop["default"]; ok {
 			fmt.Fprintf(&b, " default=%v", def)
 		}
-		if enum, ok := prop["enum"].([]any); ok && len(enum) > 0 && len(enum) <= 8 {
+		if enum, ok := prop["enum"].([]any); ok && len(enum) > 0 {
 			parts := make([]string, 0, len(enum))
 			for _, item := range enum {
 				parts = append(parts, fmt.Sprintf("%v", item))
@@ -1216,6 +1550,116 @@ func modelItems(models json.RawMessage) []map[string]any {
 		}
 	}
 	return items
+}
+
+type modelCatalogSummary struct {
+	ModelID     string              `json:"model_id"`
+	Name        string              `json:"name,omitempty"`
+	Type        string              `json:"type,omitempty"`
+	Price       string              `json:"price"`
+	BasePrice   any                 `json:"base_price,omitempty"`
+	Formula     string              `json:"formula,omitempty"`
+	Resolutions map[string][]string `json:"resolutions,omitempty"`
+}
+
+func summarizeModelsForCapability(data json.RawMessage, capability string) (json.RawMessage, error) {
+	items := modelItems(data)
+	out := make([]modelCatalogSummary, 0, len(items))
+	for _, model := range items {
+		if !modelMatchesCapability(model, capability) {
+			continue
+		}
+		id := modelIDFromObject(model)
+		if id == "" {
+			continue
+		}
+		info := modelHelpSummary(id, model)
+		out = append(out, modelCatalogSummary{
+			ModelID:     id,
+			Name:        info.Name,
+			Type:        info.Type,
+			Price:       info.Price,
+			BasePrice:   info.BasePrice,
+			Formula:     info.Formula,
+			Resolutions: info.ResolutionOptions,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		pi, iok := numericSummaryPrice(out[i])
+		pj, jok := numericSummaryPrice(out[j])
+		if iok && jok && pi != pj {
+			return pi < pj
+		}
+		if iok != jok {
+			return iok
+		}
+		return out[i].ModelID < out[j].ModelID
+	})
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(raw), nil
+}
+
+func modelIDFromObject(model map[string]any) string {
+	for _, key := range []string{"model_id", "id", "path", "model", "name"} {
+		if s := stringFromAny(model[key]); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func numericSummaryPrice(s modelCatalogSummary) (float64, bool) {
+	switch v := s.BasePrice.(type) {
+	case json.Number:
+		f, err := v.Float64()
+		return f, err == nil
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	}
+	if s.Price != "" && s.Price != "?" {
+		f, err := strconv.ParseFloat(strings.TrimPrefix(s.Price, "$"), 64)
+		return f, err == nil
+	}
+	return 0, false
+}
+
+func modelMatchesCapability(model map[string]any, capability string) bool {
+	capability = strings.ToLower(strings.TrimSpace(capability))
+	if capability == "" {
+		return true
+	}
+	textParts := []string{}
+	for _, key := range []string{"model_id", "id", "name", "description", "type", "category"} {
+		if s := stringFromAny(model[key]); s != "" {
+			textParts = append(textParts, strings.ToLower(s))
+		}
+	}
+	text := strings.Join(textParts, " ")
+	schema, _ := schemaFromModelObject(model)
+	fields := schemaFields(schema)
+	fieldNames := map[string]bool{}
+	for _, f := range fields {
+		fieldNames[strings.ToLower(f.Name)] = true
+	}
+	switch capability {
+	case "image-edit", "image_edit", "edit", "image-to-image", "i2i":
+		if strings.Contains(text, "image-to-image") || strings.Contains(text, "image edit") || strings.Contains(text, "edit") {
+			return true
+		}
+		return fieldNames["image"] || fieldNames["images"] || fieldNames["reference_images"] || fieldNames["reference_image"]
+	case "text-to-image", "t2i", "image-generate", "image-generation":
+		return strings.Contains(text, "text-to-image") || strings.Contains(text, "image") && fieldNames["prompt"]
+	case "video", "text-to-video", "t2v":
+		return strings.Contains(text, "video") || fieldNames["video"]
+	default:
+		needle := strings.ReplaceAll(capability, "-", " ")
+		return strings.Contains(text, capability) || strings.Contains(text, needle)
+	}
 }
 
 func filterModelsForCLI(data json.RawMessage, query, modelType, category string, popular bool) (json.RawMessage, error) {

--- a/library/ai/wavespeed/internal/cli/run.go
+++ b/library/ai/wavespeed/internal/cli/run.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -503,11 +504,32 @@ func newOpenCmd(flags *rootFlags) *cobra.Command {
 				return fmt.Errorf("opening %s: %w", p, err)
 			}
 			if flags.dryRun {
-				fmt.Fprintf(cmd.OutOrStdout(), "open %s\n", p)
+				name, args, err := openCommand(p, runtime.GOOS)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", name, strings.Join(args, " "))
 				return nil
 			}
-			return exec.CommandContext(cmd.Context(), "open", p).Run()
+			name, args, err := openCommand(p, runtime.GOOS)
+			if err != nil {
+				return err
+			}
+			return exec.CommandContext(cmd.Context(), name, args...).Run()
 		},
+	}
+}
+
+func openCommand(p, goos string) (string, []string, error) {
+	switch goos {
+	case "darwin":
+		return "open", []string{p}, nil
+	case "windows":
+		return "rundll32", []string{"url.dll,FileProtocolHandler", p}, nil
+	case "linux":
+		return "xdg-open", []string{p}, nil
+	default:
+		return "", nil, fmt.Errorf("opening files is not supported on %s", goos)
 	}
 }
 

--- a/library/ai/wavespeed/internal/cli/run_test.go
+++ b/library/ai/wavespeed/internal/cli/run_test.go
@@ -130,6 +130,38 @@ func TestRequestSchemaForModel(t *testing.T) {
 	}
 }
 
+func TestModelHelpShowsResolutionEnumAndPricing(t *testing.T) {
+	models := json.RawMessage(`{"data":[{"model_id":"google/nano-banana-pro/edit","name":"Nano Banana Pro Edit","type":"image-to-image","base_price":0.04,"formula":"base_price * resolution_multiplier","api_schema":{"api_schemas":[{"request_schema":{"type":"object","required":["prompt","images"],"properties":{"prompt":{"type":"string"},"images":{"type":"array","items":{"type":"string"}},"resolution":{"type":"string","enum":["1k","2k","4k"],"default":"2k"}}}}]}}]}`)
+	model, ok := findModelObject(models, "google/nano-banana-pro/edit")
+	if !ok {
+		t.Fatal("model not found")
+	}
+	text := modelHelpText("google/nano-banana-pro/edit", model)
+	for _, want := range []string{"price: 0.04", "resolution: 1k | 2k | 4k", "enum=1k|2k|4k"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("help text missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestSummarizeModelsForCapabilityReturnsModelIDAndPrice(t *testing.T) {
+	models := json.RawMessage(`{"data":[{"model_id":"cheap/edit","type":"image-to-image","base_price":0.01,"api_schema":{"api_schemas":[{"request_schema":{"type":"object","properties":{"images":{"type":"array","items":{"type":"string"}},"size":{"type":"string","enum":["1024x1024","1792x1024"]}}}}]}},{"model_id":"video/t2v","type":"text-to-video","base_price":1.25}]}`)
+	raw, err := summarizeModelsForCapability(models, "image-edit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []modelCatalogSummary
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ModelID != "cheap/edit" || got[0].Price != "0.01" {
+		t.Fatalf("summary = %#v", got)
+	}
+	if got[0].Resolutions["size"][1] != "1792x1024" {
+		t.Fatalf("resolutions = %#v", got[0].Resolutions)
+	}
+}
+
 func TestDownloadOutputPath(t *testing.T) {
 	if got := downloadOutputPath("./out/{index}.{ext}", "https://example.com/a/photo.png", 0, 2); got != "out/1.png" {
 		t.Fatalf("templated path = %q", got)
@@ -173,6 +205,7 @@ func TestCollectURLStringsSkipsEchoedInputs(t *testing.T) {
 }
 
 func TestRunWaitDownloadPrintsResultAndDownloadsCDNWithoutAuth(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Chdir(t.TempDir())
 	outPath := filepath.Join(t.TempDir(), "generated.png")
 

--- a/receipts/2026-06-09-17-19-24-wavespeed-daily-image-workflow.json
+++ b/receipts/2026-06-09-17-19-24-wavespeed-daily-image-workflow.json
@@ -1,0 +1,16 @@
+{
+  "action": "wavespeed_daily_image_workflow_fix",
+  "scope": "library/ai/wavespeed",
+  "summary": "Implemented image-edit model discovery with pricing, enum-rich model help, reusable image profiles, last/open commands, and installed the updated local wavespeed-pp-cli binary.",
+  "validation": [
+    "go test ./...",
+    "go vet ./...",
+    "python3 .github/scripts/verify-skill/verify_skill.py --dir library/ai/wavespeed",
+    "go build -o /Users/knox/go/bin/wavespeed-pp-cli ./cmd/wavespeed-pp-cli",
+    "installed binary help exposes last/open and models --capability",
+    "HOME=temp wavespeed-pp-cli profile save littlemight --images @a @b @c + run --profile littlemight --price-only --dry-run"
+  ],
+  "known_blockers": [
+    "publish validate still fails on pre-existing environment/baseline gates: gh is unauthenticated for manifest printer verification, govulncheck flags Go 1.26.3 stdlib CVEs fixed in Go 1.26.4, and the generated SKILL install-section canonical drift pre-existed this change."
+  ]
+}


### PR DESCRIPTION
## wavespeed

Improves the published WaveSpeed CLI daily image workflow so agents can price, profile, generate, and reopen image outputs without retyping long flag sets.

### What changed

- Adds model/pricing summary helpers for image-generation models.
- Adds profile-aware image flag handling so repeated `--images` values survive profile save/load.
- Records latest downloaded image output and adds dry-run-friendly last/open workflows.
- Documents the workflow additions and records the published-library patch guard.

### Validation

- `go test ./...` from `library/ai/wavespeed` — passed.
- `go vet ./...` from `library/ai/wavespeed` — passed.
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/ai/wavespeed` — passed.

### Notes

- No generated binaries or secrets included.
