### PR TITLE
feat(linear): fix pp-linear lookup ergonomics for workflow states and docs

### DIFF
--- a/library/project-management/linear/.printing-press-patches/mob-104-greptile-list-and-agent-error-followups.json
+++ b/library/project-management/linear/.printing-press-patches/mob-104-greptile-list-and-agent-error-followups.json
@@ -9,9 +9,11 @@
   "files": [
     "internal/cli/documents.go",
     "internal/cli/helpers.go",
+    "internal/cli/issues_create.go",
+    "internal/cli/issues_edit.go",
     "internal/cli/workflow_states.go",
     "internal/cli/linear_agent_test.go",
     "internal/cli/mob104_ergonomics_test.go"
   ],
-  "validated_outcome": "`documents list --team <key>` uses a case-insensitive team-key GraphQL filter; invalid `--state-type` values return code-2 usage with the valid Linear state-type set before workflow-state lookup; parent commands invoked with `--agent` emit exactly one JSON error envelope."
+  "validated_outcome": "`documents list --team <key>` uses a case-insensitive team-key GraphQL filter; invalid `--state-type` values return code-2 usage with the valid Linear state-type set before any live request, including Linear's documented `duplicate` state type; parent commands invoked with `--agent` emit exactly one JSON error envelope."
 }

--- a/library/project-management/linear/.printing-press-patches/mob-104-greptile-list-and-agent-error-followups.json
+++ b/library/project-management/linear/.printing-press-patches/mob-104-greptile-list-and-agent-error-followups.json
@@ -15,5 +15,5 @@
     "internal/cli/linear_agent_test.go",
     "internal/cli/mob104_ergonomics_test.go"
   ],
-  "validated_outcome": "`documents list --team <key>` uses a case-insensitive team-key GraphQL filter; invalid `--state-type` values return code-2 usage with the valid Linear state-type set before any live request, including Linear's documented `duplicate` state type; parent commands invoked with `--agent` emit exactly one JSON error envelope."
+  "validated_outcome": "`documents list --team <key>` uses a case-insensitive team-key GraphQL filter; invalid `--state-type` values return code-2 usage with the valid Linear state-type set before any live request, including Linear's documented `duplicate` state type; parent commands invoked with `--agent` emit exactly one JSON error envelope with `code: 2` and `type: usage`."
 }

--- a/library/project-management/linear/.printing-press-patches/mob-104-greptile-list-and-agent-error-followups.json
+++ b/library/project-management/linear/.printing-press-patches/mob-104-greptile-list-and-agent-error-followups.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "mob-104-greptile-list-and-agent-error-followups",
+  "applied_at": "2026-06-19",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "Agent-facing list filters, state-type selectors, and parent command errors must fail or filter in the same human-key-friendly way documented in the skill.",
+  "reason": "Greptile found that `documents list --team SYMPH` could silently return an empty result because it used an ID-only team filter, `--state-type in-progress` failed as an opaque not-found instead of a local usage error, and parent commands could emit two JSON envelopes in agent mode. These are all agent ergonomics regressions: a fresh agent should get either the intended key-based result or one precise machine-parseable error.",
+  "files": [
+    "internal/cli/documents.go",
+    "internal/cli/helpers.go",
+    "internal/cli/workflow_states.go",
+    "internal/cli/linear_agent_test.go",
+    "internal/cli/mob104_ergonomics_test.go"
+  ],
+  "validated_outcome": "`documents list --team <key>` uses a case-insensitive team-key GraphQL filter; invalid `--state-type` values return code-2 usage with the valid Linear state-type set before workflow-state lookup; parent commands invoked with `--agent` emit exactly one JSON error envelope."
+}

--- a/library/project-management/linear/.printing-press-patches/mob-104-issues-create-state-validates-like-edit.json
+++ b/library/project-management/linear/.printing-press-patches/mob-104-issues-create-state-validates-like-edit.json
@@ -4,8 +4,8 @@
   "applied_at": "2026-06-13",
   "base_run_id": "20260518-232543",
   "base_printing_press_version": "4.9.0",
-  "summary": "issues create must handle --state the same way issues edit does: reject a non-UUID --state as a usage error, and resolve --state-name/--state-type against the issue's team. Neither command may pass a raw state string through to Linear as stateId.",
-  "reason": "Linear's issueCreate/issueUpdate take a stateId UUID. When only issues edit validated --state, 'issues create --state \"In Progress\"' sent the literal name as stateId and failed with an opaque API error, an asymmetry agents would re-hit. The two write surfaces must stay symmetric so the helpful 'use --state-name' error stays truthful on both.",
-  "files": ["internal/cli/issues_create.go"],
-  "validated_outcome": "issues create --state with a non-UUID is a code-2 usage error before any network call; issues create --state-name resolves to the team's workflow-state UUID and sends it as stateId."
+  "summary": "issues create must handle --state the same way issues edit does: reject a non-UUID --state as a usage error, resolve --state-name/--state-type against the issue's team, and work from a fresh local store when --team is passed as a human key.",
+  "reason": "Linear's issueCreate/issueUpdate take a stateId UUID. When only issues edit validated --state, 'issues create --state \"In Progress\"' sent the literal name as stateId and failed with an opaque API error, an asymmetry agents would re-hit. The two write surfaces must stay symmetric so the helpful 'use --state-name' error stays truthful on both. Agents also commonly start from unsynced workspaces, so create must resolve team keys live instead of requiring a pre-populated local team UUID before state-name lookup.",
+  "files": ["internal/cli/issues_create.go", "internal/cli/workflow_states.go"],
+  "validated_outcome": "issues create --state with a non-UUID is a code-2 usage error before any network call; issues create --state-name resolves to the team's workflow-state UUID and sends it as stateId; issues create --team MOB --state-name works with an empty local store by resolving the team key live before issueCreate."
 }

--- a/library/project-management/linear/.printing-press-patches/mob-104-issues-create-state-validates-like-edit.json
+++ b/library/project-management/linear/.printing-press-patches/mob-104-issues-create-state-validates-like-edit.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "mob-104-issues-create-state-validates-like-edit",
+  "applied_at": "2026-06-13",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "issues create must handle --state the same way issues edit does: reject a non-UUID --state as a usage error, and resolve --state-name/--state-type against the issue's team. Neither command may pass a raw state string through to Linear as stateId.",
+  "reason": "Linear's issueCreate/issueUpdate take a stateId UUID. When only issues edit validated --state, 'issues create --state \"In Progress\"' sent the literal name as stateId and failed with an opaque API error, an asymmetry agents would re-hit. The two write surfaces must stay symmetric so the helpful 'use --state-name' error stays truthful on both.",
+  "files": ["internal/cli/issues_create.go"],
+  "validated_outcome": "issues create --state with a non-UUID is a code-2 usage error before any network call; issues create --state-name resolves to the team's workflow-state UUID and sends it as stateId."
+}

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -210,6 +210,12 @@ These capabilities aren't available in any other tool for this API.
   linear-pp-cli issues edit ENG-123 --state-type started --agent   # usage error if the team has several 'started' states
   ```
 
+  `issues create` takes the same trio, resolved against `--team`, so an issue can open directly in the right state. `--state` requires a UUID (a non-UUID value is a usage error pointing at `--state-name`):
+
+  ```bash
+  linear-pp-cli issues create --title "..." --team ENG --state-name "In Progress" --agent
+  ```
+
   Do not use `linear-pp-cli api` or `linear-pp-cli sql` for workflow states — `api` only exposes generated REST-shaped interfaces (currently `integrations`), not Linear GraphQL objects.
 - **Linear document reads** — `documents <ref>` accepts every identifier form Linear surfaces: the document UUID, the bare `slugId` (`f7f48ab36080`), the full URL slug (`my-runbook-f7f48ab36080`), or the entire document URL. Copy whichever you have; no slug trimming or parsing shims needed.
 

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -185,11 +185,37 @@ These capabilities aren't available in any other tool for this API.
   ```
 
   `documents create` requires exactly one parent (`--issue`, `--project`, `--team`, `--initiative`, `--cycle`, `--release`, or `--folder`); `--team` accepts a key such as `ENG` or a UUID. `issues edit --media`, `comments edit --media`, and `documents edit --media` with no body/content flag fetch the existing Markdown live and append uploaded media links. Images become Markdown image embeds; non-images become Markdown links. Add `--media-public` only when the uploaded asset must be reachable outside the Linear workspace.
-- **Current issue reads and comments** — Read full issue bodies and discussion without falling back to stale local state.
+- **Current issue reads and comments** — Read full issue bodies and discussion without falling back to stale local state. `comments list` takes the issue positionally (preferred) or via `--issue`.
 
   ```bash
-  linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.name,url
-  linear-pp-cli comments list --issue ENG-123 --agent
+  linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.id,state.name,url
+  linear-pp-cli comments list ENG-123 --agent
+  linear-pp-cli comments list --issue ENG-123 --agent --limit 100
+  ```
+- **State transitions** — Move an issue between workflow states without raw SQL, GraphQL, or `api` spelunking. The exact recipe:
+
+  1. List the states for the issue's team: `workflow-states list --team <key>` (alias: `states list`).
+  2. Pick the target by `name` or `type` and copy its `id` UUID.
+  3. Pass that UUID to `issues edit --state`.
+
+  ```bash
+  linear-pp-cli workflow-states list --team ENG --agent --select id,name,type
+  linear-pp-cli issues edit ENG-123 --state <state-uuid> --agent
+  ```
+
+  Or skip the lookup entirely with one-command transitions resolved against the issue's own team:
+
+  ```bash
+  linear-pp-cli issues edit ENG-123 --state-name "In Progress" --agent
+  linear-pp-cli issues edit ENG-123 --state-type started --agent   # usage error if the team has several 'started' states
+  ```
+
+  Do not use `linear-pp-cli api` or `linear-pp-cli sql` for workflow states — `api` only exposes generated REST-shaped interfaces (currently `integrations`), not Linear GraphQL objects.
+- **Linear document reads** — `documents <ref>` accepts every identifier form Linear surfaces: the document UUID, the bare `slugId` (`f7f48ab36080`), the full URL slug (`my-runbook-f7f48ab36080`), or the entire document URL. Copy whichever you have; no slug trimming or parsing shims needed.
+
+  ```bash
+  linear-pp-cli documents my-runbook-f7f48ab36080 --agent --select title,updatedAt,content
+  linear-pp-cli documents "https://linear.app/<org>/document/my-runbook-f7f48ab36080" --agent
   ```
 
 ## Command Reference
@@ -306,6 +332,10 @@ These capabilities aren't available in any other tool for this API.
 **users** — Manage users
 
 - `linear-pp-cli users` — Get a single user
+
+**workflow-states** — List Linear workflow states (alias: `states`)
+
+- `linear-pp-cli workflow-states list --team ENG --agent --select id,name,type` — List a team's states with the UUIDs `issues edit --state` needs
 
 
 ### Finding the right command
@@ -439,7 +469,13 @@ Every `issues create` records the new ticket in a local `pp_created` table tagge
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
 
-- **Pipeable** — JSON on stdout, errors on stderr
+- **Pipeable** — JSON on stdout. Failures are JSON too: in `--agent`/`--json` mode every typed error (usage, not-found, auth, API, rate-limit, config) is a one-line envelope on stdout, so piping stdout straight into a JSON parser is always safe:
+
+  ```json
+  {"error":"document \"missing-doc\" not found","code":3,"type":"not_found"}
+  ```
+
+  The process still exits with the typed code from the Exit Codes table; `type` is the machine-readable name for it (`usage`, `not_found`, `auth`, `api`, `partial_failure`, `rate_limit`, `config`). No `2>&1 | python json` defensive wrappers needed on read paths.
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash

--- a/library/project-management/linear/internal/cli/comments.go
+++ b/library/project-management/linear/internal/cli/comments.go
@@ -22,6 +22,7 @@ func newCommentsCmd(flags *rootFlags) *cobra.Command {
 
 func newCommentsListCmd(flags *rootFlags) *cobra.Command {
 	var issue string
+	var after string
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "list [issue]",
@@ -52,10 +53,10 @@ positionally or via --issue; the positional form is the preferred agent shape.`,
 			if limit <= 0 {
 				limit = 50
 			}
-			const query = `query($issueId: String!, $first: Int!) {
+			const query = `query($issueId: String!, $first: Int!, $after: String) {
 				issue(id: $issueId) {
 					id identifier title
-					comments(first: $first) {
+					comments(first: $first, after: $after) {
 						nodes {
 							id body createdAt updatedAt url quotedText
 							user { id name displayName email }
@@ -79,7 +80,11 @@ positionally or via --issue; the positional form is the preferred agent shape.`,
 					} `json:"comments"`
 				} `json:"issue"`
 			}
-			if err := c.QueryInto(query, map[string]any{"issueId": issueID, "first": limit}, &resp); err != nil {
+			vars := map[string]any{"issueId": issueID, "first": limit, "after": nil}
+			if after != "" {
+				vars["after"] = after
+			}
+			if err := c.QueryInto(query, vars, &resp); err != nil {
 				return classifyAPIError(err, flags)
 			}
 			out, err := json.Marshal(map[string]any{
@@ -100,6 +105,7 @@ positionally or via --issue; the positional form is the preferred agent shape.`,
 		},
 	}
 	cmd.Flags().StringVar(&issue, "issue", "", "Issue identifier or UUID")
+	cmd.Flags().StringVar(&after, "after", "", "Cursor from pageInfo.endCursor for the next page")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum comments to return")
 	return cmd
 }
@@ -189,7 +195,7 @@ for Markdown so shell snippets, backticks, and GraphQL variables stay literal.`,
 			}
 			comment, err := extractMutationObject(resp, "commentCreate", "comment")
 			if err != nil {
-				return err
+				return mediaUploadFailure(err, uploaded)
 			}
 			return renderLiveObject(cmd, flags, comment, "comments")
 		},
@@ -299,7 +305,7 @@ func newCommentsEditCmd(flags *rootFlags) *cobra.Command {
 			}
 			comment, err := extractMutationObject(resp, "commentUpdate", "comment")
 			if err != nil {
-				return err
+				return mediaUploadFailure(err, uploaded)
 			}
 			return renderLiveObject(cmd, flags, comment, "comments")
 		},

--- a/library/project-management/linear/internal/cli/comments.go
+++ b/library/project-management/linear/internal/cli/comments.go
@@ -24,13 +24,22 @@ func newCommentsListCmd(flags *rootFlags) *cobra.Command {
 	var issue string
 	var limit int
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   "list [issue]",
 		Short: "List comments on an issue",
-		Example: `  linear-pp-cli comments list --issue ENG-123 --agent
+		Long: `List comments on an issue. The issue accepts an identifier (ENG-123) or UUID,
+positionally or via --issue; the positional form is the preferred agent shape.`,
+		Example: `  linear-pp-cli comments list ENG-123 --agent
   linear-pp-cli comments list --issue ENG-123 --limit 100 --select comments.id,comments.body`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				if issue != "" && issue != args[0] {
+					return usageErr(fmt.Errorf("conflicting issue references: positional %q vs --issue %q; pass just one", args[0], issue))
+				}
+				issue = args[0]
+			}
 			if issue == "" {
-				return usageErr(fmt.Errorf("--issue is required"))
+				return usageErr(fmt.Errorf("issue is required; pass it positionally (comments list ENG-123) or via --issue"))
 			}
 			c, err := flags.newClient()
 			if err != nil {

--- a/library/project-management/linear/internal/cli/documents.go
+++ b/library/project-management/linear/internal/cli/documents.go
@@ -482,6 +482,9 @@ func normalizeDocumentRef(ref string) string {
 			ref = path.Base(u.Path)
 		}
 	}
+	if store.IsUUID(ref) {
+		return ref
+	}
 	// Title-slug + slugId: the slugId is the segment after the last hyphen.
 	if idx := strings.LastIndex(ref, "-"); idx >= 0 && idx < len(ref)-1 {
 		ref = ref[idx+1:]
@@ -491,6 +494,9 @@ func normalizeDocumentRef(ref string) string {
 
 func fetchDocumentLive(c graphqlQueryer, ref string) (json.RawMessage, error) {
 	idOrSlug := normalizeDocumentRef(ref)
+	if idOrSlug == "" || strings.Trim(idOrSlug, "-") == "" {
+		return nil, notFoundErr(fmt.Errorf("document %q not found (could not extract a document UUID or slugId); pass a document UUID, bare slugId, full URL slug, or the document URL", ref))
+	}
 	if store.IsUUID(idOrSlug) {
 		const byID = `query($id: String!) {
 		document(id: $id) {

--- a/library/project-management/linear/internal/cli/documents.go
+++ b/library/project-management/linear/internal/cli/documents.go
@@ -74,7 +74,11 @@ func newDocumentsListCmd(flags *rootFlags) *cobra.Command {
 				filter["project"] = map[string]any{"id": map[string]any{"eq": project}}
 			}
 			if team != "" {
-				filter["team"] = map[string]any{"id": map[string]any{"eq": team}}
+				if store.IsUUID(team) {
+					filter["team"] = map[string]any{"id": map[string]any{"eq": team}}
+				} else {
+					filter["team"] = map[string]any{"key": map[string]any{"eqIgnoreCase": team}}
+				}
 			}
 			if limit <= 0 {
 				limit = 50
@@ -120,7 +124,7 @@ func newDocumentsListCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&issue, "issue", "", "Filter by issue identifier or UUID")
 	cmd.Flags().StringVar(&project, "project", "", "Filter by project UUID")
-	cmd.Flags().StringVar(&team, "team", "", "Filter by team UUID")
+	cmd.Flags().StringVar(&team, "team", "", "Filter by team key or UUID")
 	cmd.Flags().StringVar(&after, "after", "", "Cursor from pageInfo.endCursor for the next page")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum documents to return")
 	return cmd

--- a/library/project-management/linear/internal/cli/documents.go
+++ b/library/project-management/linear/internal/cli/documents.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"path"
 	"strings"
 
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
@@ -12,8 +14,17 @@ import (
 
 func newDocumentsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "documents [document-id-or-slug]",
-		Short:       "View, list, create, and edit Linear documents",
+		Use:   "documents [document-ref]",
+		Short: "View, list, create, and edit Linear documents",
+		Long: `View a Linear document, or manage documents with the subcommands.
+
+The positional document reference accepts every form Linear surfaces:
+  - document UUID:  4a09c2e6-3a25-4cb8-ab63-9c9f6754b24e
+  - bare slugId:    f7f48ab36080
+  - full URL slug:  my-runbook-f7f48ab36080
+  - document URL:   https://linear.app/<org>/document/my-runbook-f7f48ab36080`,
+		Example: `  linear-pp-cli documents my-runbook-f7f48ab36080 --agent --select title,updatedAt,content
+  linear-pp-cli documents f7f48ab36080 --agent`,
 		Annotations: map[string]string{"pp:typed-exit-codes": "0,2,3,4,5,7"},
 		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -437,7 +448,39 @@ func resolveTeamIDFromQuery(c graphqlQueryer, query string, variables map[string
 	return resp.Teams.Nodes[0].ID, nil
 }
 
-func fetchDocumentLive(c graphqlQueryer, idOrSlug string) (json.RawMessage, error) {
+// normalizeDocumentRef maps the document references humans and Linear surface
+// to the identifier shapes the GraphQL lookup accepts. Accepted inputs:
+//
+//   - UUID document id (passed through)
+//   - bare slugId, e.g. "f7f48ab36080" (passed through)
+//   - full URL slug, e.g. "symphony-pipeline-restart-runbook-f7f48ab36080"
+//     (trailing slugId segment extracted)
+//   - full Linear document URL, e.g.
+//     "https://linear.app/<org>/document/<title-slug>-<slugId>"
+//     (path tail extracted, then the trailing slugId segment)
+//
+// Linear's documents(filter: {slugId: ...}) only matches the bare slugId, so
+// title-slug and URL forms must be reduced to the segment after the last "-".
+func normalizeDocumentRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if store.IsUUID(ref) {
+		return ref
+	}
+	// Full URL: keep the last path segment, dropping any query/fragment.
+	if strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") {
+		if u, err := url.Parse(ref); err == nil {
+			ref = path.Base(u.Path)
+		}
+	}
+	// Title-slug + slugId: the slugId is the segment after the last hyphen.
+	if idx := strings.LastIndex(ref, "-"); idx >= 0 && idx < len(ref)-1 {
+		ref = ref[idx+1:]
+	}
+	return ref
+}
+
+func fetchDocumentLive(c graphqlQueryer, ref string) (json.RawMessage, error) {
+	idOrSlug := normalizeDocumentRef(ref)
 	if store.IsUUID(idOrSlug) {
 		const byID = `query($id: String!) {
 		document(id: $id) {
@@ -455,7 +498,7 @@ func fetchDocumentLive(c graphqlQueryer, idOrSlug string) (json.RawMessage, erro
 			return nil, err
 		}
 		if len(resp.Document) == 0 || string(resp.Document) == "null" {
-			return nil, notFoundErr(fmt.Errorf("document %q not found", idOrSlug))
+			return nil, notFoundErr(fmt.Errorf("document %q not found", ref))
 		}
 		return resp.Document, nil
 	}
@@ -479,7 +522,7 @@ func fetchDocumentLive(c graphqlQueryer, idOrSlug string) (json.RawMessage, erro
 		return nil, err
 	}
 	if len(slugResp.Documents.Nodes) == 0 {
-		return nil, notFoundErr(fmt.Errorf("document %q not found", idOrSlug))
+		return nil, notFoundErr(fmt.Errorf("document %q not found (looked up slugId %q); pass a document UUID, bare slugId, full URL slug, or the document URL", ref, idOrSlug))
 	}
 	return slugResp.Documents.Nodes[0], nil
 }

--- a/library/project-management/linear/internal/cli/documents.go
+++ b/library/project-management/linear/internal/cli/documents.go
@@ -50,6 +50,7 @@ The positional document reference accepts every form Linear surfaces:
 
 func newDocumentsListCmd(flags *rootFlags) *cobra.Command {
 	var issue, project, team string
+	var after string
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -78,8 +79,8 @@ func newDocumentsListCmd(flags *rootFlags) *cobra.Command {
 			if limit <= 0 {
 				limit = 50
 			}
-			const query = `query($first: Int!, $filter: DocumentFilter) {
-				documents(first: $first, filter: $filter) {
+			const query = `query($first: Int!, $filter: DocumentFilter, $after: String) {
+				documents(first: $first, filter: $filter, after: $after) {
 					nodes {
 						id title slugId url createdAt updatedAt summary
 						creator { id name displayName email }
@@ -100,7 +101,11 @@ func newDocumentsListCmd(flags *rootFlags) *cobra.Command {
 					} `json:"pageInfo"`
 				} `json:"documents"`
 			}
-			if err := c.QueryInto(query, map[string]any{"first": limit, "filter": filter}, &resp); err != nil {
+			vars := map[string]any{"first": limit, "filter": filter, "after": nil}
+			if after != "" {
+				vars["after"] = after
+			}
+			if err := c.QueryInto(query, vars, &resp); err != nil {
 				return classifyAPIError(err, flags)
 			}
 			out, err := json.Marshal(map[string]any{
@@ -116,6 +121,7 @@ func newDocumentsListCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&issue, "issue", "", "Filter by issue identifier or UUID")
 	cmd.Flags().StringVar(&project, "project", "", "Filter by project UUID")
 	cmd.Flags().StringVar(&team, "team", "", "Filter by team UUID")
+	cmd.Flags().StringVar(&after, "after", "", "Cursor from pageInfo.endCursor for the next page")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum documents to return")
 	return cmd
 }
@@ -194,7 +200,7 @@ func newDocumentsCreateCmd(flags *rootFlags) *cobra.Command {
 			}
 			doc, err := extractMutationObject(resp, "documentCreate", "document")
 			if err != nil {
-				return err
+				return mediaUploadFailure(err, uploaded)
 			}
 			return renderLiveObject(cmd, flags, doc, "documents")
 		},
@@ -316,7 +322,7 @@ func newDocumentsEditCmd(flags *rootFlags) *cobra.Command {
 			}
 			docRaw, err := extractMutationObject(resp, "documentUpdate", "document")
 			if err != nil {
-				return err
+				return mediaUploadFailure(err, uploaded)
 			}
 			return renderLiveObject(cmd, flags, docRaw, "documents")
 		},

--- a/library/project-management/linear/internal/cli/helpers.go
+++ b/library/project-management/linear/internal/cli/helpers.go
@@ -214,7 +214,9 @@ func parentNoSubcommandRunE(flags *rootFlags) func(*cobra.Command, []string) err
 			}
 			sort.Strings(subs)
 			_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+				"code":              2,
 				"error":             "subcommand required",
+				"type":              "usage",
 				"valid_subcommands": subs,
 			})
 			flags.errorWritten = true

--- a/library/project-management/linear/internal/cli/helpers.go
+++ b/library/project-management/linear/internal/cli/helpers.go
@@ -273,6 +273,51 @@ func cliErrorType(code int) string {
 	}
 }
 
+// jsonErrorMode reports whether a failed invocation should emit a JSON error
+// envelope. The parsed flags are authoritative, but flag parsing itself can
+// fail before --agent/--json are bound (unknown flag, bad value), so the raw
+// args are scanned as a fallback. Agents that asked for JSON must never get
+// plain text on a typed failure.
+func jsonErrorMode(flags *rootFlags, args []string) bool {
+	if flags != nil && (flags.agent || flags.asJSON) {
+		return true
+	}
+	for _, a := range args {
+		if a == "--" {
+			break
+		}
+		if a == "--agent" || a == "--json" || a == "--agent=true" || a == "--json=true" {
+			return true
+		}
+	}
+	return false
+}
+
+// finalizeError gives every failure a consistent surface now that the root
+// command silences cobra's own error printing. In JSON/agent mode the error
+// is a machine-parseable envelope on stdout ({"error","code","type"}) so
+// agents piping stdout never JSON-decode plain text; otherwise the
+// conventional "Error: ..." line goes to stderr. Errors that already wrote
+// an envelope mid-command (writeAPIErrorEnvelope) are not double-emitted.
+func finalizeError(flags *rootFlags, args []string, stdout, stderr io.Writer, err error) {
+	if err == nil {
+		return
+	}
+	if jsonErrorMode(flags, args) {
+		if flags != nil && flags.errorWritten {
+			return
+		}
+		code := ExitCode(err)
+		_ = json.NewEncoder(stdout).Encode(map[string]any{
+			"error": err.Error(),
+			"code":  code,
+			"type":  cliErrorType(code),
+		})
+		return
+	}
+	fmt.Fprintf(stderr, "Error: %v\n", err)
+}
+
 // classifyAPIError maps API errors to structured exit codes with actionable hints.
 func classifyAPIError(err error, flags *rootFlags) error {
 	msg := err.Error()

--- a/library/project-management/linear/internal/cli/helpers.go
+++ b/library/project-management/linear/internal/cli/helpers.go
@@ -217,6 +217,7 @@ func parentNoSubcommandRunE(flags *rootFlags) func(*cobra.Command, []string) err
 				"error":             "subcommand required",
 				"valid_subcommands": subs,
 			})
+			flags.errorWritten = true
 			return usageErr(fmt.Errorf("subcommand required for %q", cmd.CommandPath()))
 		}
 		return cmd.Help()

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -206,7 +206,7 @@ func fetchIssueLive(c *client.Client, identifier string) (json.RawMessage, error
 		issues(filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }, first: 1) {
 			nodes {
 				id identifier title description priority estimate dueDate url updatedAt createdAt
-				state { name type }
+				state { id name type }
 				team { id key name }
 				project { id name }
 				assignee { id name displayName email }

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -110,6 +110,13 @@ sub-issue under an existing parent.`,
 			if stateFlag != "" && !store.IsUUID(stateFlag) {
 				return usageErr(fmt.Errorf("--state expects a workflow state UUID (got %q); use --state-name %q, or run 'linear-pp-cli workflow-states list --team %s' to find the UUID", stateFlag, stateFlag, teamFlag))
 			}
+			if stateTypeFlag != "" {
+				normalizedType, err := normalizeWorkflowStateType(stateTypeFlag)
+				if err != nil {
+					return err
+				}
+				stateTypeFlag = normalizedType
+			}
 
 			input := map[string]any{
 				"title":  titleFlag,
@@ -365,7 +372,7 @@ sub-issue under an existing parent.`,
 	cmd.Flags().StringVar(&projectFlag, "project", "", "Project UUID")
 	cmd.Flags().StringVar(&stateFlag, "state", "", "Workflow state UUID (see 'workflow-states list --team <key>'); use --state-name to set by name")
 	cmd.Flags().StringVar(&stateNameFlag, "state-name", "", "Workflow state name (e.g. \"In Progress\"); resolved against --team")
-	cmd.Flags().StringVar(&stateTypeFlag, "state-type", "", "Workflow state type (triage, backlog, unstarted, started, completed, canceled); resolved against --team")
+	cmd.Flags().StringVar(&stateTypeFlag, "state-type", "", "Workflow state type (triage, backlog, unstarted, started, completed, canceled, duplicate); resolved against --team")
 	cmd.Flags().StringVar(&parentFlag, "parent", "", "Parent issue identifier or UUID; creates the issue as a sub-issue")
 	cmd.Flags().StringSliceVar(&labelsFlag, "label", nil, "Label UUIDs (repeatable)")
 	cmd.Flags().StringSliceVar(&mediaFlag, "media", nil, "Upload file and append it to the description markdown (repeatable)")

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -16,6 +16,7 @@ import (
 // into the local pp_created ledger so pp-cleanup can find it later.
 func newIssuesCreateCmd(flags *rootFlags) *cobra.Command {
 	var titleFlag, teamFlag, descFlag, assigneeFlag, projectFlag, stateFlag, parentFlag string
+	var stateNameFlag, stateTypeFlag string
 	var descFile string
 	var descStdin bool
 	var priorityFlag int
@@ -36,6 +37,9 @@ Pass --parent with an issue identifier or UUID to create the new issue as a
 sub-issue under an existing parent.`,
 		Example: `  # Quick test ticket in team ENG
   linear-pp-cli issues create --title "pp-test sanity" --team ENG
+
+  # Open the issue directly in a named workflow state
+  linear-pp-cli issues create --title "x" --team ENG --state-name "In Progress"
 
   # Dry-run (shows the GraphQL request without sending)
   linear-pp-cli issues create --title "x" --team ENG --dry-run
@@ -94,6 +98,19 @@ sub-issue under an existing parent.`,
 				}
 			}
 
+			stateSelectors := 0
+			for _, v := range []string{stateFlag, stateNameFlag, stateTypeFlag} {
+				if v != "" {
+					stateSelectors++
+				}
+			}
+			if stateSelectors > 1 {
+				return usageErr(fmt.Errorf("pass exactly one of --state, --state-name, or --state-type"))
+			}
+			if stateFlag != "" && !store.IsUUID(stateFlag) {
+				return usageErr(fmt.Errorf("--state expects a workflow state UUID (got %q); use --state-name %q, or run 'linear-pp-cli workflow-states list --team %s' to find the UUID", stateFlag, stateFlag, teamFlag))
+			}
+
 			input := map[string]any{
 				"title":  titleFlag,
 				"teamId": teamID,
@@ -130,6 +147,12 @@ sub-issue under an existing parent.`,
 					out["media"] = mediaFlag
 					out["media_public"] = mediaPublic
 				}
+				if stateNameFlag != "" {
+					out["state_name"] = stateNameFlag
+				}
+				if stateTypeFlag != "" {
+					out["state_type"] = stateTypeFlag
+				}
 				return renderMutationDryRun(cmd, flags, "would_create_issue", "issueCreate", out)
 			}
 
@@ -143,6 +166,16 @@ sub-issue under an existing parent.`,
 					return classifyLiveReadError(err, flags)
 				}
 				input["parentId"] = parentID
+			}
+			if stateNameFlag != "" || stateTypeFlag != "" {
+				if teamInfo.ID == "" {
+					return usageErr(fmt.Errorf("--state-name/--state-type resolve against the team UUID, but team %q is not in the local store; pass --team <uuid>, run 'linear-pp-cli sync' first, or use --state <uuid>", teamFlag))
+				}
+				stateID, err := resolveWorkflowState(c, teamInfo, stateNameFlag, stateTypeFlag)
+				if err != nil {
+					return classifyLiveReadError(err, flags)
+				}
+				input["stateId"] = stateID
 			}
 			if len(labelsFlag) > 0 {
 				if err := validateIssueLabelTeams(c, labelsFlag, teamInfo); err != nil {
@@ -324,7 +357,9 @@ sub-issue under an existing parent.`,
 	cmd.Flags().IntVar(&priorityFlag, "priority", 0, "Priority: 1=Urgent, 2=High, 3=Medium, 4=Low (0=None)")
 	cmd.Flags().StringVar(&assigneeFlag, "assignee", "", "Assignee user UUID")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "Project UUID")
-	cmd.Flags().StringVar(&stateFlag, "state", "", "Workflow state UUID")
+	cmd.Flags().StringVar(&stateFlag, "state", "", "Workflow state UUID (see 'workflow-states list --team <key>'); use --state-name to set by name")
+	cmd.Flags().StringVar(&stateNameFlag, "state-name", "", "Workflow state name (e.g. \"In Progress\"); resolved against --team")
+	cmd.Flags().StringVar(&stateTypeFlag, "state-type", "", "Workflow state type (triage, backlog, unstarted, started, completed, canceled); resolved against --team")
 	cmd.Flags().StringVar(&parentFlag, "parent", "", "Parent issue identifier or UUID; creates the issue as a sub-issue")
 	cmd.Flags().StringSliceVar(&labelsFlag, "label", nil, "Label UUIDs (repeatable)")
 	cmd.Flags().StringSliceVar(&mediaFlag, "media", nil, "Upload file and append it to the description markdown (repeatable)")

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -167,10 +167,16 @@ sub-issue under an existing parent.`,
 				}
 				input["parentId"] = parentID
 			}
-			if stateNameFlag != "" || stateTypeFlag != "" {
-				if teamInfo.ID == "" {
-					return usageErr(fmt.Errorf("--state-name/--state-type resolve against the team UUID, but team %q is not in the local store; pass --team <uuid>, run 'linear-pp-cli sync' first, or use --state <uuid>", teamFlag))
+			if teamInfo.ID == "" && teamInfo.Key != "" {
+				resolvedTeamID, err := resolveTeamIDLive(c, teamInfo.Key)
+				if err != nil {
+					return classifyLiveReadError(err, flags)
 				}
+				teamID = resolvedTeamID
+				teamInfo.ID = resolvedTeamID
+				input["teamId"] = teamID
+			}
+			if stateNameFlag != "" || stateTypeFlag != "" {
 				stateID, err := resolveWorkflowState(c, teamInfo, stateNameFlag, stateTypeFlag)
 				if err != nil {
 					return classifyLiveReadError(err, flags)

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -69,6 +69,13 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				}
 				input["stateId"] = stateFlag
 			}
+			if stateTypeFlag != "" {
+				normalizedType, err := normalizeWorkflowStateType(stateTypeFlag)
+				if err != nil {
+					return err
+				}
+				stateTypeFlag = normalizedType
+			}
 			if parentFlag != "" && noParentFlag {
 				return usageErr(fmt.Errorf("pass either --parent or --no-parent, not both"))
 			}
@@ -233,7 +240,7 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 	cmd.Flags().StringVar(&projectFlag, "project", "", "Project UUID")
 	cmd.Flags().StringVar(&stateFlag, "state", "", "Workflow state UUID (see 'workflow-states list --team <key>')")
 	cmd.Flags().StringVar(&stateNameFlag, "state-name", "", "Workflow state name (e.g. \"In Progress\"); resolved against the issue's team")
-	cmd.Flags().StringVar(&stateTypeFlag, "state-type", "", "Workflow state type (triage, backlog, unstarted, started, completed, canceled); resolved against the issue's team")
+	cmd.Flags().StringVar(&stateTypeFlag, "state-type", "", "Workflow state type (triage, backlog, unstarted, started, completed, canceled, duplicate); resolved against the issue's team")
 	cmd.Flags().StringVar(&parentFlag, "parent", "", "Parent issue identifier or UUID")
 	cmd.Flags().BoolVar(&noParentFlag, "no-parent", false, "Clear issue parentage")
 	cmd.Flags().StringSliceVar(&labelsFlag, "label", nil, "Replacement label UUIDs (repeatable)")

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
 
@@ -252,8 +253,11 @@ func writeIssueBack(dbPath string, raw json.RawMessage) {
 	}
 	db, err := store.Open(dbPath)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: cannot open ledger at %s: %v\n", dbPath, err)
 		return
 	}
 	defer db.Close()
-	_ = db.UpsertIssue(issue.ID, issue.Identifier, issue.Title, raw)
+	if err := db.UpsertIssue(issue.ID, issue.Identifier, issue.Title, raw); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: local store write-back failed: %v\n", err)
+	}
 }

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -11,6 +11,7 @@ import (
 
 func newIssuesEditCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 	var titleFlag, descFlag, descFile, assigneeFlag, projectFlag, stateFlag, parentFlag string
+	var stateNameFlag, stateTypeFlag string
 	var descStdin bool
 	var noParentFlag bool
 	var priorityFlag int
@@ -30,6 +31,8 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 		Example: `  linear-pp-cli issues edit ENG-123 --description-file /tmp/body.md --agent
   linear-pp-cli issues edit ENG-123 --media /tmp/screenshot.png --agent
   linear-pp-cli issues edit ENG-123 --state <state-uuid> --project <project-uuid> --agent
+  linear-pp-cli issues edit ENG-123 --state-name "In Progress" --agent
+  linear-pp-cli issues edit ENG-123 --state-type started --agent
   linear-pp-cli issues edit ENG-123 --parent ENG-100 --agent
   linear-pp-cli issues edit ENG-123 --no-parent --agent`,
 		Args: cobra.ExactArgs(1),
@@ -50,7 +53,19 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 			if projectFlag != "" {
 				input["projectId"] = projectFlag
 			}
+			stateSelectors := 0
+			for _, v := range []string{stateFlag, stateNameFlag, stateTypeFlag} {
+				if v != "" {
+					stateSelectors++
+				}
+			}
+			if stateSelectors > 1 {
+				return usageErr(fmt.Errorf("pass exactly one of --state, --state-name, or --state-type"))
+			}
 			if stateFlag != "" {
+				if !store.IsUUID(stateFlag) {
+					return usageErr(fmt.Errorf("--state expects a workflow state UUID (got %q); use --state-name %q, or run 'linear-pp-cli workflow-states list --team <key>' to find the UUID", stateFlag, stateFlag))
+				}
 				input["stateId"] = stateFlag
 			}
 			if parentFlag != "" && noParentFlag {
@@ -87,8 +102,8 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 			if descSet {
 				input["description"] = descBody
 			}
-			if len(input) == 0 && len(mediaFlag) == 0 {
-				return usageErr(fmt.Errorf("no issue fields supplied; pass --title, --description-file, --media, --state, --project, --assignee, --priority, --label, --parent, or --no-parent"))
+			if len(input) == 0 && len(mediaFlag) == 0 && stateNameFlag == "" && stateTypeFlag == "" {
+				return usageErr(fmt.Errorf("no issue fields supplied; pass --title, --description-file, --media, --state, --state-name, --state-type, --project, --assignee, --priority, --label, --parent, or --no-parent"))
 			}
 			if flags.dryRun {
 				out := map[string]any{"issue": args[0], "input": input}
@@ -96,13 +111,19 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 					out["media"] = mediaFlag
 					out["media_public"] = mediaPublic
 				}
+				if stateNameFlag != "" {
+					out["state_name"] = stateNameFlag
+				}
+				if stateTypeFlag != "" {
+					out["state_type"] = stateTypeFlag
+				}
 				return renderMutationDryRun(cmd, flags, "would_update_issue", "issueUpdate", out)
 			}
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
-			if (len(mediaFlag) > 0 && !descSet) || len(labelsFlag) > 0 {
+			if (len(mediaFlag) > 0 && !descSet) || len(labelsFlag) > 0 || stateNameFlag != "" || stateTypeFlag != "" {
 				existing, err := fetchIssueLive(c, args[0])
 				if err != nil {
 					return classifyLiveReadError(err, flags)
@@ -149,6 +170,16 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				if err := validateIssueLabelTeams(c, labelsFlag, issueTeam); err != nil {
 					return classifyLiveReadError(err, flags)
 				}
+			}
+			if stateNameFlag != "" || stateTypeFlag != "" {
+				if !issueMetaLoaded {
+					return fmt.Errorf("internal error: state resolution requires issue metadata")
+				}
+				stateID, err := resolveWorkflowState(c, issueTeam, stateNameFlag, stateTypeFlag)
+				if err != nil {
+					return classifyLiveReadError(err, flags)
+				}
+				input["stateId"] = stateID
 			}
 			descBody, uploaded, err := uploadMediaAndAppend(c, descBody, mediaFlag, mediaPublic)
 			if err != nil {
@@ -199,7 +230,9 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 	cmd.Flags().IntVar(&priorityFlag, "priority", 0, "Priority: 1=Urgent, 2=High, 3=Medium, 4=Low")
 	cmd.Flags().StringVar(&assigneeFlag, "assignee", "", "Assignee user UUID")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "Project UUID")
-	cmd.Flags().StringVar(&stateFlag, "state", "", "Workflow state UUID")
+	cmd.Flags().StringVar(&stateFlag, "state", "", "Workflow state UUID (see 'workflow-states list --team <key>')")
+	cmd.Flags().StringVar(&stateNameFlag, "state-name", "", "Workflow state name (e.g. \"In Progress\"); resolved against the issue's team")
+	cmd.Flags().StringVar(&stateTypeFlag, "state-type", "", "Workflow state type (triage, backlog, unstarted, started, completed, canceled); resolved against the issue's team")
 	cmd.Flags().StringVar(&parentFlag, "parent", "", "Parent issue identifier or UUID")
 	cmd.Flags().BoolVar(&noParentFlag, "no-parent", false, "Clear issue parentage")
 	cmd.Flags().StringSliceVar(&labelsFlag, "label", nil, "Replacement label UUIDs (repeatable)")

--- a/library/project-management/linear/internal/cli/labels.go
+++ b/library/project-management/linear/internal/cli/labels.go
@@ -166,10 +166,18 @@ func validateIssueLabelTeams(c *client.Client, labelIDs []string, target issueTe
 	if targetID == "" && targetKey == "" {
 		return fmt.Errorf("cannot validate labels without target issue team")
 	}
+	labels, err := fetchIssueLabelsByIDsLive(c, labelIDs)
+	if err != nil {
+		return err
+	}
+	byID := make(map[string]issueLabelInfo, len(labels))
+	for _, label := range labels {
+		byID[strings.ToLower(label.ID)] = label
+	}
 	for _, id := range labelIDs {
-		label, err := fetchIssueLabelLive(c, id)
-		if err != nil {
-			return err
+		label, ok := byID[strings.ToLower(strings.TrimSpace(id))]
+		if !ok {
+			return notFoundErr(fmt.Errorf("issue label %q not found", id))
 		}
 		if label.Team == nil || (label.Team.ID == "" && label.Team.Key == "") {
 			continue
@@ -184,23 +192,37 @@ func validateIssueLabelTeams(c *client.Client, labelIDs []string, target issueTe
 	return nil
 }
 
-func fetchIssueLabelLive(c *client.Client, id string) (issueLabelInfo, error) {
-	const query = `query($id: String!) {
-		issueLabel(id: $id) {
-			id name color
-			team { id key name }
+// fetchIssueLabelsByIDsLive resolves all requested label UUIDs in a single
+// batched GraphQL call. The previous shape issued one round-trip per label,
+// so a multi-label edit paid N sequential API calls before the mutation fired.
+func fetchIssueLabelsByIDsLive(c *client.Client, ids []string) ([]issueLabelInfo, error) {
+	unique := make([]string, 0, len(ids))
+	seen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		key := strings.ToLower(strings.TrimSpace(id))
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		unique = append(unique, strings.TrimSpace(id))
+	}
+	const query = `query($ids: [ID!]!, $first: Int!) {
+		issueLabels(filter: { id: { in: $ids } }, first: $first) {
+			nodes {
+				id name color
+				team { id key name }
+			}
 		}
 	}`
 	var resp struct {
-		IssueLabel *issueLabelInfo `json:"issueLabel"`
+		IssueLabels struct {
+			Nodes []issueLabelInfo `json:"nodes"`
+		} `json:"issueLabels"`
 	}
-	if err := c.QueryInto(query, map[string]any{"id": id}, &resp); err != nil {
-		return issueLabelInfo{}, err
+	if err := c.QueryInto(query, map[string]any{"ids": unique, "first": len(unique)}, &resp); err != nil {
+		return nil, err
 	}
-	if resp.IssueLabel == nil || resp.IssueLabel.ID == "" {
-		return issueLabelInfo{}, notFoundErr(fmt.Errorf("issue label %q not found", id))
-	}
-	return *resp.IssueLabel, nil
+	return resp.IssueLabels.Nodes, nil
 }
 
 func labelTeamName(team *issueLabelTeam) string {

--- a/library/project-management/linear/internal/cli/labels.go
+++ b/library/project-management/linear/internal/cli/labels.go
@@ -58,21 +58,32 @@ func newLabelsListCmd(flags *rootFlags) *cobra.Command {
 			if limit <= 0 {
 				limit = 100
 			}
+			includeGlobals := includeGlobal && !noGlobal
 			var labels []json.RawMessage
 			prov := DataProvenance{ResourceType: "issue_labels"}
-			switch flags.dataSource {
-			case "local":
+			fetchLocal := func(reason string) ([]json.RawMessage, DataProvenance, error) {
 				db, err := store.Open(resolveDBPath(dbPath))
 				if err != nil {
-					return fmt.Errorf("opening local database: %w", err)
+					return nil, DataProvenance{}, fmt.Errorf("opening local database: %w", err)
 				}
 				defer db.Close()
-				labels, err = db.ListIssueLabels(limit)
-				if err != nil {
-					return fmt.Errorf("listing issue labels: %w", err)
+				if team != "" {
+					labels, err = db.ListIssueLabelsForTeam(limit, team, includeGlobals)
+				} else {
+					labels, err = db.ListIssueLabels(limit)
 				}
-				prov.Source = "local"
-				prov.Reason = "user_requested"
+				if err != nil {
+					return nil, DataProvenance{}, fmt.Errorf("listing issue labels: %w", err)
+				}
+				return labels, DataProvenance{Source: "local", ResourceType: "issue_labels", Reason: reason}, nil
+			}
+			switch flags.dataSource {
+			case "local":
+				var err error
+				labels, prov, err = fetchLocal("user_requested")
+				if err != nil {
+					return err
+				}
 			default:
 				c, err := flags.newClient()
 				if err != nil {
@@ -80,13 +91,21 @@ func newLabelsListCmd(flags *rootFlags) *cobra.Command {
 				}
 				nodes, err := c.PaginatedQueryMax(client.IssueLabelsQuery, map[string]any{"first": limit}, "issueLabels", limit, 10)
 				if err != nil {
-					return classifyAPIError(err, flags)
+					if flags.dataSource == "live" || !isNetworkError(err) {
+						return classifyAPIError(err, flags)
+					}
+					var fallbackErr error
+					labels, prov, fallbackErr = fetchLocal("api_unreachable")
+					if fallbackErr != nil {
+						return fmt.Errorf("API unreachable and no local issue labels. Run 'linear-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
+					}
+					break
 				}
 				labels = nodes
 				prov.Source = "live"
 				prov.Reason = "user_requested"
 			}
-			filtered := filterIssueLabelsForTeam(labels, team, includeGlobal && !noGlobal)
+			filtered := filterIssueLabelsForTeam(labels, team, includeGlobals)
 			out, err := json.Marshal(filtered)
 			if err != nil {
 				return err

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -918,6 +918,38 @@ func TestDocumentsListSendsAfterCursor(t *testing.T) {
 	}
 }
 
+func TestDocumentsListTeamKeyFilter(t *testing.T) {
+	var seenFilter map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(req.Query, "documents(first") {
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+			return
+		}
+		seenFilter, _ = req.Variables["filter"].(map[string]any)
+		fmt.Fprint(w, `{"data":{"documents":{"nodes":[{"id":"doc-1","title":"Runbook","slugId":"runbook-f7f48ab36080","url":"https://linear.app/acme/document/runbook-f7f48ab36080","team":{"id":"team-symph","key":"SYMPH","name":"Symphony"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("documents", "list", "--team", "SYMPH", "--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("documents list failed: %v\n%s", err, out)
+	}
+	teamFilter, _ := seenFilter["team"].(map[string]any)
+	keyFilter, _ := teamFilter["key"].(map[string]any)
+	if keyFilter == nil || keyFilter["eqIgnoreCase"] != "SYMPH" {
+		t.Fatalf("documents list team filter = %#v, want key eqIgnoreCase SYMPH", teamFilter)
+	}
+}
+
 func TestPromotedGraphQLReadsUsePost(t *testing.T) {
 	var seen []string
 	var teamsAfter []string

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -1042,8 +1042,8 @@ func TestIssueCreateRejectsCrossTeamLabelBeforeMutation(t *testing.T) {
 			return
 		}
 		switch {
-		case strings.Contains(req.Query, "issueLabel(id:"):
-			fmt.Fprint(w, `{"data":{"issueLabel":{"id":"label-hsui","name":"area:protocols","color":"#333","team":{"id":"team-hsui","key":"HSUI","name":"HS UI"}}}}`)
+		case strings.Contains(req.Query, "issueLabels(filter"):
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-hsui","name":"area:protocols","color":"#333","team":{"id":"team-hsui","key":"HSUI","name":"HS UI"}}]}}}`)
 		case strings.Contains(req.Query, "issueCreate"):
 			createCalled = true
 			http.Error(w, "issueCreate should not be called", http.StatusInternalServerError)
@@ -1767,12 +1767,12 @@ func TestIssuesCreateValidatesLabelsBeforeUploadingMedia(t *testing.T) {
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
 		}
-		if !strings.Contains(req.Query, "issueLabel") {
+		if !strings.Contains(req.Query, "issueLabels(filter") {
 			t.Errorf("unexpected query before media upload: %s", req.Query)
 			http.Error(w, "unexpected query", http.StatusBadRequest)
 			return
 		}
-		fmt.Fprint(w, `{"data":{"issueLabel":{"id":"label-1","name":"area:protocols","color":"#333","team":{"id":"team-hsui","key":"HSUI","name":"HS UI"}}}}`)
+		fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-1","name":"area:protocols","color":"#333","team":{"id":"team-hsui","key":"HSUI","name":"HS UI"}}]}}}`)
 	}))
 	t.Cleanup(srv.Close)
 	t.Setenv("LINEAR_BASE_URL", srv.URL)

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -1288,8 +1288,15 @@ func TestMutationFailureAfterMediaUploadReportsAssetURL(t *testing.T) {
 	if got := ExitCode(err); got != 5 {
 		t.Fatalf("ExitCode() = %d, want 5; err=%v\n%s", got, err, out)
 	}
-	if !strings.Contains(err.Error(), assetURL) || !strings.Contains(out, assetURL) {
+	if !strings.Contains(err.Error(), assetURL) {
 		t.Fatalf("uploaded asset URL was not surfaced; err=%v\n%s", err, out)
+	}
+	// SilenceErrors moved error printing from cobra to finalizeError; assert
+	// the agent-mode envelope still carries the asset URL to the user.
+	var envelope bytes.Buffer
+	finalizeError(&rootFlags{agent: true, asJSON: true}, nil, &envelope, io.Discard, err)
+	if !strings.Contains(envelope.String(), assetURL) {
+		t.Fatalf("agent error envelope dropped the asset URL: %s", envelope.String())
 	}
 }
 

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -853,6 +853,7 @@ func TestDocumentsEditUUIDTitleDoesNotFetchExistingDocument(t *testing.T) {
 }
 
 func TestCommentsListKeepsBodiesInAgentMode(t *testing.T) {
+	var seenAfter string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req client.GraphQLRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -864,6 +865,7 @@ func TestCommentsListKeepsBodiesInAgentMode(t *testing.T) {
 		case strings.Contains(req.Query, "issues(filter"):
 			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid"}]}}}`)
 		case strings.Contains(req.Query, "comments(first"):
+			seenAfter, _ = req.Variables["after"].(string)
 			fmt.Fprint(w, `{"data":{"issue":{"id":"issue-uuid","identifier":"MOB-99","title":"Issue","comments":{"nodes":[{"id":"comment-1","body":"full comment body","createdAt":"2026-06-09T00:00:00Z","updatedAt":"2026-06-09T00:00:00Z","user":{"id":"user-1","name":"eric"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`)
 		default:
 			t.Errorf("unexpected query: %s", req.Query)
@@ -874,12 +876,45 @@ func TestCommentsListKeepsBodiesInAgentMode(t *testing.T) {
 	t.Setenv("LINEAR_BASE_URL", srv.URL)
 	t.Setenv("LINEAR_API_KEY", "test-token")
 
-	out, err := executeRootForTest("comments", "list", "--issue", "MOB-99", "--agent", "--data-source", "live")
+	out, err := executeRootForTest("comments", "list", "--issue", "MOB-99", "--after", "cursor-1", "--agent", "--data-source", "live")
 	if err != nil {
 		t.Fatalf("comments list failed: %v\n%s", err, out)
 	}
 	if !strings.Contains(out, "full comment body") {
 		t.Fatalf("agent output stripped comment body: %s", out)
+	}
+	if seenAfter != "cursor-1" {
+		t.Fatalf("comments list after cursor = %q, want cursor-1", seenAfter)
+	}
+}
+
+func TestDocumentsListSendsAfterCursor(t *testing.T) {
+	var seenAfter string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(req.Query, "documents(first") {
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+			return
+		}
+		seenAfter, _ = req.Variables["after"].(string)
+		fmt.Fprint(w, `{"data":{"documents":{"nodes":[{"id":"doc-1","title":"Runbook","slugId":"runbook-f7f48ab36080","url":"https://linear.app/acme/document/runbook-f7f48ab36080"}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("documents", "list", "--after", "cursor-1", "--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("documents list failed: %v\n%s", err, out)
+	}
+	if seenAfter != "cursor-1" {
+		t.Fatalf("documents list after cursor = %q, want cursor-1", seenAfter)
 	}
 }
 
@@ -1029,6 +1064,24 @@ func TestLabelsListUsesLocalIssueLabelTable(t *testing.T) {
 	}
 	if envelope.Meta.Source != "local" {
 		t.Fatalf("local labels source = %q, want local: %s", envelope.Meta.Source, out)
+	}
+
+	out, err = executeRootForTest("labels", "list", "--team", "SYMPH", "--agent", "--data-source", "local", "--db", dbPath, "--select", "name,team.key", "--limit", "2")
+	if err != nil {
+		t.Fatalf("labels list local with limit failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, `"pipeline-halt"`) {
+		t.Fatalf("local labels applied limit before team filter: %s", out)
+	}
+
+	t.Setenv("LINEAR_BASE_URL", "http://127.0.0.1:1")
+	t.Setenv("LINEAR_API_KEY", "test-token")
+	out, err = executeRootForTest("labels", "list", "--team", "SYMPH", "--agent", "--data-source", "auto", "--db", dbPath, "--select", "name,team.key", "--limit", "2")
+	if err != nil {
+		t.Fatalf("labels list auto fallback failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, `"pipeline-halt"`) || !strings.Contains(out, `"api_unreachable"`) {
+		t.Fatalf("labels list auto did not fall back to local labels: %s", out)
 	}
 }
 
@@ -1271,7 +1324,7 @@ func TestMutationFailureAfterMediaUploadReportsAssetURL(t *testing.T) {
 				t.Errorf("encode fileUpload response: %v", err)
 			}
 		case strings.Contains(req.Query, "commentCreate"):
-			fmt.Fprint(w, `{"errors":[{"message":"mutation rejected"}]}`)
+			fmt.Fprint(w, `{"data":{"commentCreate":{"success":false,"comment":null}}}`)
 		default:
 			t.Errorf("unexpected query: %s", req.Query)
 			http.Error(w, "unexpected query", http.StatusBadRequest)

--- a/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
+++ b/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
@@ -182,6 +182,7 @@ func TestNormalizeDocumentRef(t *testing.T) {
 		{"symphony-pipeline-restart-runbook-f7f48ab36080", "f7f48ab36080"},
 		{"https://linear.app/mobilyze-llc/document/symphony-pipeline-restart-runbook-f7f48ab36080", "f7f48ab36080"},
 		{"https://linear.app/mobilyze-llc/document/symphony-pipeline-restart-runbook-f7f48ab36080?view=full", "f7f48ab36080"},
+		{"https://linear.app/mobilyze-llc/document/4a09c2e6-3a25-4cb8-ab63-9c9f6754b24e", "4a09c2e6-3a25-4cb8-ab63-9c9f6754b24e"},
 		{"  f7f48ab36080  ", "f7f48ab36080"},
 	}
 	for _, c := range cases {
@@ -216,6 +217,25 @@ func TestDocumentsAcceptsFullURLSlug(t *testing.T) {
 	}
 	if !strings.Contains(out, "doc-uuid") {
 		t.Fatalf("document output missing id: %s", out)
+	}
+}
+
+func TestDocumentsRejectsEmptySlugRefBeforeNetwork(t *testing.T) {
+	var liveRequest bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		liveRequest = true
+		http.Error(w, "document lookup should not run for an empty slug ref", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	_, err := executeRootForTest("documents", "-", "--agent")
+	if err == nil || ExitCode(err) != 3 {
+		t.Fatalf("hyphen-only document ref should be a code-3 not-found error, got %v", err)
+	}
+	if liveRequest {
+		t.Fatalf("document lookup should not run for an empty slug ref")
 	}
 }
 
@@ -665,24 +685,10 @@ func TestIssuesCreateStateNameResolvesTeamKeyWithoutLocalStore(t *testing.T) {
 }
 
 func TestResolveWorkflowStateRejectsInvalidStateType(t *testing.T) {
-	var workflowStateLookup bool
+	var liveRequest bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req client.GraphQLRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("decode request: %v", err)
-			http.Error(w, "bad request", http.StatusBadRequest)
-			return
-		}
-		switch {
-		case strings.Contains(req.Query, "issues(filter"):
-			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid","identifier":"MOB-105","title":"Issue","description":"","team":{"id":"team-1","key":"MOB","name":"Mobilyze"}}]}}}`)
-		case strings.Contains(req.Query, "workflowStates("):
-			workflowStateLookup = true
-			http.Error(w, "workflow state lookup should not run for invalid state type", http.StatusInternalServerError)
-		default:
-			t.Errorf("unexpected query: %s", req.Query)
-			http.Error(w, "unexpected query", http.StatusBadRequest)
-		}
+		liveRequest = true
+		http.Error(w, "invalid state type should not make a live request", http.StatusInternalServerError)
 	}))
 	t.Cleanup(srv.Close)
 	t.Setenv("LINEAR_BASE_URL", srv.URL)
@@ -696,7 +702,7 @@ func TestResolveWorkflowStateRejectsInvalidStateType(t *testing.T) {
 	if !strings.Contains(err.Error(), validLinearWorkflowStateTypeList) {
 		t.Fatalf("invalid type error should list valid types, got: %v", err)
 	}
-	if workflowStateLookup {
-		t.Fatalf("workflow state lookup should not run for invalid --state-type")
+	if liveRequest {
+		t.Fatalf("invalid --state-type should not make a live request")
 	}
 }

--- a/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
+++ b/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
@@ -61,6 +61,10 @@ func TestWorkflowStatesListLiveIncludesIDs(t *testing.T) {
 	if team == nil {
 		t.Fatalf("team filter was not sent to GraphQL: %v", seenFilter)
 	}
+	keyFilter, _ := team["key"].(map[string]any)
+	if keyFilter == nil || keyFilter["eqIgnoreCase"] != "SYMPH" {
+		t.Fatalf("team key filter = %v, want eqIgnoreCase SYMPH", keyFilter)
+	}
 }
 
 func TestStatesListAlias(t *testing.T) {
@@ -528,14 +532,15 @@ func TestFinalizeErrorSkipsDoubleEnvelope(t *testing.T) {
 // exclusive.
 func TestIssuesCreateStateFlagValidation(t *testing.T) {
 	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
 	_, err := executeRootForTest("issues", "create", "--title", "x", "--team", "ENG",
-		"--state", "In Progress", "--agent", "--dry-run")
+		"--state", "In Progress", "--agent", "--dry-run", "--db", dbPath)
 	if err == nil || ExitCode(err) != 2 {
 		t.Fatalf("create --state with a non-UUID should be a code-2 usage error, got %v", err)
 	}
 
 	_, err = executeRootForTest("issues", "create", "--title", "x", "--team", "ENG",
-		"--state", "11111111-2222-3333-4444-555555555555", "--state-name", "Done", "--agent", "--dry-run")
+		"--state", "11111111-2222-3333-4444-555555555555", "--state-name", "Done", "--agent", "--dry-run", "--db", dbPath)
 	if err == nil || ExitCode(err) != 2 {
 		t.Fatalf("create --state plus --state-name should be a code-2 usage error, got %v", err)
 	}

--- a/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
+++ b/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
@@ -559,6 +559,9 @@ func TestParentNoSubcommandAgentModeSingleEnvelope(t *testing.T) {
 	if envelope["error"] != "subcommand required" {
 		t.Fatalf("unexpected envelope: %#v", envelope)
 	}
+	if envelope["code"] != float64(2) || envelope["type"] != "usage" {
+		t.Fatalf("parent command envelope missing typed error fields: %#v", envelope)
+	}
 	var extra map[string]any
 	if err := dec.Decode(&extra); err != io.EOF {
 		t.Fatalf("expected exactly one JSON envelope, second decode err=%v extra=%#v output=%s", err, extra, out)

--- a/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
+++ b/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
@@ -1,0 +1,415 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+)
+
+const workflowStatesResponse = `{"data":{"workflowStates":{"nodes":[
+	{"id":"state-todo","name":"Todo","type":"unstarted","color":"#aaa","position":1,"team":{"id":"team-1","key":"SYMPH","name":"Symphony"}},
+	{"id":"state-progress","name":"In Progress","type":"started","color":"#bbb","position":2,"team":{"id":"team-1","key":"SYMPH","name":"Symphony"}}
+]}}}`
+
+func TestWorkflowStatesListLiveIncludesIDs(t *testing.T) {
+	var seenFilter map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(req.Query, "workflowStates(") {
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+			return
+		}
+		seenFilter, _ = req.Variables["filter"].(map[string]any)
+		fmt.Fprint(w, workflowStatesResponse)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("workflow-states", "list", "--team", "SYMPH",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--agent", "--data-source", "live", "--select", "id,name,type")
+	if err != nil {
+		t.Fatalf("workflow-states list failed: %v\n%s", err, out)
+	}
+	var rows []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("output is not a JSON array: %v\n%s", err, out)
+	}
+	if len(rows) != 2 || rows[0].ID == "" || rows[1].ID == "" {
+		t.Fatalf("expected 2 states with ids, got: %s", out)
+	}
+	team, _ := seenFilter["team"].(map[string]any)
+	if team == nil {
+		t.Fatalf("team filter was not sent to GraphQL: %v", seenFilter)
+	}
+}
+
+func TestStatesListAlias(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, workflowStatesResponse)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("states", "list", "--team", "SYMPH",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("states list alias failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "state-progress") {
+		t.Fatalf("alias output missing state id: %s", out)
+	}
+}
+
+func TestWorkflowStatesListLocalStore(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.UpsertTeam("team-1", json.RawMessage(`{"id":"team-1","key":"SYMPH","name":"Symphony"}`)); err != nil {
+		t.Fatalf("UpsertTeam: %v", err)
+	}
+	states := []string{
+		`{"id":"state-todo","name":"Todo","type":"unstarted","position":1,"team":{"id":"team-1","key":"SYMPH","name":"Symphony"}}`,
+		`{"id":"state-done","name":"Done","type":"completed","position":5,"team":{"id":"team-1","key":"SYMPH","name":"Symphony"}}`,
+		`{"id":"state-other","name":"Todo","type":"unstarted","position":1,"team":{"id":"team-2","key":"MOB","name":"Mobilyze"}}`,
+	}
+	for _, s := range states {
+		var meta struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(s), &meta); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.UpsertWorkflowState(meta.ID, json.RawMessage(s)); err != nil {
+			t.Fatalf("UpsertWorkflowState: %v", err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeRootForTest("workflow-states", "list", "--team", "SYMPH",
+		"--db", dbPath, "--agent", "--data-source", "local", "--select", "id,name,type")
+	if err != nil {
+		t.Fatalf("workflow-states list local failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "state-todo") || !strings.Contains(out, "state-done") {
+		t.Fatalf("local output missing SYMPH states: %s", out)
+	}
+	if strings.Contains(out, "state-other") {
+		t.Fatalf("team filter leaked other team's states: %s", out)
+	}
+}
+
+func TestIssuesGetByIdentifierSelectsStateID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(req.Query, "state { id name type }") {
+			t.Errorf("identifier-path issue query does not request state.id: %s", req.Query)
+		}
+		fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid","identifier":"SYMPH-331","title":"Issue","state":{"id":"state-progress","name":"In Progress","type":"started"},"team":{"id":"team-1","key":"SYMPH","name":"Symphony"}}]}}}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "SYMPH-331",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--agent", "--data-source", "live",
+		"--select", "identifier,state.id,state.name,state.type")
+	if err != nil {
+		t.Fatalf("issues get failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Results struct {
+			Identifier string `json:"identifier"`
+			State      struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+				Type string `json:"type"`
+			} `json:"state"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out)
+	}
+	if got.Results.State.ID != "state-progress" {
+		t.Fatalf("--select state.id did not include the state UUID: %s", out)
+	}
+}
+
+func TestNormalizeDocumentRef(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want string
+	}{
+		{"4a09c2e6-3a25-4cb8-ab63-9c9f6754b24e", "4a09c2e6-3a25-4cb8-ab63-9c9f6754b24e"},
+		{"f7f48ab36080", "f7f48ab36080"},
+		{"symphony-pipeline-restart-runbook-f7f48ab36080", "f7f48ab36080"},
+		{"https://linear.app/mobilyze-llc/document/symphony-pipeline-restart-runbook-f7f48ab36080", "f7f48ab36080"},
+		{"https://linear.app/mobilyze-llc/document/symphony-pipeline-restart-runbook-f7f48ab36080?view=full", "f7f48ab36080"},
+		{"  f7f48ab36080  ", "f7f48ab36080"},
+	}
+	for _, c := range cases {
+		if got := normalizeDocumentRef(c.in); got != c.want {
+			t.Errorf("normalizeDocumentRef(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDocumentsAcceptsFullURLSlug(t *testing.T) {
+	var seenSlug string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		seenSlug, _ = req.Variables["slug"].(string)
+		fmt.Fprint(w, `{"data":{"documents":{"nodes":[{"id":"doc-uuid","title":"Runbook","slugId":"f7f48ab36080","content":"runbook body"}]}}}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("documents", "symphony-pipeline-restart-runbook-f7f48ab36080", "--agent")
+	if err != nil {
+		t.Fatalf("documents lookup by full slug failed: %v\n%s", err, out)
+	}
+	if seenSlug != "f7f48ab36080" {
+		t.Fatalf("slug sent to GraphQL = %q, want normalized %q", seenSlug, "f7f48ab36080")
+	}
+	if !strings.Contains(out, "doc-uuid") {
+		t.Fatalf("document output missing id: %s", out)
+	}
+}
+
+func TestCommentsListPositionalIssue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issues(filter"):
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid"}]}}}`)
+		case strings.Contains(req.Query, "comments(first"):
+			fmt.Fprint(w, `{"data":{"issue":{"id":"issue-uuid","identifier":"SYMPH-317","title":"Issue","comments":{"nodes":[{"id":"comment-1","body":"latest update"}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("comments", "list", "SYMPH-317", "--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("comments list positional failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "latest update") {
+		t.Fatalf("positional comments list missing comment body: %s", out)
+	}
+}
+
+func TestCommentsListIssueRequiredAndConflicts(t *testing.T) {
+	_, err := executeRootForTest("comments", "list", "--agent")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("missing issue should be a code-2 usage error, got %v", err)
+	}
+
+	_, err = executeRootForTest("comments", "list", "SYMPH-317", "--issue", "SYMPH-1", "--agent")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("conflicting positional/--issue should be a code-2 usage error, got %v", err)
+	}
+
+	// Same value both ways is not a conflict — needs a live endpoint, so only
+	// assert it is not rejected as a usage error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if strings.Contains(req.Query, "issues(filter") {
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid"}]}}}`)
+			return
+		}
+		fmt.Fprint(w, `{"data":{"issue":{"id":"issue-uuid","identifier":"SYMPH-317","title":"Issue","comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`)
+	}))
+	defer srv.Close()
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+	if _, err := executeRootForTest("comments", "list", "SYMPH-317", "--issue", "SYMPH-317", "--agent", "--data-source", "live"); err != nil {
+		t.Fatalf("matching positional/--issue should be accepted, got %v", err)
+	}
+}
+
+func TestIssuesEditStateNameResolvesUUID(t *testing.T) {
+	var seenStateID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issues(filter"):
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid","identifier":"MOB-105","title":"Issue","description":"","state":{"id":"state-todo","name":"Todo","type":"unstarted"},"team":{"id":"team-1","key":"MOB","name":"Mobilyze"}}]}}}`)
+		case strings.Contains(req.Query, "workflowStates("):
+			fmt.Fprint(w, `{"data":{"workflowStates":{"nodes":[{"id":"state-progress","name":"In Progress","type":"started"}]}}}`)
+		case strings.Contains(req.Query, "issueUpdate"):
+			input, _ := req.Variables["input"].(map[string]any)
+			seenStateID, _ = input["stateId"].(string)
+			fmt.Fprint(w, `{"data":{"issueUpdate":{"success":true,"issue":{"id":"issue-uuid","identifier":"MOB-105","title":"Issue","state":{"id":"state-progress","name":"In Progress","type":"started"},"team":{"id":"team-1","key":"MOB","name":"Mobilyze"}}}}}`)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "edit", "MOB-105", "--state-name", "In Progress",
+		"--db", filepath.Join(t.TempDir(), "linear.db"), "--agent")
+	if err != nil {
+		t.Fatalf("issues edit --state-name failed: %v\n%s", err, out)
+	}
+	if seenStateID != "state-progress" {
+		t.Fatalf("stateId sent to issueUpdate = %q, want resolved %q", seenStateID, "state-progress")
+	}
+}
+
+func TestIssuesEditStateTypeAmbiguousIsUsageError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		switch {
+		case strings.Contains(req.Query, "issues(filter"):
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid","identifier":"MOB-105","title":"Issue","description":"","team":{"id":"team-1","key":"MOB","name":"Mobilyze"}}]}}}`)
+		case strings.Contains(req.Query, "workflowStates("):
+			fmt.Fprint(w, `{"data":{"workflowStates":{"nodes":[{"id":"s1","name":"In Progress","type":"started"},{"id":"s2","name":"In Review","type":"started"}]}}}`)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	_, err := executeRootForTest("issues", "edit", "MOB-105", "--state-type", "started",
+		"--db", filepath.Join(t.TempDir(), "linear.db"), "--agent")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("ambiguous --state-type should be a code-2 usage error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "In Review") {
+		t.Fatalf("ambiguity error should list candidates, got: %v", err)
+	}
+}
+
+func TestIssuesEditStateFlagValidation(t *testing.T) {
+	t.Parallel()
+	_, err := executeRootForTest("issues", "edit", "MOB-105", "--state", "In Progress", "--agent", "--dry-run")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("--state with a non-UUID should be a code-2 usage error, got %v", err)
+	}
+
+	_, err = executeRootForTest("issues", "edit", "MOB-105",
+		"--state", "11111111-2222-3333-4444-555555555555", "--state-name", "Done", "--agent", "--dry-run")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("--state plus --state-name should be a code-2 usage error, got %v", err)
+	}
+}
+
+func TestFinalizeErrorEmitsJSONEnvelope(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	flags := &rootFlags{agent: true, asJSON: true}
+	finalizeError(flags, nil, &stdout, &stderr, notFoundErr(fmt.Errorf("document \"missing-doc\" not found")))
+
+	var envelope struct {
+		Error string `json:"error"`
+		Code  int    `json:"code"`
+		Type  string `json:"type"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("agent error output is not JSON: %v\n%s", err, stdout.String())
+	}
+	if envelope.Code != 3 || envelope.Type != "not_found" || !strings.Contains(envelope.Error, "missing-doc") {
+		t.Fatalf("unexpected envelope: %+v", envelope)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("agent mode should not write plain text to stderr: %s", stderr.String())
+	}
+}
+
+func TestFinalizeErrorUsageEnvelopeAndArgFallback(t *testing.T) {
+	t.Parallel()
+	// Flags unparsed (e.g. unknown-flag failure) — detection falls back to raw args.
+	var stdout, stderr bytes.Buffer
+	finalizeError(&rootFlags{}, []string{"comments", "list", "--agent"}, &stdout, &stderr, usageErr(fmt.Errorf("--issue is required")))
+	var envelope struct {
+		Code int    `json:"code"`
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("usage error output is not JSON: %v\n%s", err, stdout.String())
+	}
+	if envelope.Code != 2 || envelope.Type != "usage" {
+		t.Fatalf("unexpected usage envelope: %+v", envelope)
+	}
+}
+
+func TestFinalizeErrorPlainModeWritesStderr(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	finalizeError(&rootFlags{}, []string{"issues", "MOB-1"}, &stdout, &stderr, notFoundErr(fmt.Errorf("issue not found")))
+	if stdout.Len() != 0 {
+		t.Fatalf("plain mode should not write to stdout: %s", stdout.String())
+	}
+	if !strings.HasPrefix(stderr.String(), "Error: ") {
+		t.Fatalf("plain mode should keep the Error: prefix, got: %s", stderr.String())
+	}
+}
+
+func TestFinalizeErrorSkipsDoubleEnvelope(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	flags := &rootFlags{agent: true, asJSON: true, envelopeEmitted: true}
+	finalizeError(flags, nil, &stdout, &stderr, apiErr(fmt.Errorf("HTTP 409 conflict")))
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("already-emitted envelope should not be duplicated: stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+}

--- a/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
+++ b/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
@@ -520,3 +520,63 @@ func TestFinalizeErrorSkipsDoubleEnvelope(t *testing.T) {
 		t.Fatalf("already-emitted envelope should not be duplicated: stdout=%s stderr=%s", stdout.String(), stderr.String())
 	}
 }
+
+// TestIssuesCreateStateFlagValidation mirrors the issues-edit guard: --state on
+// create now rejects a non-UUID before any network call (MOB-104 follow-up:
+// the original gap let "In Progress" pass straight through as stateId and fail
+// with an opaque Linear API error), and the three state selectors are mutually
+// exclusive.
+func TestIssuesCreateStateFlagValidation(t *testing.T) {
+	t.Parallel()
+	_, err := executeRootForTest("issues", "create", "--title", "x", "--team", "ENG",
+		"--state", "In Progress", "--agent", "--dry-run")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("create --state with a non-UUID should be a code-2 usage error, got %v", err)
+	}
+
+	_, err = executeRootForTest("issues", "create", "--title", "x", "--team", "ENG",
+		"--state", "11111111-2222-3333-4444-555555555555", "--state-name", "Done", "--agent", "--dry-run")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("create --state plus --state-name should be a code-2 usage error, got %v", err)
+	}
+}
+
+// TestIssuesCreateStateNameResolvesUUID verifies create resolves --state-name to
+// the team's workflow-state UUID and sends the resolved UUID as stateId, the
+// same first-class surface issues edit gained in this PR.
+func TestIssuesCreateStateNameResolvesUUID(t *testing.T) {
+	const teamUUID = "11111111-1111-1111-1111-111111111111"
+	var seenStateID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "workflowStates("):
+			fmt.Fprint(w, `{"data":{"workflowStates":{"nodes":[{"id":"state-progress","name":"In Progress","type":"started"}]}}}`)
+		case strings.Contains(req.Query, "issueCreate"):
+			input, _ := req.Variables["input"].(map[string]any)
+			seenStateID, _ = input["stateId"].(string)
+			fmt.Fprint(w, `{"data":{"issueCreate":{"success":true,"issue":{"id":"issue-new","identifier":"ENG-1","title":"Issue","team":{"id":"`+teamUUID+`","key":"ENG"},"state":{"id":"state-progress","name":"In Progress","type":"started"}}}}}`)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "create", "--title", "Issue", "--team", teamUUID,
+		"--state-name", "In Progress",
+		"--db", filepath.Join(t.TempDir(), "linear.db"), "--agent")
+	if err != nil {
+		t.Fatalf("issues create --state-name failed: %v\n%s", err, out)
+	}
+	if seenStateID != "state-progress" {
+		t.Fatalf("stateId sent to issueCreate = %q, want resolved %q", seenStateID, "state-progress")
+	}
+}

--- a/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
+++ b/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
@@ -353,6 +353,113 @@ func TestIssuesEditStateFlagValidation(t *testing.T) {
 	}
 }
 
+func TestWorkflowStatesListPaginatesAllPages(t *testing.T) {
+	var stateCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		stateCalls++
+		if after, ok := req.Variables["after"].(string); ok && after == "cursor-1" {
+			fmt.Fprint(w, `{"data":{"workflowStates":{"nodes":[{"id":"state-page2","name":"Done","type":"completed","position":9,"team":{"id":"team-1","key":"SYMPH","name":"Symphony"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+			return
+		}
+		fmt.Fprint(w, `{"data":{"workflowStates":{"nodes":[{"id":"state-page1","name":"Todo","type":"unstarted","position":1,"team":{"id":"team-1","key":"SYMPH","name":"Symphony"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("workflow-states", "list", "--team", "SYMPH",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--agent", "--data-source", "live", "--select", "id")
+	if err != nil {
+		t.Fatalf("workflow-states list failed: %v\n%s", err, out)
+	}
+	if stateCalls != 2 {
+		t.Fatalf("expected 2 paginated requests, got %d", stateCalls)
+	}
+	if !strings.Contains(out, "state-page1") || !strings.Contains(out, "state-page2") {
+		t.Fatalf("paginated results missing a page: %s", out)
+	}
+}
+
+func TestValidateIssueLabelTeamsBatchesOneRequest(t *testing.T) {
+	var labelQueryCalls int
+	var seenIDs []any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issues(filter"):
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid","identifier":"MOB-105","title":"Issue","description":"","team":{"id":"team-1","key":"MOB","name":"Mobilyze"}}]}}}`)
+		case strings.Contains(req.Query, "issueLabels(filter"):
+			labelQueryCalls++
+			seenIDs, _ = req.Variables["ids"].([]any)
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[
+				{"id":"label-1","name":"kind:bug","color":"#111","team":{"id":"team-1","key":"MOB","name":"Mobilyze"}},
+				{"id":"label-2","name":"area:cli","color":"#222","team":null},
+				{"id":"label-3","name":"risk:low","color":"#333","team":{"id":"team-1","key":"MOB","name":"Mobilyze"}}
+			]}}}`)
+		case strings.Contains(req.Query, "issueUpdate"):
+			fmt.Fprint(w, `{"data":{"issueUpdate":{"success":true,"issue":{"id":"issue-uuid","identifier":"MOB-105","title":"Issue"}}}}`)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "edit", "MOB-105",
+		"--label", "label-1", "--label", "label-2", "--label", "label-3",
+		"--db", filepath.Join(t.TempDir(), "linear.db"), "--agent")
+	if err != nil {
+		t.Fatalf("issues edit with labels failed: %v\n%s", err, out)
+	}
+	if labelQueryCalls != 1 {
+		t.Fatalf("label validation made %d requests, want 1 batched call", labelQueryCalls)
+	}
+	if len(seenIDs) != 3 {
+		t.Fatalf("batched query sent %d ids, want 3: %v", len(seenIDs), seenIDs)
+	}
+}
+
+func TestValidateIssueLabelTeamsMissingLabelIsNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		switch {
+		case strings.Contains(req.Query, "issues(filter"):
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid","identifier":"MOB-105","title":"Issue","description":"","team":{"id":"team-1","key":"MOB","name":"Mobilyze"}}]}}}`)
+		case strings.Contains(req.Query, "issueLabels(filter"):
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[]}}}`)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	_, err := executeRootForTest("issues", "edit", "MOB-105", "--label", "label-missing",
+		"--db", filepath.Join(t.TempDir(), "linear.db"), "--agent")
+	if err == nil || ExitCode(err) != 3 {
+		t.Fatalf("missing label should be a code-3 not-found error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "label-missing") {
+		t.Fatalf("error should name the missing label: %v", err)
+	}
+}
+
 func TestFinalizeErrorEmitsJSONEnvelope(t *testing.T) {
 	t.Parallel()
 	var stdout, stderr bytes.Buffer

--- a/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
+++ b/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
@@ -514,7 +514,7 @@ func TestFinalizeErrorPlainModeWritesStderr(t *testing.T) {
 func TestFinalizeErrorSkipsDoubleEnvelope(t *testing.T) {
 	t.Parallel()
 	var stdout, stderr bytes.Buffer
-	flags := &rootFlags{agent: true, asJSON: true, envelopeEmitted: true}
+	flags := &rootFlags{agent: true, asJSON: true, errorWritten: true}
 	finalizeError(flags, nil, &stdout, &stderr, apiErr(fmt.Errorf("HTTP 409 conflict")))
 	if stdout.Len() != 0 || stderr.Len() != 0 {
 		t.Fatalf("already-emitted envelope should not be duplicated: stdout=%s stderr=%s", stdout.String(), stderr.String())
@@ -575,6 +575,64 @@ func TestIssuesCreateStateNameResolvesUUID(t *testing.T) {
 		"--db", filepath.Join(t.TempDir(), "linear.db"), "--agent")
 	if err != nil {
 		t.Fatalf("issues create --state-name failed: %v\n%s", err, out)
+	}
+	if seenStateID != "state-progress" {
+		t.Fatalf("stateId sent to issueCreate = %q, want resolved %q", seenStateID, "state-progress")
+	}
+}
+
+func TestIssuesCreateStateNameResolvesTeamKeyWithoutLocalStore(t *testing.T) {
+	const teamUUID = "11111111-1111-1111-1111-111111111111"
+	var sawTeamLookup, sawStateLookup bool
+	var seenTeamID, seenStateID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "teams("):
+			sawTeamLookup = true
+			if key, _ := req.Variables["key"].(string); key != "MOB" {
+				t.Errorf("team lookup key = %q, want MOB", key)
+			}
+			fmt.Fprint(w, `{"data":{"teams":{"nodes":[{"id":"`+teamUUID+`","key":"MOB","name":"Mobilyze"}]}}}`)
+		case strings.Contains(req.Query, "workflowStates("):
+			sawStateLookup = true
+			filter, _ := req.Variables["filter"].(map[string]any)
+			teamFilter, _ := filter["team"].(map[string]any)
+			idFilter, _ := teamFilter["id"].(map[string]any)
+			if got, _ := idFilter["eq"].(string); got != teamUUID {
+				t.Errorf("workflow-state team id filter = %q, want %q", got, teamUUID)
+			}
+			fmt.Fprint(w, `{"data":{"workflowStates":{"nodes":[{"id":"state-progress","name":"In Progress","type":"started"}]}}}`)
+		case strings.Contains(req.Query, "issueCreate"):
+			input, _ := req.Variables["input"].(map[string]any)
+			seenTeamID, _ = input["teamId"].(string)
+			seenStateID, _ = input["stateId"].(string)
+			fmt.Fprint(w, `{"data":{"issueCreate":{"success":true,"issue":{"id":"issue-new","identifier":"MOB-1","title":"Issue","team":{"id":"`+teamUUID+`","key":"MOB"},"state":{"id":"state-progress","name":"In Progress","type":"started"}}}}}`)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "create", "--title", "Issue", "--team", "MOB",
+		"--state-name", "In Progress",
+		"--db", filepath.Join(t.TempDir(), "linear.db"), "--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("issues create --state-name with fresh team key failed: %v\n%s", err, out)
+	}
+	if !sawTeamLookup || !sawStateLookup {
+		t.Fatalf("expected live team and workflow-state lookups; sawTeamLookup=%t sawStateLookup=%t", sawTeamLookup, sawStateLookup)
+	}
+	if seenTeamID != teamUUID {
+		t.Fatalf("teamId sent to issueCreate = %q, want resolved UUID %q", seenTeamID, teamUUID)
 	}
 	if seenStateID != "state-progress" {
 		t.Fatalf("stateId sent to issueCreate = %q, want resolved %q", seenStateID, "state-progress")

--- a/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
+++ b/library/project-management/linear/internal/cli/mob104_ergonomics_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -525,6 +526,25 @@ func TestFinalizeErrorSkipsDoubleEnvelope(t *testing.T) {
 	}
 }
 
+func TestParentNoSubcommandAgentModeSingleEnvelope(t *testing.T) {
+	out, err := executeRootForTestWithRenderedError("workflow-states", "--agent")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("workflow-states without subcommand should be a code-2 usage error, got %v\n%s", err, out)
+	}
+	dec := json.NewDecoder(strings.NewReader(out))
+	var envelope map[string]any
+	if err := dec.Decode(&envelope); err != nil {
+		t.Fatalf("output is not a JSON envelope: %v\n%s", err, out)
+	}
+	if envelope["error"] != "subcommand required" {
+		t.Fatalf("unexpected envelope: %#v", envelope)
+	}
+	var extra map[string]any
+	if err := dec.Decode(&extra); err != io.EOF {
+		t.Fatalf("expected exactly one JSON envelope, second decode err=%v extra=%#v output=%s", err, extra, out)
+	}
+}
+
 // TestIssuesCreateStateFlagValidation mirrors the issues-edit guard: --state on
 // create now rejects a non-UUID before any network call (MOB-104 follow-up:
 // the original gap let "In Progress" pass straight through as stateId and fail
@@ -641,5 +661,42 @@ func TestIssuesCreateStateNameResolvesTeamKeyWithoutLocalStore(t *testing.T) {
 	}
 	if seenStateID != "state-progress" {
 		t.Fatalf("stateId sent to issueCreate = %q, want resolved %q", seenStateID, "state-progress")
+	}
+}
+
+func TestResolveWorkflowStateRejectsInvalidStateType(t *testing.T) {
+	var workflowStateLookup bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issues(filter"):
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid","identifier":"MOB-105","title":"Issue","description":"","team":{"id":"team-1","key":"MOB","name":"Mobilyze"}}]}}}`)
+		case strings.Contains(req.Query, "workflowStates("):
+			workflowStateLookup = true
+			http.Error(w, "workflow state lookup should not run for invalid state type", http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	_, err := executeRootForTest("issues", "edit", "MOB-105", "--state-type", "in-progress",
+		"--db", filepath.Join(t.TempDir(), "linear.db"), "--agent")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("invalid --state-type should be a code-2 usage error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), validLinearWorkflowStateTypeList) {
+		t.Fatalf("invalid type error should list valid types, got: %v", err)
+	}
+	if workflowStateLookup {
+		t.Fatalf("workflow state lookup should not run for invalid --state-type")
 	}
 }

--- a/library/project-management/linear/internal/cli/root.go
+++ b/library/project-management/linear/internal/cli/root.go
@@ -175,17 +175,8 @@ Highlights (not in the official API docs):
 Agent mode: add --agent to any command for JSON output + non-interactive mode.
 Health check: run 'linear-pp-cli doctor' to verify auth and connectivity.
 See README.md or the bundled SKILL.md for recipes.`,
-<<<<<<< HEAD
 		SilenceErrors: true,
 		SilenceUsage:  true,
-=======
-		SilenceUsage: true,
-		// Errors are printed by Execute's finalizeError so JSON/agent mode
-		// can emit a machine-parseable envelope instead of cobra's plain
-		// "Error: ..." line (which broke agents piping stdout to a JSON
-		// parser — see MOB-104).
-		SilenceErrors: true,
->>>>>>> 0f8714c01 (feat(linear): add workflow-states lookup and one-command state transitions)
 		Version:       version,
 	}
 	rootCmd.SetVersionTemplate("linear-pp-cli {{ .Version }}\n")

--- a/library/project-management/linear/internal/cli/root.go
+++ b/library/project-management/linear/internal/cli/root.go
@@ -82,13 +82,9 @@ func Execute() error {
 		if idx := strings.Index(msg, "unknown flag: "); idx >= 0 {
 			flagStr := strings.TrimSpace(msg[idx+len("unknown flag: "):])
 			if suggestion := suggestFlag(flagStr, rootCmd); suggestion != "" {
-				// Cobra already printed `Error: unknown flag: --foob` before
-				// returning; the wrap below attaches the hint to err.Error()
-				// for downstream consumers and exit-code classification, but
-				// would never reach stderr now that main.go no longer prints
-				// err. Emit the hint explicitly so the suggestion still
-				// shows up under Cobra's error line.
-				fmt.Fprintf(os.Stderr, "hint: did you mean --%s?\n", suggestion)
+				// SilenceErrors is set, so finalizeError below is the single
+				// printer; wrapping puts the hint on both the human stderr
+				// line and the JSON envelope's "error" field.
 				err = fmt.Errorf("%w\nhint: did you mean --%s?", err, suggestion)
 			}
 		}
@@ -108,13 +104,7 @@ func Execute() error {
 		// usage errors that the helpers.go contract already promises.
 		err = usageErr(err)
 	}
-	if err != nil {
-		if flags.asJSON && !flags.errorWritten {
-			writeCLIErrorEnvelope(&flags, err, ExitCode(err))
-		} else if !flags.asJSON {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		}
-	}
+	finalizeError(&flags, os.Args[1:], os.Stdout, os.Stderr, err)
 	return err
 }
 
@@ -185,8 +175,17 @@ Highlights (not in the official API docs):
 Agent mode: add --agent to any command for JSON output + non-interactive mode.
 Health check: run 'linear-pp-cli doctor' to verify auth and connectivity.
 See README.md or the bundled SKILL.md for recipes.`,
+<<<<<<< HEAD
 		SilenceErrors: true,
 		SilenceUsage:  true,
+=======
+		SilenceUsage: true,
+		// Errors are printed by Execute's finalizeError so JSON/agent mode
+		// can emit a machine-parseable envelope instead of cobra's plain
+		// "Error: ..." line (which broke agents piping stdout to a JSON
+		// parser — see MOB-104).
+		SilenceErrors: true,
+>>>>>>> 0f8714c01 (feat(linear): add workflow-states lookup and one-command state transitions)
 		Version:       version,
 	}
 	rootCmd.SetVersionTemplate("linear-pp-cli {{ .Version }}\n")
@@ -317,6 +316,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 
 	// v3-ported top-level commands
 	rootCmd.AddCommand(newIssuesCmd(flags))
+	rootCmd.AddCommand(newWorkflowStatesCmd(flags))
 	rootCmd.AddCommand(newCommentsCmd(flags))
 	rootCmd.AddCommand(newDocumentsCmd(flags))
 	rootCmd.AddCommand(newLabelsCmd(flags))

--- a/library/project-management/linear/internal/cli/workflow_states.go
+++ b/library/project-management/linear/internal/cli/workflow_states.go
@@ -34,9 +34,18 @@ var validLinearWorkflowStateTypes = map[string]struct{}{
 	"started":   {},
 	"completed": {},
 	"canceled":  {},
+	"duplicate": {},
 }
 
-const validLinearWorkflowStateTypeList = "triage, backlog, unstarted, started, completed, canceled"
+const validLinearWorkflowStateTypeList = "triage, backlog, unstarted, started, completed, canceled, duplicate"
+
+func normalizeWorkflowStateType(stateType string) (string, error) {
+	normalizedType := strings.ToLower(strings.TrimSpace(stateType))
+	if _, ok := validLinearWorkflowStateTypes[normalizedType]; !ok {
+		return "", usageErr(fmt.Errorf("--state-type %q is not a valid Linear workflow state type; valid types: %s", stateType, validLinearWorkflowStateTypeList))
+	}
+	return normalizedType, nil
+}
 
 func newWorkflowStatesCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
@@ -184,9 +193,9 @@ func resolveWorkflowState(c graphqlQueryer, team issueTeamInfo, name, stateType 
 		filter["name"] = map[string]any{"eqIgnoreCase": name}
 		selector = fmt.Sprintf("--state-name %q", name)
 	case stateType != "":
-		normalizedType := strings.ToLower(strings.TrimSpace(stateType))
-		if _, ok := validLinearWorkflowStateTypes[normalizedType]; !ok {
-			return "", usageErr(fmt.Errorf("--state-type %q is not a valid Linear workflow state type; valid types: %s", stateType, validLinearWorkflowStateTypeList))
+		normalizedType, err := normalizeWorkflowStateType(stateType)
+		if err != nil {
+			return "", err
 		}
 		filter["type"] = map[string]any{"eq": normalizedType}
 		selector = fmt.Sprintf("--state-type %q", normalizedType)

--- a/library/project-management/linear/internal/cli/workflow_states.go
+++ b/library/project-management/linear/internal/cli/workflow_states.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+// workflowStateRow is the projection rendered by `workflow-states list`. It
+// mirrors the node shape WorkflowStatesQuery syncs into the local store, so
+// live and local reads produce identical output fields.
+type workflowStateRow struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	Type     string  `json:"type"`
+	Color    string  `json:"color,omitempty"`
+	Position float64 `json:"position"`
+	Team     struct {
+		ID   string `json:"id"`
+		Key  string `json:"key"`
+		Name string `json:"name"`
+	} `json:"team"`
+}
+
+func newWorkflowStatesCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "workflow-states",
+		Aliases:     []string{"states"},
+		Short:       "List Linear workflow states (the UUIDs 'issues edit --state' needs)",
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,2,3,4,5,7"},
+		RunE:        parentNoSubcommandRunE(flags),
+	}
+	cmd.AddCommand(newWorkflowStatesListCmd(flags))
+	return cmd
+}
+
+func newWorkflowStatesListCmd(flags *rootFlags) *cobra.Command {
+	var team, dbPath string
+	cmd := &cobra.Command{
+		Use:         "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		Short:       "List workflow states, optionally filtered by team",
+		Long: `List workflow states with their UUIDs, names, and types.
+
+Use this before 'issues edit <issue> --state <state-uuid>' to find the UUID for
+a target state. --team accepts a team key (e.g. SYMPH) or a team UUID.
+
+With --data-source live (or auto, the default), states are fetched from the
+Linear GraphQL API. With --data-source local, states are read from the synced
+workflow_states table; run 'linear-pp-cli sync' first.`,
+		Example: `  linear-pp-cli workflow-states list --team SYMPH --agent --select id,name,type
+  linear-pp-cli states list --team SYMPH --agent
+  linear-pp-cli workflow-states list --agent --select id,name,type,team.key`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWorkflowStatesList(cmd, flags, resolveDBPath(dbPath), team)
+		},
+	}
+	cmd.Flags().StringVar(&team, "team", "", "Filter by team key or UUID")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
+	return cmd
+}
+
+func runWorkflowStatesList(cmd *cobra.Command, flags *rootFlags, dbPath, team string) error {
+	var raw []json.RawMessage
+	var prov DataProvenance
+
+	db, openErr := openStoreAt(dbPath)
+	if db != nil {
+		defer db.Close()
+	}
+
+	fetchLocal := func() ([]json.RawMessage, error) {
+		if openErr != nil {
+			return nil, fmt.Errorf("opening local database: %w\nRun 'linear-pp-cli sync' first", openErr)
+		}
+		if db == nil {
+			return nil, fmt.Errorf("no local data. Run 'linear-pp-cli sync' first")
+		}
+		teamID := team
+		if team != "" && !store.IsUUID(team) {
+			var err error
+			teamID, err = resolveTeamFilter(db, team)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return db.ListWorkflowStates(teamID)
+	}
+
+	switch flags.dataSource {
+	case "local":
+		rows, err := fetchLocal()
+		if err != nil {
+			return err
+		}
+		raw = rows
+		prov = localProvenance(db, "workflow_states", "user_requested")
+	default: // live and auto: live first, auto falls back to local on network error
+		rows, err := fetchWorkflowStatesLive(flags, team)
+		if err != nil {
+			if flags.dataSource == "live" || !isNetworkError(err) {
+				return classifyLiveReadError(err, flags)
+			}
+			fmt.Fprintln(cmd.ErrOrStderr(), "  (live API unreachable — falling back to local store)")
+			rows, err = fetchLocal()
+			if err != nil {
+				return err
+			}
+			raw = rows
+			prov = localProvenance(db, "workflow_states", "api_unreachable")
+			break
+		}
+		raw = rows
+		prov = DataProvenance{Source: "live", ResourceType: "workflow_states", Reason: "user_requested"}
+		// Write-through so a follow-up --data-source local read is fresh.
+		if db != nil {
+			for _, n := range rows {
+				var meta struct {
+					ID string `json:"id"`
+				}
+				if json.Unmarshal(n, &meta) == nil && meta.ID != "" {
+					_ = db.UpsertWorkflowState(meta.ID, n)
+				}
+			}
+		}
+	}
+
+	rows := make([]workflowStateRow, 0, len(raw))
+	for _, r := range raw {
+		var row workflowStateRow
+		if err := json.Unmarshal(r, &row); err != nil {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Team.Key != rows[j].Team.Key {
+			return rows[i].Team.Key < rows[j].Team.Key
+		}
+		return rows[i].Position < rows[j].Position
+	})
+
+	prov = attachFreshness(prov, flags)
+	printProvenance(cmd, len(rows), prov)
+	return printJSONFiltered(cmd.OutOrStdout(), rows, flags)
+}
+
+// resolveWorkflowState maps a --state-name or --state-type value to the
+// matching workflow state UUID within the issue's team. Exactly one of name or
+// stateType must be non-empty. Zero matches is a not-found error; multiple
+// matches (common for --state-type when a team has several states of one
+// type) is a usage error listing the candidates so the agent can retry with
+// --state-name or --state.
+func resolveWorkflowState(c graphqlQueryer, team issueTeamInfo, name, stateType string) (string, error) {
+	if team.ID == "" {
+		return "", fmt.Errorf("cannot resolve workflow state: issue team id is empty")
+	}
+	filter := map[string]any{"team": map[string]any{"id": map[string]any{"eq": team.ID}}}
+	selector := ""
+	switch {
+	case name != "":
+		filter["name"] = map[string]any{"eqIgnoreCase": name}
+		selector = fmt.Sprintf("--state-name %q", name)
+	case stateType != "":
+		filter["type"] = map[string]any{"eq": stateType}
+		selector = fmt.Sprintf("--state-type %q", stateType)
+	default:
+		return "", fmt.Errorf("cannot resolve workflow state: no name or type given")
+	}
+	const query = `query($filter: WorkflowStateFilter) {
+		workflowStates(first: 50, filter: $filter) {
+			nodes { id name type }
+		}
+	}`
+	var resp struct {
+		WorkflowStates struct {
+			Nodes []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+				Type string `json:"type"`
+			} `json:"nodes"`
+		} `json:"workflowStates"`
+	}
+	if err := c.QueryInto(query, map[string]any{"filter": filter}, &resp); err != nil {
+		return "", err
+	}
+	nodes := resp.WorkflowStates.Nodes
+	switch len(nodes) {
+	case 0:
+		return "", notFoundErr(fmt.Errorf("no workflow state matching %s in team %s; run 'linear-pp-cli workflow-states list --team %s' to see valid states", selector, team.Key, team.Key))
+	case 1:
+		return nodes[0].ID, nil
+	default:
+		candidates := make([]string, 0, len(nodes))
+		for _, n := range nodes {
+			candidates = append(candidates, fmt.Sprintf("%q (%s, %s)", n.Name, n.Type, n.ID))
+		}
+		return "", usageErr(fmt.Errorf("%s is ambiguous in team %s: matches %s; pass --state-name with the exact name or --state with the UUID", selector, team.Key, strings.Join(candidates, ", ")))
+	}
+}
+
+// fetchWorkflowStatesLive queries workflowStates via GraphQL, filtered by team
+// key or UUID when provided. Linear's workflowStates filter accepts a nested
+// TeamFilter, so team keys resolve server-side without a local sync.
+func fetchWorkflowStatesLive(flags *rootFlags, team string) ([]json.RawMessage, error) {
+	c, err := flags.newClient()
+	if err != nil {
+		return nil, err
+	}
+	filter := map[string]any{}
+	if team != "" {
+		if store.IsUUID(team) {
+			filter["team"] = map[string]any{"id": map[string]any{"eq": team}}
+		} else {
+			filter["team"] = map[string]any{"key": map[string]any{"eqIgnoreCase": team}}
+		}
+	}
+	const query = `query($filter: WorkflowStateFilter) {
+		workflowStates(first: 250, filter: $filter) {
+			nodes {
+				id name type color position
+				team { id name key }
+			}
+		}
+	}`
+	var resp struct {
+		WorkflowStates struct {
+			Nodes []json.RawMessage `json:"nodes"`
+		} `json:"workflowStates"`
+	}
+	if err := c.QueryInto(query, map[string]any{"filter": filter}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.WorkflowStates.Nodes, nil
+}

--- a/library/project-management/linear/internal/cli/workflow_states.go
+++ b/library/project-management/linear/internal/cli/workflow_states.go
@@ -190,9 +190,10 @@ func resolveWorkflowState(c graphqlQueryer, team issueTeamInfo, name, stateType 
 		return "", err
 	}
 	nodes := resp.WorkflowStates.Nodes
+	teamLabel := issueTeamName(team)
 	switch len(nodes) {
 	case 0:
-		return "", notFoundErr(fmt.Errorf("no workflow state matching %s in team %s; run 'linear-pp-cli workflow-states list --team %s' to see valid states", selector, team.Key, team.Key))
+		return "", notFoundErr(fmt.Errorf("no workflow state matching %s in team %s; run 'linear-pp-cli workflow-states list --team %s' to see valid states", selector, teamLabel, teamLabel))
 	case 1:
 		return nodes[0].ID, nil
 	default:
@@ -200,13 +201,16 @@ func resolveWorkflowState(c graphqlQueryer, team issueTeamInfo, name, stateType 
 		for _, n := range nodes {
 			candidates = append(candidates, fmt.Sprintf("%q (%s, %s)", n.Name, n.Type, n.ID))
 		}
-		return "", usageErr(fmt.Errorf("%s is ambiguous in team %s: matches %s; pass --state-name with the exact name or --state with the UUID", selector, team.Key, strings.Join(candidates, ", ")))
+		return "", usageErr(fmt.Errorf("%s is ambiguous in team %s: matches %s; pass --state-name with the exact name or --state with the UUID", selector, teamLabel, strings.Join(candidates, ", ")))
 	}
 }
 
 // fetchWorkflowStatesLive queries workflowStates via GraphQL, filtered by team
 // key or UUID when provided. Linear's workflowStates filter accepts a nested
-// TeamFilter, so team keys resolve server-side without a local sync.
+// TeamFilter, so team keys resolve server-side without a local sync. Results
+// are paginated via pageInfo.endCursor — a single capped page would silently
+// truncate the state list on workspaces with many teams, which is exactly the
+// failure mode this command exists to eliminate.
 func fetchWorkflowStatesLive(flags *rootFlags, team string) ([]json.RawMessage, error) {
 	c, err := flags.newClient()
 	if err != nil {
@@ -220,21 +224,38 @@ func fetchWorkflowStatesLive(flags *rootFlags, team string) ([]json.RawMessage, 
 			filter["team"] = map[string]any{"key": map[string]any{"eqIgnoreCase": team}}
 		}
 	}
-	const query = `query($filter: WorkflowStateFilter) {
-		workflowStates(first: 250, filter: $filter) {
+	const query = `query($filter: WorkflowStateFilter, $after: String) {
+		workflowStates(first: 250, filter: $filter, after: $after) {
 			nodes {
 				id name type color position
 				team { id name key }
 			}
+			pageInfo { hasNextPage endCursor }
 		}
 	}`
-	var resp struct {
-		WorkflowStates struct {
-			Nodes []json.RawMessage `json:"nodes"`
-		} `json:"workflowStates"`
+	var all []json.RawMessage
+	cursor := ""
+	for {
+		vars := map[string]any{"filter": filter}
+		if cursor != "" {
+			vars["after"] = cursor
+		}
+		var resp struct {
+			WorkflowStates struct {
+				Nodes    []json.RawMessage `json:"nodes"`
+				PageInfo struct {
+					HasNextPage bool   `json:"hasNextPage"`
+					EndCursor   string `json:"endCursor"`
+				} `json:"pageInfo"`
+			} `json:"workflowStates"`
+		}
+		if err := c.QueryInto(query, vars, &resp); err != nil {
+			return nil, err
+		}
+		all = append(all, resp.WorkflowStates.Nodes...)
+		if !resp.WorkflowStates.PageInfo.HasNextPage || resp.WorkflowStates.PageInfo.EndCursor == "" {
+			return all, nil
+		}
+		cursor = resp.WorkflowStates.PageInfo.EndCursor
 	}
-	if err := c.QueryInto(query, map[string]any{"filter": filter}, &resp); err != nil {
-		return nil, err
-	}
-	return resp.WorkflowStates.Nodes, nil
 }

--- a/library/project-management/linear/internal/cli/workflow_states.go
+++ b/library/project-management/linear/internal/cli/workflow_states.go
@@ -157,10 +157,16 @@ func runWorkflowStatesList(cmd *cobra.Command, flags *rootFlags, dbPath, team st
 // type) is a usage error listing the candidates so the agent can retry with
 // --state-name or --state.
 func resolveWorkflowState(c graphqlQueryer, team issueTeamInfo, name, stateType string) (string, error) {
-	if team.ID == "" {
-		return "", fmt.Errorf("cannot resolve workflow state: issue team id is empty")
+	teamFilter := map[string]any{}
+	switch {
+	case team.ID != "":
+		teamFilter["id"] = map[string]any{"eq": team.ID}
+	case team.Key != "":
+		teamFilter["key"] = map[string]any{"eqIgnoreCase": team.Key}
+	default:
+		return "", fmt.Errorf("cannot resolve workflow state: issue team is empty")
 	}
-	filter := map[string]any{"team": map[string]any{"id": map[string]any{"eq": team.ID}}}
+	filter := map[string]any{"team": teamFilter}
 	selector := ""
 	switch {
 	case name != "":

--- a/library/project-management/linear/internal/cli/workflow_states.go
+++ b/library/project-management/linear/internal/cli/workflow_states.go
@@ -27,6 +27,17 @@ type workflowStateRow struct {
 	} `json:"team"`
 }
 
+var validLinearWorkflowStateTypes = map[string]struct{}{
+	"triage":    {},
+	"backlog":   {},
+	"unstarted": {},
+	"started":   {},
+	"completed": {},
+	"canceled":  {},
+}
+
+const validLinearWorkflowStateTypeList = "triage, backlog, unstarted, started, completed, canceled"
+
 func newWorkflowStatesCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "workflow-states",
@@ -173,8 +184,12 @@ func resolveWorkflowState(c graphqlQueryer, team issueTeamInfo, name, stateType 
 		filter["name"] = map[string]any{"eqIgnoreCase": name}
 		selector = fmt.Sprintf("--state-name %q", name)
 	case stateType != "":
-		filter["type"] = map[string]any{"eq": stateType}
-		selector = fmt.Sprintf("--state-type %q", stateType)
+		normalizedType := strings.ToLower(strings.TrimSpace(stateType))
+		if _, ok := validLinearWorkflowStateTypes[normalizedType]; !ok {
+			return "", usageErr(fmt.Errorf("--state-type %q is not a valid Linear workflow state type; valid types: %s", stateType, validLinearWorkflowStateTypeList))
+		}
+		filter["type"] = map[string]any{"eq": normalizedType}
+		selector = fmt.Sprintf("--state-type %q", normalizedType)
 	default:
 		return "", fmt.Errorf("cannot resolve workflow state: no name or type given")
 	}

--- a/library/project-management/linear/internal/store/store.go
+++ b/library/project-management/linear/internal/store/store.go
@@ -680,6 +680,26 @@ func (s *Store) ListIssueLabels(limit int) ([]json.RawMessage, error) {
 	return s.queryJSON(`SELECT data FROM issue_labels ORDER BY COALESCE(team_key, ''), name LIMIT ?`, limit)
 }
 
+func (s *Store) ListIssueLabelsForTeam(limit int, team string, includeGlobal bool) ([]json.RawMessage, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	includeGlobalValue := 0
+	if includeGlobal {
+		includeGlobalValue = 1
+	}
+	return s.queryJSON(`SELECT data FROM issue_labels
+		WHERE lower(COALESCE(team_id, '')) = lower(?)
+			OR lower(COALESCE(team_key, '')) = lower(?)
+			OR lower(COALESCE(team_name, '')) = lower(?)
+			OR (? = 1
+				AND COALESCE(team_id, '') = ''
+				AND COALESCE(team_key, '') = ''
+				AND COALESCE(team_name, '') = '')
+		ORDER BY COALESCE(team_key, ''), name
+		LIMIT ?`, team, team, team, includeGlobalValue, limit)
+}
+
 func (s *Store) GetByID(table string, id string) (json.RawMessage, error) {
 	if !allowedEntityTable(table) {
 		return nil, fmt.Errorf("unknown table %q", table)

--- a/library/project-management/linear/internal/store/store.go
+++ b/library/project-management/linear/internal/store/store.go
@@ -659,6 +659,16 @@ func (s *Store) ListTeams() ([]json.RawMessage, error) {
 	return s.queryJSON(`SELECT data FROM teams ORDER BY name, key`)
 }
 
+// ListWorkflowStates returns synced workflow states, optionally filtered by
+// team UUID. Ordered by position so board order is stable for agents picking
+// a target state.
+func (s *Store) ListWorkflowStates(teamID string) ([]json.RawMessage, error) {
+	if teamID != "" {
+		return s.queryJSON(`SELECT data FROM workflow_states WHERE team_id = ? ORDER BY position`, teamID)
+	}
+	return s.queryJSON(`SELECT data FROM workflow_states ORDER BY team_id, position`)
+}
+
 func (s *Store) ListUsers() ([]json.RawMessage, error) {
 	return s.queryJSON(`SELECT data FROM users ORDER BY active DESC, display_name, name, email`)
 }

--- a/library/project-management/linear/internal/store/store.go
+++ b/library/project-management/linear/internal/store/store.go
@@ -696,8 +696,13 @@ func (s *Store) ListIssueLabelsForTeam(limit int, team string, includeGlobal boo
 				AND COALESCE(team_id, '') = ''
 				AND COALESCE(team_key, '') = ''
 				AND COALESCE(team_name, '') = '')
-		ORDER BY COALESCE(team_key, ''), name
-		LIMIT ?`, team, team, team, includeGlobalValue, limit)
+		ORDER BY CASE
+				WHEN lower(COALESCE(team_id, '')) = lower(?)
+					OR lower(COALESCE(team_key, '')) = lower(?)
+					OR lower(COALESCE(team_name, '')) = lower(?)
+				THEN 0 ELSE 1 END,
+			COALESCE(team_key, ''), name
+		LIMIT ?`, team, team, team, includeGlobalValue, team, team, team, limit)
 }
 
 func (s *Store) GetByID(table string, id string) (json.RawMessage, error) {


### PR DESCRIPTION
## Summary

Fixes the agent-ergonomics gaps reported in MOB-104: agents driving `linear-pp-cli` headlessly were falling back to raw SQL, GraphQL probes, `api --help` spelunking, and JSON-parse crashes for what should be first-class command surfaces.

- **`workflow-states list`** (alias `states list`) — first-class workflow-state lookup with `--team <key-or-uuid>`, live/local/auto data sources, and write-through caching. No more `sql` queries against `workflow_states` to find the UUID for `issues edit --state`.
- **One-command state transitions** — `issues edit <id> --state-name "In Progress"` / `--state-type started`, resolved against the issue's own team; ambiguous or unknown selectors fail with typed errors listing candidates. `--state` now rejects non-UUID values with a pointer to `--state-name`.
- **`--select state.id` works on issue reads** — the identifier-path live query now requests `state { id name type }`.
- **Document refs as humans see them** — `documents <ref>` accepts the document UUID, bare `slugId`, full URL slug (`my-runbook-f7f48ab36080`), and the entire Linear document URL.
- **Positional comments issue** — `comments list ENG-123` works as an alias for `--issue ENG-123`; conflicting values are a typed usage error.
- **JSON error envelopes in agent mode** — with `--agent`/`--json`, every typed failure (usage, not-found, auth, API, rate-limit, config) emits `{"error","code","type"}` on stdout with the typed exit code preserved, so piping stdout into a JSON parser is always safe. Plain mode keeps the conventional `Error: ...` stderr line.
- SKILL.md documents the state-transition recipe, document identifier contract, positional comments shape, and the envelope contract.

## Notes for review

- **Stacks on #1128** (`codex/MOB-99-pp-linear-read-contract`): the first 5 commits here are #1128's; review the 5 commits from `feat(linear): add workflow-states lookup…` onward. MOB-104 was filed as a follow-up to #1128 and builds on its read-contract surfaces (`comments.go`, `documents.go`).
- `SilenceErrors` is now set on the root command; `cli.Execute`'s `finalizeError` is the single error printer. The MCP server shells out to the CLI binary, so it inherits the envelope behavior.
- `cli-skills/pp-linear` is intentionally untouched — CI regenerates it post-merge.

## Testing

- `go test ./...` — 225 passed (15 new tests covering every surface above)
- `go build ./...`, `gofmt -l` clean
- Live smoke against a real workspace: `workflow-states list --team SYMPH`, `issues edit --state-name "In Progress"`, full-URL document lookup, positional `comments list`, not-found/usage JSON envelopes with exit codes 3/2

Linear: MOB-104

🤖 Generated with [Claude Code](https://claude.com/claude-code)