### PR TITLE
fix: correct go install command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The skill handles everything: validation, packaging, and PR creation. You don't 
 
 ### Prerequisites
 
-- [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press) installed (`go install github.com/mvanhorn/cli-printing-press/cmd/printing-press@latest`)
+- [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press) installed (`go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest`)
 - `gh` CLI installed and authenticated (`gh auth login`)
 - A generated CLI in your local library (`~/printing-press/library/`)
 


### PR DESCRIPTION
The Prerequisites `go install` command in `CONTRIBUTING.md` doesn't resolve as written:

```
go install github.com/mvanhorn/cli-printing-press/cmd/printing-press@latest
```

Two issues, verified against the main repo:
- The module is `github.com/mvanhorn/cli-printing-press/v4` (see its `go.mod`), so the install path must include the `/v4` major-version segment.
- The canonical entrypoint is `cmd/cli-printing-press` (see the main README install line), not `cmd/printing-press`.

Corrected to match the main repo's README exactly:

```
go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest
```

Docs-only, single line.