### PR TITLE
feat(chrome-history): opt-in accumulating archive that outlives Chrome's pruning

### DIFF
--- a/library/productivity/chrome-history/.printing-press-patches/chrome-history-accumulating-archive-slice-1.json
+++ b/library/productivity/chrome-history/.printing-press-patches/chrome-history-accumulating-archive-slice-1.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 2,
+  "id": "chrome-history-accumulating-archive-slice-1",
+  "applied_at": "2026-06-12T00:00:00Z",
+  "base_run_id": "20260524-023512",
+  "base_printing_press_version": "4.13.0",
+  "summary": "Adds sticky accumulating archive storage, scoped active read routing, sync --accumulate, and archive status.",
+  "reason": "The browser's local History DB is pruned by Chrome; an opt-in archive preserves visits while rich Chrome-only commands keep reading the snapshot to avoid silent archive degradation.",
+  "files": [
+    "internal/store/archive.go",
+    "internal/store/archive_test.go",
+    "internal/cli/archive.go",
+    "internal/cli/path.go",
+    "internal/cli/path_test.go",
+    "internal/cli/root.go",
+    "internal/cli/list.go",
+    "internal/cli/domains.go",
+    "internal/cli/searches.go",
+    "internal/cli/downloads.go",
+    "internal/cli/devices.go",
+    "internal/cli/visited.go",
+    "internal/cli/report.go",
+    "internal/cli/heatmap.go",
+    "internal/cli/journeys.go",
+    "internal/cli/timeline.go",
+    "internal/cli/rabbitholes.go",
+    "internal/cli/dwell.go",
+    "internal/cli/graph.go",
+    "internal/cli/profile.go",
+    "internal/cli/topic.go",
+    "internal/mcp/server.go"
+  ]
+}

--- a/library/productivity/chrome-history/.printing-press-patches/chrome-history-archive-lifecycle-peer-gate-fixes.json
+++ b/library/productivity/chrome-history/.printing-press-patches/chrome-history-archive-lifecycle-peer-gate-fixes.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-history-archive-lifecycle-peer-gate-fixes",
+  "applied_at": "2026-06-12T00:00:00Z",
+  "base_run_id": "20260524-023512",
+  "base_printing_press_version": "4.13.0",
+  "summary": "Hardens archive lifecycle backup naming and peer-gate regression coverage.",
+  "reason": "Preserved reset backups are irreplaceable, and lifecycle command/store tests need to lock the FTS, VACUUM, and typed-error contracts.",
+  "files": [
+    "internal/store/archive.go",
+    "internal/store/archive_test.go",
+    "internal/cli/archive_cmd_test.go"
+  ]
+}

--- a/library/productivity/chrome-history/.printing-press-patches/chrome-history-archive-lifecycle-slice-2.json
+++ b/library/productivity/chrome-history/.printing-press-patches/chrome-history-archive-lifecycle-slice-2.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "chrome-history-archive-lifecycle-slice-2",
+  "applied_at": "2026-06-12T00:00:00Z",
+  "base_run_id": "20260524-023512",
+  "base_printing_press_version": "4.13.0",
+  "summary": "Adds archive enable/disable/clobber/reset/vacuum lifecycle commands and safety tests.",
+  "reason": "The generated CLI needs explicit archive lifecycle controls so users can opt in, freeze, compact, or guardedly reset irreplaceable accumulated history without changing snapshot writes.",
+  "files": [
+    "internal/store/archive.go",
+    "internal/store/archive_test.go",
+    "internal/cli/archive.go",
+    "internal/cli/archive_cmd_test.go"
+  ]
+}

--- a/library/productivity/chrome-history/.printing-press-patches/chrome-history-archive-mcp-surface.json
+++ b/library/productivity/chrome-history/.printing-press-patches/chrome-history-archive-mcp-surface.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "chrome-history-archive-mcp-surface",
+  "applied_at": "2026-06-12T00:00:00Z",
+  "base_run_id": "20260524-023512",
+  "base_printing_press_version": "4.13.0",
+  "summary": "Exposes the archive surface over MCP (archive_status read; archive_enable/archive_disable writes; sync.accumulate boolean) and reworks the sync-first SKILL steering; destructive clobber/reset/vacuum kept CLI-only.",
+  "reason": "An AQL discoverability eval found the archive was CLI-complete but MCP-incomplete (an MCP-only agent could read but not enable/refresh the archive), and the legibility eval found the SKILL's 'run sync first' steering caused a wasted, now-mutating sync reflex; both fixed and re-verified against a real agent.",
+  "files": [
+    "internal/mcp/server.go",
+    "internal/mcp/server_test.go",
+    "README.md",
+    "SKILL.md"
+  ]
+}

--- a/library/productivity/chrome-history/.printing-press.json
+++ b/library/productivity/chrome-history/.printing-press.json
@@ -13,11 +13,12 @@
   "printer": "vinnyp",
   "printer_name": "Vinny Pasceri",
   "spec_format": "sqlite",
+  "category": "productivity",
   "run_id": "20260524-023512",
   "description": "Query local Chrome browsing history from a snapshot index; no remote API spec.",
   "mcp_binary": "chrome-history-pp-mcp",
-  "mcp_tool_count": 19,
-  "mcp_public_tool_count": 19,
+  "mcp_tool_count": 22,
+  "mcp_public_tool_count": 22,
   "mcp_ready": "full",
   "api_version": "local",
   "auth_type": "none",
@@ -36,6 +37,11 @@
       "name": "Rabbithole Drift Detection",
       "command": "rabbitholes",
       "description": "Detects sessions that drift from productive starts into distracting browsing patterns."
+    },
+    {
+      "name": "Accumulating History Archive",
+      "command": "archive",
+      "description": "Opt-in sticky archive that preserves browsing history past Chrome's pruning/clears; sync --accumulate appends, archive enable/disable/status/clobber/reset/vacuum manage it, with scoped read routing so rich Chrome-only commands keep reading the live snapshot."
     }
   ]
 }

--- a/library/productivity/chrome-history/README.md
+++ b/library/productivity/chrome-history/README.md
@@ -15,7 +15,7 @@ go build -o chrome-history-pp-cli ./cmd/chrome-history-pp-cli
 ## Quick Start
 
 ```bash
-export XDG_CACHE_HOME=$PWD/.cache
+export XDG_CACHE_HOME="$PWD/.cache"
 ./chrome-history-pp-cli sync
 ./chrome-history-pp-cli search "github mcp" --since 30d --limit 10
 ./chrome-history-pp-cli journeys --limit 20
@@ -30,6 +30,21 @@ export XDG_CACHE_HOME=$PWD/.cache
 - `dwell`: derived engagement estimate when `visit_duration` is sparse.
 - `profile`: compact behavioral browsing profile.
 - `topic`: merges FTS and journeys context around one theme.
+- `archive`: opt-in accumulating archive that retains history Chrome later prunes or the user clears.
+
+## Archive: durable history that outlives Chrome's pruning
+
+By default the snapshot is a faithful mirror of **Chrome's current** history: when Chrome ages out old visits or the user clears history, the next `sync` drops them from the snapshot too. The optional **archive** keeps an accumulating, deduplicated copy so that history survives — without changing how you query.
+
+```bash
+./chrome-history-pp-cli archive enable      # opt in: seed the durable archive from the current snapshot
+./chrome-history-pp-cli sync --accumulate    # refresh: append new visits (dedup on url + visit_time), never dropping old ones
+./chrome-history-pp-cli archive status --json
+```
+
+How it works — **active store + sticky mode**: once enabled, reads transparently open the archive (a superset of the snapshot), so `search`/`list`/`domains`/`report`/`heatmap`/`timeline`/`sql` answer from the fuller history with no flag change. Rich Chrome-only views that need per-visit transition/duration/download data (`journeys`/`downloads`/`searches`/`dwell`/`graph`/`profile`/`visited`) continue to read the current snapshot. Because the archive is a superset of the snapshot, there is no cross-store join or reconciliation.
+
+Lifecycle: `archive enable` (or `sync --accumulate`) turns it on (sticky); `archive disable` stops accumulating but keeps the file; `archive clobber` resets the archive to a fresh current-snapshot baseline; `archive reset --force [--purge]` turns the mode off and moves (or with `--purge` deletes) `archive.db`; `archive vacuum` compacts it; `archive status` reports state. It stays **off until you enable it** — normal history queries need only the snapshot.
 
 ## Agent Usage
 
@@ -39,7 +54,7 @@ Start MCP stdio server:
 ./chrome-history-pp-cli mcp
 ```
 
-All MCP tools are read-only. They mirror the CLI and return JSON by shelling out to the same binary.
+MCP tools mirror the CLI and return JSON by shelling out to the same binary. The query tools are read-only; `sync` and `archive_enable`/`archive_disable` mutate local state only (on-device, never the network). The archive lifecycle's destructive operations (`clobber`/`reset`) are intentionally CLI-only, not exposed over MCP.
 
 JSON/select examples:
 
@@ -103,6 +118,14 @@ JSON/select examples:
 
 ```bash
 ./chrome-history-pp-cli downloads --since 30d --json --limit 50
+```
+
+7. Keep a durable history that survives Chrome clears (opt-in archive):
+
+```bash
+./chrome-history-pp-cli archive enable          # one-time
+./chrome-history-pp-cli sync --accumulate        # periodically; queries then read the fuller archive automatically
+./chrome-history-pp-cli archive status --json
 ```
 
 ## Privacy

--- a/library/productivity/chrome-history/SKILL.md
+++ b/library/productivity/chrome-history/SKILL.md
@@ -17,13 +17,15 @@ This skill drives the `chrome-history-pp-cli` binary. **You must verify the CLI 
 2. Verify: `chrome-history-pp-cli --version`
 3. Ensure the reported install directory is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.4 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/cmd/chrome-history-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
+
+`chrome-history-pp-cli` reads your local Chrome history SQLite database, snapshots it to `~/.cache/chrome-history/`, builds an offline full-text index, and answers questions about your browsing. **Read-only, zero network — nothing leaves the machine.** Every query command supports `--json` and `--select`, and the same surface is exposed as MCP tools via `chrome-history-pp-cli mcp` — the query tools are read-only; only `sync` and `archive_enable`/`archive_disable` mutate local state (on-device, never the network). An optional accumulating **archive** (off by default) can retain history that Chrome later prunes or the user clears — see [Archive](#archive-keep-history-that-chrome-would-delete) below.
 
 ## When to use
 
@@ -51,12 +53,29 @@ chrome-history-pp-cli doctor    # health check; warns if Chrome's DB schema drif
 
 If `doctor` reports the Chrome DB is unreadable, grant your terminal Full Disk Access (System Settings → Privacy & Security → Full Disk Access).
 
+You do **not** need to `sync` before answering a question — query commands read the snapshot that already exists. Only `sync` to pull in newer browsing (or the first time, if no snapshot exists yet).
+
+## Archive: keep history that Chrome would delete
+
+By default the snapshot mirrors **Chrome's current** history — when Chrome prunes old visits or the user clears history, those visits leave the snapshot on the next `sync` too. The optional **archive** keeps an accumulating, durable copy so history outlives Chrome's pruning. It is **opt-in and off by default** — a normal "what did I browse" question needs only the snapshot, so don't enable it reflexively.
+
+```bash
+chrome-history-pp-cli archive enable     # turn on the durable archive (seeds from the current snapshot)
+chrome-history-pp-cli sync --accumulate  # refresh: append new visits into the archive (dedup on url+visit_time)
+chrome-history-pp-cli archive status --json
+```
+
+- **Once enabled, reads answer from the archive automatically** (it is a superset of the snapshot) — you don't change how you query; `search`/`list`/`domains`/`report`/`heatmap`/`timeline`/`sql` simply see the fuller history. Rich Chrome-only views (`journeys`/`downloads`/`searches`/`dwell`/`graph`/`profile`/`visited`) still read the current snapshot.
+- **Keep it fresh** with `sync --accumulate` (appends, never drops).
+- **Manage it:** `archive disable` (stop accumulating, keep the file) · `archive clobber` (reset the archive to a fresh current-snapshot baseline) · `archive reset --force [--purge]` (turn mode off and move, or with `--purge` delete, `archive.db`) · `archive vacuum` (compact).
+
 ## Key commands
 
 - **Find:** `search <query>` (FTS), `visited <url|domain>`, `topic <name>` (FTS + Journeys merged), `list`, `searches` (your past search terms)
 - **Aggregate:** `domains`, `report` (time + productivity buckets), `heatmap`, `profile` (behavioral summary), `dwell` (estimated time-on-site)
 - **Reconstruct:** `journeys` (Chrome's own topic clusters), `timeline <date>` (sessionized), `rabbitholes` (distraction drift), `graph` (navigation graph)
 - **Data:** `downloads`, `sql "<SELECT…>"` (read-only), `sync`, `doctor`, `version`, `mcp`
+- **Archive (durable history, opt-in):** `archive enable|status|disable|clobber|reset|vacuum`, `sync --accumulate`
 
 ## Recipes
 
@@ -78,11 +97,15 @@ chrome-history-pp-cli profile
 
 # Agent-friendly: narrow deeply nested output to just the fields you need
 chrome-history-pp-cli journeys --json --select label,page_count --limit 10
+
+# Keep history that Chrome would later prune/clear (opt-in, one-time enable + periodic refresh)
+chrome-history-pp-cli archive enable
+chrome-history-pp-cli sync --accumulate     # run periodically; reads then see the fuller archive automatically
 ```
 
 ## Agent notes
 
 - Prefer `--json` for parsing and `--select a,b` (dotted paths) to keep responses small.
-- All commands are read-only and operate on the local snapshot — run `sync` first (or when data feels stale).
+- Query commands answer from the **existing** local snapshot — you do **not** need to `sync` before reading. Only `sync` to pull in newer browsing (a query on a truly empty store will tell you with `run sync first`). With archive mode on, `sync`/`sync --accumulate` also writes the durable archive, so don't sync just to read.
 - `searches`/`downloads`/`journeys` are Chrome-specific; a future Safari CLI reports them as "not available" rather than faking data.
 - All data stays local on-device; no browsing data leaves your machine.

--- a/library/productivity/chrome-history/go.mod
+++ b/library/productivity/chrome-history/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/printing-press-library/library/productivity/chrome-history
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/mark3labs/mcp-go v0.54.0

--- a/library/productivity/chrome-history/internal/cli/archive.go
+++ b/library/productivity/chrome-history/internal/cli/archive.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
+	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newArchiveCmd(opts *RootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "archive",
+		Short: "Manage the accumulating archive",
+	}
+	cmd.AddCommand(
+		newArchiveStatusCmd(opts),
+		newArchiveEnableCmd(opts),
+		newArchiveDisableCmd(opts),
+		newArchiveClobberCmd(opts),
+		newArchiveResetCmd(opts),
+		newArchiveVacuumCmd(opts),
+	)
+	return cmd
+}
+
+func newArchiveEnableCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:         "enable",
+		Short:       "Enable the accumulating archive from the current snapshot",
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,3"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			snapshot, err := snapshotPath()
+			if err != nil {
+				return err
+			}
+			counts, alreadyEnabled, err := store.EnableArchiveFromSource(snapshot, time.Now().UTC())
+			if err != nil {
+				if os.IsNotExist(err) {
+					return ErrNoSnapshot
+				}
+				return err
+			}
+			status, err := store.ReadArchiveStatus()
+			if err != nil {
+				return err
+			}
+			row := map[string]any{
+				"archive_enabled": status.Enabled,
+				"archive_path":    status.ArchivePath,
+				"baseline_at":     status.BaselineAt,
+				"already_enabled": alreadyEnabled,
+				"archive_visits":  counts.Total,
+				"appended":        counts.Appended,
+			}
+			output.DefaultToJSONIfNotTTY(&opts.Output)
+			return output.Render(opts.Output, []map[string]any{row})
+		},
+	}
+}
+
+func newArchiveDisableCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:         "disable",
+		Short:       "Disable archive mode while keeping the archive file",
+		Annotations: map[string]string{"pp:typed-exit-codes": "0"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			status, err := store.DisableArchive()
+			if err != nil {
+				return err
+			}
+			output.DefaultToJSONIfNotTTY(&opts.Output)
+			return output.Render(opts.Output, status)
+		},
+	}
+}
+
+func newArchiveClobberCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:         "clobber",
+		Short:       "Replace the archive with a fresh current snapshot baseline",
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,3"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			snapshot, err := snapshotPath()
+			if err != nil {
+				return err
+			}
+			result, err := store.ClobberArchiveFromSource(snapshot, time.Now().UTC())
+			if err != nil {
+				if os.IsNotExist(err) {
+					return ErrNoSnapshot
+				}
+				return err
+			}
+			status, err := store.ReadArchiveStatus()
+			if err != nil {
+				return err
+			}
+			row := map[string]any{
+				"archive_enabled":    status.Enabled,
+				"archive_path":       status.ArchivePath,
+				"baseline_at":        result.BaselineAt,
+				"old_archive_visits": result.OldVisits,
+				"new_archive_visits": result.NewVisits,
+			}
+			output.DefaultToJSONIfNotTTY(&opts.Output)
+			return output.Render(opts.Output, []map[string]any{row})
+		},
+	}
+}
+
+func newArchiveResetCmd(opts *RootOptions) *cobra.Command {
+	var force bool
+	var purge bool
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Disable archive mode and move or purge archive.db",
+		Annotations: map[string]string{
+			"pp:typed-exit-codes": "0,2",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			output.DefaultToJSONIfNotTTY(&opts.Output)
+			if !force {
+				plan, err := store.PlanArchiveReset()
+				if err != nil {
+					return err
+				}
+				if err := output.Render(opts.Output, plan); err != nil {
+					return err
+				}
+				return errors.Join(ErrUsage, fmt.Errorf("archive reset requires --force"))
+			}
+			result, err := store.ResetArchive(purge, time.Now().UTC())
+			if err != nil {
+				return err
+			}
+			return output.Render(opts.Output, result)
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "perform the guarded reset")
+	cmd.Flags().BoolVar(&purge, "purge", false, "delete archive.db instead of moving it to a .bak")
+	return cmd
+}
+
+func newArchiveVacuumCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:         "vacuum",
+		Short:       "Compact archive.db with VACUUM and PRAGMA optimize",
+		Annotations: map[string]string{"pp:typed-exit-codes": "0"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := store.VacuumArchive()
+			if err != nil {
+				return err
+			}
+			output.DefaultToJSONIfNotTTY(&opts.Output)
+			return output.Render(opts.Output, result)
+		},
+	}
+}
+
+func newArchiveStatusCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:         "status",
+		Short:       "Show accumulating archive status",
+		Annotations: map[string]string{"pp:typed-exit-codes": "0", "mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			status, err := store.ReadArchiveStatus()
+			if err != nil {
+				return err
+			}
+			output.DefaultToJSONIfNotTTY(&opts.Output)
+			return output.Render(opts.Output, status)
+		},
+	}
+}

--- a/library/productivity/chrome-history/internal/cli/archive_cmd_test.go
+++ b/library/productivity/chrome-history/internal/cli/archive_cmd_test.go
@@ -1,0 +1,206 @@
+package cli
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
+	_ "modernc.org/sqlite"
+)
+
+func TestArchiveResetCommandWithoutForceRefusesAndDoesNotMutate(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	source := newCLIArchiveSourceFixture(t, 1, 2)
+	archive, err := store.ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	if _, err := store.AccumulateFromSource(archive, source, time.Now()); err != nil {
+		t.Fatalf("accumulate: %v", err)
+	}
+	var cmdErr error
+	out := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"archive", "reset", "--json"})
+		cmdErr = cmd.Execute()
+	})
+	if !errors.Is(cmdErr, ErrUsage) {
+		t.Fatalf("archive reset err=%v, want ErrUsage", cmdErr)
+	}
+	if !strings.Contains(out, `"would_destroy": true`) || !strings.Contains(out, `"archive_visits": 2`) {
+		t.Fatalf("reset output=%s, want guarded destruction plan", out)
+	}
+	if _, err := os.Stat(archive); err != nil {
+		t.Fatalf("archive stat after refused reset: %v", err)
+	}
+	if got := countCLIArchiveRows(t, archive); got != 2 {
+		t.Fatalf("archive rows after refused reset = %d, want 2", got)
+	}
+}
+
+func TestArchiveEnableCommandIdempotent(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	source := newCLIArchiveSourceFixture(t, 1, 2)
+	snapshot, err := store.SnapshotPath()
+	if err != nil {
+		t.Fatalf("SnapshotPath: %v", err)
+	}
+	copyCLIArchiveFile(t, source, snapshot)
+	for i := 0; i < 2; i++ {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"archive", "enable", "--json"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("archive enable %d: %v", i+1, err)
+		}
+	}
+	archive, err := store.ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	if got := countCLIArchiveRows(t, archive); got != 2 {
+		t.Fatalf("archive rows after enable twice = %d, want 2", got)
+	}
+	status, err := store.ReadArchiveStatus()
+	if err != nil {
+		t.Fatalf("ReadArchiveStatus: %v", err)
+	}
+	if !status.Enabled {
+		t.Fatalf("archive enabled = false, want true")
+	}
+}
+
+func TestArchiveEnableAndClobberNoSnapshotReturnTypedError(t *testing.T) {
+	for _, args := range [][]string{
+		{"archive", "enable", "--json"},
+		{"archive", "clobber", "--json"},
+	} {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			cache := t.TempDir()
+			t.Setenv("XDG_CACHE_HOME", cache)
+			cmd := NewRootCmd()
+			cmd.SetArgs(args)
+			if err := cmd.Execute(); !errors.Is(err, ErrNoSnapshot) {
+				t.Fatalf("%v err=%v, want ErrNoSnapshot", args, err)
+			}
+		})
+	}
+}
+
+func TestArchiveLifecycleCommandSmoke(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	source := newCLIArchiveSourceFixture(t, 1, 2)
+	snapshot, err := store.SnapshotPath()
+	if err != nil {
+		t.Fatalf("SnapshotPath: %v", err)
+	}
+	copyCLIArchiveFile(t, source, snapshot)
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"archive", "enable", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("archive enable: %v", err)
+	}
+	out := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"archive", "disable", "--json"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("archive disable: %v", err)
+		}
+	})
+	if !strings.Contains(out, `"archive_enabled": false`) {
+		t.Fatalf("disable output=%s, want archive_enabled false", out)
+	}
+	out = captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"archive", "clobber", "--json"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("archive clobber: %v", err)
+		}
+	})
+	if !strings.Contains(out, `"new_archive_visits": 2`) {
+		t.Fatalf("clobber output=%s, want new_archive_visits 2", out)
+	}
+	out = captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"archive", "vacuum", "--json"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("archive vacuum: %v", err)
+		}
+	})
+	if !strings.Contains(out, `"size_before_bytes":`) || !strings.Contains(out, `"size_after_bytes":`) {
+		t.Fatalf("vacuum output=%s, want size fields", out)
+	}
+}
+
+func newCLIArchiveSourceFixture(t *testing.T, start, end int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "source.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer db.Close()
+	_, err = db.Exec(`CREATE TABLE urls (
+		id INTEGER PRIMARY KEY,
+		url TEXT,
+		title TEXT,
+		visit_count INTEGER,
+		last_visit_time INTEGER,
+		typed_count INTEGER DEFAULT 0,
+		hidden INTEGER DEFAULT 0
+	);
+	CREATE TABLE visits (
+		id INTEGER PRIMARY KEY,
+		url INTEGER,
+		visit_time INTEGER,
+		from_visit INTEGER DEFAULT 0,
+		transition INTEGER DEFAULT 0,
+		visit_duration INTEGER DEFAULT 0
+	);`)
+	if err != nil {
+		t.Fatalf("create fixture schema: %v", err)
+	}
+	for i := start; i <= end; i++ {
+		visitTime := int64(13200000000000000 + i)
+		if _, err := db.Exec(`INSERT INTO urls(id, url, title, visit_count, last_visit_time) VALUES(?,?,?,?,?)`, i, fmt.Sprintf("https://example.test/cmd-v%d", i), fmt.Sprintf("Visit %d", i), 1, visitTime); err != nil {
+			t.Fatalf("insert url: %v", err)
+		}
+		if _, err := db.Exec(`INSERT INTO visits(id, url, visit_time) VALUES(?,?,?)`, i, i, visitTime); err != nil {
+			t.Fatalf("insert visit: %v", err)
+		}
+	}
+	return path
+}
+
+func countCLIArchiveRows(t *testing.T, path string) int64 {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	defer db.Close()
+	var n int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM history_archive`).Scan(&n); err != nil {
+		t.Fatalf("count archive: %v", err)
+	}
+	return n
+}
+
+func copyCLIArchiveFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}

--- a/library/productivity/chrome-history/internal/cli/devices.go
+++ b/library/productivity/chrome-history/internal/cli/devices.go
@@ -1,11 +1,9 @@
 package cli
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -16,15 +14,8 @@ func newDevicesCmd(opts *RootOptions) *cobra.Command {
 		Example:     strings.Trim("chrome-history-pp-cli devices --json", "\n"),
 		Annotations: map[string]string{"pp:typed-exit-codes": "0,3", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			snapshot, err := snapshotPath()
+			st, err := openSnapshotStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/domains.go
+++ b/library/productivity/chrome-history/internal/cli/domains.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/categorize"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -25,15 +24,8 @@ func newDomainsCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
+			st, _, err := openCoreHistoryStore(opts.Device)
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/downloads.go
+++ b/library/productivity/chrome-history/internal/cli/downloads.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -24,15 +23,8 @@ func newDownloadsCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
+			st, err := openSnapshotStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/dwell.go
+++ b/library/productivity/chrome-history/internal/cli/dwell.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/categorize"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -29,15 +28,8 @@ func newDwellCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
+			st, err := openSnapshotStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/graph.go
+++ b/library/productivity/chrome-history/internal/cli/graph.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -24,15 +23,8 @@ func newGraphCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
+			st, err := openSnapshotStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/heatmap.go
+++ b/library/productivity/chrome-history/internal/cli/heatmap.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -24,15 +23,8 @@ func newHeatmapCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
+			st, _, err := openCoreHistoryStore(opts.Device)
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/journeys.go
+++ b/library/productivity/chrome-history/internal/cli/journeys.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -31,15 +30,8 @@ func newJourneysCmd(opts *RootOptions) *cobra.Command {
 					return errors.Join(ErrUsage, err)
 				}
 			}
-			snapshot, err := snapshotPath()
+			st, err := openSnapshotStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/list.go
+++ b/library/productivity/chrome-history/internal/cli/list.go
@@ -24,16 +24,19 @@ func newListCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
-			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
+			var st *store.Store
+			if strings.TrimSpace(transition) == "" {
+				var err error
+				st, _, err = openCoreHistoryStore(opts.Device)
+				if err != nil {
+					return err
 				}
-				return err
+			} else {
+				var err error
+				st, err = openSnapshotStore()
+				if err != nil {
+					return err
+				}
 			}
 			defer st.Close()
 			rows, err := opts.Source.RecentVisits(st.DB(), source.VisitFilter{Since: start, Until: end, Limit: opts.Output.Limit, MinVisits: minVisits, Domain: domain, Device: opts.Device})

--- a/library/productivity/chrome-history/internal/cli/path.go
+++ b/library/productivity/chrome-history/internal/cli/path.go
@@ -1,23 +1,47 @@
 package cli
 
 import (
-	"os"
-	"path/filepath"
+	"errors"
 	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 )
 
 func snapshotPath() (string, error) {
-	base := os.Getenv("XDG_CACHE_HOME")
-	if strings.TrimSpace(base) == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
+	return store.SnapshotPath()
+}
+
+func openActiveStore() (*store.Store, bool, error) {
+	st, isArchive, err := store.OpenActiveStore()
+	if err != nil {
+		if errors.Is(err, store.ErrNoSnapshot) {
+			return nil, false, ErrNoSnapshot
 		}
-		base = filepath.Join(home, ".cache")
+		return nil, false, err
 	}
-	dir := filepath.Join(base, "chrome-history")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", err
+	return st, isArchive, nil
+}
+
+func openSnapshotStore() (*store.Store, error) {
+	path, err := snapshotPath()
+	if err != nil {
+		return nil, err
 	}
-	return filepath.Join(dir, "snapshot.db"), nil
+	st, err := store.OpenExisting(path)
+	if err != nil {
+		if errors.Is(err, store.ErrNoSnapshot) {
+			return nil, ErrNoSnapshot
+		}
+		return nil, err
+	}
+	return st, nil
+}
+
+func openCoreHistoryStore(device string) (*store.Store, bool, error) {
+	d := strings.TrimSpace(strings.ToLower(device))
+	if d != "" && d != "all" {
+		st, err := openSnapshotStore()
+		return st, false, err
+	}
+	return openActiveStore()
 }

--- a/library/productivity/chrome-history/internal/cli/path_test.go
+++ b/library/productivity/chrome-history/internal/cli/path_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"database/sql"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
+	_ "modernc.org/sqlite"
+)
+
+func TestRichDataCommandReadsSnapshotWhenArchiveEnabled(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	snapshot, err := store.SnapshotPath()
+	if err != nil {
+		t.Fatalf("SnapshotPath: %v", err)
+	}
+	db, err := sql.Open("sqlite", snapshot)
+	if err != nil {
+		t.Fatalf("open snapshot: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE downloads (
+		target_path TEXT,
+		received_bytes INTEGER,
+		mime_type TEXT,
+		original_mime_type TEXT,
+		site_url TEXT,
+		referrer TEXT,
+		start_time INTEGER,
+		state INTEGER
+	)`); err != nil {
+		t.Fatalf("create downloads: %v", err)
+	}
+	when := (time.Now().UTC().Unix() + 11644473600) * 1_000_000
+	if _, err := db.Exec(`INSERT INTO downloads(target_path, received_bytes, mime_type, site_url, start_time, state) VALUES(?,?,?,?,?,?)`,
+		filepath.Join(t.TempDir(), "snapshot-file.txt"), 42, "text/plain", "https://example.test/file", when, 1); err != nil {
+		t.Fatalf("insert download: %v", err)
+	}
+	db.Close()
+
+	archive, err := store.ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	adb, err := sql.Open("sqlite", archive)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	if err := store.InitArchiveSchema(adb); err != nil {
+		t.Fatalf("InitArchiveSchema: %v", err)
+	}
+	if _, err := adb.Exec(`UPDATE meta_pp SET archive_enabled=1`); err != nil {
+		t.Fatalf("enable archive: %v", err)
+	}
+	adb.Close()
+
+	out := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"downloads", "--json", "--since", "3650d"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("downloads command: %v", err)
+		}
+	})
+	if !strings.Contains(out, "snapshot-file.txt") {
+		t.Fatalf("downloads output = %s, want snapshot download row", out)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return string(data)
+}

--- a/library/productivity/chrome-history/internal/cli/profile.go
+++ b/library/productivity/chrome-history/internal/cli/profile.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -23,15 +22,8 @@ func newProfileCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
+			st, err := openSnapshotStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/rabbitholes.go
+++ b/library/productivity/chrome-history/internal/cli/rabbitholes.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/categorize"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -28,15 +27,8 @@ func newRabbitholesCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
+			st, err := openSnapshotStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/report.go
+++ b/library/productivity/chrome-history/internal/cli/report.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -23,15 +22,8 @@ func newReportCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
+			st, _, err := openCoreHistoryStore(opts.Device)
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/root.go
+++ b/library/productivity/chrome-history/internal/cli/root.go
@@ -72,6 +72,7 @@ func NewRootCmd() *cobra.Command {
 
 	root.AddCommand(
 		newSyncCmd(opts),
+		newArchiveCmd(opts),
 		newDoctorCmd(opts),
 		newSearchCmd(opts),
 		newSQLCmd(opts),
@@ -98,6 +99,7 @@ func NewRootCmd() *cobra.Command {
 }
 
 func newSyncCmd(opts *RootOptions) *cobra.Command {
+	var accumulate bool
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Snapshot Chrome history and build FTS",
@@ -122,6 +124,22 @@ func newSyncCmd(opts *RootOptions) *cobra.Command {
 				_ = os.Remove(si.SnapshotPath)
 				return err
 			}
+			archiveStatus, err := store.ReadArchiveStatus()
+			if err != nil {
+				return err
+			}
+			var archiveCounts store.ArchiveCounts
+			var archivePath string
+			if accumulate || archiveStatus.Enabled {
+				archivePath, err = store.ArchivePath()
+				if err != nil {
+					return err
+				}
+				archiveCounts, err = store.AccumulateFromSource(archivePath, snapshot, time.Now().UTC())
+				if err != nil {
+					return err
+				}
+			}
 			rows := []map[string]any{{
 				"snapshot":                       snapshot,
 				"profile":                        meta.Profile,
@@ -132,10 +150,19 @@ func newSyncCmd(opts *RootOptions) *cobra.Command {
 				"chrome_schema_version":          meta.ChromeSchemaVersion,
 				"chrome_last_compatible_version": meta.ChromeLastCompatibleVersion,
 			}}
+			if archivePath != "" {
+				rows[0]["archive_enabled"] = true
+				rows[0]["archive_path"] = archivePath
+				rows[0]["archive_appended"] = archiveCounts.Appended
+				rows[0]["archive_visits"] = archiveCounts.Total
+			} else {
+				rows[0]["archive_enabled"] = archiveStatus.Enabled
+			}
 			output.DefaultToJSONIfNotTTY(&opts.Output)
 			return output.Render(opts.Output, rows)
 		},
 	}
+	cmd.Flags().BoolVar(&accumulate, "accumulate", false, "append current history into the sticky archive")
 	return cmd
 }
 
@@ -155,6 +182,11 @@ func newDoctorCmd(opts *RootOptions) *cobra.Command {
 				status["chrome_db_error"] = srcErr.Error()
 			} else {
 				status["chrome_db"] = src
+			}
+			activePath, activeIsArchive, activeErr := store.ActiveStorePath()
+			if activeErr == nil {
+				status["active_store"] = activePath
+				status["archive_enabled"] = activeIsArchive
 			}
 			st, err := os.Stat(snapshot)
 			if err != nil {
@@ -199,6 +231,19 @@ func newDoctorCmd(opts *RootOptions) *cobra.Command {
 					}
 				}
 			}
+			if activeErr == nil {
+				if info, err := os.Stat(activePath); err == nil {
+					status["active_store_age"] = time.Since(info.ModTime()).String()
+				}
+				activeStore, openErr := store.OpenExisting(activePath)
+				if openErr == nil {
+					defer activeStore.Close()
+					status["active_fts_ready"] = activeStore.IsFTSReady()
+					status["active_urls_count"] = activeStore.RowCount("urls")
+					status["active_visits_count"] = activeStore.RowCount("visits")
+					status["active_history_fts_count"] = activeStore.RowCount("history_fts")
+				}
+			}
 			status["healthy"] = status["chrome_db"] != "missing" && status["snapshot"] != "missing"
 			rows := []map[string]any{status}
 			output.DefaultToJSONIfNotTTY(&opts.Output)
@@ -225,15 +270,8 @@ func newSearchCmd(opts *RootOptions) *cobra.Command {
 					return errors.Join(ErrUsage, err)
 				}
 			}
-			snapshot, err := snapshotPath()
+			st, _, err := openCoreHistoryStore(opts.Device)
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()
@@ -269,7 +307,7 @@ func newSearchCmd(opts *RootOptions) *cobra.Command {
 func newSQLCmd(opts *RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "sql <SELECT...>",
-		Short:       "Run a read-only SELECT query against the snapshot's urls/visits/downloads/history_fts tables (non-SELECT statements are rejected)",
+		Short:       "Run a read-only SELECT query against the active store; archive mode exposes url/time/title history tables (non-SELECT statements are rejected)",
 		Args:        usageMinArgs(1),
 		Annotations: map[string]string{"pp:typed-exit-codes": "0,2,3", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -277,15 +315,8 @@ func newSQLCmd(opts *RootOptions) *cobra.Command {
 			if !store.IsSelectOnly(q) {
 				return fmt.Errorf("%w: only SELECT statements are allowed", ErrUsage)
 			}
-			snapshot, err := snapshotPath()
+			st, _, err := openActiveStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/searches.go
+++ b/library/productivity/chrome-history/internal/cli/searches.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -23,15 +22,8 @@ func newSearchesCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
+			st, err := openSnapshotStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/timeline.go
+++ b/library/productivity/chrome-history/internal/cli/timeline.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -32,15 +31,8 @@ func newTimelineCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, fmt.Errorf("invalid --gap: %w", err))
 			}
-			snapshot, err := snapshotPath()
+			st, _, err := openCoreHistoryStore(opts.Device)
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/topic.go
+++ b/library/productivity/chrome-history/internal/cli/topic.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -25,15 +24,8 @@ func newTopicCmd(opts *RootOptions) *cobra.Command {
 			if err != nil {
 				return errors.Join(ErrUsage, err)
 			}
-			snapshot, err := snapshotPath()
+			st, err := openSnapshotStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/cli/visited.go
+++ b/library/productivity/chrome-history/internal/cli/visited.go
@@ -1,13 +1,11 @@
 package cli
 
 import (
-	"errors"
 	"strings"
 	"time"
 
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/output"
 	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
-	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -19,15 +17,8 @@ func newVisitedCmd(opts *RootOptions) *cobra.Command {
 		Example:     strings.Trim("chrome-history-pp-cli visited github.com\n  chrome-history-pp-cli visited https://docs.github.com", "\n"),
 		Annotations: map[string]string{"pp:typed-exit-codes": "0,2,3", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			snapshot, err := snapshotPath()
+			st, err := openSnapshotStore()
 			if err != nil {
-				return err
-			}
-			st, err := store.OpenExisting(snapshot)
-			if err != nil {
-				if errors.Is(err, store.ErrNoSnapshot) {
-					return ErrNoSnapshot
-				}
 				return err
 			}
 			defer st.Close()

--- a/library/productivity/chrome-history/internal/mcp/server.go
+++ b/library/productivity/chrome-history/internal/mcp/server.go
@@ -25,11 +25,12 @@ func ServeStdio() error { return server.ServeStdio(NewServer()) }
 type toolSpec struct {
 	tool    mcp.Tool
 	handler server.ToolHandlerFunc
+	cmdArgs func(mcp.CallToolRequest) []string
 }
 
 func tools() []toolSpec {
 	return []toolSpec{
-		mk("search", "FTS search over URL/title/search terms", []arg{{"query", true, "Search query"}, {"domain", false, "Domain filter"}, {"device", false, "Device filter"}, {"since", false, "Since window"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("search", "FTS search over URL/title/search terms", []arg{{name: "query", required: true, desc: "Search query"}, {name: "domain", desc: "Domain filter"}, {name: "device", desc: "Device filter"}, {name: "since", desc: "Since window"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"search"}
 			args = appendFlag(args, "domain", reqStr(r, "domain"))
 			args = appendFlag(args, "device", reqStr(r, "device"))
@@ -37,7 +38,7 @@ func tools() []toolSpec {
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return append(args, "--", reqStr(r, "query"))
 		}),
-		mk("list", "Recent history list", []arg{{"since", false, "Since window"}, {"until", false, "Until window"}, {"domain", false, "Domain filter"}, {"device", false, "Device filter"}, {"transition", false, "Transition filter"}, {"min_visits", false, "Minimum visits"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("list", "Recent history list", []arg{{name: "since", desc: "Since window"}, {name: "until", desc: "Until window"}, {name: "domain", desc: "Domain filter"}, {name: "device", desc: "Device filter"}, {name: "transition", desc: "Transition filter"}, {name: "min_visits", desc: "Minimum visits"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"list"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "until", reqStr(r, "until"))
@@ -48,14 +49,14 @@ func tools() []toolSpec {
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("domains", "Domain frequency ranking", []arg{{"since", false, "Since window"}, {"device", false, "Device filter"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("domains", "Domain frequency ranking", []arg{{name: "since", desc: "Since window"}, {name: "device", desc: "Device filter"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"domains"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "device", reqStr(r, "device"))
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("searches", "Search terms from browser history", []arg{{"since", false, "Since window"}, {"domain", false, "Domain filter"}, {"device", false, "Device filter"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("searches", "Search terms from browser history", []arg{{name: "since", desc: "Since window"}, {name: "domain", desc: "Domain filter"}, {name: "device", desc: "Device filter"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"searches"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "domain", reqStr(r, "domain"))
@@ -63,39 +64,39 @@ func tools() []toolSpec {
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("downloads", "Download history", []arg{{"since", false, "Since window"}, {"device", false, "Device filter"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("downloads", "Download history", []arg{{name: "since", desc: "Since window"}, {name: "device", desc: "Device filter"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"downloads"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "device", reqStr(r, "device"))
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("visited", "Check whether a URL/domain was visited", []arg{{"target", true, "URL or domain"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("visited", "Check whether a URL/domain was visited", []arg{{name: "target", required: true, desc: "URL or domain"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"visited"}
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return append(args, "--", reqStr(r, "target"))
 		}),
-		mk("report", "Activity report", []arg{{"since", false, "Since window"}, {"device", false, "Device filter"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("report", "Activity report", []arg{{name: "since", desc: "Since window"}, {name: "device", desc: "Device filter"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"report"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "device", reqStr(r, "device"))
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("heatmap", "Hour x weekday activity grid", []arg{{"since", false, "Since window"}, {"device", false, "Device filter"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("heatmap", "Hour x weekday activity grid", []arg{{name: "since", desc: "Since window"}, {name: "device", desc: "Device filter"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"heatmap"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "device", reqStr(r, "device"))
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("journeys", "Chrome journeys cluster listing", []arg{{"since", false, "Since window"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("journeys", "Chrome journeys cluster listing", []arg{{name: "since", desc: "Since window"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"journeys"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("timeline", "Sessionized browsing timeline", []arg{{"since", false, "Since window/date"}, {"until", false, "Until date"}, {"device", false, "Device filter"}, {"gap", false, "Session gap"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("timeline", "Sessionized browsing timeline", []arg{{name: "since", desc: "Since window/date"}, {name: "until", desc: "Until date"}, {name: "device", desc: "Device filter"}, {name: "gap", desc: "Session gap"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"timeline"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "until", reqStr(r, "until"))
@@ -104,7 +105,7 @@ func tools() []toolSpec {
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("rabbitholes", "Detect productive-to-distracting drift", []arg{{"since", false, "Since window"}, {"device", false, "Device filter"}, {"gap", false, "Session gap"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("rabbitholes", "Detect productive-to-distracting drift", []arg{{name: "since", desc: "Since window"}, {name: "device", desc: "Device filter"}, {name: "gap", desc: "Session gap"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"rabbitholes"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "device", reqStr(r, "device"))
@@ -112,7 +113,7 @@ func tools() []toolSpec {
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("dwell", "Derived dwell-time estimate", []arg{{"since", false, "Since window"}, {"device", false, "Device filter"}, {"gap", false, "Dwell cap gap"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("dwell", "Derived dwell-time estimate", []arg{{name: "since", desc: "Since window"}, {name: "device", desc: "Device filter"}, {name: "gap", desc: "Dwell cap gap"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"dwell"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "device", reqStr(r, "device"))
@@ -120,7 +121,7 @@ func tools() []toolSpec {
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("graph", "Navigation graph from visit referrers", []arg{{"since", false, "Since window"}, {"domain", false, "Domain filter"}, {"device", false, "Device filter"}, {"format", false, "json|dot"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("graph", "Navigation graph from visit referrers", []arg{{name: "since", desc: "Since window"}, {name: "domain", desc: "Domain filter"}, {name: "device", desc: "Device filter"}, {name: "format", desc: "json|dot"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"graph"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "domain", reqStr(r, "domain"))
@@ -129,35 +130,47 @@ func tools() []toolSpec {
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("profile", "Behavioral self-profile", []arg{{"since", false, "Since window"}, {"device", false, "Device filter"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("profile", "Behavioral self-profile", []arg{{name: "since", desc: "Since window"}, {name: "device", desc: "Device filter"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"profile"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "device", reqStr(r, "device"))
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("devices", "List local/synced/imported/extension origin buckets", []arg{{"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("devices", "List local/synced/imported/extension origin buckets", []arg{{name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"devices"}
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return args
 		}),
-		mk("topic", "Merge FTS and journeys by topic", []arg{{"name", true, "Topic name"}, {"since", false, "Since window"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("topic", "Merge FTS and journeys by topic", []arg{{name: "name", required: true, desc: "Topic name"}, {name: "since", desc: "Since window"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"topic"}
 			args = appendFlag(args, "since", reqStr(r, "since"))
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return append(args, "--", reqStr(r, "name"))
 		}),
-		mk("sql", "Run SELECT-only SQL on snapshot", []arg{{"query", true, "SELECT query"}, {"limit", false, "Row limit"}}, func(r mcp.CallToolRequest) []string {
+		mk("sql", "Run SELECT-only SQL on the active store; archive mode exposes url/time/title history tables", []arg{{name: "query", required: true, desc: "SELECT query"}, {name: "limit", desc: "Row limit"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"sql"}
 			args = appendFlag(args, "limit", reqStr(r, "limit"))
 			return append(args, "--", reqStr(r, "query"))
 		}),
-		mkWrite("sync", "Snapshot and index browser history", []arg{{"profile", false, "Profile name"}}, func(r mcp.CallToolRequest) []string {
+		mkWrite("sync", "Snapshot and index browser history", []arg{{name: "profile", desc: "Profile name"}, {name: "accumulate", desc: "Also append into the durable archive (archive mode)", isBool: true}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"sync"}
 			args = appendFlag(args, "profile", reqStr(r, "profile"))
+			if reqBool(r, "accumulate") {
+				args = append(args, "--accumulate")
+			}
 			return args
 		}),
-		mk("doctor", "Health-check source and snapshot", []arg{{"profile", false, "Profile name"}}, func(r mcp.CallToolRequest) []string {
+		mk("archive_status", "Show accumulating-archive status (enabled?, counts, baseline).", nil, func(r mcp.CallToolRequest) []string {
+			return []string{"archive", "status"}
+		}),
+		mkWrite("archive_enable", "Enable the durable accumulating archive (seeds from the current snapshot) so history survives Chrome's pruning/clears.", nil, func(r mcp.CallToolRequest) []string {
+			return []string{"archive", "enable"}
+		}),
+		mkWrite("archive_disable", "Stop accumulating into the archive but keep the archive file.", nil, func(r mcp.CallToolRequest) []string {
+			return []string{"archive", "disable"}
+		}),
+		mk("doctor", "Health-check source and snapshot", []arg{{name: "profile", desc: "Profile name"}}, func(r mcp.CallToolRequest) []string {
 			args := []string{"doctor"}
 			args = appendFlag(args, "profile", reqStr(r, "profile"))
 			return args
@@ -169,6 +182,7 @@ type arg struct {
 	name     string
 	required bool
 	desc     string
+	isBool   bool
 }
 
 // mk builds a read-only tool (the common case: every query command).
@@ -185,10 +199,14 @@ func mkWrite(name, desc string, args []arg, cmdArgs func(mcp.CallToolRequest) []
 func mkTool(name, desc string, readOnly bool, args []arg, cmdArgs func(mcp.CallToolRequest) []string) toolSpec {
 	opts := []mcp.ToolOption{mcp.WithDescription(desc), mcp.WithReadOnlyHintAnnotation(readOnly)}
 	for _, a := range args {
+		propOpts := []mcp.PropertyOption{mcp.Description(a.desc)}
 		if a.required {
-			opts = append(opts, mcp.WithString(a.name, mcp.Required(), mcp.Description(a.desc)))
+			propOpts = append(propOpts, mcp.Required())
+		}
+		if a.isBool {
+			opts = append(opts, mcp.WithBoolean(a.name, propOpts...))
 		} else {
-			opts = append(opts, mcp.WithString(a.name, mcp.Description(a.desc)))
+			opts = append(opts, mcp.WithString(a.name, propOpts...))
 		}
 	}
 	tool := mcp.NewTool(name, opts...)
@@ -206,7 +224,7 @@ func mkTool(name, desc string, readOnly bool, args []arg, cmdArgs func(mcp.CallT
 		}
 		return mcp.NewToolResultText(out), nil
 	}
-	return toolSpec{tool: tool, handler: h}
+	return toolSpec{tool: tool, handler: h, cmdArgs: cmdArgs}
 }
 
 func runSelf(args ...string) (string, error) {
@@ -236,6 +254,14 @@ func reqStr(r mcp.CallToolRequest, k string) string {
 		return strings.TrimSpace(s)
 	}
 	return ""
+}
+
+func reqBool(r mcp.CallToolRequest, k string) bool {
+	v, _ := r.GetArguments()[k]
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return false
 }
 
 func appendFlag(args []string, flag, val string) []string {

--- a/library/productivity/chrome-history/internal/mcp/server_test.go
+++ b/library/productivity/chrome-history/internal/mcp/server_test.go
@@ -1,16 +1,21 @@
 package mcp
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
 
 // Read tools must advertise readOnlyHint; sync mutates local state (writes the
 // snapshot DB + FTS index) and must not. A false readOnlyHint on a mutating
 // tool is a real bug, so guard the count and the per-tool annotation.
 func TestToolReadOnlyHints(t *testing.T) {
 	ts := tools()
-	if len(ts) != 19 {
-		t.Fatalf("expected 19 tools, got %d", len(ts))
+	if len(ts) != 22 {
+		t.Fatalf("expected 22 tools, got %d", len(ts))
 	}
-	writeTools := map[string]bool{"sync": true}
+	writeTools := map[string]bool{"sync": true, "archive_enable": true, "archive_disable": true}
 	for _, spec := range ts {
 		hint := spec.tool.Annotations.ReadOnlyHint
 		if hint == nil {
@@ -20,5 +25,110 @@ func TestToolReadOnlyHints(t *testing.T) {
 		if *hint != wantReadOnly {
 			t.Fatalf("tool %q readOnlyHint = %v, want %v", spec.tool.Name, *hint, wantReadOnly)
 		}
+	}
+}
+
+func TestToolListIncludesArchiveAndSyncAccumulate(t *testing.T) {
+	wantNames := []string{
+		"search",
+		"list",
+		"domains",
+		"searches",
+		"downloads",
+		"visited",
+		"report",
+		"heatmap",
+		"journeys",
+		"timeline",
+		"rabbitholes",
+		"dwell",
+		"graph",
+		"profile",
+		"devices",
+		"topic",
+		"sql",
+		"sync",
+		"archive_status",
+		"archive_enable",
+		"archive_disable",
+		"doctor",
+	}
+
+	ts := tools()
+	gotNames := make([]string, 0, len(ts))
+	for _, spec := range ts {
+		gotNames = append(gotNames, spec.tool.Name)
+	}
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("tool names = %#v, want %#v", gotNames, wantNames)
+	}
+
+	byName := toolSpecsByName(ts)
+	for _, forbidden := range []string{"archive_clobber", "archive_reset", "archive_vacuum"} {
+		if _, ok := byName[forbidden]; ok {
+			t.Fatalf("tool %q must not be exposed over MCP", forbidden)
+		}
+	}
+
+	syncTool := byName["sync"].tool
+	accumulate, ok := syncTool.InputSchema.Properties["accumulate"].(map[string]any)
+	if !ok {
+		t.Fatalf("sync accumulate schema missing or wrong shape: %#v", syncTool.InputSchema.Properties["accumulate"])
+	}
+	if got := accumulate["type"]; got != "boolean" {
+		t.Fatalf("sync accumulate type = %#v, want boolean", got)
+	}
+	profile, ok := syncTool.InputSchema.Properties["profile"].(map[string]any)
+	if !ok {
+		t.Fatalf("sync profile schema missing or wrong shape: %#v", syncTool.InputSchema.Properties["profile"])
+	}
+	if got := profile["type"]; got != "string" {
+		t.Fatalf("sync profile type = %#v, want string", got)
+	}
+}
+
+func TestArchiveAndSyncCommandArgs(t *testing.T) {
+	ts := toolSpecsByName(tools())
+	tests := []struct {
+		name string
+		req  mcp.CallToolRequest
+		want []string
+	}{
+		{name: "archive_status", want: []string{"archive", "status"}},
+		{name: "archive_enable", want: []string{"archive", "enable"}},
+		{name: "archive_disable", want: []string{"archive", "disable"}},
+		{name: "sync", req: toolRequest(map[string]any{"profile": "Default"}), want: []string{"sync", "--profile", "Default"}},
+		{name: "sync", req: toolRequest(map[string]any{"profile": "Default", "accumulate": false}), want: []string{"sync", "--profile", "Default"}},
+		{name: "sync", req: toolRequest(map[string]any{"profile": "Default", "accumulate": true}), want: []string{"sync", "--profile", "Default", "--accumulate"}},
+		// Contract pin: a non-boolean accumulate (e.g. a client sending the string
+		// "true") is treated as false by reqBool — no --accumulate, no error. The MCP
+		// schema declares accumulate as boolean, so a conforming client never hits this;
+		// this case documents the silent-false coercion so any future change is conscious.
+		{name: "sync", req: toolRequest(map[string]any{"profile": "Default", "accumulate": "true"}), want: []string{"sync", "--profile", "Default"}},
+	}
+
+	for _, tt := range tests {
+		spec, ok := ts[tt.name]
+		if !ok {
+			t.Fatalf("missing tool %q", tt.name)
+		}
+		got := spec.cmdArgs(tt.req)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("%s args = %#v, want %#v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func toolSpecsByName(ts []toolSpec) map[string]toolSpec {
+	byName := make(map[string]toolSpec, len(ts))
+	for _, spec := range ts {
+		byName[spec.tool.Name] = spec
+	}
+	return byName
+}
+
+func toolRequest(args map[string]any) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Arguments: args},
 	}
 }

--- a/library/productivity/chrome-history/internal/store/archive.go
+++ b/library/productivity/chrome-history/internal/store/archive.go
@@ -146,6 +146,7 @@ func OpenActiveStore() (*Store, bool, error) {
 func InitArchiveSchema(db *sql.DB) error {
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS meta_pp (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
 			archive_enabled INTEGER NOT NULL DEFAULT 0,
 			baseline_at TEXT,
 			schema_version INTEGER
@@ -167,15 +168,17 @@ func InitArchiveSchema(db *sql.DB) error {
 			search_terms
 		)`,
 		`CREATE TRIGGER IF NOT EXISTS history_archive_ai AFTER INSERT ON history_archive BEGIN
+			DELETE FROM history_fts WHERE url = new.url;
 			INSERT INTO history_fts(rowid, url, title, search_terms)
-				SELECT new.rowid, new.url, COALESCE(new.title,''), ''
-				WHERE NOT EXISTS (SELECT 1 FROM history_fts WHERE url = new.url);
+				SELECT MIN(rowid), url, COALESCE((SELECT title FROM history_archive h2 WHERE h2.url = history_archive.url ORDER BY visit_time DESC, rowid DESC LIMIT 1), ''), ''
+				FROM history_archive WHERE url = new.url GROUP BY url;
 		END`,
 		`CREATE TRIGGER IF NOT EXISTS history_archive_ad AFTER DELETE ON history_archive BEGIN
 			DELETE FROM history_fts WHERE url = old.url AND NOT EXISTS (SELECT 1 FROM history_archive WHERE url = old.url);
 		END`,
 		`CREATE TRIGGER IF NOT EXISTS history_archive_au AFTER UPDATE ON history_archive BEGIN
 			DELETE FROM history_fts WHERE url = old.url;
+			DELETE FROM history_fts WHERE url = new.url;
 			INSERT INTO history_fts(rowid, url, title, search_terms)
 				SELECT MIN(rowid), url, COALESCE((SELECT title FROM history_archive h2 WHERE h2.url = history_archive.url ORDER BY visit_time DESC, rowid DESC LIMIT 1), ''), ''
 				FROM history_archive WHERE url IN (old.url, new.url) GROUP BY url;
@@ -223,8 +226,8 @@ func InitArchiveSchema(db *sql.DB) error {
 			return err
 		}
 	}
-	_, err := db.Exec(`INSERT INTO meta_pp(archive_enabled, schema_version)
-		SELECT 0, ? WHERE NOT EXISTS (SELECT 1 FROM meta_pp)`, archiveSchemaVersion)
+	_, err := db.Exec(`INSERT INTO meta_pp(id, archive_enabled, schema_version)
+		SELECT 1, 0, ? WHERE NOT EXISTS (SELECT 1 FROM meta_pp)`, archiveSchemaVersion)
 	if err != nil {
 		return err
 	}
@@ -276,16 +279,23 @@ func migrateArchiveFTS(db *sql.DB) error {
 	if version.Valid && version.Int64 >= archiveSchemaVersion {
 		return nil
 	}
-	if _, err := db.Exec(`DELETE FROM history_fts`); err != nil {
+	tx, err := db.Begin()
+	if err != nil {
 		return err
 	}
-	if _, err := db.Exec(`INSERT INTO history_fts(rowid, url, title, search_terms)
+	defer tx.Rollback()
+	if _, err := tx.Exec(`DELETE FROM history_fts`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`INSERT INTO history_fts(rowid, url, title, search_terms)
 		SELECT MIN(rowid), url, COALESCE((SELECT title FROM history_archive h2 WHERE h2.url = history_archive.url ORDER BY visit_time DESC, rowid DESC LIMIT 1), ''), ''
 		FROM history_archive GROUP BY url`); err != nil {
 		return err
 	}
-	_, err := db.Exec(`UPDATE meta_pp SET schema_version=?`, archiveSchemaVersion)
-	return err
+	if _, err := tx.Exec(`UPDATE meta_pp SET schema_version=?`, archiveSchemaVersion); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // AccumulateFromSource appends current source visits to archivePath, deduping

--- a/library/productivity/chrome-history/internal/store/archive.go
+++ b/library/productivity/chrome-history/internal/store/archive.go
@@ -1,0 +1,604 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const archiveSchemaVersion = 2
+
+// ArchiveCounts reports how many source visits were appended and how many are
+// present after an accumulation run.
+type ArchiveCounts struct {
+	Appended int64 `json:"appended"`
+	Total    int64 `json:"total"`
+}
+
+// ArchiveStatus describes the read-only state shown by `archive status`.
+type ArchiveStatus struct {
+	Enabled          bool   `json:"archive_enabled"`
+	BaselineAt       string `json:"baseline_at,omitempty"`
+	ArchiveVisits    int64  `json:"archive_visits,omitempty"`
+	ArchivePath      string `json:"archive_path,omitempty"`
+	ArchiveSizeBytes int64  `json:"archive_size_bytes,omitempty"`
+}
+
+// ArchiveClobberResult reports the before/after counts for a reset baseline.
+type ArchiveClobberResult struct {
+	OldVisits  int64  `json:"old_archive_visits"`
+	NewVisits  int64  `json:"new_archive_visits"`
+	BaselineAt string `json:"baseline_at"`
+}
+
+// ArchiveResetPlan describes the guarded data that archive reset would remove.
+type ArchiveResetPlan struct {
+	ArchiveVisits int64  `json:"archive_visits"`
+	BaselineAt    string `json:"baseline_at,omitempty"`
+	ArchivePath   string `json:"archive_path,omitempty"`
+	WouldDestroy  bool   `json:"would_destroy"`
+}
+
+// ArchiveResetResult reports the outcome of archive reset.
+type ArchiveResetResult struct {
+	ArchivePath string `json:"archive_path,omitempty"`
+	BackupPath  string `json:"backup_path,omitempty"`
+	Purged      bool   `json:"purged"`
+	NoOp        bool   `json:"noop"`
+}
+
+// ArchiveVacuumResult reports compaction sizes for archive vacuum.
+type ArchiveVacuumResult struct {
+	ArchivePath     string `json:"archive_path,omitempty"`
+	SizeBeforeBytes int64  `json:"size_before_bytes"`
+	SizeAfterBytes  int64  `json:"size_after_bytes"`
+	NoOp            bool   `json:"noop"`
+}
+
+// SnapshotPath returns the generated CLI's snapshot location.
+func SnapshotPath() (string, error) {
+	dir, err := cacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "snapshot.db"), nil
+}
+
+// ArchivePath returns the generated CLI's accumulating archive location.
+func ArchivePath() (string, error) {
+	dir, err := cacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "archive.db"), nil
+}
+
+func cacheDir() (string, error) {
+	base := os.Getenv("XDG_CACHE_HOME")
+	if strings.TrimSpace(base) == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = filepath.Join(home, ".cache")
+	}
+	dir := filepath.Join(base, "chrome-history")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// ActiveStorePath returns the archive when it exists and has archive mode
+// enabled; otherwise it falls back to the current snapshot.
+func ActiveStorePath() (string, bool, error) {
+	archive, err := ArchivePath()
+	if err != nil {
+		return "", false, err
+	}
+	snapshot, err := SnapshotPath()
+	if err != nil {
+		return "", false, err
+	}
+	if _, err := os.Stat(archive); err != nil {
+		if os.IsNotExist(err) {
+			return snapshot, false, nil
+		}
+		return "", false, err
+	}
+	db, err := openReadOnlyDB(archive)
+	if err != nil {
+		return "", false, err
+	}
+	defer db.Close()
+	enabled, err := readArchiveEnabled(db)
+	if err != nil {
+		return "", false, err
+	}
+	if enabled {
+		return archive, true, nil
+	}
+	return snapshot, false, nil
+}
+
+// OpenActiveStore opens the currently active read store.
+func OpenActiveStore() (*Store, bool, error) {
+	path, isArchive, err := ActiveStorePath()
+	if err != nil {
+		return nil, false, err
+	}
+	st, err := OpenExisting(path)
+	if err != nil {
+		return nil, false, err
+	}
+	return st, isArchive, nil
+}
+
+// InitArchiveSchema creates the accumulating archive schema without dropping
+// existing data.
+func InitArchiveSchema(db *sql.DB) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS meta_pp (
+			archive_enabled INTEGER NOT NULL DEFAULT 0,
+			baseline_at TEXT,
+			schema_version INTEGER
+		)`,
+		`CREATE TABLE IF NOT EXISTS history_archive (
+			url TEXT NOT NULL,
+			visit_time INTEGER NOT NULL,
+			title TEXT,
+			visit_count INTEGER,
+			UNIQUE(url, visit_time)
+		)`,
+		`DROP TRIGGER IF EXISTS history_archive_ai`,
+		`DROP TRIGGER IF EXISTS history_archive_ad`,
+		`DROP TRIGGER IF EXISTS history_archive_au`,
+		`DROP TABLE IF EXISTS history_archive_fts`,
+		`CREATE VIRTUAL TABLE IF NOT EXISTS history_fts USING fts5(
+			url,
+			title,
+			search_terms
+		)`,
+		`CREATE TRIGGER IF NOT EXISTS history_archive_ai AFTER INSERT ON history_archive BEGIN
+			INSERT INTO history_fts(rowid, url, title, search_terms)
+				SELECT new.rowid, new.url, COALESCE(new.title,''), ''
+				WHERE NOT EXISTS (SELECT 1 FROM history_fts WHERE url = new.url);
+		END`,
+		`CREATE TRIGGER IF NOT EXISTS history_archive_ad AFTER DELETE ON history_archive BEGIN
+			DELETE FROM history_fts WHERE url = old.url AND NOT EXISTS (SELECT 1 FROM history_archive WHERE url = old.url);
+		END`,
+		`CREATE TRIGGER IF NOT EXISTS history_archive_au AFTER UPDATE ON history_archive BEGIN
+			DELETE FROM history_fts WHERE url = old.url;
+			INSERT INTO history_fts(rowid, url, title, search_terms)
+				SELECT MIN(rowid), url, COALESCE((SELECT title FROM history_archive h2 WHERE h2.url = history_archive.url ORDER BY visit_time DESC, rowid DESC LIMIT 1), ''), ''
+				FROM history_archive WHERE url IN (old.url, new.url) GROUP BY url;
+		END`,
+		`CREATE VIEW IF NOT EXISTS urls AS
+			SELECT
+				MIN(rowid) AS id,
+				url,
+				COALESCE((SELECT title FROM history_archive h2 WHERE h2.url = h.url ORDER BY visit_time DESC, rowid DESC LIMIT 1), '') AS title,
+				COUNT(*) AS visit_count,
+				MAX(visit_time) AS last_visit_time,
+				0 AS typed_count,
+				0 AS hidden
+			FROM history_archive h
+			GROUP BY url`,
+		`CREATE VIEW IF NOT EXISTS visits AS
+			SELECT
+				h.rowid AS id,
+				(SELECT MIN(h2.rowid) FROM history_archive h2 WHERE h2.url = h.url) AS url,
+				h.visit_time AS visit_time,
+				0 AS from_visit,
+				0 AS transition,
+				0 AS visit_duration,
+				'' AS originator_cache_guid
+			FROM history_archive h`,
+		`CREATE VIEW IF NOT EXISTS visit_source AS
+			SELECT rowid AS id, 1 AS source, '' AS originator_cache_guid FROM history_archive`,
+		`CREATE TABLE IF NOT EXISTS keyword_search_terms (
+			url_id INTEGER,
+			term TEXT
+		)`,
+		`CREATE TABLE IF NOT EXISTS downloads (
+			target_path TEXT,
+			received_bytes INTEGER,
+			mime_type TEXT,
+			original_mime_type TEXT,
+			site_url TEXT,
+			referrer TEXT,
+			start_time INTEGER,
+			state INTEGER
+		)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	_, err := db.Exec(`INSERT INTO meta_pp(archive_enabled, schema_version)
+		SELECT 0, ? WHERE NOT EXISTS (SELECT 1 FROM meta_pp)`, archiveSchemaVersion)
+	if err != nil {
+		return err
+	}
+	return migrateArchiveFTS(db)
+}
+
+// IsArchiveEnabled reads the sticky archive mode flag.
+func IsArchiveEnabled(db *sql.DB) (bool, error) {
+	if err := InitArchiveSchema(db); err != nil {
+		return false, err
+	}
+	return readArchiveEnabled(db)
+}
+
+func readArchiveEnabled(db *sql.DB) (bool, error) {
+	if !tableExists(db, "meta_pp") {
+		return false, nil
+	}
+	var enabled int
+	err := db.QueryRow(`SELECT archive_enabled FROM meta_pp LIMIT 1`).Scan(&enabled)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return enabled != 0, err
+}
+
+func openReadOnlyDB(path string) (*sql.DB, error) {
+	u := url.URL{Scheme: "file", Path: path, RawQuery: "mode=ro"}
+	db, err := sql.Open("sqlite", u.String())
+	if err != nil {
+		return nil, err
+	}
+	if _, err := db.Exec(`PRAGMA query_only=ON`); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func migrateArchiveFTS(db *sql.DB) error {
+	var version sql.NullInt64
+	if err := db.QueryRow(`SELECT schema_version FROM meta_pp LIMIT 1`).Scan(&version); err != nil {
+		return err
+	}
+	if version.Valid && version.Int64 >= archiveSchemaVersion {
+		return nil
+	}
+	if _, err := db.Exec(`DELETE FROM history_fts`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`INSERT INTO history_fts(rowid, url, title, search_terms)
+		SELECT MIN(rowid), url, COALESCE((SELECT title FROM history_archive h2 WHERE h2.url = history_archive.url ORDER BY visit_time DESC, rowid DESC LIMIT 1), ''), ''
+		FROM history_archive GROUP BY url`); err != nil {
+		return err
+	}
+	_, err := db.Exec(`UPDATE meta_pp SET schema_version=?`, archiveSchemaVersion)
+	return err
+}
+
+// AccumulateFromSource appends current source visits to archivePath, deduping
+// by URL and Chrome-native visit_time.
+func AccumulateFromSource(archivePath, sourcePath string, now time.Time) (ArchiveCounts, error) {
+	var counts ArchiveCounts
+	if err := os.MkdirAll(filepath.Dir(archivePath), 0o755); err != nil {
+		return counts, err
+	}
+	db, err := sql.Open("sqlite", archivePath)
+	if err != nil {
+		return counts, err
+	}
+	defer db.Close()
+	if err := InitArchiveSchema(db); err != nil {
+		return counts, err
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return counts, err
+	}
+	defer tx.Rollback()
+	var enabled int
+	var baseline sql.NullString
+	if err := tx.QueryRow(`SELECT archive_enabled, baseline_at FROM meta_pp LIMIT 1`).Scan(&enabled, &baseline); err != nil {
+		return counts, err
+	}
+	appended, err := accumulateFromSourceTx(tx, sourcePath)
+	if err != nil {
+		return counts, err
+	}
+	counts.Appended = appended
+	if enabled == 0 {
+		ts := now.UTC().Format(time.RFC3339)
+		if _, err := tx.Exec(`UPDATE meta_pp SET archive_enabled=1, baseline_at=COALESCE(NULLIF(baseline_at,''), ?), schema_version=?`, ts, archiveSchemaVersion); err != nil {
+			return counts, err
+		}
+	}
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM history_archive`).Scan(&counts.Total); err != nil {
+		return counts, err
+	}
+	if err := tx.Commit(); err != nil {
+		return counts, err
+	}
+	_, err = db.Exec(`PRAGMA optimize`)
+	return counts, err
+}
+
+func accumulateFromSourceTx(tx *sql.Tx, sourcePath string) (int64, error) {
+	if _, err := os.Stat(sourcePath); err != nil {
+		return 0, err
+	}
+	if _, err := tx.Exec(`ATTACH DATABASE ? AS source_db`, sourcePath); err != nil {
+		return 0, err
+	}
+	defer tx.Exec(`DETACH DATABASE source_db`)
+	res, err := tx.Exec(`INSERT OR IGNORE INTO history_archive(url, visit_time, title, visit_count)
+		SELECT COALESCE(u.url,''), COALESCE(v.visit_time,0), COALESCE(u.title,''), COALESCE(u.visit_count,0)
+		FROM source_db.visits v JOIN source_db.urls u ON u.id = v.url
+		WHERE COALESCE(u.url,'') <> '' AND COALESCE(v.visit_time,0) > 0`)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// EnableArchiveFromSource baselines a disabled or absent archive from sourcePath.
+// Already-enabled archives are left unchanged so explicit enable is idempotent.
+func EnableArchiveFromSource(sourcePath string, now time.Time) (ArchiveCounts, bool, error) {
+	var counts ArchiveCounts
+	if _, err := os.Stat(sourcePath); err != nil {
+		return counts, false, err
+	}
+	status, err := ReadArchiveStatus()
+	if err != nil {
+		return counts, false, err
+	}
+	if status.Enabled {
+		counts.Total = status.ArchiveVisits
+		return counts, true, nil
+	}
+	archivePath, err := ArchivePath()
+	if err != nil {
+		return counts, false, err
+	}
+	counts, err = AccumulateFromSource(archivePath, sourcePath, now)
+	return counts, false, err
+}
+
+// DisableArchive turns archive mode off while preserving the archive file.
+func DisableArchive() (ArchiveStatus, error) {
+	path, err := ArchivePath()
+	if err != nil {
+		return ArchiveStatus{}, err
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return ArchiveStatus{Enabled: false}, nil
+		}
+		return ArchiveStatus{}, err
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return ArchiveStatus{}, err
+	}
+	defer db.Close()
+	if err := InitArchiveSchema(db); err != nil {
+		return ArchiveStatus{}, err
+	}
+	if _, err := db.Exec(`UPDATE meta_pp SET archive_enabled=0, schema_version=?`, archiveSchemaVersion); err != nil {
+		return ArchiveStatus{}, err
+	}
+	return ReadArchiveStatus()
+}
+
+// ClobberArchiveFromSource keeps archive mode enabled while replacing archive
+// contents with a fresh baseline from sourcePath in one transaction.
+func ClobberArchiveFromSource(sourcePath string, now time.Time) (ArchiveClobberResult, error) {
+	var out ArchiveClobberResult
+	if _, err := os.Stat(sourcePath); err != nil {
+		return out, err
+	}
+	archivePath, err := ArchivePath()
+	if err != nil {
+		return out, err
+	}
+	if err := os.MkdirAll(filepath.Dir(archivePath), 0o755); err != nil {
+		return out, err
+	}
+	db, err := sql.Open("sqlite", archivePath)
+	if err != nil {
+		return out, err
+	}
+	defer db.Close()
+	if err := InitArchiveSchema(db); err != nil {
+		return out, err
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return out, err
+	}
+	defer tx.Rollback()
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM history_archive`).Scan(&out.OldVisits); err != nil {
+		return out, err
+	}
+	if _, err := tx.Exec(`DELETE FROM history_archive`); err != nil {
+		return out, err
+	}
+	if _, err := accumulateFromSourceTx(tx, sourcePath); err != nil {
+		return out, err
+	}
+	out.BaselineAt = now.UTC().Format(time.RFC3339)
+	if _, err := tx.Exec(`UPDATE meta_pp SET archive_enabled=1, baseline_at=?, schema_version=?`, out.BaselineAt, archiveSchemaVersion); err != nil {
+		return out, err
+	}
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM history_archive`).Scan(&out.NewVisits); err != nil {
+		return out, err
+	}
+	if err := tx.Commit(); err != nil {
+		return out, err
+	}
+	_, err = db.Exec(`PRAGMA optimize`)
+	return out, err
+}
+
+// PlanArchiveReset reports what guarded archive reset would destroy.
+func PlanArchiveReset() (ArchiveResetPlan, error) {
+	status, err := ReadArchiveStatus()
+	if err != nil {
+		return ArchiveResetPlan{}, err
+	}
+	return ArchiveResetPlan{
+		ArchiveVisits: status.ArchiveVisits,
+		BaselineAt:    status.BaselineAt,
+		ArchivePath:   status.ArchivePath,
+		WouldDestroy:  status.ArchivePath != "",
+	}, nil
+}
+
+// ResetArchive disables archive mode and then moves archive.db aside by
+// default. purge=true deletes it outright.
+func ResetArchive(purge bool, now time.Time) (ArchiveResetResult, error) {
+	var out ArchiveResetResult
+	path, err := ArchivePath()
+	if err != nil {
+		return out, err
+	}
+	out.ArchivePath = path
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			out.NoOp = true
+			return out, nil
+		}
+		return out, err
+	}
+	if _, err := DisableArchive(); err != nil {
+		return out, err
+	}
+	if purge {
+		if err := os.Remove(path); err != nil {
+			return out, err
+		}
+		out.Purged = true
+		return out, nil
+	}
+	out.BackupPath, err = resetBackupPath(path, now)
+	if err != nil {
+		return out, err
+	}
+	if err := os.Rename(path, out.BackupPath); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+func resetBackupPath(path string, now time.Time) (string, error) {
+	stamp := now.UTC().Format("2006-01-02T15-04-05Z")
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s.reset-%s.bak", path, stamp)
+		if i > 1 {
+			candidate = fmt.Sprintf("%s.reset-%s-%d.bak", path, stamp, i)
+		}
+		if _, err := os.Stat(candidate); err != nil {
+			if os.IsNotExist(err) {
+				return candidate, nil
+			}
+			return "", err
+		}
+	}
+}
+
+// VacuumArchive compacts archive.db and reports file sizes before and after.
+func VacuumArchive() (ArchiveVacuumResult, error) {
+	var out ArchiveVacuumResult
+	path, err := ArchivePath()
+	if err != nil {
+		return out, err
+	}
+	out.ArchivePath = path
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			out.NoOp = true
+			return out, nil
+		}
+		return out, err
+	}
+	out.SizeBeforeBytes = info.Size()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return out, err
+	}
+	defer db.Close()
+	if err := InitArchiveSchema(db); err != nil {
+		return out, err
+	}
+	if _, err := db.Exec(`VACUUM`); err != nil {
+		return out, err
+	}
+	if _, err := db.Exec(`PRAGMA optimize`); err != nil {
+		return out, err
+	}
+	info, err = os.Stat(path)
+	if err != nil {
+		return out, err
+	}
+	out.SizeAfterBytes = info.Size()
+	return out, nil
+}
+
+// ReadArchiveStatus returns archive status without creating an archive file.
+func ReadArchiveStatus() (ArchiveStatus, error) {
+	path, err := ArchivePath()
+	if err != nil {
+		return ArchiveStatus{}, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ArchiveStatus{Enabled: false}, nil
+		}
+		return ArchiveStatus{}, err
+	}
+	db, err := openReadOnlyDB(path)
+	if err != nil {
+		return ArchiveStatus{}, err
+	}
+	defer db.Close()
+	if !tableExists(db, "meta_pp") {
+		return ArchiveStatus{Enabled: false, ArchivePath: path, ArchiveSizeBytes: info.Size()}, nil
+	}
+	var enabled int
+	var baseline sql.NullString
+	var visits int64
+	if err := db.QueryRow(`SELECT archive_enabled, baseline_at FROM meta_pp LIMIT 1`).Scan(&enabled, &baseline); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ArchiveStatus{Enabled: false, ArchivePath: path, ArchiveSizeBytes: info.Size()}, nil
+		}
+		return ArchiveStatus{}, err
+	}
+	if tableExists(db, "history_archive") {
+		if err := db.QueryRow(`SELECT COUNT(*) FROM history_archive`).Scan(&visits); err != nil {
+			return ArchiveStatus{}, err
+		}
+	}
+	status := ArchiveStatus{
+		Enabled:          enabled != 0,
+		ArchiveVisits:    visits,
+		ArchivePath:      path,
+		ArchiveSizeBytes: info.Size(),
+	}
+	if baseline.Valid {
+		status.BaselineAt = baseline.String
+	}
+	return status, nil
+}

--- a/library/productivity/chrome-history/internal/store/archive_test.go
+++ b/library/productivity/chrome-history/internal/store/archive_test.go
@@ -160,6 +160,151 @@ func TestArchiveFTSIncrementalAndPrunedRowStillFound(t *testing.T) {
 	}
 }
 
+func TestArchiveAUTriggerNoDuplicateFTSOnURLChange(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	defer db.Close()
+	if err := InitArchiveSchema(db); err != nil {
+		t.Fatalf("InitArchiveSchema: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO history_archive(url, visit_time, title, visit_count) VALUES
+		('https://example.test/a', 1, 'A', 1),
+		('https://example.test/b', 2, 'B', 1)`); err != nil {
+		t.Fatalf("insert archive rows: %v", err)
+	}
+	if _, err := db.Exec(`UPDATE history_archive SET url='https://example.test/b' WHERE url='https://example.test/a'`); err != nil {
+		t.Fatalf("update archive url: %v", err)
+	}
+	var ftsRows int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM history_fts WHERE url='https://example.test/b'`).Scan(&ftsRows); err != nil {
+		t.Fatalf("count FTS rows: %v", err)
+	}
+	if ftsRows != 1 {
+		t.Fatalf("FTS rows for updated URL = %d, want 1", ftsRows)
+	}
+}
+
+func TestArchiveFTSTitleRefreshedOnRevisit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	defer db.Close()
+	if err := InitArchiveSchema(db); err != nil {
+		t.Fatalf("InitArchiveSchema: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO history_archive(url, visit_time, title) VALUES
+		('https://x.test/page', 100, 'old boring title'),
+		('https://x.test/page', 200, 'fresh kayak rental')`); err != nil {
+		t.Fatalf("insert archive rows: %v", err)
+	}
+	var ftsRows int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM history_fts WHERE url='https://x.test/page'`).Scan(&ftsRows); err != nil {
+		t.Fatalf("count FTS rows: %v", err)
+	}
+	if ftsRows != 1 {
+		t.Fatalf("FTS rows for revisited URL = %d, want 1", ftsRows)
+	}
+	var title string
+	if err := db.QueryRow(`SELECT title FROM history_fts WHERE url='https://x.test/page'`).Scan(&title); err != nil {
+		t.Fatalf("read FTS title: %v", err)
+	}
+	if title != "fresh kayak rental" {
+		t.Fatalf("FTS title = %q, want newest title", title)
+	}
+	var matches int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM history_fts WHERE history_fts MATCH 'kayak'`).Scan(&matches); err != nil {
+		t.Fatalf("count kayak FTS matches: %v", err)
+	}
+	if matches != 1 {
+		t.Fatalf("kayak FTS matches = %d, want 1", matches)
+	}
+}
+
+func TestMetaPPSingletonEnforced(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	defer db.Close()
+	if err := InitArchiveSchema(db); err != nil {
+		t.Fatalf("InitArchiveSchema: %v", err)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin rollback-only duplicate probe: %v", err)
+	}
+	_, err = tx.Exec(`INSERT INTO meta_pp(id, archive_enabled, schema_version) VALUES (1, 1, 2)`)
+	if rbErr := tx.Rollback(); rbErr != nil {
+		t.Fatalf("rollback duplicate probe: %v", rbErr)
+	}
+	if err == nil {
+		t.Errorf("second meta_pp insert succeeded, want constraint error")
+	}
+	if _, err := db.Exec(`INSERT INTO meta_pp(archive_enabled, schema_version) VALUES (1, 2)`); err == nil {
+		t.Errorf("second meta_pp insert without id succeeded, want constraint error")
+	}
+	var rows int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM meta_pp`).Scan(&rows); err != nil {
+		t.Fatalf("count meta_pp rows: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("meta_pp rows = %d, want 1", rows)
+	}
+	var id int64
+	if err := db.QueryRow(`SELECT id FROM meta_pp`).Scan(&id); err != nil {
+		t.Fatalf("read meta_pp id: %v", err)
+	}
+	if id != 1 {
+		t.Fatalf("meta_pp id = %d, want 1", id)
+	}
+}
+
+func TestMigrateArchiveFTSRebuildsIndex(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	defer db.Close()
+	if err := InitArchiveSchema(db); err != nil {
+		t.Fatalf("InitArchiveSchema: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO history_archive(url, visit_time, title, visit_count) VALUES
+		('https://example.test/a', 1, 'A old', 1),
+		('https://example.test/a', 2, 'A new', 1),
+		('https://example.test/b', 3, 'B', 1)`); err != nil {
+		t.Fatalf("insert archive rows: %v", err)
+	}
+	if _, err := db.Exec(`UPDATE meta_pp SET schema_version=1`); err != nil {
+		t.Fatalf("lower schema version: %v", err)
+	}
+	if _, err := db.Exec(`DELETE FROM history_fts`); err != nil {
+		t.Fatalf("empty FTS: %v", err)
+	}
+	if err := migrateArchiveFTS(db); err != nil {
+		t.Fatalf("migrateArchiveFTS: %v", err)
+	}
+	var ftsRows, version int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM history_fts`).Scan(&ftsRows); err != nil {
+		t.Fatalf("count FTS rows: %v", err)
+	}
+	if ftsRows != 2 {
+		t.Fatalf("FTS rows = %d, want 2 distinct URLs", ftsRows)
+	}
+	if err := db.QueryRow(`SELECT schema_version FROM meta_pp LIMIT 1`).Scan(&version); err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	if version != archiveSchemaVersion {
+		t.Fatalf("schema_version = %d, want %d", version, archiveSchemaVersion)
+	}
+}
+
 func TestArchiveCompatibilityViewsSupportCoreReads(t *testing.T) {
 	cache := t.TempDir()
 	t.Setenv("XDG_CACHE_HOME", cache)

--- a/library/productivity/chrome-history/internal/store/archive_test.go
+++ b/library/productivity/chrome-history/internal/store/archive_test.go
@@ -1,0 +1,641 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source"
+	chromeSource "github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/internal/source/chrome"
+	_ "modernc.org/sqlite"
+)
+
+func TestAccumulateDedupIdempotency(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	source := newSourceFixture(t, 1, 10)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	first, err := AccumulateFromSource(archive, source, time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("first accumulate: %v", err)
+	}
+	second, err := AccumulateFromSource(archive, source, time.Date(2026, 6, 11, 12, 1, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("second accumulate: %v", err)
+	}
+	if first.Appended != 10 || first.Total != 10 {
+		t.Fatalf("first counts = %+v, want appended=10 total=10", first)
+	}
+	if second.Appended != 0 || second.Total != 10 {
+		t.Fatalf("second counts = %+v, want appended=0 total=10", second)
+	}
+}
+
+func TestAccumulateDurabilityAcrossSourcePrune(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	source := newSourceFixture(t, 1, 10)
+	if _, err := AccumulateFromSource(archive, source, time.Now()); err != nil {
+		t.Fatalf("first accumulate: %v", err)
+	}
+	prunedSource := newSourceFixture(t, 8, 15)
+	counts, err := AccumulateFromSource(archive, prunedSource, time.Now())
+	if err != nil {
+		t.Fatalf("second accumulate: %v", err)
+	}
+	if counts.Appended != 5 || counts.Total != 15 {
+		t.Fatalf("counts = %+v, want appended=5 total=15", counts)
+	}
+	if got := countRows(t, archive, "history_archive"); got != 15 {
+		t.Fatalf("archive rows = %d, want 15", got)
+	}
+	snapshot := filepath.Join(t.TempDir(), "snapshot.db")
+	copyFile(t, prunedSource, snapshot)
+	if _, err := BuildSnapshotIndex(snapshot, "Default"); err != nil {
+		t.Fatalf("BuildSnapshotIndex: %v", err)
+	}
+	if got := countRows(t, snapshot, "visits"); got != 8 {
+		t.Fatalf("snapshot visits = %d, want 8", got)
+	}
+}
+
+func TestActiveStorePathMatrix(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	snapshot, err := SnapshotPath()
+	if err != nil {
+		t.Fatalf("SnapshotPath: %v", err)
+	}
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	path, isArchive, err := ActiveStorePath()
+	if err != nil {
+		t.Fatalf("ActiveStorePath absent: %v", err)
+	}
+	if path != snapshot || isArchive {
+		t.Fatalf("absent archive path=%q isArchive=%v, want snapshot %q false", path, isArchive, snapshot)
+	}
+	source := newSourceFixture(t, 1, 1)
+	if _, err := AccumulateFromSource(archive, source, time.Now()); err != nil {
+		t.Fatalf("accumulate: %v", err)
+	}
+	path, isArchive, err = ActiveStorePath()
+	if err != nil {
+		t.Fatalf("ActiveStorePath enabled: %v", err)
+	}
+	if path != archive || !isArchive {
+		t.Fatalf("enabled archive path=%q isArchive=%v, want archive %q true", path, isArchive, archive)
+	}
+	if err := os.Remove(archive); err != nil {
+		t.Fatalf("remove archive: %v", err)
+	}
+	path, isArchive, err = ActiveStorePath()
+	if err != nil {
+		t.Fatalf("ActiveStorePath removed: %v", err)
+	}
+	if path != snapshot || isArchive {
+		t.Fatalf("removed archive path=%q isArchive=%v, want snapshot %q false", path, isArchive, snapshot)
+	}
+}
+
+func TestArchiveFTSIncrementalAndPrunedRowStillFound(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	source := newSourceFixtureWithTitle(t, []fixtureVisit{
+		{N: 1, URL: "https://example.test/old", Title: "durable needle"},
+		{N: 2, URL: "https://example.test/new", Title: "current row"},
+		{N: 3, URL: "https://example.test/repeated", Title: "repeat needle"},
+		{N: 4, URL: "https://example.test/repeated", Title: "repeat needle again"},
+	})
+	if _, err := AccumulateFromSource(archive, source, time.Now()); err != nil {
+		t.Fatalf("first accumulate: %v", err)
+	}
+	st, err := Open(archive)
+	if err != nil {
+		t.Fatalf("Open archive: %v", err)
+	}
+	src := chromeSource.New()
+	matches, err := src.FullTextSearch(st.DB(), "repeat", archiveReadFilter())
+	if err != nil {
+		t.Fatalf("FullTextSearch repeat: %v", err)
+	}
+	if len(matches) != 1 || matches[0].URL != "https://example.test/repeated" {
+		t.Fatalf("repeat matches = %+v, want one repeated URL", matches)
+	}
+	st.Close()
+	pruned := newSourceFixtureWithTitle(t, []fixtureVisit{
+		{N: 2, URL: "https://example.test/new", Title: "current row"},
+		{N: 3, URL: "https://example.test/repeated", Title: "repeat needle"},
+	})
+	if _, err := AccumulateFromSource(archive, pruned, time.Now()); err != nil {
+		t.Fatalf("second accumulate: %v", err)
+	}
+	st, err = Open(archive)
+	if err != nil {
+		t.Fatalf("reopen archive: %v", err)
+	}
+	defer st.Close()
+	matches, err = src.FullTextSearch(st.DB(), "durable", archiveReadFilter())
+	if err != nil {
+		t.Fatalf("FullTextSearch durable: %v", err)
+	}
+	if len(matches) != 1 || matches[0].URL != "https://example.test/old" {
+		t.Fatalf("durable matches = %+v, want pruned archive row", matches)
+	}
+}
+
+func TestArchiveCompatibilityViewsSupportCoreReads(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	source := newSourceFixtureWithTitle(t, []fixtureVisit{
+		{N: 1, URL: "https://example.test/list-search-sql", Title: "compatibility needle"},
+	})
+	if _, err := AccumulateFromSource(archive, source, time.Now()); err != nil {
+		t.Fatalf("accumulate: %v", err)
+	}
+	st, err := Open(archive)
+	if err != nil {
+		t.Fatalf("Open archive: %v", err)
+	}
+	defer st.Close()
+	src := chromeSource.New()
+	visits, err := src.RecentVisits(st.DB(), archiveReadFilter())
+	if err != nil {
+		t.Fatalf("RecentVisits: %v", err)
+	}
+	if len(visits) != 1 || visits[0].URL != "https://example.test/list-search-sql" {
+		t.Fatalf("RecentVisits = %+v, want archive row", visits)
+	}
+	matches, err := src.FullTextSearch(st.DB(), "needle", archiveReadFilter())
+	if err != nil {
+		t.Fatalf("FullTextSearch: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Title != "compatibility needle" {
+		t.Fatalf("FullTextSearch = %+v, want archive row", matches)
+	}
+	rows, err := st.RunSelect(`SELECT url, title FROM urls WHERE url LIKE '%list-search-sql%'`, 10)
+	if err != nil {
+		t.Fatalf("RunSelect: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["url"] != "https://example.test/list-search-sql" {
+		t.Fatalf("RunSelect = %+v, want archive url view row", rows)
+	}
+}
+
+func TestStickyPlainAccumulateGrowsAfterEnable(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	firstSource := newSourceFixture(t, 1, 2)
+	if _, err := AccumulateFromSource(archive, firstSource, time.Now()); err != nil {
+		t.Fatalf("enable accumulate: %v", err)
+	}
+	status, err := ReadArchiveStatus()
+	if err != nil {
+		t.Fatalf("ReadArchiveStatus: %v", err)
+	}
+	if !status.Enabled {
+		t.Fatalf("archive status enabled = false, want true")
+	}
+	nextSource := newSourceFixture(t, 1, 3)
+	if _, err := AccumulateFromSource(archive, nextSource, time.Now()); err != nil {
+		t.Fatalf("sticky accumulate: %v", err)
+	}
+	if got := countRows(t, archive, "history_archive"); got != 3 {
+		t.Fatalf("archive rows after sticky accumulate = %d, want 3", got)
+	}
+}
+
+func TestReadArchiveStatusAbsent(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	status, err := ReadArchiveStatus()
+	if err != nil {
+		t.Fatalf("ReadArchiveStatus: %v", err)
+	}
+	if status.Enabled {
+		t.Fatalf("status enabled = true, want false")
+	}
+}
+
+func TestEnableArchiveFromSourceIdempotent(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	source := newSourceFixture(t, 1, 3)
+	first, alreadyEnabled, err := EnableArchiveFromSource(source, time.Date(2026, 6, 12, 1, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("first enable: %v", err)
+	}
+	if alreadyEnabled || first.Appended != 3 || first.Total != 3 {
+		t.Fatalf("first enable counts=%+v already=%v, want appended=3 total=3 already=false", first, alreadyEnabled)
+	}
+	second, alreadyEnabled, err := EnableArchiveFromSource(source, time.Date(2026, 6, 12, 1, 1, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("second enable: %v", err)
+	}
+	if !alreadyEnabled || second.Appended != 0 || second.Total != 3 {
+		t.Fatalf("second enable counts=%+v already=%v, want appended=0 total=3 already=true", second, alreadyEnabled)
+	}
+	status, err := ReadArchiveStatus()
+	if err != nil {
+		t.Fatalf("ReadArchiveStatus: %v", err)
+	}
+	if !status.Enabled || status.ArchiveVisits != 3 {
+		t.Fatalf("status=%+v, want enabled with 3 visits", status)
+	}
+}
+
+func TestDisableArchiveRoutesToSnapshotAndReenableRoutesToArchive(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	snapshot, err := SnapshotPath()
+	if err != nil {
+		t.Fatalf("SnapshotPath: %v", err)
+	}
+	source := newSourceFixture(t, 1, 2)
+	copyFile(t, source, snapshot)
+	if _, _, err := EnableArchiveFromSource(snapshot, time.Now()); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	if _, err := DisableArchive(); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	path, isArchive, err := ActiveStorePath()
+	if err != nil {
+		t.Fatalf("ActiveStorePath disabled: %v", err)
+	}
+	if path != snapshot || isArchive {
+		t.Fatalf("disabled path=%q isArchive=%v, want snapshot %q false", path, isArchive, snapshot)
+	}
+	if _, _, err := EnableArchiveFromSource(snapshot, time.Now()); err != nil {
+		t.Fatalf("re-enable: %v", err)
+	}
+	path, isArchive, err = ActiveStorePath()
+	if err != nil {
+		t.Fatalf("ActiveStorePath re-enabled: %v", err)
+	}
+	if path != archive || !isArchive {
+		t.Fatalf("re-enabled path=%q isArchive=%v, want archive %q true", path, isArchive, archive)
+	}
+}
+
+func TestClobberArchiveDropsOldRowsAndRefreshesFTS(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	oldSource := newSourceFixtureWithTitle(t, []fixtureVisit{
+		{N: 1, URL: "https://example.test/old", Title: "oldonly needle"},
+		{N: 2, URL: "https://example.test/current", Title: "current needle"},
+	})
+	if _, err := AccumulateFromSource(archive, oldSource, time.Now()); err != nil {
+		t.Fatalf("accumulate old: %v", err)
+	}
+	currentSource := newSourceFixtureWithTitle(t, []fixtureVisit{
+		{N: 2, URL: "https://example.test/current", Title: "current needle"},
+	})
+	result, err := ClobberArchiveFromSource(currentSource, time.Date(2026, 6, 12, 2, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("clobber: %v", err)
+	}
+	if result.OldVisits != 2 || result.NewVisits != 1 {
+		t.Fatalf("clobber result=%+v, want old=2 new=1", result)
+	}
+	status, err := ReadArchiveStatus()
+	if err != nil {
+		t.Fatalf("ReadArchiveStatus: %v", err)
+	}
+	if !status.Enabled || status.ArchiveVisits != 1 {
+		t.Fatalf("status=%+v, want enabled with 1 visit", status)
+	}
+	st, err := Open(archive)
+	if err != nil {
+		t.Fatalf("Open archive: %v", err)
+	}
+	defer st.Close()
+	var oldFTSRows int64
+	if err := st.DB().QueryRow(`SELECT COUNT(*) FROM history_fts WHERE url LIKE '%/old'`).Scan(&oldFTSRows); err != nil {
+		t.Fatalf("count old FTS rows: %v", err)
+	}
+	if oldFTSRows != 0 {
+		t.Fatalf("old FTS rows = %d, want 0 after clobber", oldFTSRows)
+	}
+	var ftsRows, distinctURLs int64
+	if err := st.DB().QueryRow(`SELECT COUNT(*) FROM history_fts`).Scan(&ftsRows); err != nil {
+		t.Fatalf("count FTS rows: %v", err)
+	}
+	if err := st.DB().QueryRow(`SELECT COUNT(DISTINCT url) FROM history_archive`).Scan(&distinctURLs); err != nil {
+		t.Fatalf("count distinct archive URLs: %v", err)
+	}
+	if ftsRows != distinctURLs {
+		t.Fatalf("FTS rows = %d, want distinct archive URLs %d", ftsRows, distinctURLs)
+	}
+	src := chromeSource.New()
+	oldMatches, err := src.FullTextSearch(st.DB(), "oldonly", archiveReadFilter())
+	if err != nil {
+		t.Fatalf("FullTextSearch oldonly: %v", err)
+	}
+	if len(oldMatches) != 0 {
+		t.Fatalf("oldonly matches=%+v, want none after clobber", oldMatches)
+	}
+	currentMatches, err := src.FullTextSearch(st.DB(), "current", archiveReadFilter())
+	if err != nil {
+		t.Fatalf("FullTextSearch current: %v", err)
+	}
+	if len(currentMatches) != 1 || currentMatches[0].URL != "https://example.test/current" {
+		t.Fatalf("current matches=%+v, want current row", currentMatches)
+	}
+}
+
+func TestResetArchiveRequiresForcePlanDoesNotMutate(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	source := newSourceFixture(t, 1, 2)
+	if _, err := AccumulateFromSource(archive, source, time.Now()); err != nil {
+		t.Fatalf("accumulate: %v", err)
+	}
+	plan, err := PlanArchiveReset()
+	if err != nil {
+		t.Fatalf("PlanArchiveReset: %v", err)
+	}
+	if !plan.WouldDestroy || plan.ArchiveVisits != 2 || plan.ArchivePath != archive {
+		t.Fatalf("plan=%+v, want would_destroy with 2 visits at archive path", plan)
+	}
+	if _, err := os.Stat(archive); err != nil {
+		t.Fatalf("archive stat after plan: %v", err)
+	}
+	if got := countRows(t, archive, "history_archive"); got != 2 {
+		t.Fatalf("archive rows after plan = %d, want 2", got)
+	}
+}
+
+func TestResetArchiveForceMovesBackupAndRoutesSnapshot(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	snapshot, err := SnapshotPath()
+	if err != nil {
+		t.Fatalf("SnapshotPath: %v", err)
+	}
+	source := newSourceFixture(t, 1, 1)
+	copyFile(t, source, snapshot)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	if _, err := AccumulateFromSource(archive, source, time.Now()); err != nil {
+		t.Fatalf("accumulate: %v", err)
+	}
+	result, err := ResetArchive(false, time.Date(2026, 6, 12, 3, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ResetArchive: %v", err)
+	}
+	if result.BackupPath == "" || result.Purged || result.NoOp {
+		t.Fatalf("reset result=%+v, want backup move", result)
+	}
+	if _, err := os.Stat(archive); !os.IsNotExist(err) {
+		t.Fatalf("archive stat err=%v, want not exist", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(archive), "archive.db.reset-*.bak"))
+	if err != nil {
+		t.Fatalf("glob backups: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("backup matches=%v, want one backup", matches)
+	}
+	path, isArchive, err := ActiveStorePath()
+	if err != nil {
+		t.Fatalf("ActiveStorePath: %v", err)
+	}
+	if path != snapshot || isArchive {
+		t.Fatalf("active path=%q isArchive=%v, want snapshot %q false", path, isArchive, snapshot)
+	}
+}
+
+func TestResetArchiveForceBackupNameCollisionKeepsBothBackups(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	sameSecond := time.Date(2026, 6, 12, 3, 0, 0, 0, time.UTC)
+	firstSource := newSourceFixture(t, 1, 1)
+	if _, err := AccumulateFromSource(archive, firstSource, time.Now()); err != nil {
+		t.Fatalf("first accumulate: %v", err)
+	}
+	first, err := ResetArchive(false, sameSecond)
+	if err != nil {
+		t.Fatalf("first ResetArchive: %v", err)
+	}
+	secondSource := newSourceFixture(t, 1, 2)
+	if _, err := AccumulateFromSource(archive, secondSource, time.Now()); err != nil {
+		t.Fatalf("second accumulate: %v", err)
+	}
+	second, err := ResetArchive(false, sameSecond)
+	if err != nil {
+		t.Fatalf("second ResetArchive: %v", err)
+	}
+	if first.BackupPath == "" || second.BackupPath == "" || first.BackupPath == second.BackupPath {
+		t.Fatalf("backup paths first=%q second=%q, want distinct non-empty paths", first.BackupPath, second.BackupPath)
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(archive), "archive.db.reset-*.bak"))
+	if err != nil {
+		t.Fatalf("glob backups: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("backup matches=%v, want two surviving backups", matches)
+	}
+	if got := countRows(t, first.BackupPath, "history_archive"); got != 1 {
+		t.Fatalf("first backup rows = %d, want 1", got)
+	}
+	if got := countRows(t, second.BackupPath, "history_archive"); got != 2 {
+		t.Fatalf("second backup rows = %d, want 2", got)
+	}
+}
+
+func TestResetArchiveForcePurgeDeletesWithoutBackup(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	source := newSourceFixture(t, 1, 1)
+	if _, err := AccumulateFromSource(archive, source, time.Now()); err != nil {
+		t.Fatalf("accumulate: %v", err)
+	}
+	result, err := ResetArchive(true, time.Date(2026, 6, 12, 3, 5, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ResetArchive purge: %v", err)
+	}
+	if !result.Purged || result.BackupPath != "" || result.NoOp {
+		t.Fatalf("purge result=%+v, want purged without backup", result)
+	}
+	if _, err := os.Stat(archive); !os.IsNotExist(err) {
+		t.Fatalf("archive stat err=%v, want not exist", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(archive), "archive.db.reset-*.bak"))
+	if err != nil {
+		t.Fatalf("glob backups: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("backup matches=%v, want none after purge", matches)
+	}
+}
+
+func TestResetArchiveForceAbsentIsNoop(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	result, err := ResetArchive(false, time.Now())
+	if err != nil {
+		t.Fatalf("ResetArchive absent: %v", err)
+	}
+	if !result.NoOp {
+		t.Fatalf("reset absent result=%+v, want noop", result)
+	}
+}
+
+func TestVacuumArchivePopulated(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+	archive, err := ArchivePath()
+	if err != nil {
+		t.Fatalf("ArchivePath: %v", err)
+	}
+	source := newSourceFixture(t, 1, 10)
+	if _, err := AccumulateFromSource(archive, source, time.Now()); err != nil {
+		t.Fatalf("accumulate: %v", err)
+	}
+	result, err := VacuumArchive()
+	if err != nil {
+		t.Fatalf("VacuumArchive: %v", err)
+	}
+	if result.NoOp || result.SizeBeforeBytes == 0 || result.SizeAfterBytes == 0 {
+		t.Fatalf("vacuum result=%+v, want non-noop sizes", result)
+	}
+	if got := countRows(t, archive, "history_archive"); got != 10 {
+		t.Fatalf("archive rows after vacuum = %d, want 10", got)
+	}
+}
+
+func archiveReadFilter() source.VisitFilter {
+	return source.VisitFilter{Limit: 10, MinVisits: 0, Device: "all"}
+}
+
+type fixtureVisit struct {
+	N     int
+	URL   string
+	Title string
+}
+
+func newSourceFixture(t *testing.T, start, end int) string {
+	t.Helper()
+	visits := make([]fixtureVisit, 0, end-start+1)
+	for i := start; i <= end; i++ {
+		visits = append(visits, fixtureVisit{
+			N:     i,
+			URL:   fmt.Sprintf("https://example.test/v%d", i),
+			Title: fmt.Sprintf("Visit %d", i),
+		})
+	}
+	return newSourceFixtureWithTitle(t, visits)
+}
+
+func newSourceFixtureWithTitle(t *testing.T, visits []fixtureVisit) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "source.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer db.Close()
+	_, err = db.Exec(`CREATE TABLE urls (
+		id INTEGER PRIMARY KEY,
+		url TEXT,
+		title TEXT,
+		visit_count INTEGER,
+		last_visit_time INTEGER,
+		typed_count INTEGER DEFAULT 0,
+		hidden INTEGER DEFAULT 0
+	);
+	CREATE TABLE visits (
+		id INTEGER PRIMARY KEY,
+		url INTEGER,
+		visit_time INTEGER,
+		from_visit INTEGER DEFAULT 0,
+		transition INTEGER DEFAULT 0,
+		visit_duration INTEGER DEFAULT 0
+	);
+	CREATE TABLE meta(key TEXT, value TEXT);`)
+	if err != nil {
+		t.Fatalf("create fixture schema: %v", err)
+	}
+	for _, v := range visits {
+		visitTime := int64(13200000000000000 + v.N)
+		if _, err := db.Exec(`INSERT INTO urls(id, url, title, visit_count, last_visit_time) VALUES(?,?,?,?,?)`, v.N, v.URL, v.Title, 1, visitTime); err != nil {
+			t.Fatalf("insert url: %v", err)
+		}
+		if _, err := db.Exec(`INSERT INTO visits(id, url, visit_time) VALUES(?,?,?)`, v.N, v.N, visitTime); err != nil {
+			t.Fatalf("insert visit: %v", err)
+		}
+	}
+	return path
+}
+
+func countRows(t *testing.T, path, table string) int64 {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer db.Close()
+	var n int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}


### PR DESCRIPTION
Fixes DEV-81

### Summary

Adds an **opt-in, sticky accumulating archive** so browsing history survives Chrome's prune/clear — with **no breaking change** to `sync` and **without reopening** the blocked `sql` ATTACH path. Off by default; a normal "what did I browse" question still needs only the snapshot.

### Model — active-store + sticky archive mode

- Reads open **one** store: `archive.db` when archive mode is enabled and the file is present (file presence is the authoritative migration-fallback signal), else `snapshot.db`. Because `archive ⊇ snapshot` there is **no UNION / reconciliation / ATTACH**.
- **Scoped routing:** archive-faithful commands (`list`/`domains`/`report`/`heatmap`/`timeline`/`search`/`sql`) read the active store; rich Chrome-only commands (`dwell`/`graph`/`journeys`/`rabbitholes`/`searches`/`downloads`/`devices`/`topic`/`profile`/`visited`) keep reading the snapshot, since the archive can't carry transition / from_visit / visit_duration / downloads / keyword data — this avoids silent archive degradation.
- Dedup key `UNIQUE(url, visit_time)`; incremental one-row-per-url FTS via triggers (not a DROP+rebuild on the unbounded archive); `archive.db` exposes `urls`/`visits` compat VIEWS so the identical CLI code reads both stores.

### Lifecycle

`sync --accumulate` / `archive enable` set the sticky flag; `archive disable` / `status` / `clobber` / `reset --force [--purge]` / `vacuum`. `reset` refuses without `--force` (prints the would-destroy plan), moves to a collision-safe `.bak` on `--force`, deletes on `--purge`.

### MCP

Adds `archive_status` (read), `archive_enable` / `archive_disable` (writes), and a `sync.accumulate` boolean. Destructive `clobber`/`reset`/`vacuum` kept CLI-only + human-gated. **MCP tool count 19 → 22.**

### Changes (findings)

| Area | Type | What |
|------|------|------|
| archive store + routing | feature | active-store + sticky mode, scoped read routing, incremental FTS, compat views |
| lifecycle | feature | `archive enable/disable/status/clobber/reset/vacuum`, `sync --accumulate` |
| MCP surface | feature | `archive_status`/`archive_enable`/`archive_disable` + `sync.accumulate` |
| docs | feature | README + SKILL archive docs; reworked the sync-first steering |
| toolchain | fix | Go 1.26.3 → 1.26.4 (clears GO-2026-5039 + GO-2026-5037) |

`git diff --stat upstream/main..HEAD`: **32 files, +2129 / -199.**

### Verification

- `go build ./...` + `go vet ./...` clean; `go test ./...` green across all packages.
- `cli-printing-press publish validate` — **exit 0, all 11 checks PASS** (manifest, transcendence, phase5, go mod tidy, govulncheck, go vet, go build, --help, --version, verify-skill, manuscripts).
- **Tiered peer-gate (Tier-1 code + test always):** the gate caught a real Blocker per slice — over-routing degradation (fixed by scoped routing + a mutation-verified boundary test) and a `.bak` name collision (fixed + mutation-verified).
- **AQL pre-amend gate:** correctness 5/5 on golden stores; a real-agent run caught + fixed two genuine agent-facing gaps **introduced/exposed by this amend** — the sync reflex (wasted, now-mutating sync) and the archive being MCP-incomplete. Both re-verified.
- PII scrub: clean (no secrets, no real browsing-history PII in source; test fixtures use `example.test`).

### Notes for the reviewer

- The chrome/safari history CLIs are hand-duplicated separate modules; this subsystem is duplicated rather than abstracted. The real fix is upstream in the generator (a native SQLite-archive datasource) — a machine-retro candidate, not a printed-CLI change.
- A live dogfood against the user's real Chrome store is left **opt-in** (enabling archive mode mutates real ~37MB history); golden-store correctness + unit tests stand in.
