### PR TITLE
fix(outlook-calendar): fix event delta sync (Prefer header) and relative dates in events range

### DIFF
--- a/library/productivity/outlook-calendar/.printing-press-patches/outlook-calendar-events-delta-prefer-pagesize.json
+++ b/library/productivity/outlook-calendar/.printing-press-patches/outlook-calendar-events-delta-prefer-pagesize.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "outlook-calendar-events-delta-prefer-pagesize",
+  "applied_at": "2026-06-14",
+  "base_run_id": "20260510-094714",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Fix event delta sync (use Prefer: odata.maxpagesize instead of $top) and resolve relative dates (today/+7d) in events range.",
+  "reason": "Two generator-emitted defects broke calendar reads against Microsoft Graph. (1) `delta events` and the sync `delta` resource sent $top on /me/events/delta, which Graph rejects on the SyncEvents resource with ErrorInvalidUrlQuery ('$top is not supported with change tracking … express page size via the Prefer header'); the event store never populated, disabling conflicts/freetime/review/prep. (2) `events range` forwarded the raw --from/--to flag values to /me/calendarView, so the relative-date shortcuts shown in the CLI's own Quick Start examples (today, +7d, tomorrow) returned ErrorInvalidParameter. The fix sends page size via the Prefer: odata.maxpagesize header on the delta command, drops the $top-bearing delta resource from the default sync set (the events resource already populates the store via /me/events; `delta events` remains the incremental path), and routes events range through the existing resolveWindow() helper so the documented shortcuts resolve to ISO 8601 — the same helper conflicts/freetime already use.",
+  "files": [
+    "internal/cli/delta_events.go",
+    "internal/cli/events_range.go",
+    "internal/cli/sync.go"
+  ],
+  "validated_outcome": "Patch-relevant checks pass: go build ./..., go vet, --help, --version, manifest, phase5, transcendence. Any remaining publish-validate failures match the clean upstream baseline (pre-existing / unrelated). Live test on a personal MSA calendar: `delta events` returned 200 events with no error (previously HTTP 400 ErrorInvalidUrlQuery); `events range --from today --to +7d` returned events (previously HTTP 400 ErrorInvalidParameter).",
+  "findings_addressed": ["F1-events-delta-top-http-400", "F2-events-range-relative-dates", "F3-sync-delta-resource-http-400"]
+}

--- a/library/productivity/outlook-calendar/internal/cli/delta_events.go
+++ b/library/productivity/outlook-calendar/internal/cli/delta_events.go
@@ -28,10 +28,18 @@ func newDeltaEventsCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/me/events/delta"
-			data, prov, err := resolvePaginatedRead(cmd.Context(), c, flags, "delta", path, map[string]string{
-				"$deltatoken": fmt.Sprintf("%v", flagDeltatoken),
-				"$top":        fmt.Sprintf("%v", flagTop),
-			}, nil, flagAll, "", "", "")
+			// PATCH(outlook-calendar-events-delta-prefer-pagesize): Microsoft Graph
+			// rejects $top on /me/events/delta (the SyncEvents resource) with
+			// ErrorInvalidUrlQuery — page size must be requested via the
+			// "Prefer: odata.maxpagesize=N" header instead. Send $top as that
+			// header, and omit an empty delta token so a fresh sync isn't sent
+			// "$deltatoken=".
+			params := map[string]string{}
+			if flagDeltatoken != "" {
+				params["$deltatoken"] = flagDeltatoken
+			}
+			headers := map[string]string{"Prefer": fmt.Sprintf("odata.maxpagesize=%d", flagTop)}
+			data, prov, err := resolvePaginatedRead(cmd.Context(), c, flags, "delta", path, params, headers, flagAll, "", "", "")
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/library/productivity/outlook-calendar/internal/cli/events_range.go
+++ b/library/productivity/outlook-calendar/internal/cli/events_range.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -36,10 +37,19 @@ func newEventsRangeCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
+			// PATCH(outlook-calendar-range-relative-dates): resolve --from/--to
+			// through resolveWindow so the documented shortcuts (today, tomorrow,
+			// +Nd, -Nh) work, not just raw ISO 8601. Previously the literal flag
+			// value was forwarded to /me/calendarView, so "today"/"+7d" (used in
+			// the CLI's own Quick Start examples) returned ErrorInvalidParameter.
+			start, end, werr := resolveWindow(flagStartDateTime, flagEndDateTime, 7)
+			if werr != nil {
+				return usageErr(werr)
+			}
 			path := "/me/calendarView"
 			data, prov, err := resolvePaginatedRead(cmd.Context(), c, flags, "events", path, map[string]string{
-				"startDateTime": fmt.Sprintf("%v", flagStartDateTime),
-				"endDateTime":   fmt.Sprintf("%v", flagEndDateTime),
+				"startDateTime": start.Format(time.RFC3339),
+				"endDateTime":   end.Format(time.RFC3339),
 				"$top":          fmt.Sprintf("%v", flagTop),
 				"$orderby":      fmt.Sprintf("%v", flagOrderby),
 				"$select":       fmt.Sprintf("%v", flagSelect),

--- a/library/productivity/outlook-calendar/internal/cli/sync.go
+++ b/library/productivity/outlook-calendar/internal/cli/sync.go
@@ -825,7 +825,12 @@ func defaultSyncResources() []string {
 	return []string{
 		"calendars",
 		"categories",
-		"delta",
+		// PATCH(outlook-calendar-events-delta-prefer-pagesize): dropped "delta"
+		// (/me/events/delta). The generic sync loop sends $top, which Graph
+		// rejects on the SyncEvents resource (ErrorInvalidUrlQuery). The
+		// "events" resource below already populates the event store via
+		// /me/events; incremental delta is available via the dedicated
+		// `delta events` command, which sends Prefer: odata.maxpagesize instead.
 		"events",
 	}
 }


### PR DESCRIPTION
## Summary

Two generator-emitted defects broke calendar reads against Microsoft Graph (reproduced on a personal Microsoft account, but the API behavior is account-agnostic):

1. `delta events` (and the `delta` resource inside `sync`) sent `$top` on `/me/events/delta`. Graph rejects `$top` on the SyncEvents resource with `ErrorInvalidUrlQuery` — page size must be requested via the `Prefer: odata.maxpagesize` header. The event store never populated, disabling `conflicts` / `freetime` / `review` / `prep`.
2. `events range` forwarded the raw `--from` / `--to` values to `/me/calendarView`, so the relative-date shortcuts shown in the CLI's own Quick Start (`today`, `+7d`, `tomorrow`) returned `ErrorInvalidParameter`.

## Findings

| # | Type | What |
|---|------|------|
| 1 | bug | `delta events` sent `$top` on `/me/events/delta` → HTTP 400. Now sends page size via `Prefer: odata.maxpagesize=N`, and omits an empty `$deltatoken` on a fresh sync. |
| 2 | bug | `events range --from today --to +7d` (a documented example) → HTTP 400. Now resolved through the existing `resolveWindow()` helper (same one `conflicts`/`freetime` use), so `today`/`tomorrow`/`+Nd`/`-Nh`/ISO all work. |
| 3 | bug | The `sync` default set included a `delta` resource → `/me/events/delta` with `$top` via the generic loop → HTTP 400 each run. Dropped from `defaultSyncResources()`; the `events` resource (`/me/events`) already populates the store, and `delta events` is the incremental path. |

## Approach

Both fixes reuse infrastructure already present in the generated tree — `resolvePaginatedRead` already accepts a `headers` argument (previously passed `nil`), and `resolveWindow`/`parseHumanTime` already resolve relative dates for the novel commands. No new helpers, no behavior change for callers passing ISO 8601.

## Verification

- `go build ./...`, `go vet`, `--help`, `--version`, `manifest`, `phase5`, `transcendence`: **pass**.
- `cli-printing-press publish validate` reports `passed:false` only because of **three checks that fail identically on a clean `upstream/main` checkout** — `go mod tidy`, `govulncheck` (Go stdlib advisories GO-2026-5039/5037), and a pre-existing `SKILL.md` install-section drift. All are pre-existing and unrelated to this patch (none of the three touched files affect them).

## Evidence (live, personal MSA calendar)

- **Before:** `delta events` → HTTP 400 `ErrorInvalidUrlQuery` ($top); `events range --from today --to +7d` → HTTP 400 `ErrorInvalidParameter`.
- **After:** `delta events` → 200 events, no error; `events range --from today --to +7d` → events returned.

## Files

`internal/cli/delta_events.go`, `internal/cli/events_range.go`, `internal/cli/sync.go` (+ patch manifest under `.printing-press-patches/`).

## Upstream note

Root causes are generator-level (the synthesized `delta` sync resource + emitting `$top` for delta endpoints; and `events range` not routing through the relative-date resolver the novel commands already use). A CLI Printing Press fix would prevent every Graph-style printed CLI from shipping these. Happy to open an issue against `mvanhorn/cli-printing-press` if useful.
