### PR TITLE
fix(ci): fix generated artifact workflow concurrency

### DIFF
--- a/.github/workflows/generate-registry.yml
+++ b/.github/workflows/generate-registry.yml
@@ -42,12 +42,13 @@ jobs:
   regenerate:
     name: Regenerate and commit
     runs-on: ubuntu-latest
-    # Share one push lane with generate-skills.yml. Both workflows
-    # commit generated artifacts back to main after the same source
-    # changes, so letting them run concurrently causes non-fast-forward
-    # push failures when one generated commit lands first.
+    # Queue registry regenerations, but do not share this group with sibling
+    # generated-artifact workflows. GitHub keeps only one pending run per
+    # concurrency group, so a shared group lets a skills or release-ledger run
+    # evict the pending registry run and leave registry.json stale. Push races
+    # with sibling workflows are handled by the rebase-before-push step below.
     concurrency:
-      group: generated-artifact-push-main
+      group: generate-registry-main
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
@@ -81,12 +82,9 @@ jobs:
           # the sentinel region would normally re-trigger; this commit
           # itself is suppressed by [skip ci] so we don't loop.
           git commit -m "chore(registry): regenerate from library/ [skip ci]"
-          # Defense-in-depth against the cross-workflow race with
-          # generate-skills.yml — the concurrency group serializes most
-          # runs, but a rebase before push handles the moment when the
-          # sibling workflow lands between our checkout and our push.
-          # The two workflows touch disjoint paths (registry.json +
-          # README.md vs cli-skills/), so the rebase is conflict-free
-          # in practice.
+          # Defense-in-depth against sibling generated-artifact workflows
+          # landing between our checkout and push. They touch disjoint paths
+          # (registry.json + README.md vs cli-skills/ or library release
+          # metadata), so the rebase is conflict-free in practice.
           git pull --rebase origin main
           git push

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -16,12 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    # Share one push lane with generate-registry.yml. Both workflows
-    # commit generated artifacts back to main after library metadata
-    # changes, so queue them and check out main only after the lane is
-    # acquired.
+    # Queue skill regenerations, but do not share this group with sibling
+    # generated-artifact workflows. GitHub keeps only one pending run per
+    # concurrency group, so a shared group lets unrelated workflows evict a
+    # pending skills run. Push races with sibling workflows are handled by the
+    # rebase-before-push step below.
     concurrency:
-      group: generated-artifact-push-main
+      group: generate-skills-main
       cancel-in-progress: false
 
     steps:
@@ -48,13 +49,10 @@ jobs:
             echo "No skill changes to commit"
           else
             git commit -m "chore(skills): regenerate per-app skills [skip ci]"
-            # Defense-in-depth against the cross-workflow race with
-            # generate-registry.yml — the concurrency group serializes
-            # most runs, but a rebase before push handles the moment
-            # when the sibling workflow lands between our checkout and
-            # our push. The two workflows touch disjoint paths
-            # (cli-skills/ vs registry.json + README.md), so the rebase
-            # is conflict-free in practice.
+            # Defense-in-depth against sibling generated-artifact workflows
+            # landing between our checkout and push. They touch disjoint paths
+            # (cli-skills/ vs registry.json + README.md or library release
+            # metadata), so the rebase is conflict-free in practice.
             git pull --rebase origin main
             git push
           fi

--- a/.github/workflows/normalize-patches.yml
+++ b/.github/workflows/normalize-patches.yml
@@ -48,13 +48,13 @@ jobs:
   normalize:
     name: Normalize and commit
     runs-on: ubuntu-latest
-    # Share one push lane with generate-registry.yml / generate-skills.yml. All
-    # three commit back to main after a library/** change; serializing avoids
-    # non-fast-forward push failures. The three touch disjoint paths
-    # (.printing-press-patches/ vs registry.json+README.md vs cli-skills/), so
-    # the rebase-before-push below is conflict-free in practice.
+    # Queue patch-normalization runs, but do not share this group with sibling
+    # generated-artifact workflows. GitHub keeps only one pending run per
+    # concurrency group, so a shared group lets unrelated workflows evict a
+    # pending normalizer run. Push races with sibling workflows are handled by
+    # the rebase-before-push step below.
     concurrency:
-      group: generated-artifact-push-main
+      group: normalize-patches-main
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
@@ -142,9 +142,8 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           # [skip ci] suppresses a re-trigger of this workflow on its own commit.
           git commit -m "chore(patches): normalize patches manifests to per-patch dirs [skip ci]"
-          # Defense-in-depth against the cross-workflow race with the sibling
-          # generated-artifact workflows — the concurrency group serializes most
-          # runs; the rebase handles a sibling landing between checkout and push.
-          # Paths are disjoint, so the rebase is conflict-free.
+          # Defense-in-depth against sibling generated-artifact workflows
+          # landing between checkout and push. Paths are disjoint, so the rebase
+          # is conflict-free.
           git pull --rebase origin main
           git push

--- a/.github/workflows/update-cli-release-ledger.yml
+++ b/.github/workflows/update-cli-release-ledger.yml
@@ -31,11 +31,13 @@ jobs:
   update:
     name: Update and commit
     runs-on: ubuntu-latest
-    # Share one push lane with the other generated-artifact workflows. They
-    # all commit back to main after source changes land, so serializing avoids
-    # non-fast-forward push races.
+    # Queue release-ledger runs, but do not share this group with sibling
+    # generated-artifact workflows. GitHub keeps only one pending run per
+    # concurrency group, so a shared group lets unrelated workflows evict a
+    # pending release-ledger run. Push races with sibling workflows are handled
+    # by the rebase-before-push step below.
     concurrency:
-      group: generated-artifact-push-main
+      group: update-cli-release-ledger-main
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Split post-merge generated-artifact workflows into per-workflow concurrency groups.
- Keep each workflow queued with `cancel-in-progress: false`, while preserving `git pull --rebase origin main` before pushing generated commits.
- Update comments so the workflow docs explain why the queues are separate and how sibling push races are handled.

## Root Cause

`generate-registry`, `generate-skills`, `normalize-patches`, and `update-cli-release-ledger` all shared `generated-artifact-push-main`. GitHub Actions only keeps one running and one pending run per concurrency group, so rapid post-merge pushes let unrelated sibling workflows evict a pending registry regeneration. That left `registry.json` stale until a manual workflow dispatch.

## Impact

A burst of library merges should no longer cause the registry job to be cancelled by a skills, patches, or release-ledger job. Each workflow still serializes its own runs, and cross-workflow push races are handled by the existing rebase-before-push step.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/generate-registry.yml .github/workflows/generate-skills.yml .github/workflows/normalize-patches.yml .github/workflows/update-cli-release-ledger.yml`
- `actionlint .github/workflows/generate-registry.yml .github/workflows/generate-skills.yml .github/workflows/normalize-patches.yml .github/workflows/update-cli-release-ledger.yml`
- `go run ./tools/generate-registry/main.go --check`
