### PR TITLE
fix(ci): pin clawhub 0.20.0 and drop the removed --clawscan-note flag

### DIFF
--- a/.github/workflows/publish-clawhub-discovery-skill.yml
+++ b/.github/workflows/publish-clawhub-discovery-skill.yml
@@ -107,8 +107,8 @@ jobs:
             echo "::error::Missing CLAW_TOKEN repository secret"
             exit 1
           fi
-          npx -y clawhub@0.18.0 --no-input login --token "$CLAW_TOKEN"
-          npx -y clawhub@0.18.0 --no-input whoami
+          npx -y clawhub@0.20.0 --no-input login --token "$CLAW_TOKEN"
+          npx -y clawhub@0.20.0 --no-input whoami
 
       - name: Ensure ClawHub version is new
         if: steps.changes.outputs.changed == 'true'
@@ -118,7 +118,7 @@ jobs:
         run: |
           set -euo pipefail
           set +e
-          npx -y clawhub@0.18.0 --no-input inspect printing-press-library --versions --limit 200 --json > /tmp/clawhub-existing.json 2>/tmp/clawhub-existing.err
+          npx -y clawhub@0.20.0 --no-input inspect printing-press-library --versions --limit 200 --json > /tmp/clawhub-existing.json 2>/tmp/clawhub-existing.err
           rc=$?
           set -e
 
@@ -177,12 +177,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npx -y clawhub@0.18.0 --no-input skill publish skills/printing-press-library \
+          # clawhub >=0.19 removed --clawscan-note. Former scanner note, kept for
+          # when an equivalent returns: "Catalog/discovery skill only. It may
+          # instruct agents to run npx @mvanhorn/printing-press-library commands
+          # and install focused pp-* skills, but this package itself does not
+          # include executable code or credentials."
+          npx -y clawhub@0.20.0 --no-input skill publish skills/printing-press-library \
             --slug printing-press-library \
             --name "Printing Press Library" \
             --version "${{ steps.version.outputs.version }}" \
-            --changelog "Publish Printing Press Library discovery skill from ${GITHUB_SHA}" \
-            --clawscan-note "Catalog/discovery skill only. It may instruct agents to run npx @mvanhorn/printing-press-library commands and install focused pp-* skills, but this package itself does not include executable code or credentials."
+            --changelog "Publish Printing Press Library discovery skill from ${GITHUB_SHA}"
 
       - name: Skip publish
         if: steps.changes.outputs.changed != 'true'


### PR DESCRIPTION
While adapting this workflow for another repo (tmchow/agent-skills#30), version-checking surfaced two issues here:

1. **The pin is stale**: `clawhub@0.18.0` (2026-05-26) vs current `0.20.0` (2026-06-07).
2. **A used flag no longer exists**: `--clawscan-note` was removed from `skill publish` after 0.18.x (0.20.0 has `--owner`/`--migrate-owner` in that spot) — so the first pin bump without noticing would break the publish step on an unknown flag.

This PR bumps all four invocations to `0.20.0` and removes the flag, preserving the scanner-note text as a comment above the publish step for when an equivalent mechanism returns. Every other flag the workflow uses was verified against 0.20.0's `--help`: `--no-input`, `login --token`, `whoami`, `inspect --versions --limit --json`, `skill publish --slug --name --version --changelog`. Workflow YAML validates.

No behavior change to the publish gating (push-paths + dispatch, version-is-new guard) — version pin and flag removal only.