### PR TITLE
fix(suno): wire --exclude through to negative_tags on generate create

### DIFF
--- a/library/media-and-entertainment/suno/.printing-press-patches/generate-exclude-negative-tags.json
+++ b/library/media-and-entertainment/suno/.printing-press-patches/generate-exclude-negative-tags.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 2,
+  "id": "generate-exclude-negative-tags",
+  "applied_at": "2026-06-12",
+  "base_run_id": "20260528-222057",
+  "base_printing_press_version": "4.14.0",
+  "summary": "Wire --exclude through to negative_tags on 'generate create' (was accepted but folded out).",
+  "reason": "The --exclude flag on 'generate create' was registered and documented but discarded: suno_generate.go did `_ = exclude` and buildGenerateBody hardcoded NegativeTags to \"\" under a wrong \"upstream contract\" assumption. Suno's UI Exclude-Styles feature populates negative_tags, so the flag value is now plumbed through generateInput.negativeTags into the request body. Empty stays \"\", so the default body is byte-identical to the known-good flow. Verified live: generated clips round-trip negative_tags=\"country, banjo\" intact (request body -> Suno server -> clip metadata), no HTTP 500.",
+  "files": [
+    "internal/cli/suno_generate.go",
+    "internal/cli/suno_generate_types.go",
+    "internal/cli/suno_generate_types_test.go"
+  ],
+  "validated_outcome": "publish validate passed; go test ./internal/cli/ -run TestBuildGenerateBody passes; live smoke test confirmed negative_tags round-trip.",
+  "findings_addressed": [
+    "generate-exclude-negative-tags"
+  ]
+}

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate.go
@@ -99,7 +99,6 @@ description-driven (non-custom) generation, use the 'generate describe' command 
 			if v := vocalTag(vocal); v != "" {
 				finalTags = appendTag(finalTags, v)
 			}
-			_ = exclude // negative_tags is always "" per upstream contract; --exclude is accepted but folded out.
 
 			variationVal, verr := variationPtr(variation)
 			if verr != nil {
@@ -111,6 +110,7 @@ description-driven (non-custom) generation, use the 'generate describe' command 
 				mv:             mv,
 				title:          title,
 				tags:           finalTags,
+				negativeTags:   strings.TrimSpace(exclude),
 				prompt:         resolvedLyrics,
 				instrumental:   instrumental,
 				personaID:      persona,
@@ -125,7 +125,7 @@ description-driven (non-custom) generation, use the 'generate describe' command 
 
 	cmd.Flags().StringVar(&title, "title", "", "Song title")
 	cmd.Flags().StringVar(&tags, "tags", "", "Style tags (comma-separated, e.g. \"synthwave, melodic\")")
-	cmd.Flags().StringVar(&exclude, "exclude", "", "Styles to exclude (accepted for compatibility; negative_tags is sent empty)")
+	cmd.Flags().StringVar(&exclude, "exclude", "", "Styles to exclude from the generation (comma-separated; sent as negative_tags)")
 	cmd.Flags().StringVar(&lyrics, "lyrics", "", "Lyrics for the song")
 	cmd.Flags().StringVar(&lyricsFile, "lyrics-file", "", "Read lyrics from this file")
 	cmd.Flags().StringVar(&model, "model", defaultGenerateModel, "Model: v5.5, v5, v4.5+, v4.5, v4, v3.5, v3, v2")

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_types.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_types.go
@@ -130,8 +130,8 @@ type generateInput struct {
 	mv           string // wire model key
 	title        string
 	tags         string
-	prompt       string // lyrics for custom, description for inspiration
 	negativeTags string // styles to exclude; empty -> sent as ""
+	prompt       string // lyrics for custom, description for inspiration
 	instrumental bool
 	personaID    string
 	token        string // hCaptcha token; empty -> nil

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_types.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_types.go
@@ -131,6 +131,7 @@ type generateInput struct {
 	title        string
 	tags         string
 	prompt       string // lyrics for custom, description for inspiration
+	negativeTags string // styles to exclude; empty -> sent as ""
 	instrumental bool
 	personaID    string
 	token        string // hCaptcha token; empty -> nil
@@ -195,7 +196,7 @@ func buildGenerateBody(in generateInput) sunoGenerateBody {
 		GenerationType:        "TEXT",
 		Title:                 alwaysStrPtr(in.title),
 		Tags:                  alwaysStrPtr(in.tags),
-		NegativeTags:          "",
+		NegativeTags:          in.negativeTags,
 		Mv:                    in.mv,
 		Prompt:                in.prompt,
 		MakeInstrumental:      in.instrumental,

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_types_test.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_types_test.go
@@ -47,6 +47,19 @@ func TestBuildGenerateBody_Custom(t *testing.T) {
 	}
 }
 
+func TestBuildGenerateBody_NegativeTags(t *testing.T) {
+	body := buildGenerateBody(generateInput{
+		createMode:   "custom",
+		mv:           "chirp-fenix",
+		tags:         "synthwave",
+		negativeTags: "country, banjo",
+		prompt:       "la la la",
+	})
+	if body.NegativeTags != "country, banjo" {
+		t.Errorf("negative_tags = %q, want %q", body.NegativeTags, "country, banjo")
+	}
+}
+
 func TestBuildGenerateBody_WebSchemaPlaceholders(t *testing.T) {
 	body := buildGenerateBody(generateInput{
 		createMode: "custom",


### PR DESCRIPTION
## Summary

The `--exclude` flag on `suno-pp-cli generate create` was accepted and documented but silently folded out — generations never excluded the requested styles. This wires the flag through to `negative_tags` so style exclusion actually works.

## Findings

| ID | Category | Type | Rationale |
|----|----------|------|-----------|
| generate-exclude-negative-tags | silent-noop-flag | bug | `--exclude` was registered + documented but discarded (`_ = exclude`) and `buildGenerateBody` hardcoded `negative_tags: ""` under a wrong "upstream contract" assumption. Suno's UI Exclude-Styles feature populates `negative_tags`. |

## Changes

```
 .../generate-exclude-negative-tags.json                | 18 ++++++++++++++++++
 .../suno/internal/cli/suno_generate.go                 |  4 ++--
 .../suno/internal/cli/suno_generate_types.go           |  3 ++-
 .../suno/internal/cli/suno_generate_types_test.go      | 13 +++++++++++++
 4 files changed, 35 insertions(+), 3 deletions(-)
```

- `internal/cli/suno_generate.go` — drop `_ = exclude`, pass `negativeTags: strings.TrimSpace(exclude)` into `generateInput`, fix the flag help text.
- `internal/cli/suno_generate_types.go` — add `negativeTags` field to `generateInput`; `buildGenerateBody` now sets `NegativeTags: in.negativeTags` (empty stays `""`, so the default body is byte-identical to the known-good flow).
- `internal/cli/suno_generate_types_test.go` — add `TestBuildGenerateBody_NegativeTags` regression test.

## Verification

- `cli-printing-press publish validate`: **passed** (manifest, transcendence, phase5, go mod tidy, govulncheck, go vet, go build, --help, --version, verify-skill, manuscripts all green).
- `go test ./internal/cli/ -run TestBuildGenerateBody`: **pass**.
- Live smoke test (dogfood): generated clips round-trip `negative_tags: "country, banjo"` intact from `--exclude` → request body → Suno server → clip metadata; no HTTP 500.

## Evidence

- Patch entry: [`.printing-press-patches/generate-exclude-negative-tags.json`](https://github.com/mvanhorn/printing-press-library/blob/61426a0ff9359794535851c6e3255dbc19d8769a/library/media-and-entertainment/suno/.printing-press-patches/generate-exclude-negative-tags.json)
