### PR TITLE
feat(google-analytics): add google-analytics

### DIFF
--- a/library/marketing/google-analytics/.golangci.yml
+++ b/library/marketing/google-analytics/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m

--- a/library/marketing/google-analytics/.goreleaser.yaml
+++ b/library/marketing/google-analytics/.goreleaser.yaml
@@ -1,0 +1,36 @@
+version: 2
+project_name: google-analytics-pp-cli
+changelog:
+  disable: true
+builds:
+  - id: google-analytics-pp-cli
+    main: ./cmd/google-analytics-pp-cli
+    binary: google-analytics-pp-cli
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/cli.version={{ .Version }}
+    targets:
+      - darwin_amd64
+      - darwin_arm64
+      - linux_amd64
+      - linux_arm64
+      - windows_amd64
+      - windows_arm64
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+checksum:
+  name_template: checksums.txt
+brews:
+  - name: google-analytics-pp-cli
+    repository:
+      owner: user
+      name: homebrew-tap
+    homepage: "https://github.com/mvanhorn/printing-press-library"
+    description: "Agent-first Google Analytics 4 CLI with raw Data/Admin wrappers and novel analytics reports."
+    install: |
+      bin.install "google-analytics-pp-cli"

--- a/library/marketing/google-analytics/.manuscripts/ga4-20260612/proofs/phase5-acceptance.json
+++ b/library/marketing/google-analytics/.manuscripts/ga4-20260612/proofs/phase5-acceptance.json
@@ -1,0 +1,24 @@
+{
+  "status": "pass",
+  "run_id": "ga4-20260612",
+  "validated_at": "2026-06-12T00:00:00Z",
+  "tests": {
+    "go_test": "pass",
+    "packages": [
+      "cmd/google-analytics-pp-cli",
+      "internal/cli",
+      "internal/ga4"
+    ]
+  },
+  "build": "pass",
+  "live_smoke": {
+    "properties": [
+      "$GA4_PROPERTY_ID",
+      "$GA4_PROPERTY_ID_2"
+    ],
+    "commands": 40,
+    "failures": [],
+    "evidence_dir": ".manuscripts/ga4-20260612/proofs/live-smoke"
+  },
+  "notes": "Replaced draft claims with executed go test/build and live GA4 smoke evidence."
+}

--- a/library/marketing/google-analytics/.manuscripts/ga4-20260612/proofs/proofs.md
+++ b/library/marketing/google-analytics/.manuscripts/ga4-20260612/proofs/proofs.md
@@ -1,0 +1,78 @@
+# GA4 publish-grade proof bundle
+
+Run id: `ga4-20260612`
+Date: 2026-06-12
+
+## Structural proof
+
+The CLI was decomposed from a single 1,037-line `internal/cli/root.go` into a publish-grade layout with a typed `internal/ga4` API layer and per-command/per-command-family CLI files. Tests were added under both `internal/cli` and `internal/ga4`.
+
+## Executed validation
+
+Latest local validation executed during this rebuild:
+
+```text
+go test ./... -> PASS
+go build ./... -> PASS
+go build -o bin/google-analytics-pp-cli ./cmd/google-analytics-pp-cli -> PASS
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run -> PASS
+python3 .github/scripts/verify-skill/verify_skill.py --dir library/marketing/google-analytics -> PASS
+python3 .github/scripts/verify-manifest/verify_manifest.py -> PASS
+python3 .github/scripts/verify-press-version/verify_press_version.py --base-ref origin/main -> PASS
+python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main -> PASS
+python3 .github/scripts/normalize-patches/normalize.py --check library/marketing/google-analytics -> PASS after normalization
+git diff --check -> PASS
+```
+
+## Live smoke evidence
+
+Credentials used: local service-account resolution only; no secrets printed. Properties checked: an authorized GA4 property, a second authorized GA4 property. Each row below exited 0 and has its full JSON response captured under `.manuscripts/ga4-20260612/proofs/live-smoke/`.
+
+| Command proof | Exit | Captured result | File |
+| --- | ---: | --- | --- |
+| `agent-context` | 0 | json captured | `live-smoke/agent-context.json` |
+| `properties` | 0 | accountSummaries=3 | `live-smoke/properties.json` |
+| `$GA4_PROPERTY_ID-property` | 0 | json captured | `live-smoke/$GA4_PROPERTY_ID-property.json` |
+| `$GA4_PROPERTY_ID-streams` | 0 | dataStreams=1 | `live-smoke/$GA4_PROPERTY_ID-streams.json` |
+| `$GA4_PROPERTY_ID-report` | 0 | rows=3 | `live-smoke/$GA4_PROPERTY_ID-report.json` |
+| `$GA4_PROPERTY_ID-pivot` | 0 | rows=3 | `live-smoke/$GA4_PROPERTY_ID-pivot.json` |
+| `$GA4_PROPERTY_ID-batch` | 0 | json captured | `live-smoke/$GA4_PROPERTY_ID-batch.json` |
+| `$GA4_PROPERTY_ID-realtime` | 0 | rows=3 | `live-smoke/$GA4_PROPERTY_ID-realtime.json` |
+| `$GA4_PROPERTY_ID-metadata` | 0 | dimensions=386, metrics=116 | `live-smoke/$GA4_PROPERTY_ID-metadata.json` |
+| `$GA4_PROPERTY_ID-compatibility` | 0 | json captured | `live-smoke/$GA4_PROPERTY_ID-compatibility.json` |
+| `$GA4_PROPERTY_ID-channels` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID-channels.json` |
+| `$GA4_PROPERTY_ID-sources` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID-sources.json` |
+| `$GA4_PROPERTY_ID-top-pages` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID-top-pages.json` |
+| `$GA4_PROPERTY_ID-events` | 0 | rows=5 | `live-smoke/$GA4_PROPERTY_ID-events.json` |
+| `$GA4_PROPERTY_ID-conversions` | 0 | rows=5 | `live-smoke/$GA4_PROPERTY_ID-conversions.json` |
+| `$GA4_PROPERTY_ID-funnel` | 0 | funnel response captured | `live-smoke/$GA4_PROPERTY_ID-funnel.json` |
+| `$GA4_PROPERTY_ID-compare` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID-compare.json` |
+| `$GA4_PROPERTY_ID-whats-changed` | 0 | movers=5 | `live-smoke/$GA4_PROPERTY_ID-whats-changed.json` |
+| `$GA4_PROPERTY_ID-revenue` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID-revenue.json` |
+| `$GA4_PROPERTY_ID-audience` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID-audience.json` |
+| `$GA4_PROPERTY_ID-cohort` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID-cohort.json` |
+| `$GA4_PROPERTY_ID_2-property` | 0 | json captured | `live-smoke/$GA4_PROPERTY_ID_2-property.json` |
+| `$GA4_PROPERTY_ID_2-streams` | 0 | dataStreams=1 | `live-smoke/$GA4_PROPERTY_ID_2-streams.json` |
+| `$GA4_PROPERTY_ID_2-report` | 0 | rows=3 | `live-smoke/$GA4_PROPERTY_ID_2-report.json` |
+| `$GA4_PROPERTY_ID_2-pivot` | 0 | rows=3 | `live-smoke/$GA4_PROPERTY_ID_2-pivot.json` |
+| `$GA4_PROPERTY_ID_2-batch` | 0 | json captured | `live-smoke/$GA4_PROPERTY_ID_2-batch.json` |
+| `$GA4_PROPERTY_ID_2-realtime` | 0 | rows=0 | `live-smoke/$GA4_PROPERTY_ID_2-realtime.json` |
+| `$GA4_PROPERTY_ID_2-metadata` | 0 | dimensions=375, metrics=89 | `live-smoke/$GA4_PROPERTY_ID_2-metadata.json` |
+| `$GA4_PROPERTY_ID_2-compatibility` | 0 | json captured | `live-smoke/$GA4_PROPERTY_ID_2-compatibility.json` |
+| `$GA4_PROPERTY_ID_2-channels` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID_2-channels.json` |
+| `$GA4_PROPERTY_ID_2-sources` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID_2-sources.json` |
+| `$GA4_PROPERTY_ID_2-top-pages` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID_2-top-pages.json` |
+| `$GA4_PROPERTY_ID_2-events` | 0 | rows=5 | `live-smoke/$GA4_PROPERTY_ID_2-events.json` |
+| `$GA4_PROPERTY_ID_2-conversions` | 0 | rows=0 | `live-smoke/$GA4_PROPERTY_ID_2-conversions.json` |
+| `$GA4_PROPERTY_ID_2-funnel` | 0 | funnel response captured | `live-smoke/$GA4_PROPERTY_ID_2-funnel.json` |
+| `$GA4_PROPERTY_ID_2-compare` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID_2-compare.json` |
+| `$GA4_PROPERTY_ID_2-whats-changed` | 0 | movers=5 | `live-smoke/$GA4_PROPERTY_ID_2-whats-changed.json` |
+| `$GA4_PROPERTY_ID_2-revenue` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID_2-revenue.json` |
+| `$GA4_PROPERTY_ID_2-audience` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID_2-audience.json` |
+| `$GA4_PROPERTY_ID_2-cohort` | 0 | row_count=5 | `live-smoke/$GA4_PROPERTY_ID_2-cohort.json` |
+
+## Notes from live proof
+
+- `runPivotReport` requires pivot-level `limit`; a live 400 from Google caught the draft top-level limit shape and the typed builder now emits the valid request.
+- `cohort` orders by the visible dimension `firstSessionDate`; a live 400 caught metric-vs-dimension ordering and `addOrder` now emits `dimension` order-bys when appropriate.
+- Both properties returned successful live data across raw and novel commands. Empty realtime/funnel tables are still valid JSON command responses when the property has no current users or no matching funnel rows.

--- a/library/marketing/google-analytics/.manuscripts/ga4-20260612/proofs/validation.log
+++ b/library/marketing/google-analytics/.manuscripts/ga4-20260612/proofs/validation.log
@@ -1,0 +1,20 @@
+# Validation log commands
+
+Executed from `library/marketing/google-analytics` and repo root on 2026-06-12.
+
+```bash
+gofmt -w internal/ga4/*.go internal/cli/*.go
+go test ./...
+go build ./...
+go build -o bin/google-analytics-pp-cli ./cmd/google-analytics-pp-cli
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run
+cd /path/to/printing-press-library
+python3 .github/scripts/verify-skill/verify_skill.py --dir library/marketing/google-analytics
+python3 .github/scripts/verify-manifest/verify_manifest.py
+python3 .github/scripts/verify-press-version/verify_press_version.py --base-ref origin/main
+python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main
+python3 .github/scripts/normalize-patches/normalize.py --check library/marketing/google-analytics
+git diff --check
+```
+
+All commands above exited 0 in the final validation run. Live smoke command matrix is captured under `live-smoke/` as JSON plus stderr sidecars.

--- a/library/marketing/google-analytics/.manuscripts/ga4-20260612/research/research.md
+++ b/library/marketing/google-analytics/.manuscripts/ga4-20260612/research/research.md
@@ -1,0 +1,91 @@
+# Google Analytics 4 CLI research
+
+Run id: `ga4-20260612`
+Target CLI: `google-analytics-pp-cli`
+API family: GA4 Data API v1beta, GA4 Data API v1alpha funnel endpoint, and Google Analytics Admin API v1beta.
+
+## Scope and command surface
+
+This CLI is GA4-only. Search Console stays in `google-search-console-pp-cli`; Universal Analytics is intentionally excluded because the public UA Reporting API is sunset and would create misleading commands for agents.
+
+The publishable command surface is split into:
+
+- Raw Data API wrappers: `report`, `pivot`, `batch`, `realtime`, `metadata`, `compatibility`.
+- Raw Admin API wrappers: `properties`, `property`, `streams`.
+- Novel agent reports: `channels`, `sources`, `top-pages`, `events`, `conversions`, `funnel`, `compare`, `whats-changed`, `revenue`, `audience`, `cohort`.
+- Agent/operator utilities: `agent-context`, `health`, `doctor`.
+
+All data commands resolve property IDs as `--property` first, then `GA4_PROPERTY_ID`. Fleet checks can pass `health --properties` or set `GA4_PROPERTY_IDS`. Brand IDs such as two authorized GA4 properties are proof inputs only, not implementation defaults.
+
+## Auth model
+
+GA4 Data/Admin reads work with a Google service account JWT bearer flow using scope:
+
+`https://www.googleapis.com/auth/analytics.readonly`
+
+The CLI reads credentials in this order:
+
+1. `--credentials <service-account-json>`
+2. `GOOGLE_APPLICATION_CREDENTIALS`
+
+The service account JSON must include `client_email`, `private_key`, and `token_uri` (defaulting to `https://oauth2.googleapis.com/token` when omitted). The CLI signs an RS256 JWT assertion, exchanges it for an access token, and sends an `Authorization: Bearer <token>` header on every Google API request. Tokens and key material are never printed in proofs.
+
+## Property-level grant gotcha
+
+Enabling the Google Analytics Data API in Google Cloud is not enough. GA4 property access is controlled inside Google Analytics Admin. A service account can mint a valid token and still receive 403/404 for a property if the service account email was not granted Viewer access on that GA4 property.
+
+`health`/`doctor` are designed around this gotcha:
+
+- token/key failures are reported as `creds_invalid` or `api_or_token_error`;
+- Admin API visibility is reported via account summaries;
+- each requested property is checked with a tiny `runReport` for `sessions` over `7daysAgo..yesterday`;
+- 403 is classified as `api_enabled_but_property_not_shared_or_permission_denied`;
+- 404 is classified as `property_not_found_or_not_shared`.
+
+## GA4 Data API v1beta endpoints
+
+`runReport` posts to `/v1beta/properties/{property}:runReport`. The typed request includes date ranges, dimensions, metrics, limit, dimension filter, and order-bys. GA4 accepts relative date tokens such as `today`, `yesterday`, `NdaysAgo` (for example `28daysAgo`) as well as ISO dates.
+
+`runPivotReport` posts to `/v1beta/properties/{property}:runPivotReport`. The top-level report request is similar to `runReport`, but row limits belong inside each pivot object. A live proof caught and fixed the invalid top-level `limit` draft shape.
+
+`batchRunReports` posts to `/v1beta/properties/{property}:batchRunReports` with a typed array of `RunReportRequest` objects. The property is supplied by the URL, not the body.
+
+`runRealtimeReport` posts to `/v1beta/properties/{property}:runRealtimeReport` and uses realtime-compatible metrics/dimensions such as `activeUsers` and `unifiedScreenName`.
+
+`getMetadata` reads `/v1beta/properties/{property}/metadata` and returns the current property-specific dimension and metric catalog.
+
+`checkCompatibility` posts to `/v1beta/properties/{property}:checkCompatibility` and validates metric/dimension combinations before agents build larger reports.
+
+## GA4 Data API v1alpha funnel endpoint
+
+`runFunnelReport` posts to `/v1alpha/properties/{property}:runFunnelReport`. Funnel steps are typed as event-name filters. The novel `funnel` command turns a comma-separated step list such as `view_item,add_to_cart,begin_checkout,purchase` into a GA4 funnel request.
+
+## Google Analytics Admin API v1beta endpoints
+
+`accountSummaries` reads `/v1beta/accountSummaries?pageSize=200` and is the safest discovery endpoint for service-account visibility.
+
+`property` reads `/v1beta/properties/{property}` for display metadata, timezone, currency, and parent account.
+
+`streams` reads `/v1beta/properties/{property}/dataStreams` and surfaces web/app stream metadata.
+
+## Quotas, limits, and operational notes
+
+GA4 Data API quotas are property-scoped and token-budgeted. Requests consume quota based on complexity; high-cardinality dimensions, many metrics, pivots, funnel reports, and broad date ranges cost more than narrow summaries. Agents should default to modest `--limit` values, use novel commands for common questions, and run `compatibility` before unusual metric/dimension combinations.
+
+Common safe defaults used by this CLI:
+
+- `30daysAgo..yesterday` for most summary commands;
+- `7daysAgo..yesterday` for health and short event trends;
+- `28daysAgo..yesterday` in proofs to avoid partial same-day reporting;
+- `--limit 25` for novel tables and smaller limits in smoke tests.
+
+## Implementation structure
+
+The draft single-file CLI was decomposed into the same shape as modern Printing Press CLIs:
+
+- `internal/ga4/types.go`, `client.go`, `auth.go` — typed Google API layer and service-account JWT flow.
+- `internal/cli/root.go`, `agent_context.go`, `health.go` — root flags and operator utilities.
+- `internal/cli/raw_commands.go`, `admin_commands.go` — raw endpoint wrappers.
+- `internal/cli/novel_*.go` — one file per novel command family.
+- `internal/cli/builders.go`, `transform.go`, `render.go` — shared request builders, response shaping, and output helpers.
+- Unit tests cover typed request building, global flag behavior, response flattening/enrichment, compare deltas, anomaly ranking math, and API-client HTTP/error paths.

--- a/library/marketing/google-analytics/.printing-press-patches/ga4-publish-grade-rebuild.json
+++ b/library/marketing/google-analytics/.printing-press-patches/ga4-publish-grade-rebuild.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 2,
+  "id": "ga4-publish-grade-rebuild",
+  "applied_at": "2026-06-12",
+  "base_run_id": "ga4-20260612",
+  "base_printing_press_version": "4.20.1",
+  "summary": "Rebuilds the GA4 CLI from a single-file draft into a typed, tested, publish-grade command tree.",
+  "reason": "The original generated artifact had the right command surface but was not publicly publishable: one 1,037-line root.go, no typed API layer, no tests, and draft-only proofs.",
+  "files": [
+    "internal/ga4/types.go",
+    "internal/ga4/client.go",
+    "internal/ga4/auth.go",
+    "internal/cli/*.go",
+    "internal/cli/*_test.go",
+    "internal/ga4/*_test.go",
+    ".manuscripts/ga4-20260612/research/research.md",
+    ".manuscripts/ga4-20260612/proofs/proofs.md"
+  ],
+  "validated_outcome": "go test ./..., go build ./..., verify-skill, and 40 live smoke commands across two authorized GA4 properties passed."
+}

--- a/library/marketing/google-analytics/.printing-press.json
+++ b/library/marketing/google-analytics/.printing-press.json
@@ -1,0 +1,69 @@
+{
+  "api_name": "google-analytics",
+  "cli_name": "google-analytics-pp-cli",
+  "category": "marketing",
+  "description": "Agent-first Google Analytics 4 CLI with typed Data/Admin/Funnel API coverage and novel one-call analytics reports for channels, sources, pages, funnels, comparisons, anomalies, revenue, and health checks.",
+  "spec_format": "openapi3-curated",
+  "spec_source": "curated-ga4-data-admin-apis",
+  "spec_checksum": "sha256:2dfe6cb7ef79f217ae73793eda907af9aa0f5368f4fa9a41ed16a89e62089da0",
+  "printing_press_version": "4.20.1",
+  "run_id": "ga4-20260612",
+  "printer": "cathrynlavery",
+  "creator": {
+    "handle": "cathrynlavery",
+    "name": "Cathryn Lavery"
+  },
+  "contributors": [
+    {
+      "handle": "cathrynlavery",
+      "name": "Cathryn Lavery"
+    }
+  ],
+  "auth_env_vars": [
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GA4_PROPERTY_ID",
+    "GA4_PROPERTY_IDS"
+  ],
+  "novel_features": [
+    {
+      "name": "Health/Doctor",
+      "command": "health",
+      "description": "health/doctor distinguishes token/API errors from property-level GA4 access grant failures"
+    },
+    {
+      "name": "Channels,",
+      "command": "channels",
+      "description": "channels, sources, top-pages, revenue produce curated acquisition/ecommerce tables"
+    },
+    {
+      "name": "Compare",
+      "command": "compare",
+      "description": "compare calculates period-over-period deltas and percentage changes in one call"
+    },
+    {
+      "name": "Whats-Changed",
+      "command": "whats-changed",
+      "description": "whats-changed scans movers across channels, source/medium, and landing pages"
+    },
+    {
+      "name": "Funnel",
+      "command": "funnel",
+      "description": "funnel wraps v1alpha runFunnelReport for named event sequences"
+    },
+    {
+      "name": "Agent-Context",
+      "command": "agent-context",
+      "description": "agent-context emits structured tool metadata for agents"
+    }
+  ],
+  "mcp": false,
+  "schema_version": 1,
+  "generated_at": "2026-06-12T12:00:00Z",
+  "display_name": "Google Analytics 4",
+  "printer_name": "Cathryn Lavery",
+  "owner": "cathrynlavery",
+  "owner_name": "Cathryn Lavery",
+  "auth_type": "service_account_jwt",
+  "spec_url": "https://developers.google.com/analytics/devguides/reporting/data/v1",
+  "version": "1.1.0"
+}

--- a/library/marketing/google-analytics/AGENTS.md
+++ b/library/marketing/google-analytics/AGENTS.md
@@ -1,0 +1,21 @@
+# google-analytics Printing Press CLI
+
+This CLI is GA4-only. Do not add Search Console endpoints here; use `google-search-console-pp-cli` for GSC.
+
+## Auth
+
+Use a Google service account JSON key with `https://www.googleapis.com/auth/analytics.readonly`. Resolution order:
+
+1. `--credentials`
+2. `GOOGLE_APPLICATION_CREDENTIALS`
+3. No implicit local fallback. Pass `--credentials` or set `GOOGLE_APPLICATION_CREDENTIALS`.
+
+Property resolution for data commands is `--property`, then `GA4_PROPERTY_ID`. Do not hard-code brand property IDs in command implementations. Fleet checks can pass `health --properties <comma-list>` or set `GA4_PROPERTY_IDS`.
+
+## Required validation
+
+- `go test ./...`
+- `go build ./...`
+- `google-analytics-pp-cli agent-context --agent`
+- `google-analytics-pp-cli health --properties $GA4_PROPERTY_IDS --agent` when credentials/property grants are available
+- Live the first authorized property smoke: `channels`, `compare`, `whats-changed`, `funnel`

--- a/library/marketing/google-analytics/CHANGELOG.md
+++ b/library/marketing/google-analytics/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 1.1.0 - 2026-06-12
+
+- Rebuilds the GA4 CLI to publish-grade structure with a typed `internal/ga4` Data/Admin/Funnel API layer and per-command CLI files.
+- Adds meaningful unit tests for request builders, global flag behavior, response shaping, compare delta/% math, anomaly ranking, and HTTP error paths.
+- Replaces draft research/proofs with real GA4 API research and live smoke JSON for every raw and novel command against two authorized GA4 properties.
+- Fixes live-discovered request-shape bugs for pivot limits and dimension order-bys.
+
+## 1.0.0 - 2026-06-12
+
+- Initial private GA4-only Printing Press CLI.
+- Adds raw Data/Admin API wrappers.
+- Adds novel agent commands for channels, sources, top pages, events/conversions, funnels, compare, whats-changed, revenue, audience/cohort, and health/doctor.

--- a/library/marketing/google-analytics/LICENSE
+++ b/library/marketing/google-analytics/LICENSE
@@ -1,0 +1,4 @@
+Apache License
+Version 2.0, January 2004
+
+Generated Printing Press CLI. See repository root for full Apache-2.0 terms.

--- a/library/marketing/google-analytics/Makefile
+++ b/library/marketing/google-analytics/Makefile
@@ -1,0 +1,8 @@
+BINARY=google-analytics-pp-cli
+
+.PHONY: build test
+build:
+	go build ./...
+
+test:
+	go test ./...

--- a/library/marketing/google-analytics/NOTICE
+++ b/library/marketing/google-analytics/NOTICE
@@ -1,0 +1,5 @@
+google-analytics Printing Press CLI
+Copyright 2026 Cathryn Lavery and contributors.
+
+Contributors:
+  - Cathryn Lavery (@cathrynlavery)

--- a/library/marketing/google-analytics/README.md
+++ b/library/marketing/google-analytics/README.md
@@ -1,0 +1,71 @@
+# Google Analytics 4 Printing Press CLI
+
+`google-analytics-pp-cli` is an agent-first GA4 CLI for live analytics work. It covers the GA4 Data API, the GA4 Admin API discovery calls, and curated novel commands that answer the questions agents actually ask without stitching multiple raw API calls together.
+
+Created by [@cathrynlavery](https://github.com/cathrynlavery) (Cathryn Lavery).
+Contributors: [@cathrynlavery](https://github.com/cathrynlavery) (Cathryn Lavery).
+
+## Install / build
+
+```bash
+PP_LIBRARY_REPO=/path/to/printing-press-library pp-sync build google-analytics-pp-cli
+```
+
+## Auth
+
+Use a service-account JSON key with Analytics readonly scope. Set `GOOGLE_APPLICATION_CREDENTIALS` to your service-account JSON path, or pass `--credentials` explicitly.
+
+Resolution order: `--credentials`, then `GOOGLE_APPLICATION_CREDENTIALS`. There is no implicit developer-local credential fallback.
+
+GA4 property resolution for data commands: `--property`, then `GA4_PROPERTY_ID`. The CLI does not hard-code the first authorized property or the second authorized property property IDs. For fleet health checks, pass explicit properties or set `GA4_PROPERTY_IDS`.
+
+Important gotcha: Google Cloud API access is not GA4 property access. The service account must also be granted Viewer access inside each GA4 property. `health` / `doctor` distinguishes invalid credentials from property not shared / permission denied.
+
+## Global agent flags
+
+Every command inherits:
+
+- `--agent` = `--json --compact --no-input --yes`
+- `--json`
+- `--compact`
+- `--no-input`
+- `--yes`
+- `--property`
+- `--credentials`
+- `--timeout`
+
+## Raw API wrappers
+
+- `report` — GA4 Data API `runReport` (`--metrics`, `--dimensions`, `--start`, `--end`, `--filter`, `--order`, `--limit`)
+- `pivot` — `runPivotReport`
+- `batch` — `batchRunReports`
+- `realtime` — `runRealtimeReport`
+- `metadata` — list valid dimensions/metrics for a property
+- `compatibility` — `checkCompatibility`
+- `properties` — Admin API `accountSummaries.list`
+- `property` — Admin API `properties.get`
+- `streams` — Admin API `properties.dataStreams.list`
+
+## Novel commands
+
+- `channels` — sessions/users/conversions/revenue by default channel group.
+- `sources` — source/medium acquisition breakdown with computed conversion rate.
+- `top-pages` — landing pages by sessions, engagement, conversions, revenue.
+- `events` / `conversions` — events or conversions over time with trend summary.
+- `funnel` — v1alpha `runFunnelReport` for a named event sequence.
+- `compare` — period-over-period metric deltas and percent changes.
+- `whats-changed` — anomaly-style mover scan across key dimensions.
+- `revenue` — ecommerce revenue, AOV, transactions by channel/source.
+- `audience` / `cohort` — cheap audience and retention snapshots.
+- `health` / `doctor` — token mint, Admin visibility, and per-property access grants.
+
+## Examples
+
+```bash
+google-analytics-pp-cli agent-context --agent
+google-analytics-pp-cli health --properties $GA4_PROPERTY_IDS --agent
+google-analytics-pp-cli channels --property $GA4_PROPERTY_ID --start 28daysAgo --end yesterday --agent
+google-analytics-pp-cli compare --property $GA4_PROPERTY_ID --metric sessions,totalRevenue --period wow --agent
+google-analytics-pp-cli whats-changed --property $GA4_PROPERTY_ID --agent
+google-analytics-pp-cli funnel --property $GA4_PROPERTY_ID --steps view_item,add_to_cart,begin_checkout,purchase --agent
+```

--- a/library/marketing/google-analytics/SKILL.md
+++ b/library/marketing/google-analytics/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: pp-google-analytics
+description: Google Analytics 4 Printing Press CLI for GA4 raw reports, funnels, acquisition/revenue insights, period comparisons, anomaly scans, and property-access health checks.
+tags: [printing-press, ga4, google-analytics, analytics, marketing]
+---
+
+# pp-google-analytics
+
+## Prerequisites: Install the CLI
+
+This skill drives the `google-analytics-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
+
+1. Install via the Printing Press installer into a user bin directory:
+   ```bash
+   npx -y @mvanhorn/printing-press-library install google-analytics --cli-only --bin-dir ~/.local/bin
+   ```
+2. Verify: `google-analytics-pp-cli --version`
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
+
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.4 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/cmd/google-analytics-pp-cli@latest
+```
+
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
+
+## When to Use This CLI
+
+Use this CLI when an agent needs live GA4 property data, acquisition/revenue summaries, ecommerce diagnostics, funnels, period comparisons, anomaly scans, or property-access diagnostics. Use `google-search-console-pp-cli` for Search Console.
+
+
+Use `google-analytics-pp-cli` for GA4-only analytics work. Search Console is covered by `google-search-console-pp-cli`; do not use the legacy combined GSC/GA4 CLI for new work.
+
+## Auth and property selection
+
+- Service account key: `--credentials`, else `GOOGLE_APPLICATION_CREDENTIALS`.
+- Scope: `https://www.googleapis.com/auth/analytics.readonly`.
+- Property: pass `--property`, or set `GA4_PROPERTY_ID`.
+- Fleet health checks: `health --properties $GA4_PROPERTY_IDS --agent` or set `GA4_PROPERTY_IDS`.
+
+Durable gotcha: Google Cloud API access is not GA4 property access. The service account must be granted Viewer access inside the GA4 property. If `health` shows token/admin OK but a property check is 403/404, fix the GA4 property grant rather than rotating credentials.
+
+## Best commands for agents
+
+```bash
+google-analytics-pp-cli agent-context --agent
+google-analytics-pp-cli health --properties $GA4_PROPERTY_IDS --agent
+google-analytics-pp-cli channels --property "$GA4_PROPERTY_ID" --start 28daysAgo --end yesterday --agent
+google-analytics-pp-cli sources --property "$GA4_PROPERTY_ID" --agent
+google-analytics-pp-cli top-pages --property "$GA4_PROPERTY_ID" --agent
+google-analytics-pp-cli compare --property "$GA4_PROPERTY_ID" --metric sessions,totalRevenue --period wow --agent
+google-analytics-pp-cli whats-changed --property "$GA4_PROPERTY_ID" --agent
+google-analytics-pp-cli revenue --property "$GA4_PROPERTY_ID" --by channel --agent
+google-analytics-pp-cli funnel --property "$GA4_PROPERTY_ID" --steps view_item,add_to_cart,begin_checkout,purchase --agent
+```
+
+## Raw wrappers
+
+`report`, `pivot`, `batch`, `realtime`, `metadata`, `compatibility`, `properties`, `property`, and `streams` are available for low-level escape hatches. Prefer novel commands when answering business questions.

--- a/library/marketing/google-analytics/cmd/google-analytics-pp-cli/main.go
+++ b/library/marketing/google-analytics/cmd/google-analytics-pp-cli/main.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Cathryn Lavery and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/cli"
+)
+
+func main() {
+	if err := cli.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/library/marketing/google-analytics/dogfood-results.json
+++ b/library/marketing/google-analytics/dogfood-results.json
@@ -1,0 +1,4 @@
+{
+  "status": "pass",
+  "notes": "Publish-grade rebuild validated with go test/build, verify-skill, lint, and redacted local smoke checks. Private live GA4 output is intentionally not committed."
+}

--- a/library/marketing/google-analytics/go.mod
+++ b/library/marketing/google-analytics/go.mod
@@ -1,0 +1,10 @@
+module github.com/mvanhorn/printing-press-library/library/marketing/google-analytics
+
+go 1.25.11
+
+require github.com/spf13/cobra v1.9.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/library/marketing/google-analytics/go.sum
+++ b/library/marketing/google-analytics/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/library/marketing/google-analytics/internal/cli/admin_commands.go
+++ b/library/marketing/google-analytics/internal/cli/admin_commands.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/ga4"
+	"github.com/spf13/cobra"
+)
+
+func newPropertiesCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{Use: "properties", Short: "List accessible GA4 account summaries/properties", RunE: func(cmd *cobra.Command, args []string) error {
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.AccountSummaries(context.Background())
+		if err != nil {
+			return err
+		}
+		return output(cmd, flags, raw, tableProperties(raw))
+	}}
+}
+func newPropertyCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{Use: "property", Short: "Get GA4 Admin property metadata", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.Property(context.Background(), p)
+		if err != nil {
+			return err
+		}
+		return output(cmd, flags, raw, "")
+	}}
+}
+func newStreamsCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{Use: "streams", Short: "List data streams for a GA4 property", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.DataStreams(context.Background(), p)
+		if err != nil {
+			return err
+		}
+		return output(cmd, flags, raw, "")
+	}}
+}
+func tableProperties(raw ga4.AccountSummariesResponse) string {
+	rows := []map[string]any{}
+	for _, summary := range raw.AccountSummaries {
+		for _, prop := range summary.PropertySummaries {
+			rows = append(rows, map[string]any{
+				"account":       summary.Account,
+				"account_name":  summary.DisplayName,
+				"property":      cleanProperty(prop.Property),
+				"property_name": prop.DisplayName,
+			})
+		}
+	}
+	return table(rows)
+}

--- a/library/marketing/google-analytics/internal/cli/agent_context.go
+++ b/library/marketing/google-analytics/internal/cli/agent_context.go
@@ -1,0 +1,9 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+func newAgentContextCmd() *cobra.Command {
+	return &cobra.Command{Use: "agent-context", Short: "Emit structured tool description for agents", RunE: func(cmd *cobra.Command, args []string) error {
+		return printJSON(cmd.OutOrStdout(), map[string]any{"name": "google-analytics-pp-cli", "binary": "google-analytics-pp-cli", "purpose": "GA4-only analytics CLI with raw API wrappers and one-call novel reports", "auth": "Google service account JSON via --credentials or GOOGLE_APPLICATION_CREDENTIALS; analytics.readonly scope", "property_resolution": "--property, else GA4_PROPERTY_ID; health can accept --properties for fleet checks", "global_flags": []string{"--agent", "--json", "--compact", "--no-input", "--yes", "--property", "--credentials", "--timeout"}, "raw_commands": []string{"report", "pivot", "batch", "realtime", "metadata", "compatibility", "properties", "property", "streams"}, "novel_commands": []string{"channels", "sources", "top-pages", "events", "conversions", "funnel", "compare", "whats-changed", "revenue", "audience", "cohort", "health", "doctor"}, "examples": []string{"google-analytics-pp-cli health --properties $GA4_PROPERTY_IDS --agent", "google-analytics-pp-cli channels --property $GA4_PROPERTY_ID --start 28daysAgo --end yesterday --agent", "google-analytics-pp-cli compare --property $GA4_PROPERTY_ID --metrics sessions,totalRevenue --period wow --agent", "google-analytics-pp-cli funnel --property $GA4_PROPERTY_ID --steps view_item,add_to_cart,begin_checkout,purchase --agent"}})
+	}}
+}

--- a/library/marketing/google-analytics/internal/cli/builders.go
+++ b/library/marketing/google-analytics/internal/cli/builders.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/ga4"
+	"github.com/spf13/cobra"
+)
+
+func reportFlags(c *cobra.Command, metrics, dims, start, end *string, limit *int) {
+	c.Flags().StringVar(metrics, "metrics", "sessions,totalUsers,conversions,totalRevenue", "Comma-separated metrics")
+	c.Flags().StringVar(dims, "dimensions", "date", "Comma-separated dimensions")
+	dateLimitFlags(c, start, end, limit)
+}
+func dateLimitFlags(c *cobra.Command, start, end *string, limit *int) {
+	c.Flags().StringVar(start, "start", "30daysAgo", "Start date (YYYY-MM-DD or NdaysAgo)")
+	c.Flags().StringVar(end, "end", "yesterday", "End date")
+	c.Flags().IntVar(limit, "limit", 25, "Max rows")
+}
+func splitCSV(s string) []string {
+	out := []string{}
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+func splitDefault(s, d string) []string {
+	if strings.TrimSpace(s) == "" {
+		s = d
+	}
+	return splitCSV(s)
+}
+func metricNames(xs []string) []ga4.Metric {
+	out := []ga4.Metric{}
+	for _, x := range xs {
+		out = append(out, ga4.Metric{Name: x})
+	}
+	return out
+}
+func dimensionNames(xs []string) []ga4.Dimension {
+	out := []ga4.Dimension{}
+	for _, x := range xs {
+		out = append(out, ga4.Dimension{Name: x})
+	}
+	return out
+}
+func reportRequest(metrics, dims, start, end string, limit int) ga4.RunReportRequest {
+	if start == "" {
+		start = "30daysAgo"
+	}
+	if end == "" {
+		end = "yesterday"
+	}
+	if limit <= 0 {
+		limit = 25
+	}
+	return ga4.RunReportRequest{DateRanges: []ga4.DateRange{{StartDate: start, EndDate: end}}, Metrics: metricNames(splitCSV(metrics)), Dimensions: dimensionNames(splitCSV(dims)), Limit: strconv.Itoa(limit)}
+}
+func realtimeRequest(metrics, dims string, limit int) ga4.RunRealtimeReportRequest {
+	if limit <= 0 {
+		limit = 10
+	}
+	return ga4.RunRealtimeReportRequest{Metrics: metricNames(splitDefault(metrics, "activeUsers")), Dimensions: dimensionNames(splitCSV(dims)), Limit: strconv.Itoa(limit)}
+}
+func compatibilityRequest(metrics, dims string) ga4.CheckCompatibilityRequest {
+	return ga4.CheckCompatibilityRequest{Metrics: metricNames(splitCSV(metrics)), Dimensions: dimensionNames(splitCSV(dims)), CompatibilityFilter: "COMPATIBLE"}
+}
+func addRawDimensionFilter(req *ga4.RunReportRequest, raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var js json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &js); err != nil {
+		return err
+	}
+	req.DimensionFilter = &ga4.FilterExpression{Raw: js}
+	return nil
+}
+func addOrder(req *ga4.RunReportRequest, order string) {
+	if order == "" {
+		return
+	}
+	desc := strings.HasPrefix(order, "-")
+	name := strings.TrimPrefix(order, "-")
+	for _, dim := range req.Dimensions {
+		if dim.Name == name {
+			req.OrderBys = []ga4.OrderBy{{Desc: desc, Dimension: &ga4.DimensionOrderBy{DimensionName: name}}}
+			return
+		}
+	}
+	req.OrderBys = []ga4.OrderBy{{Desc: desc, Metric: &ga4.MetricOrderBy{MetricName: name}}}
+}
+func funnelRequest(steps, start, end string) ga4.RunFunnelReportRequest {
+	fs := []ga4.FunnelStep{}
+	for _, s := range splitCSV(steps) {
+		fs = append(fs, ga4.FunnelStep{Name: s, FilterExpression: &ga4.FunnelFilterExpression{FunnelEventFilter: &ga4.FunnelEventFilter{EventName: s}}})
+	}
+	return ga4.RunFunnelReportRequest{DateRanges: []ga4.DateRange{{StartDate: start, EndDate: end}}, Funnel: ga4.Funnel{Steps: fs}}
+}

--- a/library/marketing/google-analytics/internal/cli/builders_test.go
+++ b/library/marketing/google-analytics/internal/cli/builders_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestReportRequestBuildsTypedGA4Body(t *testing.T) {
+	req := reportRequest("sessions,totalRevenue", "date,sessionDefaultChannelGroup", "28daysAgo", "yesterday", 7)
+	if len(req.Metrics) != 2 || req.Metrics[1].Name != "totalRevenue" {
+		t.Fatalf("metrics not parsed: %#v", req.Metrics)
+	}
+	if len(req.Dimensions) != 2 || req.Dimensions[0].Name != "date" {
+		t.Fatalf("dimensions not parsed: %#v", req.Dimensions)
+	}
+	if req.Limit != "7" || req.DateRanges[0].StartDate != "28daysAgo" {
+		t.Fatalf("bad date/limit: %#v", req)
+	}
+}
+func TestAddOrderAndFilter(t *testing.T) {
+	req := reportRequest("sessions", "date", "", "", 0)
+	addOrder(&req, "-sessions")
+	if len(req.OrderBys) != 1 || !req.OrderBys[0].Desc || req.OrderBys[0].Metric.MetricName != "sessions" {
+		t.Fatalf("bad order: %#v", req.OrderBys)
+	}
+	if err := addRawDimensionFilter(&req, `{"filter":{"fieldName":"country"}}`); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := json.Marshal(req)
+	if !json.Valid(b) || string(b) == "" {
+		t.Fatalf("bad json: %s", b)
+	}
+}
+func TestFunnelRequestBuildsEventSteps(t *testing.T) {
+	req := funnelRequest("view_item,add_to_cart", "30daysAgo", "yesterday")
+	if len(req.Funnel.Steps) != 2 {
+		t.Fatalf("steps=%d", len(req.Funnel.Steps))
+	}
+	if req.Funnel.Steps[1].FilterExpression.FunnelEventFilter.EventName != "add_to_cart" {
+		t.Fatalf("bad step: %#v", req.Funnel.Steps[1])
+	}
+}
+func TestPropertyResolutionPrefersFlag(t *testing.T) {
+	f := &rootFlags{propertyID: "properties/123"}
+	if got := configuredProperty(f); got != "123" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/library/marketing/google-analytics/internal/cli/health.go
+++ b/library/marketing/google-analytics/internal/cli/health.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/ga4"
+	"github.com/spf13/cobra"
+)
+
+func newHealthCmd(flags *rootFlags) *cobra.Command {
+	var props string
+	c := &cobra.Command{Use: "health", Short: "Verify credentials, Admin API, and per-property GA4 access grants", RunE: func(cmd *cobra.Command, args []string) error { return runHealth(cmd, flags, props) }}
+	c.Flags().StringVar(&props, "properties", "", "Comma-separated GA4 property IDs to check (or GA4_PROPERTY_IDS)")
+	return c
+}
+func newDoctorCmd(flags *rootFlags) *cobra.Command {
+	var props string
+	c := &cobra.Command{Use: "doctor", Short: "Verify credentials, Admin API, and per-property GA4 access grants", RunE: func(cmd *cobra.Command, args []string) error { return runHealth(cmd, flags, props) }}
+	c.Flags().StringVar(&props, "properties", "", "Comma-separated GA4 property IDs to check (or GA4_PROPERTY_IDS)")
+	return c
+}
+func runHealth(cmd *cobra.Command, flags *rootFlags, props string) error {
+	cl, key, err := flags.newClient()
+	res := map[string]any{"credential_path": credentialPath(flags), "scope": ga4.AnalyticsReadonlyScope}
+	if key.ClientEmail != "" {
+		res["service_account"] = key.ClientEmail
+		res["project_id"] = key.ProjectID
+	}
+	if err != nil {
+		res["ok"] = false
+		res["status"] = "creds_invalid"
+		res["error"] = err.Error()
+		return output(cmd, flags, res, "")
+	}
+	summaries, status, err := cl.AccountSummaries(context.Background())
+	res["visible_properties"] = visibleProperties(summaries)
+	res["admin_api_status"] = status
+	if err != nil {
+		res["ok"] = false
+		res["status"] = "api_or_token_error"
+		res["error"] = err.Error()
+		return output(cmd, flags, res, "")
+	}
+	targets := splitCSV(props)
+	if len(targets) == 0 {
+		targets = append(targets, configuredProperty(flags))
+		if env := os.Getenv("GA4_PROPERTY_IDS"); env != "" {
+			targets = append(targets, splitCSV(env)...)
+		}
+	}
+	targets = uniqNonEmpty(targets)
+	checks := []map[string]any{}
+	allOK := true
+	for _, p := range targets {
+		_, st, e := cl.RunReport(context.Background(), p, reportRequest("sessions", "", "7daysAgo", "yesterday", 1))
+		chk := map[string]any{"property": p, "status_code": st, "ok": e == nil}
+		if e != nil {
+			allOK = false
+			chk["error"] = classifyAccessError(e)
+			chk["detail"] = e.Error()
+		}
+		checks = append(checks, chk)
+	}
+	res["property_checks"] = checks
+	if len(targets) == 0 {
+		res["ok"] = true
+		res["status"] = "token_valid_no_property_requested"
+	} else if allOK {
+		res["ok"] = true
+		res["status"] = "valid"
+	} else {
+		res["ok"] = false
+		res["status"] = "property_not_shared_or_invalid"
+	}
+	return output(cmd, flags, res, renderHealth(res))
+}
+func classifyAccessError(err error) string {
+	var ae ga4.APIError
+	if errors.As(err, &ae) {
+		if ae.Status == 401 {
+			return "creds_invalid_or_token_rejected"
+		}
+		if ae.Status == 403 {
+			return "api_enabled_but_property_not_shared_or_permission_denied"
+		}
+		if ae.Status == 404 {
+			return "property_not_found_or_not_shared"
+		}
+	}
+	return "request_failed"
+}

--- a/library/marketing/google-analytics/internal/cli/json.go
+++ b/library/marketing/google-analytics/internal/cli/json.go
@@ -1,0 +1,13 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+)
+
+func printJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+func jsonDecode(b []byte, v any) error { return json.Unmarshal(b, v) }

--- a/library/marketing/google-analytics/internal/cli/novel_compare.go
+++ b/library/marketing/google-analytics/internal/cli/novel_compare.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+func newCompareCmd(flags *rootFlags) *cobra.Command {
+	var start, end, prevStart, prevEnd, period, metrics, dims string
+	var limit int
+	c := &cobra.Command{Use: "compare", Short: "Period-over-period deltas and percent change without doing two calls manually", RunE: func(cmd *cobra.Command, args []string) error {
+		if start == "" {
+			start = "7daysAgo"
+		}
+		if end == "" {
+			end = "yesterday"
+		}
+		var err error
+		prevStart, prevEnd, err = previousWindow(start, end, prevStart, prevEnd, period)
+		if err != nil {
+			return err
+		}
+		dimList := splitCSV(dims)
+		reqA := reportRequest(metrics, dims, start, end, limit)
+		reqB := reportRequest(metrics, dims, prevStart, prevEnd, limit)
+		rowsA, rawA, err := runReportRows(flags, reqA)
+		if err != nil {
+			return err
+		}
+		rowsB, _, err := runReportRows(flags, reqB)
+		if err != nil {
+			return err
+		}
+		out := compareRows(rowsA, rowsB, dimList, splitCSV(metrics))
+		out["period_a"] = map[string]string{"start": start, "end": end}
+		out["period_b"] = map[string]string{"start": prevStart, "end": prevEnd}
+		out["property"] = configuredProperty(flags)
+		out["raw_row_count"] = len(rawA.Rows)
+		return output(cmd, flags, out, renderCompare(out))
+	}}
+	c.Flags().StringVar(&start, "start", "", "Current period start")
+	c.Flags().StringVar(&end, "end", "", "Current period end")
+	c.Flags().StringVar(&prevStart, "previous-start", "", "Previous period start")
+	c.Flags().StringVar(&prevEnd, "previous-end", "", "Previous period end")
+	c.Flags().StringVar(&period, "period", "wow", "If previous dates absent: wow, mom, or trailing")
+	c.Flags().StringVar(&metrics, "metrics", "sessions,totalUsers,conversions,totalRevenue", "Metrics")
+	c.Flags().StringVar(&metrics, "metric", "sessions,totalUsers,conversions,totalRevenue", "Alias for --metrics")
+	_ = c.Flags().MarkHidden("metric")
+	c.Flags().StringVar(&dims, "dimensions", "", "Optional dimensions to compare by")
+	c.Flags().IntVar(&limit, "limit", 25, "Rows per report")
+	return c
+}
+func newWhatsChangedCmd(flags *rootFlags) *cobra.Command {
+	var start, end, prevStart, prevEnd, period, metrics, dims string
+	var limit int
+	c := &cobra.Command{Use: "whats-changed", Short: "Scan key metrics for notable spikes/drops vs trailing period", RunE: func(cmd *cobra.Command, args []string) error {
+		if dims == "" {
+			dims = "sessionDefaultChannelGroup,sessionSourceMedium,landingPagePlusQueryString"
+		}
+		var err error
+		prevStart, prevEnd, err = previousWindow(start, end, prevStart, prevEnd, period)
+		if err != nil {
+			return err
+		}
+		movers := []map[string]any{}
+		for _, dim := range splitCSV(dims) {
+			reqA := reportRequest(metrics, dim, start, end, limit)
+			reqB := reportRequest(metrics, dim, prevStart, prevEnd, limit)
+			a, _, err := runReportRows(flags, reqA)
+			if err != nil {
+				return err
+			}
+			b, _, err := runReportRows(flags, reqB)
+			if err != nil {
+				return err
+			}
+			cmp := compareRows(a, b, []string{dim}, splitCSV(metrics))
+			for _, r := range cmp["rows"].([]map[string]any) {
+				r["dimension"] = dim
+				movers = append(movers, r)
+			}
+		}
+		sort.Slice(movers, func(i, j int) bool {
+			return abs(toFloat(movers[i]["largest_pct_change"])) > abs(toFloat(movers[j]["largest_pct_change"]))
+		})
+		if len(movers) > limit {
+			movers = movers[:limit]
+		}
+		out := map[string]any{"property": configuredProperty(flags), "period": map[string]string{"start": start, "end": end}, "previous": map[string]string{"start": prevStart, "end": prevEnd}, "movers": movers}
+		return output(cmd, flags, out, renderMovers(out))
+	}}
+	c.Flags().StringVar(&start, "start", "7daysAgo", "Current start")
+	c.Flags().StringVar(&end, "end", "yesterday", "Current end")
+	c.Flags().StringVar(&prevStart, "previous-start", "", "Previous start")
+	c.Flags().StringVar(&prevEnd, "previous-end", "", "Previous end")
+	c.Flags().StringVar(&period, "period", "trailing", "wow/mom/trailing")
+	c.Flags().StringVar(&metrics, "metrics", "sessions,totalUsers,conversions,totalRevenue", "Metrics")
+	c.Flags().StringVar(&dims, "dimensions", "", "Dimensions to scan")
+	c.Flags().IntVar(&limit, "limit", 20, "Movers")
+	return c
+}
+
+func previousWindow(start, end, prevStart, prevEnd, period string) (string, string, error) {
+	if (prevStart == "") != (prevEnd == "") {
+		return "", "", fmt.Errorf("pass both --previous-start and --previous-end, or omit both to infer the previous period")
+	}
+	if prevStart != "" {
+		return prevStart, prevEnd, nil
+	}
+	ps, pe := inferPrevious(start, end, period)
+	return ps, pe, nil
+}

--- a/library/marketing/google-analytics/internal/cli/novel_funnel.go
+++ b/library/marketing/google-analytics/internal/cli/novel_funnel.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+func newFunnelCmd(flags *rootFlags) *cobra.Command {
+	var steps, start, end string
+	c := &cobra.Command{Use: "funnel", Short: "Run GA4 v1alpha runFunnelReport for a named event step sequence", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.RunFunnelReport(context.Background(), p, funnelRequest(steps, start, end))
+		if err != nil {
+			return err
+		}
+		return output(cmd, flags, raw, "")
+	}}
+	c.Flags().StringVar(&steps, "steps", "view_item,add_to_cart,begin_checkout,purchase", "Comma-separated GA4 event names")
+	c.Flags().StringVar(&start, "start", "30daysAgo", "Start date")
+	c.Flags().StringVar(&end, "end", "yesterday", "End date")
+	return c
+}

--- a/library/marketing/google-analytics/internal/cli/novel_reports.go
+++ b/library/marketing/google-analytics/internal/cli/novel_reports.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/ga4"
+	"github.com/spf13/cobra"
+)
+
+func newChannelsCmd(flags *rootFlags) *cobra.Command {
+	var start, end string
+	var limit int
+	c := &cobra.Command{Use: "channels", Short: "Sessions/users/conversions/revenue by default channel group", RunE: func(cmd *cobra.Command, args []string) error {
+		req := reportRequest("sessions,totalUsers,conversions,totalRevenue", "sessionDefaultChannelGroup", start, end, limit)
+		addOrder(&req, "-sessions")
+		return novelReport(cmd, flags, req, "channels")
+	}}
+	// Keep these flags declared directly on the command rather than only through
+	// dateLimitFlags so the library SKILL verifier can associate the documented
+	// `channels --start/--end` examples with this Cobra command.
+	c.Flags().StringVar(&start, "start", "30daysAgo", "Start date (YYYY-MM-DD or NdaysAgo)")
+	c.Flags().StringVar(&end, "end", "yesterday", "End date")
+	c.Flags().IntVar(&limit, "limit", 25, "Max rows")
+	return c
+}
+func newSourcesCmd(flags *rootFlags) *cobra.Command {
+	var start, end string
+	var limit int
+	c := &cobra.Command{Use: "sources", Short: "Source/medium acquisition breakdown with conversion rate", RunE: func(cmd *cobra.Command, args []string) error {
+		req := reportRequest("sessions,totalUsers,conversions,totalRevenue", "sessionSourceMedium", start, end, limit)
+		addOrder(&req, "-sessions")
+		return novelReport(cmd, flags, req, "sources")
+	}}
+	dateLimitFlags(c, &start, &end, &limit)
+	return c
+}
+func newTopPagesCmd(flags *rootFlags) *cobra.Command {
+	var start, end string
+	var limit int
+	c := &cobra.Command{Use: "top-pages", Short: "Top landing pages by sessions, engagement, and conversions", RunE: func(cmd *cobra.Command, args []string) error {
+		req := reportRequest("sessions,engagementRate,conversions,totalRevenue", "landingPagePlusQueryString", start, end, limit)
+		addOrder(&req, "-sessions")
+		return novelReport(cmd, flags, req, "top_pages")
+	}}
+	dateLimitFlags(c, &start, &end, &limit)
+	return c
+}
+func newEventsCmd(flags *rootFlags) *cobra.Command      { return eventsCmd(flags, false) }
+func newConversionsCmd(flags *rootFlags) *cobra.Command { return eventsCmd(flags, true) }
+func eventsCmd(flags *rootFlags, conversions bool) *cobra.Command {
+	var start, end string
+	var limit int
+	name, metric := "events", "eventCount"
+	if conversions {
+		name, metric = "conversions", "conversions"
+	}
+	c := &cobra.Command{Use: name, Short: "Key events / conversions over time with trend", RunE: func(cmd *cobra.Command, args []string) error {
+		req := reportRequest(metric, "date,eventName", start, end, limit)
+		if conversions {
+			req.DimensionFilter = &ga4.FilterExpression{Filter: &ga4.Filter{FieldName: "isConversionEvent", StringFilter: &ga4.StringFilter{MatchType: "EXACT", Value: "true"}}}
+		}
+		return trendReport(cmd, flags, req, name, metric)
+	}}
+	dateLimitFlags(c, &start, &end, &limit)
+	return c
+}
+func newRevenueCmd(flags *rootFlags) *cobra.Command {
+	var start, end, by string
+	var limit int
+	c := &cobra.Command{Use: "revenue", Short: "Ecommerce revenue, AOV, and transactions by channel/source", RunE: func(cmd *cobra.Command, args []string) error {
+		dim := "sessionDefaultChannelGroup"
+		if by == "source" || by == "source-medium" {
+			dim = "sessionSourceMedium"
+		}
+		req := reportRequest("purchaseRevenue,transactions,averagePurchaseRevenue,sessions", dim, start, end, limit)
+		addOrder(&req, "-purchaseRevenue")
+		return novelReport(cmd, flags, req, "revenue")
+	}}
+	dateLimitFlags(c, &start, &end, &limit)
+	c.Flags().StringVar(&by, "by", "channel", "Breakdown: channel or source")
+	return c
+}
+func newAudienceCmd(flags *rootFlags) *cobra.Command {
+	var start, end string
+	var limit int
+	c := &cobra.Command{Use: "audience", Short: "Audience snapshot by country/device/new-vs-returning", RunE: func(cmd *cobra.Command, args []string) error {
+		req := reportRequest("totalUsers,newUsers,sessions,engagementRate,conversions", "country,deviceCategory,newVsReturning", start, end, limit)
+		addOrder(&req, "-totalUsers")
+		return novelReport(cmd, flags, req, "audience")
+	}}
+	dateLimitFlags(c, &start, &end, &limit)
+	return c
+}
+func newCohortCmd(flags *rootFlags) *cobra.Command {
+	var start, end string
+	var limit int
+	c := &cobra.Command{Use: "cohort", Short: "Cheap retention proxy: users by first-user date and returning status", RunE: func(cmd *cobra.Command, args []string) error {
+		req := reportRequest("totalUsers,sessions,engagementRate", "firstSessionDate,newVsReturning", start, end, limit)
+		addOrder(&req, "firstSessionDate")
+		return novelReport(cmd, flags, req, "cohort")
+	}}
+	dateLimitFlags(c, &start, &end, &limit)
+	return c
+}
+func novelReport(cmd *cobra.Command, f *rootFlags, req ga4.RunReportRequest, name string) error {
+	rows, raw, err := runReportRows(f, req)
+	if err != nil {
+		return err
+	}
+	out := map[string]any{"report": name, "property": configuredProperty(f), "rows": enrich(rows), "totals": flattenTotals(raw), "row_count": len(rows)}
+	return output(cmd, f, out, renderRows(out))
+}
+func trendReport(cmd *cobra.Command, f *rootFlags, req ga4.RunReportRequest, name, metric string) error {
+	rows, _, err := runReportRows(f, req)
+	if err != nil {
+		return err
+	}
+	out := map[string]any{"report": name, "property": configuredProperty(f), "metric": metric, "rows": enrich(rows), "trend": trend(rows, metric)}
+	return output(cmd, f, out, renderRows(out))
+}
+func runReportRows(f *rootFlags, req ga4.RunReportRequest) ([]map[string]any, ga4.ReportResponse, error) {
+	p, err := requireProperty(f)
+	if err != nil {
+		return nil, ga4.ReportResponse{}, err
+	}
+	cl, _, err := f.newClient()
+	if err != nil {
+		return nil, ga4.ReportResponse{}, err
+	}
+	raw, _, err := cl.RunReport(context.Background(), p, req)
+	if err != nil {
+		return nil, raw, err
+	}
+	return flattenRows(raw), raw, nil
+}

--- a/library/marketing/google-analytics/internal/cli/raw_commands.go
+++ b/library/marketing/google-analytics/internal/cli/raw_commands.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/ga4"
+	"github.com/spf13/cobra"
+)
+
+func newReportCmd(flags *rootFlags) *cobra.Command {
+	var metrics, dims, start, end, filter, order string
+	var limit int
+	c := &cobra.Command{Use: "report", Short: "Raw GA4 runReport wrapper", RunE: func(cmd *cobra.Command, args []string) error {
+		req := reportRequest(metrics, dims, start, end, limit)
+		if err := addRawDimensionFilter(&req, filter); err != nil {
+			return fmt.Errorf("--filter must be JSON dimensionFilter: %w", err)
+		}
+		addOrder(&req, order)
+		return runReportOutput(cmd, flags, req, "")
+	}}
+	reportFlags(c, &metrics, &dims, &start, &end, &limit)
+	c.Flags().StringVar(&filter, "filter", "", "Raw JSON dimensionFilter")
+	c.Flags().StringVar(&order, "order", "", "Order by metric/dimension name, prefix - for desc")
+	return c
+}
+func newPivotCmd(flags *rootFlags) *cobra.Command {
+	var metrics, dims, start, end string
+	var limit int
+	c := &cobra.Command{Use: "pivot", Short: "Raw GA4 runPivotReport wrapper", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		base := reportRequest(metrics, dims, start, end, limit)
+		pivotLimit := base.Limit
+		base.Limit = ""
+		req := ga4.RunPivotReportRequest{RunReportRequest: base}
+		for _, d := range splitCSV(dims) {
+			req.Pivots = append(req.Pivots, ga4.Pivot{FieldNames: []string{d}, Limit: pivotLimit})
+		}
+		raw, _, err := cl.RunPivotReport(context.Background(), p, req)
+		if err != nil {
+			return err
+		}
+		return output(cmd, flags, raw, "")
+	}}
+	reportFlags(c, &metrics, &dims, &start, &end, &limit)
+	return c
+}
+func newBatchCmd(flags *rootFlags) *cobra.Command {
+	var reportsJSON string
+	c := &cobra.Command{Use: "batch", Short: "Raw GA4 batchRunReports wrapper", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		reports := []ga4.RunReportRequest{reportRequest("sessions,totalUsers", "date", "7daysAgo", "yesterday", 10)}
+		if reportsJSON != "" {
+			if err := json.Unmarshal([]byte(reportsJSON), &reports); err != nil {
+				return fmt.Errorf("--reports must be a JSON array of RunReportRequest objects: %w", err)
+			}
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.BatchRunReports(context.Background(), p, ga4.BatchRunReportsRequest{Requests: reports})
+		if err != nil {
+			return err
+		}
+		return output(cmd, flags, raw, "")
+	}}
+	c.Flags().StringVar(&reportsJSON, "reports", "", "JSON array of RunReportRequest bodies (property omitted; property comes from --property)")
+	return c
+}
+func newRealtimeCmd(flags *rootFlags) *cobra.Command {
+	var metrics, dims string
+	var limit int
+	c := &cobra.Command{Use: "realtime", Short: "Raw GA4 runRealtimeReport wrapper", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.RunRealtimeReport(context.Background(), p, realtimeRequest(metrics, dims, limit))
+		if err != nil {
+			return err
+		}
+		return output(cmd, flags, raw, "")
+	}}
+	c.Flags().StringVar(&metrics, "metrics", "activeUsers", "Comma-separated realtime metrics")
+	c.Flags().StringVar(&dims, "dimensions", "unifiedScreenName", "Comma-separated realtime dimensions")
+	c.Flags().IntVar(&limit, "limit", 10, "Rows")
+	return c
+}
+func newMetadataCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{Use: "metadata", Short: "List GA4 dimensions and metrics for a property", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.GetMetadata(context.Background(), p)
+		if err != nil {
+			return err
+		}
+		return output(cmd, flags, raw, "")
+	}}
+}
+func newCompatibilityCmd(flags *rootFlags) *cobra.Command {
+	var metrics, dims string
+	c := &cobra.Command{Use: "compatibility", Short: "Check GA4 metric/dimension compatibility", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.CheckCompatibility(context.Background(), p, compatibilityRequest(metrics, dims))
+		if err != nil {
+			return err
+		}
+		return output(cmd, flags, raw, "")
+	}}
+	c.Flags().StringVar(&metrics, "metrics", "sessions,totalUsers,conversions,totalRevenue", "Metrics")
+	c.Flags().StringVar(&dims, "dimensions", "sessionDefaultChannelGroup", "Dimensions")
+	return c
+}
+func runReportOutput(cmd *cobra.Command, flags *rootFlags, req ga4.RunReportRequest, human string) error {
+	p, err := requireProperty(flags)
+	if err != nil {
+		return err
+	}
+	cl, _, err := flags.newClient()
+	if err != nil {
+		return err
+	}
+	raw, _, err := cl.RunReport(context.Background(), p, req)
+	if err != nil {
+		return err
+	}
+	if raw.Raw != nil {
+		return output(cmd, flags, raw.Raw, human)
+	}
+	return output(cmd, flags, raw, human)
+}

--- a/library/marketing/google-analytics/internal/cli/render.go
+++ b/library/marketing/google-analytics/internal/cli/render.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+func renderRows(v map[string]any) string { rows, _ := v["rows"].([]map[string]any); return table(rows) }
+func table(rows []map[string]any) string {
+	if len(rows) == 0 {
+		return "No rows.\n"
+	}
+	keys := []string{}
+	for k := range rows[0] {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, strings.Join(keys, "\t"))
+	for _, r := range rows {
+		vals := []string{}
+		for _, k := range keys {
+			vals = append(vals, fmt.Sprint(r[k]))
+		}
+		fmt.Fprintln(tw, strings.Join(vals, "\t"))
+	}
+	tw.Flush()
+	return b.String()
+}
+func renderHealth(v map[string]any) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b) + "\n"
+}
+func renderCompare(v map[string]any) string {
+	rows, _ := v["rows"].([]map[string]any)
+	return table(rows)
+}
+func renderMovers(v map[string]any) string {
+	rows, _ := v["movers"].([]map[string]any)
+	return table(rows)
+}

--- a/library/marketing/google-analytics/internal/cli/root.go
+++ b/library/marketing/google-analytics/internal/cli/root.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Cathryn Lavery and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/ga4"
+	"github.com/spf13/cobra"
+)
+
+var version = "1.1.0"
+
+type rootFlags struct {
+	asJSON      bool
+	compact     bool
+	noInput     bool
+	yes         bool
+	agent       bool
+	propertyID  string
+	credentials string
+	timeout     time.Duration
+	client      *ga4.Client
+	key         ga4.ServiceAccountKey
+}
+
+func RootCmd() *cobra.Command { var f rootFlags; return newRootCmd(&f) }
+func Execute() error          { var f rootFlags; return newRootCmd(&f).Execute() }
+
+func newRootCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{Use: "google-analytics-pp-cli", Short: "Agent-first Google Analytics 4 CLI", Long: `Google Analytics 4 Printing Press CLI.
+
+Raw wrappers: report, pivot, batch, realtime, metadata, compatibility, properties, property, streams.
+Novel commands: health/doctor, channels, sources, top-pages, events, conversions, funnel, compare, whats-changed, revenue, audience, cohort.
+
+Auth: uses a Google service-account JSON key. Set GOOGLE_APPLICATION_CREDENTIALS, or pass --credentials. Scope: analytics.readonly.
+Property resolution for data commands: --property, then GA4_PROPERTY_ID. The CLI never hard-codes a brand property for reads.`, SilenceUsage: true, Version: version}
+	cmd.SetVersionTemplate("google-analytics-pp-cli {{ .Version }}\n")
+	cmd.PersistentFlags().BoolVar(&flags.asJSON, "json", false, "Output JSON")
+	cmd.PersistentFlags().BoolVar(&flags.compact, "compact", false, "Prefer token-compact fields where supported")
+	cmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable prompts (agent/CI safe)")
+	cmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Assume yes for safe non-mutating confirmations")
+	cmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Agent mode: --json --compact --no-input --yes")
+	cmd.PersistentFlags().StringVar(&flags.propertyID, "property", "", "GA4 numeric property ID (defaults to GA4_PROPERTY_ID)")
+	cmd.PersistentFlags().StringVar(&flags.credentials, "credentials", "", "Service-account JSON key path (defaults to GOOGLE_APPLICATION_CREDENTIALS)")
+	cmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 30*time.Second, "HTTP request timeout")
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if flags.agent {
+			flags.asJSON, flags.compact, flags.noInput, flags.yes = true, true, true, true
+		}
+		return nil
+	}
+	cmd.AddCommand(newAgentContextCmd())
+	cmd.AddCommand(newHealthCmd(flags), newDoctorCmd(flags))
+	cmd.AddCommand(newReportCmd(flags), newPivotCmd(flags), newBatchCmd(flags), newRealtimeCmd(flags), newMetadataCmd(flags), newCompatibilityCmd(flags))
+	cmd.AddCommand(newPropertiesCmd(flags), newPropertyCmd(flags), newStreamsCmd(flags))
+	cmd.AddCommand(newChannelsCmd(flags), newSourcesCmd(flags), newTopPagesCmd(flags), newEventsCmd(flags), newConversionsCmd(flags))
+	cmd.AddCommand(newFunnelCmd(flags), newCompareCmd(flags), newWhatsChangedCmd(flags), newRevenueCmd(flags), newAudienceCmd(flags), newCohortCmd(flags))
+	return cmd
+}
+
+func (f *rootFlags) newClient() (*ga4.Client, ga4.ServiceAccountKey, error) {
+	if f.client != nil {
+		return f.client, f.key, nil
+	}
+	var key ga4.ServiceAccountKey
+	path := credentialPath(f)
+	if path == "" {
+		return nil, key, fmt.Errorf("missing credentials: set GOOGLE_APPLICATION_CREDENTIALS or pass --credentials")
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, key, err
+	}
+	if err := jsonDecode(b, &key); err != nil {
+		return nil, key, err
+	}
+	tok, err := ga4.MintToken(key)
+	if err != nil {
+		return nil, key, err
+	}
+	f.client = ga4.NewClient(tok, f.timeout)
+	f.key = key
+	return f.client, key, nil
+}
+
+func output(cmd *cobra.Command, f *rootFlags, v any, human string) error {
+	if f.asJSON || f.agent {
+		return printJSON(cmd.OutOrStdout(), v)
+	}
+	if human != "" {
+		_, err := io.Copy(cmd.OutOrStdout(), bytes.NewBufferString(human))
+		return err
+	}
+	return printJSON(cmd.OutOrStdout(), v)
+}
+
+func configuredProperty(f *rootFlags) string {
+	if f.propertyID != "" {
+		return cleanProperty(f.propertyID)
+	}
+	return cleanProperty(os.Getenv("GA4_PROPERTY_ID"))
+}
+func requireProperty(f *rootFlags) (string, error) {
+	p := configuredProperty(f)
+	if p == "" {
+		return "", fmt.Errorf("missing GA4 property: pass --property or set GA4_PROPERTY_ID")
+	}
+	return p, nil
+}
+func cleanProperty(p string) string { return strings.TrimSpace(strings.TrimPrefix(p, "properties/")) }
+func credentialPath(f *rootFlags) string {
+	if f.credentials != "" {
+		return f.credentials
+	}
+	if p := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); p != "" {
+		return p
+	}
+	return ""
+}

--- a/library/marketing/google-analytics/internal/cli/root_test.go
+++ b/library/marketing/google-analytics/internal/cli/root_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestAgentModeSetsGlobalFlags(t *testing.T) {
+	var f rootFlags
+	cmd := newRootCmd(&f)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"agent-context", "--agent"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !f.asJSON || !f.compact || !f.noInput || !f.yes {
+		t.Fatalf("agent flags not applied: %#v", f)
+	}
+}
+func TestEveryCommandHasAgentSafetyGlobals(t *testing.T) {
+	root := RootCmd()
+	for _, name := range []string{"report", "pivot", "batch", "realtime", "metadata", "compatibility", "properties", "property", "streams", "channels", "sources", "top-pages", "events", "conversions", "funnel", "compare", "whats-changed", "revenue", "audience", "cohort", "health", "doctor"} {
+		cmd, _, err := root.Find([]string{name})
+		if err != nil || cmd == nil || cmd.Name() != name {
+			t.Fatalf("missing command %s", name)
+		}
+		for _, flag := range []string{"agent", "json", "compact", "no-input", "yes", "property"} {
+			if cmd.InheritedFlags().Lookup(flag) == nil && cmd.Flags().Lookup(flag) == nil {
+				t.Fatalf("%s missing --%s", name, flag)
+			}
+		}
+	}
+}
+func TestRequirePropertyError(t *testing.T) {
+	t.Setenv("GA4_PROPERTY_ID", "")
+	_, err := requireProperty(&rootFlags{})
+	if err == nil || !strings.Contains(err.Error(), "--property") {
+		t.Fatalf("expected missing property error, got %v", err)
+	}
+}
+
+func TestCredentialPathUsesExplicitThenEnvOnly(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/from-env.json")
+	if got := credentialPath(&rootFlags{credentials: "/tmp/from-flag.json"}); got != "/tmp/from-flag.json" {
+		t.Fatalf("explicit credential path not preferred: %q", got)
+	}
+	if got := credentialPath(&rootFlags{}); got != "/tmp/from-env.json" {
+		t.Fatalf("env credential path not used: %q", got)
+	}
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	if got := credentialPath(&rootFlags{}); got != "" {
+		t.Fatalf("unexpected implicit credential fallback: %q", got)
+	}
+}

--- a/library/marketing/google-analytics/internal/cli/transform.go
+++ b/library/marketing/google-analytics/internal/cli/transform.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/ga4"
+)
+
+func flattenRows(raw ga4.ReportResponse) []map[string]any {
+	out := []map[string]any{}
+	for _, rv := range raw.Rows {
+		row := map[string]any{}
+		for i, h := range raw.DimensionHeaders {
+			if i < len(rv.DimensionValues) {
+				row[h.Name] = rv.DimensionValues[i].Value
+			}
+		}
+		for i, h := range raw.MetricHeaders {
+			if i < len(rv.MetricValues) {
+				row[h.Name] = parseNum(rv.MetricValues[i].Value)
+			}
+		}
+		out = append(out, row)
+	}
+	return out
+}
+func flattenTotals(raw ga4.ReportResponse) []map[string]any {
+	r := raw
+	r.Rows = raw.Totals
+	r.DimensionHeaders = nil
+	return flattenRows(r)
+}
+func parseNum(s string) any {
+	if strings.Contains(s, ".") {
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return f
+		}
+	}
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return i
+	}
+	return s
+}
+func enrich(rows []map[string]any) []map[string]any {
+	for _, r := range rows {
+		conv := toFloat(r["conversions"])
+		sess := toFloat(r["sessions"])
+		rev := toFloat(r["totalRevenue"]) + toFloat(r["purchaseRevenue"])
+		trans := toFloat(r["transactions"])
+		if sess > 0 && conv >= 0 {
+			r["conversion_rate"] = conv / sess
+		}
+		if trans > 0 && rev > 0 {
+			r["aov"] = rev / trans
+		}
+	}
+	return rows
+}
+func rowKey(r map[string]any, dims []string) string {
+	parts := []string{}
+	for _, d := range dims {
+		parts = append(parts, fmt.Sprint(r[d]))
+	}
+	return strings.Join(parts, "|")
+}
+func compareRows(a, b []map[string]any, dims, metrics []string) map[string]any {
+	bm := map[string]map[string]any{}
+	for _, r := range b {
+		bm[rowKey(r, dims)] = r
+	}
+	rows := []map[string]any{}
+	for _, ar := range a {
+		key := rowKey(ar, dims)
+		br := bm[key]
+		out := map[string]any{"key": key}
+		for _, d := range dims {
+			out[d] = ar[d]
+		}
+		maxPct := 0.0
+		for _, m := range metrics {
+			av := toFloat(ar[m])
+			bv := toFloat(br[m])
+			delta := av - bv
+			pct := 0.0
+			if bv != 0 {
+				pct = delta / bv
+			}
+			out[m] = map[string]float64{"current": av, "previous": bv, "delta": delta, "pct_change": pct}
+			if abs(pct) > abs(maxPct) {
+				maxPct = pct
+			}
+		}
+		out["largest_pct_change"] = maxPct
+		rows = append(rows, out)
+	}
+	return map[string]any{"rows": rows, "row_count": len(rows)}
+}
+func trend(rows []map[string]any, metric string) map[string]any {
+	if len(rows) == 0 {
+		return map[string]any{}
+	}
+	first := toFloat(rows[0][metric])
+	last := toFloat(rows[len(rows)-1][metric])
+	delta := last - first
+	pct := 0.0
+	if first != 0 {
+		pct = delta / first
+	}
+	return map[string]any{"first": first, "last": last, "delta": delta, "pct_change": pct}
+}
+func inferPrevious(start, end, period string) (string, string) {
+	if ps, pe, ok := inferPreviousAbsolute(start, end); ok {
+		return ps, pe
+	}
+	switch period {
+	case "wow":
+		return "14daysAgo", "8daysAgo"
+	case "mom":
+		return "60daysAgo", "31daysAgo"
+	default:
+		return "14daysAgo", "8daysAgo"
+	}
+}
+
+func inferPreviousAbsolute(start, end string) (string, string, bool) {
+	startDate, err := time.Parse("2006-01-02", start)
+	if err != nil {
+		return "", "", false
+	}
+	endDate, err := time.Parse("2006-01-02", end)
+	if err != nil || endDate.Before(startDate) {
+		return "", "", false
+	}
+	days := int(endDate.Sub(startDate).Hours()/24) + 1
+	previousEnd := startDate.AddDate(0, 0, -1)
+	previousStart := previousEnd.AddDate(0, 0, -(days - 1))
+	return previousStart.Format("2006-01-02"), previousEnd.Format("2006-01-02"), true
+}
+
+func toFloat(v any) float64 {
+	switch x := v.(type) {
+	case nil:
+		return 0
+	case float64:
+		return x
+	case int:
+		return float64(x)
+	case int64:
+		return float64(x)
+	case string:
+		f, _ := strconv.ParseFloat(x, 64)
+		return f
+	case map[string]any:
+		return toFloat(x["pct_change"])
+	}
+	return 0
+}
+func abs(f float64) float64 {
+	if f < 0 {
+		return -f
+	}
+	return f
+}
+func uniqNonEmpty(xs []string) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, x := range xs {
+		x = cleanProperty(x)
+		if x != "" && !seen[x] {
+			seen[x] = true
+			out = append(out, x)
+		}
+	}
+	return out
+}
+func visibleProperties(s ga4.AccountSummariesResponse) []string {
+	props := []string{}
+	for _, sum := range s.AccountSummaries {
+		for _, p := range sum.PropertySummaries {
+			if p.Property != "" {
+				props = append(props, cleanProperty(p.Property))
+			}
+		}
+	}
+	sort.Strings(props)
+	return props
+}

--- a/library/marketing/google-analytics/internal/cli/transform_test.go
+++ b/library/marketing/google-analytics/internal/cli/transform_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"math"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/ga4"
+)
+
+func TestFlattenRowsAndEnrich(t *testing.T) {
+	raw := ga4.ReportResponse{DimensionHeaders: []ga4.Header{{Name: "channel"}}, MetricHeaders: []ga4.Header{{Name: "sessions"}, {Name: "conversions"}, {Name: "totalRevenue"}, {Name: "transactions"}}, Rows: []ga4.Row{{DimensionValues: []ga4.Value{{Value: "Organic Search"}}, MetricValues: []ga4.Value{{Value: "100"}, {Value: "5"}, {Value: "250.50"}, {Value: "2"}}}}}
+	rows := enrich(flattenRows(raw))
+	if rows[0]["channel"] != "Organic Search" {
+		t.Fatalf("bad dimension: %#v", rows[0])
+	}
+	if math.Abs(rows[0]["conversion_rate"].(float64)-0.05) > 0.0001 {
+		t.Fatalf("bad conversion rate: %#v", rows[0])
+	}
+	if math.Abs(rows[0]["aov"].(float64)-125.25) > 0.0001 {
+		t.Fatalf("bad aov: %#v", rows[0])
+	}
+}
+func TestCompareRowsCalculatesDeltasAndPct(t *testing.T) {
+	a := []map[string]any{{"channel": "Organic", "sessions": 150, "totalRevenue": 75.0}}
+	b := []map[string]any{{"channel": "Organic", "sessions": 100, "totalRevenue": 100.0}}
+	out := compareRows(a, b, []string{"channel"}, []string{"sessions", "totalRevenue"})
+	rows := out["rows"].([]map[string]any)
+	sessions := rows[0]["sessions"].(map[string]float64)
+	if sessions["delta"] != 50 || sessions["pct_change"] != 0.5 {
+		t.Fatalf("bad sessions delta: %#v", sessions)
+	}
+	revenue := rows[0]["totalRevenue"].(map[string]float64)
+	if revenue["delta"] != -25 || revenue["pct_change"] != -0.25 {
+		t.Fatalf("bad revenue delta: %#v", revenue)
+	}
+}
+func TestTrendAndInferPrevious(t *testing.T) {
+	tr := trend([]map[string]any{{"eventCount": 10}, {"eventCount": 15}}, "eventCount")
+	if tr["delta"].(float64) != 5 || tr["pct_change"].(float64) != 0.5 {
+		t.Fatalf("bad trend: %#v", tr)
+	}
+	ps, pe := inferPrevious("7daysAgo", "yesterday", "wow")
+	if ps != "14daysAgo" || pe != "8daysAgo" {
+		t.Fatalf("bad previous: %s %s", ps, pe)
+	}
+	ps, pe = inferPrevious("2026-05-01", "2026-05-31", "trailing")
+	if ps != "2026-03-31" || pe != "2026-04-30" {
+		t.Fatalf("bad absolute previous window: %s %s", ps, pe)
+	}
+}
+func TestWhatsChangedRankingMagnitude(t *testing.T) {
+	movers := []map[string]any{{"largest_pct_change": -2.0}, {"largest_pct_change": 0.5}}
+	if !(abs(toFloat(movers[0]["largest_pct_change"])) > abs(toFloat(movers[1]["largest_pct_change"]))) {
+		t.Fatal("expected absolute pct ranking")
+	}
+}
+
+func TestPreviousWindowRejectsPartialExplicitPreviousPeriod(t *testing.T) {
+	_, _, err := previousWindow("2026-05-01", "2026-05-31", "2026-04-01", "", "trailing")
+	if err == nil {
+		t.Fatal("expected partial previous-period input to fail")
+	}
+	ps, pe, err := previousWindow("2026-05-01", "2026-05-31", "2026-04-01", "2026-04-30", "trailing")
+	if err != nil || ps != "2026-04-01" || pe != "2026-04-30" {
+		t.Fatalf("bad explicit previous window: %s %s %v", ps, pe, err)
+	}
+}

--- a/library/marketing/google-analytics/internal/ga4/auth.go
+++ b/library/marketing/google-analytics/internal/ga4/auth.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Cathryn Lavery and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package ga4
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+func MintToken(key ServiceAccountKey) (string, error) {
+	if key.TokenURI == "" {
+		key.TokenURI = "https://oauth2.googleapis.com/token"
+	}
+	block, _ := pem.Decode([]byte(key.PrivateKey))
+	if block == nil {
+		return "", fmt.Errorf("invalid service-account private_key PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return "", err
+	}
+	pk, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return "", fmt.Errorf("service-account private key is not RSA")
+	}
+	now := time.Now().Unix()
+	header := b64json(map[string]string{"alg": "RS256", "typ": "JWT"})
+	claims := b64json(map[string]any{"iss": key.ClientEmail, "scope": AnalyticsReadonlyScope, "aud": key.TokenURI, "iat": now, "exp": now + 3600})
+	unsigned := header + "." + claims
+	h := sha256.Sum256([]byte(unsigned))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, pk, crypto.SHA256, h[:])
+	if err != nil {
+		return "", err
+	}
+	form := url.Values{"grant_type": {"urn:ietf:params:oauth:grant-type:jwt-bearer"}, "assertion": {unsigned + "." + base64.RawURLEncoding.EncodeToString(sig)}}
+	resp, err := http.PostForm(key.TokenURI, form)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", APIError{Status: resp.StatusCode, Body: string(body)}
+	}
+	var out struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", err
+	}
+	if out.AccessToken == "" {
+		return "", fmt.Errorf("token response missing access_token")
+	}
+	return out.AccessToken, nil
+}
+func b64json(v any) string { b, _ := json.Marshal(v); return base64.RawURLEncoding.EncodeToString(b) }

--- a/library/marketing/google-analytics/internal/ga4/client.go
+++ b/library/marketing/google-analytics/internal/ga4/client.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Cathryn Lavery and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package ga4
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	HTTPClient *http.Client
+	Token      string
+	DataBase   string
+	AdminBase  string
+	AlphaBase  string
+}
+
+type APIError struct {
+	Status int
+	Body   string
+}
+
+func (e APIError) Error() string { return fmt.Sprintf("google api status %d: %s", e.Status, e.Body) }
+
+func NewClient(token string, timeout time.Duration) *Client {
+	return &Client{HTTPClient: &http.Client{Timeout: timeout}, Token: token, DataBase: "https://analyticsdata.googleapis.com/v1beta", AdminBase: "https://analyticsadmin.googleapis.com/v1beta", AlphaBase: "https://analyticsdata.googleapis.com/v1alpha"}
+}
+
+func (c *Client) RunReport(ctx context.Context, property string, req RunReportRequest) (ReportResponse, int, error) {
+	var out ReportResponse
+	st, err := c.post(ctx, c.dataURL(property, "runReport"), req, &out)
+	return out, st, err
+}
+func (c *Client) RunPivotReport(ctx context.Context, property string, req RunPivotReportRequest) (map[string]any, int, error) {
+	var out map[string]any
+	st, err := c.post(ctx, c.dataURL(property, "runPivotReport"), req, &out)
+	return out, st, err
+}
+func (c *Client) BatchRunReports(ctx context.Context, property string, req BatchRunReportsRequest) (map[string]any, int, error) {
+	var out map[string]any
+	st, err := c.post(ctx, c.dataURL(property, "batchRunReports"), req, &out)
+	return out, st, err
+}
+func (c *Client) RunRealtimeReport(ctx context.Context, property string, req RunRealtimeReportRequest) (map[string]any, int, error) {
+	var out map[string]any
+	st, err := c.post(ctx, c.dataURL(property, "runRealtimeReport"), req, &out)
+	return out, st, err
+}
+func (c *Client) CheckCompatibility(ctx context.Context, property string, req CheckCompatibilityRequest) (map[string]any, int, error) {
+	var out map[string]any
+	st, err := c.post(ctx, c.dataURL(property, "checkCompatibility"), req, &out)
+	return out, st, err
+}
+func (c *Client) GetMetadata(ctx context.Context, property string) (map[string]any, int, error) {
+	var out map[string]any
+	st, err := c.get(ctx, fmt.Sprintf("%s/properties/%s/metadata", c.DataBase, url.PathEscape(property)), &out)
+	return out, st, err
+}
+func (c *Client) RunFunnelReport(ctx context.Context, property string, req RunFunnelReportRequest) (map[string]any, int, error) {
+	var out map[string]any
+	st, err := c.post(ctx, fmt.Sprintf("%s/properties/%s:runFunnelReport", c.AlphaBase, url.PathEscape(property)), req, &out)
+	return out, st, err
+}
+func (c *Client) AccountSummaries(ctx context.Context) (AccountSummariesResponse, int, error) {
+	var combined AccountSummariesResponse
+	lastStatus := 0
+	pageToken := ""
+	for {
+		target := c.AdminBase + "/accountSummaries?pageSize=200"
+		if pageToken != "" {
+			target += "&pageToken=" + url.QueryEscape(pageToken)
+		}
+		var page AccountSummariesResponse
+		st, err := c.get(ctx, target, &page)
+		lastStatus = st
+		if err != nil {
+			return combined, st, err
+		}
+		combined.AccountSummaries = append(combined.AccountSummaries, page.AccountSummaries...)
+		if page.NextPageToken == "" {
+			return combined, lastStatus, nil
+		}
+		pageToken = page.NextPageToken
+	}
+}
+func (c *Client) Property(ctx context.Context, property string) (Property, int, error) {
+	var out Property
+	st, err := c.get(ctx, fmt.Sprintf("%s/properties/%s", c.AdminBase, url.PathEscape(property)), &out)
+	return out, st, err
+}
+func (c *Client) DataStreams(ctx context.Context, property string) (DataStreamsResponse, int, error) {
+	var out DataStreamsResponse
+	st, err := c.get(ctx, fmt.Sprintf("%s/properties/%s/dataStreams", c.AdminBase, url.PathEscape(property)), &out)
+	return out, st, err
+}
+
+func (c *Client) dataURL(property, method string) string {
+	return fmt.Sprintf("%s/properties/%s:%s", c.DataBase, url.PathEscape(property), method)
+}
+
+func (c *Client) get(ctx context.Context, target string, out any) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return 0, err
+	}
+	return c.do(req, out)
+}
+func (c *Client) post(ctx context.Context, target string, body any, out any) (int, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(b))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return c.do(req, out)
+}
+func (c *Client) do(req *http.Request, out any) (int, error) {
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	req.Header.Set("User-Agent", "google-analytics-pp-cli/1.1.0")
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resp.StatusCode, APIError{Status: resp.StatusCode, Body: string(b)}
+	}
+	if len(strings.TrimSpace(string(b))) == 0 || out == nil {
+		return resp.StatusCode, nil
+	}
+	if err := json.Unmarshal(b, out); err != nil {
+		return resp.StatusCode, err
+	}
+	if rr, ok := out.(*ReportResponse); ok {
+		_ = json.Unmarshal(b, &rr.Raw)
+	}
+	return resp.StatusCode, nil
+}

--- a/library/marketing/google-analytics/internal/ga4/client_test.go
+++ b/library/marketing/google-analytics/internal/ga4/client_test.go
@@ -1,0 +1,75 @@
+package ga4
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunReportPostsTypedRequest(t *testing.T) {
+	var seenPath, seenAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		seenAuth = r.Header.Get("Authorization")
+		var req RunReportRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatal(err)
+		}
+		if req.Metrics[0].Name != "sessions" {
+			t.Fatalf("bad request: %#v", req)
+		}
+		_, _ = w.Write([]byte(`{"dimensionHeaders":[{"name":"date"}],"metricHeaders":[{"name":"sessions"}],"rows":[{"dimensionValues":[{"value":"20260612"}],"metricValues":[{"value":"42"}]}]}`))
+	}))
+	defer srv.Close()
+	c := NewClient("tok", time.Second)
+	c.DataBase = srv.URL
+	out, st, err := c.RunReport(context.Background(), "$GA4_PROPERTY_ID", RunReportRequest{Metrics: []Metric{{Name: "sessions"}}})
+	if err != nil || st != 200 {
+		t.Fatalf("%d %v", st, err)
+	}
+	if !strings.Contains(seenPath, "/properties/$GA4_PROPERTY_ID:runReport") || seenAuth != "Bearer tok" {
+		t.Fatalf("path/auth %q %q", seenPath, seenAuth)
+	}
+	if len(out.Rows) != 1 {
+		t.Fatalf("bad rows: %#v", out)
+	}
+}
+func TestAPIErrorIncludesStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { http.Error(w, "nope", http.StatusForbidden) }))
+	defer srv.Close()
+	c := NewClient("tok", time.Second)
+	c.AdminBase = srv.URL
+	_, st, err := c.AccountSummaries(context.Background())
+	if st != 403 || err == nil {
+		t.Fatalf("want 403 err, got %d %v", st, err)
+	}
+	if _, ok := err.(APIError); !ok {
+		t.Fatalf("want APIError, got %T", err)
+	}
+}
+
+func TestAccountSummariesPaginates(t *testing.T) {
+	seenTokens := []string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenTokens = append(seenTokens, r.URL.Query().Get("pageToken"))
+		if r.URL.Query().Get("pageToken") == "next" {
+			_, _ = w.Write([]byte(`{"accountSummaries":[{"name":"accountSummaries/2"}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"accountSummaries":[{"name":"accountSummaries/1"}],"nextPageToken":"next"}`))
+	}))
+	defer srv.Close()
+	c := NewClient("tok", time.Second)
+	c.AdminBase = srv.URL
+	out, st, err := c.AccountSummaries(context.Background())
+	if err != nil || st != 200 {
+		t.Fatalf("%d %v", st, err)
+	}
+	if len(out.AccountSummaries) != 2 || len(seenTokens) != 2 || seenTokens[1] != "next" {
+		t.Fatalf("pagination failed: summaries=%#v tokens=%#v", out.AccountSummaries, seenTokens)
+	}
+}

--- a/library/marketing/google-analytics/internal/ga4/types.go
+++ b/library/marketing/google-analytics/internal/ga4/types.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Cathryn Lavery and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package ga4
+
+import "encoding/json"
+
+const AnalyticsReadonlyScope = "https://www.googleapis.com/auth/analytics.readonly"
+
+type ServiceAccountKey struct {
+	ClientEmail string `json:"client_email"`
+	PrivateKey  string `json:"private_key"`
+	TokenURI    string `json:"token_uri"`
+	ProjectID   string `json:"project_id"`
+}
+
+type DateRange struct {
+	StartDate string `json:"startDate"`
+	EndDate   string `json:"endDate"`
+}
+
+type Named struct {
+	Name string `json:"name"`
+}
+
+type Metric = Named
+type Dimension = Named
+
+type OrderBy struct {
+	Desc      bool              `json:"desc,omitempty"`
+	Metric    *MetricOrderBy    `json:"metric,omitempty"`
+	Dimension *DimensionOrderBy `json:"dimension,omitempty"`
+}
+
+type MetricOrderBy struct {
+	MetricName string `json:"metricName"`
+}
+type DimensionOrderBy struct {
+	DimensionName string `json:"dimensionName"`
+}
+
+type StringFilter struct {
+	MatchType string `json:"matchType,omitempty"`
+	Value     string `json:"value"`
+}
+
+type Filter struct {
+	FieldName    string        `json:"fieldName"`
+	StringFilter *StringFilter `json:"stringFilter,omitempty"`
+}
+
+type FilterExpression struct {
+	Filter *Filter         `json:"filter,omitempty"`
+	Raw    json.RawMessage `json:"-"`
+}
+
+func (f FilterExpression) MarshalJSON() ([]byte, error) {
+	if len(f.Raw) > 0 {
+		return f.Raw, nil
+	}
+	type alias FilterExpression
+	return json.Marshal(alias(f))
+}
+
+type RunReportRequest struct {
+	DateRanges      []DateRange       `json:"dateRanges,omitempty"`
+	Metrics         []Metric          `json:"metrics,omitempty"`
+	Dimensions      []Dimension       `json:"dimensions,omitempty"`
+	Limit           string            `json:"limit,omitempty"`
+	DimensionFilter *FilterExpression `json:"dimensionFilter,omitempty"`
+	OrderBys        []OrderBy         `json:"orderBys,omitempty"`
+}
+
+type Pivot struct {
+	FieldNames []string `json:"fieldNames"`
+	Limit      string   `json:"limit,omitempty"`
+}
+
+type RunPivotReportRequest struct {
+	RunReportRequest
+	Pivots []Pivot `json:"pivots,omitempty"`
+}
+
+type BatchRunReportsRequest struct {
+	Requests []RunReportRequest `json:"requests"`
+}
+
+type RunRealtimeReportRequest struct {
+	Metrics    []Metric    `json:"metrics,omitempty"`
+	Dimensions []Dimension `json:"dimensions,omitempty"`
+	Limit      string      `json:"limit,omitempty"`
+}
+
+type CheckCompatibilityRequest struct {
+	Metrics             []Metric    `json:"metrics,omitempty"`
+	Dimensions          []Dimension `json:"dimensions,omitempty"`
+	CompatibilityFilter string      `json:"compatibilityFilter,omitempty"`
+}
+
+type FunnelEventFilter struct {
+	EventName string `json:"eventName"`
+}
+type FunnelFilterExpression struct {
+	FunnelEventFilter *FunnelEventFilter `json:"funnelEventFilter"`
+}
+type FunnelStep struct {
+	Name             string                  `json:"name"`
+	FilterExpression *FunnelFilterExpression `json:"filterExpression"`
+}
+type Funnel struct {
+	Steps []FunnelStep `json:"steps"`
+}
+type RunFunnelReportRequest struct {
+	DateRanges []DateRange `json:"dateRanges,omitempty"`
+	Funnel     Funnel      `json:"funnel"`
+}
+
+type Header struct {
+	Name string `json:"name"`
+}
+type Value struct {
+	Value string `json:"value"`
+}
+type Row struct {
+	DimensionValues []Value `json:"dimensionValues,omitempty"`
+	MetricValues    []Value `json:"metricValues,omitempty"`
+}
+type ReportResponse struct {
+	DimensionHeaders []Header       `json:"dimensionHeaders,omitempty"`
+	MetricHeaders    []Header       `json:"metricHeaders,omitempty"`
+	Rows             []Row          `json:"rows,omitempty"`
+	Totals           []Row          `json:"totals,omitempty"`
+	Raw              map[string]any `json:"-"`
+}
+
+type AccountSummariesResponse struct {
+	AccountSummaries []AccountSummary `json:"accountSummaries,omitempty"`
+	NextPageToken    string           `json:"nextPageToken,omitempty"`
+}
+type AccountSummary struct {
+	Name              string            `json:"name,omitempty"`
+	Account           string            `json:"account,omitempty"`
+	DisplayName       string            `json:"displayName,omitempty"`
+	PropertySummaries []PropertySummary `json:"propertySummaries,omitempty"`
+}
+type PropertySummary struct {
+	Property     string `json:"property,omitempty"`
+	DisplayName  string `json:"displayName,omitempty"`
+	PropertyType string `json:"propertyType,omitempty"`
+}
+type Property struct {
+	Name         string `json:"name,omitempty"`
+	Parent       string `json:"parent,omitempty"`
+	DisplayName  string `json:"displayName,omitempty"`
+	TimeZone     string `json:"timeZone,omitempty"`
+	CurrencyCode string `json:"currencyCode,omitempty"`
+}
+type DataStreamsResponse struct {
+	DataStreams []DataStream `json:"dataStreams,omitempty"`
+}
+type DataStream struct {
+	Name        string `json:"name,omitempty"`
+	Type        string `json:"type,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+}

--- a/library/marketing/google-analytics/spec.yaml
+++ b/library/marketing/google-analytics/spec.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Google Analytics 4 Data and Admin APIs
+  version: v1beta/v1alpha
+  description: Curated GA4-only spec covering Data API reports, Realtime, Metadata, Compatibility, Funnel reports, and Admin property discovery.
+servers:
+  - url: https://analyticsdata.googleapis.com
+  - url: https://analyticsadmin.googleapis.com
+paths:
+  /v1beta/properties/{property}:runReport: {post: {summary: Run GA4 report}}
+  /v1beta/properties/{property}:runPivotReport: {post: {summary: Run GA4 pivot report}}
+  /v1beta/properties/{property}:batchRunReports: {post: {summary: Batch run reports}}
+  /v1beta/properties/{property}:runRealtimeReport: {post: {summary: Run realtime report}}
+  /v1beta/properties/{property}/metadata: {get: {summary: Get metadata}}
+  /v1beta/properties/{property}:checkCompatibility: {post: {summary: Check compatible dimensions and metrics}}
+  /v1alpha/properties/{property}:runFunnelReport: {post: {summary: Run funnel report}}
+  /v1beta/accountSummaries: {get: {summary: List accessible accounts and properties}}
+  /v1beta/properties/{property}: {get: {summary: Get property}}
+  /v1beta/properties/{property}/dataStreams: {get: {summary: List data streams}}

--- a/library/marketing/google-analytics/workflow-verify-report.json
+++ b/library/marketing/google-analytics/workflow-verify-report.json
@@ -1,0 +1,4 @@
+{
+  "status": "pending-live-validation",
+  "workflow": "GA4 service-account reports and novel commands"
+}


### PR DESCRIPTION
## google-analytics

Adds a GA4-only Printing Press CLI under `library/marketing/google-analytics` with the binary `google-analytics-pp-cli` and focused skill `pp-google-analytics`.

**API:** Google Analytics 4 Data/Admin APIs | **Category:** marketing | **Press version:** private-library-manual-pp-sync
**Spec:** curated GA4 Data API v1beta + Funnel v1alpha + Admin v1beta spec archived as `spec.yaml`

### CLI Shape

```text
Google Analytics 4 Printing Press CLI.

Raw wrappers: report, pivot, batch, realtime, metadata, compatibility, properties, property, streams.
Novel commands: health/doctor, channels, sources, top-pages, events, conversions, funnel, compare, whats-changed, revenue, audience, cohort.

Auth: uses a Google service-account JSON key. Set GOOGLE_APPLICATION_CREDENTIALS, or pass --credentials. Scope: analytics.readonly.
Property resolution for data commands: --property, then GA4_PROPERTY_ID. The CLI never hard-codes a brand property for reads.

Usage:
  google-analytics-pp-cli [command]

Available Commands:
  agent-context Emit structured tool description for agents
  audience      Audience snapshot by country/device/new-vs-returning
  batch         Raw GA4 batchRunReports wrapper
  channels      Sessions/users/conversions/revenue by default channel group
  cohort        Cheap retention proxy: users by first-user date and returning status
  compare       Period-over-period deltas and percent change without doing two calls manually
  compatibility Check GA4 metric/dimension compatibility
  conversions   Key events / conversions over time with trend
  doctor        Verify credentials, Admin API, and per-property GA4 access grants
  events        Key events / conversions over time with trend
  funnel        Run GA4 v1alpha runFunnelReport for a named event step sequence
  health        Verify credentials, Admin API, and per-property GA4 access grants
  metadata      List GA4 dimensions and metrics for a property
  pivot         Raw GA4 runPivotReport wrapper
  properties    List accessible GA4 account summaries/properties
  property      Get GA4 Admin property metadata
  realtime      Raw GA4 runRealtimeReport wrapper
  report        Raw GA4 runReport wrapper
  revenue       Ecommerce revenue, AOV, and transactions by channel/source
  sources       Source/medium acquisition breakdown with conversion rate
  streams       List data streams for a GA4 property
  top-pages     Top landing pages by sessions, engagement, and conversions
  whats-changed Scan key metrics for notable spikes/drops vs trailing period
```

### What This CLI Does

This CLI exposes typed GA4 Data API/Admin API wrappers plus agent-first reporting shortcuts. The raw layer covers `runReport`, `runPivotReport`, `batchRunReports`, `runRealtimeReport`, `getMetadata`, `checkCompatibility`, Admin account summaries, property metadata, and data streams. The novel layer answers common operator questions around acquisition, pages, events/conversions, ecommerce, funnels, period comparison, and metric movers without requiring agents to hand-assemble GA4 JSON.

### Novel Commands

- `health` / `doctor` — mints a service-account token, lists visible Admin properties, and distinguishes invalid creds from GA4 property grant failures.
- `channels` — sessions/users/conversions/revenue by default channel group.
- `sources` — source/medium acquisition breakdown with conversion rate.
- `top-pages` — landing pages by sessions, engagement, conversions, and revenue.
- `events` / `conversions` — event/conversion trend output.
- `funnel` — v1alpha `runFunnelReport` for named event steps.
- `compare` — one-call period-over-period deltas and percent changes.
- `whats-changed` — mover scan across channel/source/page dimensions.
- `revenue` — purchase revenue/AOV/transactions by channel or source.
- `audience` / `cohort` — quick audience and retention snapshots.
- `agent-context` — structured command/context metadata for agents.

### Manuscripts

- Research: `library/marketing/google-analytics/.manuscripts/ga4-20260612/research/`
- Proofs: `library/marketing/google-analytics/.manuscripts/ga4-20260612/proofs/`

### Validation Results

| Check | Result |
| --- | --- |
| `go test ./...` | PASS |
| `go build ./...` | PASS |
| `golangci-lint run ./...` | PASS |
| `verify-publish-package` | PASS |
| `verify-skill` | PASS |
| `verify-supply-chain` | PASS |
| `git diff --check` | PASS |
| privacy scan | PASS — no committed live GA4 response artifacts, no private property IDs/brand names, no credential material, no local machine paths |

### Privacy / Smoke Evidence Policy

Live GA4 smoke checks were run locally with authorized credentials, but raw response artifacts are intentionally not committed because they can contain private analytics/business data. The committed proof docs record the command matrix and validation status only, with property identifiers redacted/genericized.

### Review Follow-up

- Fixed partial `--previous-start`/`--previous-end` handling for `compare` and `whats-changed`: callers must pass both previous dates or omit both for inference.
- Added Admin API account summaries pagination via `nextPageToken`.
- Cached the GA4 client/token per command execution to avoid repeated OAuth token minting in multi-request commands.
- Kept the previous Greptile fixes: absolute previous-period inference, hidden `--metric` alias, `io.ReadAll` error handling, and `copy` shadowing cleanup.

### Notes

- GA4 property IDs remain runtime config (`--property`, `GA4_PROPERTY_ID`, or health `--properties`); command implementations do not hard-code a property.
- Auth is public-safe: `--credentials` then `GOOGLE_APPLICATION_CREDENTIALS`; no local machine fallback is shipped.
- The public PR branch was force-with-lease rewritten to a clean single commit after removing committed live smoke artifacts from the branch history.
