### PR TITLE
fix(amazon-orders): support marketplace cookie domains

### DIFF
--- a/library/commerce/amazon-orders/.printing-press-patches/auth-interstitial-detection.json
+++ b/library/commerce/amazon-orders/.printing-press-patches/auth-interstitial-detection.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "id": "auth-interstitial-detection",
+  "applied_at": "2026-06-16",
+  "base_run_id": "20260510-105710",
+  "base_printing_press_version": "4.2.2",
+  "summary": "A logged-out/expired Amazon buyer session is answered with HTTP 200 and a sign-in/claim/challenge page, so session validity must be judged by response content, not status code alone.",
+  "reason": "Amazon serves the sign-in form, the /ax/claim re-auth interstitial, CAPTCHA, and identity-challenge pages all with HTTP 200. Browser-session validation passed on any 2xx, and orders list / spend silently parsed zero order cards out of those interstitials and returned []. Content detection (title markers, sign-in form, /ax/claim, captcha/cvf markers) now fails validation and the order-list walk with a re-auth hint. No final-redirect URL is exposed by the HTTP client, so content detection is the only available signal.",
+  "files": [
+    "internal/parser/auth_interstitial.go",
+    "internal/parser/auth_interstitial_test.go",
+    "internal/client/client.go",
+    "internal/cli/auth.go",
+    "internal/cli/orders_list.go",
+    "internal/cli/novel_helpers.go",
+    "internal/cli/auth_interstitial_cli_test.go"
+  ],
+  "validated_outcome": "go build/vet/test ./... pass from this CLI directory. New tests confirm DetectAuthInterstitial flags Amazon Sign-In/ax-claim/captcha/cvf pages while leaving authenticated 'Your Orders' HTML (and INR order parsing) intact, and fetchOrderListPages surfaces a sign-in/interstitial error instead of an empty spend rollup when a sign-in page is served with HTTP 200."
+}

--- a/library/commerce/amazon-orders/.printing-press-patches/inr-order-list-totals.json
+++ b/library/commerce/amazon-orders/.printing-press-patches/inr-order-list-totals.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "inr-order-list-totals",
+  "applied_at": "2026-06-16",
+  "base_run_id": "20260510-105710",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Order-list parsing must detect INR totals from Amazon India instead of defaulting every order to USD with a zero total.",
+  "reason": "Amazon India order cards use rupee/INR markers such as ₹, Rs., and INR. The published parser only matched dollar amounts and initialized every order summary as USD, so spend rollups over amazon.in pages returned total 0 and currency USD even when authenticated successfully.",
+  "files": [
+    "internal/parser/parser.go",
+    "internal/parser/orders_list.go",
+    "internal/parser/parser_test.go"
+  ],
+  "validated_outcome": "Parser tests cover rupee symbol, Rs., INR, USD preservation, and an amazon.in-style order card. go test ./internal/parser, go test ./..., and go vet ./... pass from the amazon-orders CLI directory."
+}

--- a/library/commerce/amazon-orders/.printing-press-patches/marketplace-cookie-domain.json
+++ b/library/commerce/amazon-orders/.printing-press-patches/marketplace-cookie-domain.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 2,
+  "id": "marketplace-cookie-domain",
+  "applied_at": "2026-06-16",
+  "base_run_id": "20260510-105710",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Amazon buyer-cookie auth must support non-US marketplace domains such as amazon.in.",
+  "reason": "The published CLI hardcoded .amazon.com for Chrome cookie discovery, auth status, browser-session proof validation, refresh, and portable session export. Users logged in to regional marketplaces like amazon.in have valid Amazon buyer sessions under a different cookie domain, so auth login --chrome failed even though Chrome was logged in.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/cli/auth_portable.go",
+    "internal/cli/doctor.go",
+    "internal/cli/auth_count_cookies_test.go",
+    "README.md",
+    "SKILL.md",
+    "manifest.json",
+    ".printing-press.json"
+  ],
+  "validated_outcome": "Focused auth-domain tests, go test ./..., and go vet ./... passed from this CLI directory; built amazon-orders-pp-cli and smoke-tested --dry-run with --domain amazon.in, AMAZON_ORDERS_BASE_URL=https://www.amazon.in, and rejection of --domain amazon.evil.com. Browser-session validation now probes the real orders endpoint (/your-orders/orders?timeFilter=months-3) instead of the US account-history redirect path; auth login and auth refresh keep extracted cookies when Amazon blocks the validation probe so users can still verify with orders list."
+}

--- a/library/commerce/amazon-orders/.printing-press.json
+++ b/library/commerce/amazon-orders/.printing-press.json
@@ -26,7 +26,7 @@
     "AMAZON_COOKIES"
   ],
   "auth_title": "Amazon buyer session",
-  "auth_description": "Amazon does not publish a buyer-side API for order history. This CLI imports\ncookies from your logged-in Chrome / Firefox / Safari / Brave browser session,\nthen makes authenticated HTTPS GETs to the same HTML pages you see on\namazon.com. Log in to amazon.com in your browser, then run:\n\n  amazon-orders-pp-cli auth login --chrome\n\nCookies live under the .amazon.com domain. The CLI persists them locally and\nrefreshes the session-id cookie automatically when amazon.com rotates it.\n",
+  "auth_description": "Amazon does not publish a buyer-side API for order history. This CLI imports cookies from your logged-in Chrome / Firefox / Safari / Brave browser session, then makes authenticated HTTPS GETs to the same HTML pages you see on your configured Amazon marketplace. Log in to that marketplace in your browser, then run:\n\n  amazon-orders-pp-cli auth login --chrome\n\nFor India or another non-US marketplace, pass the domain, e.g.:\n\n  amazon-orders-pp-cli auth login --chrome --domain amazon.in\n\nThe CLI persists cookies locally and refreshes the session-id cookie automatically when Amazon rotates it.\n",
   "novel_features": [
     {
       "name": "Where Is My Stuff",

--- a/library/commerce/amazon-orders/README.md
+++ b/library/commerce/amazon-orders/README.md
@@ -130,6 +130,14 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 Amazon publishes no buyer API. The CLI imports cookies from your logged-in Chrome / Firefox / Safari / Brave session via `auth login --chrome`. Those cookies persist locally, refresh automatically, and authenticate every subsequent fetch — no API key, no OAuth, no resident browser at runtime.
 
+For non-US Amazon marketplaces, pass the marketplace domain during login. The CLI will read cookies for that domain and persist the matching base URL for later commands:
+
+```bash
+amazon-orders-pp-cli auth login --chrome --domain amazon.in
+```
+
+You can also set `AMAZON_ORDERS_BASE_URL=https://www.amazon.in` before running `auth login --chrome`.
+
 ### Headless agents (1Password / Vault / Bitwarden)
 
 For CI, dev containers, and remote hosts where `auth login --chrome` is not viable, capture the session once on a logged-in machine and inject it on every other host via your secrets manager. The cookie value never enters an LLM's context window because the bytes flow `op → stdin → CLI` without a shell variable in the middle.
@@ -149,6 +157,9 @@ The exported JSON shape is `amazon-orders-session/v1`. `auth import` also accept
 ```bash
 # Import cookies from your logged-in browser session — required for any authenticated fetch.
 amazon-orders-pp-cli auth login --chrome
+
+# Non-US marketplace example.
+amazon-orders-pp-cli auth login --chrome --domain amazon.in
 
 # Walk the last 3 months of orders into the local store, including per-order item detail.
 amazon-orders-pp-cli sync --since 90d --concurrency 1
@@ -338,11 +349,11 @@ Environment variables:
 
 ### API-specific
 
-- **`auth status` reports `unauthenticated` after `auth login --chrome`** — Make sure you're logged in to amazon.com in Chrome, then re-run `auth login --chrome --domain amazon.com`.
+- **`auth status` reports `unauthenticated` after `auth login --chrome`** — Make sure you're logged in to the same Amazon marketplace in Chrome, then re-run with the matching domain, e.g. `auth login --chrome --domain amazon.in`.
 - **`sync` fails with `RateLimitError` after ~10 orders** — Pass `--rate 0.5` to slow the per-order detail fetch, or omit `--full-details` to fetch only the listing pages.
 - **Order detail returns 401 even when logged in** — Amazon rotated your session-id; re-run `auth login --chrome` to refresh cookies.
 - **`track <id>` returns empty when the order has multiple shipments** — Pass `--shipment-id <SID>` (visible in `orders get <id> --json`) to disambiguate.
-- **Foreign-locale orders parse with garbled dates** — v1 supports US (.com) only. Multi-region shipping in v2; track issue.
+- **Foreign-locale orders parse with garbled dates** — marketplace auth is supported, but some localized order-history date formats may still need parser fixes.
 
 ## Discovery Signals
 

--- a/library/commerce/amazon-orders/SKILL.md
+++ b/library/commerce/amazon-orders/SKILL.md
@@ -229,6 +229,14 @@ Groups every purchased ASIN across history by total spend — surfaces the recur
 
 Amazon publishes no buyer API. The CLI imports cookies from your logged-in Chrome / Firefox / Safari / Brave session via `auth login --chrome`. Those cookies persist locally, refresh automatically, and authenticate every subsequent fetch — no API key, no OAuth, no resident browser at runtime.
 
+For non-US marketplaces, pass the marketplace domain during login. Example for India:
+
+```bash
+amazon-orders-pp-cli auth login --chrome --domain amazon.in
+```
+
+You can also set `AMAZON_ORDERS_BASE_URL=https://www.amazon.in` before running `auth login --chrome`.
+
 Run `amazon-orders-pp-cli doctor` to verify setup.
 
 ### Headless agent setup with 1Password (LLM-free roundtrip)

--- a/library/commerce/amazon-orders/internal/cli/auth.go
+++ b/library/commerce/amazon-orders/internal/cli/auth.go
@@ -15,9 +15,11 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
 	"github.com/spf13/cobra"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -61,33 +63,137 @@ func requiredAuthCookies() []string {
 	return []string{}
 }
 
+func cookieDomainFromConfig(cfg *config.Config) (string, error) {
+	baseURL := "https://www.amazon.com"
+	if cfg != nil && strings.TrimSpace(cfg.BaseURL) != "" {
+		baseURL = cfg.BaseURL
+	}
+	return cookieDomainFromBaseURL(baseURL)
+}
+
+var amazonMarketplaceDomains = map[string]struct{}{
+	"amazon.ae":     {},
+	"amazon.ca":     {},
+	"amazon.cn":     {},
+	"amazon.co.jp":  {},
+	"amazon.co.uk":  {},
+	"amazon.com":    {},
+	"amazon.com.au": {},
+	"amazon.com.be": {},
+	"amazon.com.br": {},
+	"amazon.com.mx": {},
+	"amazon.com.tr": {},
+	"amazon.de":     {},
+	"amazon.eg":     {},
+	"amazon.es":     {},
+	"amazon.fr":     {},
+	"amazon.in":     {},
+	"amazon.it":     {},
+	"amazon.nl":     {},
+	"amazon.pl":     {},
+	"amazon.sa":     {},
+	"amazon.se":     {},
+	"amazon.sg":     {},
+}
+
+func cookieDomainFromBaseURL(baseURL string) (string, error) {
+	text := strings.TrimSpace(baseURL)
+	if text == "" {
+		return ".amazon.com", nil
+	}
+	if !strings.Contains(text, "://") {
+		text = "https://" + text
+	}
+	u, err := url.Parse(text)
+	if err != nil {
+		return "", err
+	}
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	if host == "" {
+		return "", fmt.Errorf("missing host in base URL %q", baseURL)
+	}
+	return normalizeAmazonCookieDomain(host)
+}
+
+func normalizeAmazonCookieDomain(value string) (string, error) {
+	host := strings.ToLower(strings.TrimSpace(value))
+	host = strings.TrimPrefix(host, "http://")
+	host = strings.TrimPrefix(host, "https://")
+	if idx := strings.IndexAny(host, "/:"); idx >= 0 {
+		host = host[:idx]
+	}
+	host = strings.TrimPrefix(host, ".")
+	host = strings.TrimPrefix(host, "www.")
+	if i := strings.Index(host, ".amazon."); i >= 0 {
+		host = host[i+1:]
+	}
+	if _, ok := amazonMarketplaceDomains[host]; !ok {
+		return "", fmt.Errorf("%q is not an Amazon marketplace domain", value)
+	}
+	return "." + host, nil
+}
+
+func baseURLForCookieDomain(domain string) string {
+	return "https://www." + strings.TrimPrefix(domain, ".")
+}
+
+func domainFlagForHint(domain string) string {
+	if domain == "" || domain == ".amazon.com" {
+		return ""
+	}
+	return " --domain " + strings.TrimPrefix(domain, ".")
+}
+
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	var browserFlag bool
 	var profileFlag string
+	var domainFlag string
 
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with the API",
 		Long: `Authenticate using your browser session.
 
-Use --chrome to read cookies from Chrome for .amazon.com.
+Use --chrome to read cookies from Chrome for the configured Amazon marketplace.
 Use --browser as an alias for --chrome.
+Use --domain for non-US marketplaces, e.g. --domain amazon.in.
+Alternatively set AMAZON_ORDERS_BASE_URL=https://www.amazon.in before login.
 Requires a cookie extraction tool (pycookiecheat, cookies, or cookie-scoop-cli).
 
 If you have multiple Chrome profiles, pycookiecheat and cookie-scoop-cli can
 auto-detect which profile is logged in. Use --profile to select a specific
 profile by name when the installed backend supports it.`,
-		Example: `  amazon-orders-pp-cli auth login --chrome
-  amazon-orders-pp-cli auth login --browser
-  amazon-orders-pp-cli auth login --chrome --profile "Work"`,
+		Example: strings.Join([]string{
+			"  amazon-orders-pp-cli auth login --chrome",
+			"  amazon-orders-pp-cli auth login --browser",
+			"  amazon-orders-pp-cli auth login --chrome --domain amazon.in",
+			"  amazon-orders-pp-cli auth login --chrome --profile \"Work\"",
+		}, "\n"),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(flags.configPath)
+			if err != nil {
+				return configErr(err)
+			}
+			var domain string
+			if domainFlag != "" {
+				domain, err = normalizeAmazonCookieDomain(domainFlag)
+				if err != nil {
+					return authErr(err)
+				}
+				cfg.BaseURL = baseURLForCookieDomain(domain)
+			} else {
+				domain, err = cookieDomainFromConfig(cfg)
+				if err != nil {
+					return configErr(fmt.Errorf("invalid base_url: %w", err))
+				}
+			}
 			// Verify-friendly short-circuit: under PRINTING_PRESS_VERIFY=1 or
 			// --dry-run, we don't actually shell out to a cookie tool. This
 			// keeps the validate-narrative full-example walk happy in
 			// environments where pycookiecheat / cookie-scoop-cli aren't
 			// installed.
 			if flags.dryRun || cliutil.IsVerifyEnv() {
-				fmt.Fprintln(cmd.OutOrStdout(), "would import cookies from Chrome (.amazon.com domain)")
+				fmt.Fprintf(cmd.OutOrStdout(), "would import cookies from Chrome (%s domain)\n", domain)
 				return nil
 			}
 			if !browserFlag {
@@ -103,7 +209,6 @@ profile by name when the installed backend supports it.`,
 			}
 
 			w := cmd.OutOrStdout()
-			domain := ".amazon.com"
 
 			// Step 1: Detect cookie extraction tool
 			tool, err := detectCookieTool()
@@ -133,7 +238,7 @@ profile by name when the installed backend supports it.`,
 					fmt.Fprintln(w, "Log in to your account:")
 					fmt.Fprintf(w, "\n  %s\n\n", loginURL)
 					fmt.Fprintln(w, "Then run this command again:")
-					fmt.Fprintf(w, "\n  amazon-orders-pp-cli auth login --chrome\n")
+					fmt.Fprintf(w, "\n  amazon-orders-pp-cli auth login --chrome%s\n", domainFlagForHint(domain))
 					return authErr(fmt.Errorf("not logged in to %s", domain))
 				}
 			}
@@ -154,22 +259,12 @@ profile by name when the installed backend supports it.`,
 				return authErr(fmt.Errorf("cookie tool returned no cookies for %s", domain))
 			}
 			// Step 4: Save to config
-			cfg, err := config.Load(flags.configPath)
-			if err != nil {
-				return configErr(err)
-			}
-
 			if err := cfg.SaveTokens("", "", cookies, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving cookies: %w", err))
 			}
-			fmt.Fprintf(w, "Validating browser session...")
-			if err := validateAndWriteBrowserSessionProof(cfg, flags); err != nil {
-				_ = cfg.ClearTokens()
-				_ = clearBrowserSessionProof(cfg)
-				fmt.Fprintf(w, " %s\n", red("failed"))
-				return authErr(fmt.Errorf("browser session validation failed: %w", err))
-			}
-			fmt.Fprintf(w, " %s\n", green("valid"))
+			validateBrowserSessionOrWarn(w, cfg, func() error {
+				return validateAndWriteBrowserSessionProof(cfg, flags)
+			})
 
 			count := len(strings.Split(cookies, ";"))
 			fmt.Fprintf(w, "%s Found %d cookies for %s\n", green("OK"), count, domain)
@@ -181,6 +276,7 @@ profile by name when the installed backend supports it.`,
 	cmd.Flags().BoolVar(&browserFlag, "chrome", false, "Read cookies from Chrome")
 	cmd.Flags().BoolVar(&browserFlag, "browser", false, "Alias for --chrome")
 	cmd.Flags().StringVar(&profileFlag, "profile", "", "Chrome profile name (e.g. \"Work\", \"Personal\")")
+	cmd.Flags().StringVar(&domainFlag, "domain", "", "Amazon marketplace domain to read cookies for (e.g. amazon.in, amazon.co.uk)")
 	return cmd
 }
 func newAuthRefreshCmd(flags *rootFlags) *cobra.Command {
@@ -210,13 +306,11 @@ func newAuthRefreshCmd(flags *rootFlags) *cobra.Command {
 				return authErr(err)
 			}
 
-			fmt.Fprintf(w, "Validating browser session...")
-			if err := validateAndWriteBrowserSessionProofWithRetry(cfg, flags, waitTimeout); err != nil {
-				fmt.Fprintf(w, " %s\n", red("failed"))
-				return authErr(fmt.Errorf("browser session validation failed: %w", err))
+			if validateBrowserSessionOrWarn(w, cfg, func() error {
+				return validateAndWriteBrowserSessionProofWithRetry(cfg, flags, waitTimeout)
+			}) {
+				fmt.Fprintf(w, "Browser session proof refreshed at %s\n", browserSessionProofPath(cfg))
 			}
-			fmt.Fprintf(w, " %s\n", green("valid"))
-			fmt.Fprintf(w, "Browser session proof refreshed at %s\n", browserSessionProofPath(cfg))
 			return nil
 		},
 	}
@@ -224,12 +318,25 @@ func newAuthRefreshCmd(flags *rootFlags) *cobra.Command {
 	return cmd
 }
 
+func validateBrowserSessionOrWarn(w io.Writer, cfg *config.Config, validate func() error) bool {
+	fmt.Fprintf(w, "Validating browser session...")
+	if err := validate(); err != nil {
+		_ = clearBrowserSessionProof(cfg)
+		fmt.Fprintf(w, " %s\n", yellow("skipped"))
+		fmt.Fprintf(w, "Warning: saved cookies but could not validate the browser session (%v).\n", err)
+		fmt.Fprintln(w, "Run 'amazon-orders-pp-cli orders list --time-filter months-3 --json' to verify the session against the live orders endpoint.")
+		return false
+	}
+	fmt.Fprintf(w, " %s\n", green("valid"))
+	return true
+}
+
 func browserSessionTargetURL(cfg *config.Config) string {
 	baseURL := strings.TrimRight("https://www.amazon.com", "/")
 	if cfg != nil && cfg.BaseURL != "" {
 		baseURL = strings.TrimRight(cfg.BaseURL, "/")
 	}
-	validationPath := strings.TrimSpace("/gp/your-account/order-history")
+	validationPath := strings.TrimSpace("/your-orders/orders")
 	if validationPath == "" {
 		return baseURL
 	}
@@ -387,9 +494,9 @@ func waitForCookieRefreshBrowser(cmd *cobra.Command, flags *rootFlags, targetURL
 	fmt.Fprintln(w)
 }
 func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
-	domain := ".amazon.com"
-	if domain == "" {
-		return fmt.Errorf("no cookie domain configured")
+	domain, err := cookieDomainFromConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("invalid base_url: %w", err)
 	}
 
 	cookies, err := extractLiveCookies(domain)
@@ -451,9 +558,13 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 				return authErr(fmt.Errorf("no credentials configured"))
 			}
 
+			domain, err := cookieDomainFromConfig(cfg)
+			if err != nil {
+				return configErr(fmt.Errorf("invalid base_url: %w", err))
+			}
 			fmt.Fprintln(w, green("Authenticated"))
 			fmt.Fprintf(w, "  Source: %s\n", cfg.AuthSource)
-			fmt.Fprintf(w, "  Domain: .amazon.com\n")
+			fmt.Fprintf(w, "  Domain: %s\n", domain)
 			fmt.Fprintf(w, "  Config: %s\n", cfg.Path)
 			return nil
 		},
@@ -1123,7 +1234,14 @@ func browserSessionProofStatusForAuth(cfg *config.Config, authHeader string) (bo
 	if err := json.Unmarshal(data, &proof); err != nil {
 		return false, "proof is not valid JSON; re-run amazon-orders-pp-cli auth login --chrome"
 	}
-	if proof.APIName != "amazon-orders" || proof.CookieDomain != ".amazon.com" || proof.ValidationPath != "/gp/your-account/order-history" {
+	domain, err := cookieDomainFromConfig(cfg)
+	if err != nil {
+		return false, fmt.Sprintf("invalid base_url: %v", err)
+	}
+	if proof.APIName == "amazon-orders" && proof.CookieDomain == domain && proof.ValidationPath == "/gp/your-account/order-history" {
+		return false, "proof was written against an older validation endpoint; re-run amazon-orders-pp-cli auth login --chrome to refresh it"
+	}
+	if proof.APIName != "amazon-orders" || proof.CookieDomain != domain || proof.ValidationPath != "/your-orders/orders" {
 		return false, "proof does not match this CLI"
 	}
 	if authHeader != "" && proof.CredentialFingerprint != fingerprintCredential(authHeader) {
@@ -1136,7 +1254,7 @@ func browserSessionProofStatusForAuth(cfg *config.Config, authHeader string) (bo
 }
 
 func validateAndWriteBrowserSessionProof(cfg *config.Config, flags *rootFlags) error {
-	validationPath := strings.TrimSpace("/gp/your-account/order-history")
+	validationPath := strings.TrimSpace("/your-orders/orders")
 	if validationPath == "" {
 		return fmt.Errorf("no browser-session validation endpoint configured in this CLI")
 	}
@@ -1155,17 +1273,28 @@ func validateAndWriteBrowserSessionProof(cfg *config.Config, flags *rootFlags) e
 
 	c := client.New(cfg, flags.timeout, flags.rateLimit)
 	c.NoCache = true
-	status, err := c.ProbeGet(validationPath)
+	body, status, err := c.GetWithStatus(validationPath, map[string]string{"timeFilter": "months-3"})
 	if err != nil {
 		return err
 	}
 	if status < 200 || status >= 300 {
 		return fmt.Errorf("validation endpoint returned HTTP %d", status)
 	}
+	// A logged-out or expired cookie jar is answered with HTTP 200 and an
+	// Amazon sign-in/claim/challenge page, not a 4xx. Treat that as an invalid
+	// session so we don't write a "valid" proof for an unauthenticated jar.
+	if ierr := parser.AuthInterstitialError(body); ierr != nil {
+		return ierr
+	}
+
+	domain, err := cookieDomainFromConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("invalid base_url: %w", err)
+	}
 
 	proof := browserSessionProof{
 		APIName:               "amazon-orders",
-		CookieDomain:          ".amazon.com",
+		CookieDomain:          domain,
 		ValidationMethod:      method,
 		ValidationPath:        validationPath,
 		StatusCode:            status,

--- a/library/commerce/amazon-orders/internal/cli/auth_count_cookies_test.go
+++ b/library/commerce/amazon-orders/internal/cli/auth_count_cookies_test.go
@@ -1,11 +1,15 @@
 package cli
 
 import (
+	"bytes"
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/config"
 	_ "modernc.org/sqlite"
 )
 
@@ -72,5 +76,97 @@ func TestCountCookiesForDomain_MissingFile(t *testing.T) {
 		if info, err := os.Stat(e); err == nil && info.ModTime().Unix() < 1 {
 			t.Errorf("leftover temp file: %s", e)
 		}
+	}
+}
+
+func TestCookieDomainFromBaseURL_Marketplaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{"default US", "https://www.amazon.com", ".amazon.com"},
+		{"india", "https://www.amazon.in", ".amazon.in"},
+		{"india without scheme", "amazon.in", ".amazon.in"},
+		{"uk", "https://www.amazon.co.uk", ".amazon.co.uk"},
+		{"australia", "https://www.amazon.com.au", ".amazon.com.au"},
+		{"japan", "https://www.amazon.co.jp", ".amazon.co.jp"},
+		{"subdomain", "https://smile.amazon.com/gp/your-account/order-history", ".amazon.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cookieDomainFromBaseURL(tt.baseURL)
+			if err != nil {
+				t.Fatalf("cookieDomainFromBaseURL(%q) error: %v", tt.baseURL, err)
+			}
+			if got != tt.want {
+				t.Fatalf("cookieDomainFromBaseURL(%q) = %q, want %q", tt.baseURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCookieDomainFromConfig_UsesBaseURL(t *testing.T) {
+	cfg := &config.Config{BaseURL: "https://www.amazon.in"}
+	got, err := cookieDomainFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("cookieDomainFromConfig() error: %v", err)
+	}
+	if got != ".amazon.in" {
+		t.Fatalf("cookieDomainFromConfig() = %q, want .amazon.in", got)
+	}
+}
+
+func TestNormalizeAmazonCookieDomain_RejectsInvalidDomains(t *testing.T) {
+	for _, domain := range []string{"example.com", "amazon.evil.com", "amazon.phishing.io", "notamazon.in"} {
+		t.Run(domain, func(t *testing.T) {
+			if _, err := normalizeAmazonCookieDomain(domain); err == nil {
+				t.Fatalf("normalizeAmazonCookieDomain(%q) succeeded, want error", domain)
+			}
+		})
+	}
+}
+
+func TestCookieDomainFromConfig_InvalidBaseURLSurfacesError(t *testing.T) {
+	cfg := &config.Config{BaseURL: "https://www.amazon.evil.com"}
+	if _, err := cookieDomainFromConfig(cfg); err == nil {
+		t.Fatal("cookieDomainFromConfig() succeeded, want error")
+	}
+}
+
+func TestValidateBrowserSessionOrWarnClearsProofAndReturnsFalse(t *testing.T) {
+	cfg := &config.Config{Path: filepath.Join(t.TempDir(), "config.toml")}
+	if err := writeBrowserSessionProof(cfg, []byte("{}\n")); err != nil {
+		t.Fatalf("write proof: %v", err)
+	}
+
+	var out bytes.Buffer
+	ok := validateBrowserSessionOrWarn(&out, cfg, func() error {
+		return errors.New("validation blocked")
+	})
+	if ok {
+		t.Fatal("validateBrowserSessionOrWarn returned true, want false")
+	}
+	text := out.String()
+	if !strings.Contains(text, "Warning: saved cookies but could not validate") {
+		t.Fatalf("missing warning output: %s", text)
+	}
+	if strings.Contains(text, "failed") {
+		t.Fatalf("output used fatal failed wording: %s", text)
+	}
+	if _, err := os.Stat(browserSessionProofPath(cfg)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("proof was not cleared, stat err=%v", err)
+	}
+}
+
+func TestValidateBrowserSessionOrWarnReturnsTrueOnSuccess(t *testing.T) {
+	cfg := &config.Config{Path: filepath.Join(t.TempDir(), "config.toml")}
+	var out bytes.Buffer
+	ok := validateBrowserSessionOrWarn(&out, cfg, func() error { return nil })
+	if !ok {
+		t.Fatal("validateBrowserSessionOrWarn returned false, want true")
+	}
+	if !strings.Contains(out.String(), "valid") {
+		t.Fatalf("missing success output: %s", out.String())
 	}
 }

--- a/library/commerce/amazon-orders/internal/cli/auth_interstitial_cli_test.go
+++ b/library/commerce/amazon-orders/internal/cli/auth_interstitial_cli_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Brian Wishan and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/config"
+)
+
+func testClientFor(url string) *client.Client {
+	cfg := &config.Config{
+		BaseURL:     url,
+		AccessToken: "session-id=test-cookie",
+		AuthSource:  "browser",
+	}
+	c := client.New(cfg, 5_000_000_000, 0)
+	c.BaseURL = strings.TrimRight(url, "/")
+	c.NoCache = true
+	return c
+}
+
+const signInInterstitialHTML = `<html><head><title>Amazon Sign-In</title></head>
+<body><form action="/ax/claim?arb=193cca18-8b42-4d51-9a67-6e97f1363c27">
+<input name="email"><input name="password" id="ap_password"></form></body></html>`
+
+const realOrderPageHTML = `<html><head><title>Amazon.in - Your Orders</title></head><body>
+<div class="order-card js-order-card">ORDER PLACED May 5, 2026 TOTAL ₹1,234.56 SHIP TO Jane ORDER # 408-1234567-1234567</div>
+</body></html>`
+
+// A sign-in/claim interstitial served with HTTP 200 must surface as an auth
+// error from the order-list walk (the path spend and the novel commands use),
+// not roll up an empty result.
+func TestFetchOrderListPages_FailsOnInterstitial(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(signInInterstitialHTML))
+	}))
+	defer srv.Close()
+
+	c := testClientFor(srv.URL)
+	orders, err := fetchOrderListPages(context.Background(), c, "year-2026", 3)
+	if err == nil {
+		t.Fatalf("expected auth/interstitial error, got nil (orders=%d)", len(orders))
+	}
+	if !strings.Contains(err.Error(), "sign-in/interstitial") {
+		t.Errorf("error = %v, want it to mention sign-in/interstitial", err)
+	}
+}
+
+// A genuine order page must still parse to orders — the interstitial guard must
+// not break the authenticated path.
+func TestFetchOrderListPages_ParsesRealOrderPage(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		// First page returns one order; subsequent pages are empty so the walk
+		// terminates without a "HasNext" link.
+		if calls == 1 {
+			_, _ = w.Write([]byte(realOrderPageHTML))
+			return
+		}
+		_, _ = w.Write([]byte(`<html><head><title>Your Orders</title></head><body></body></html>`))
+	}))
+	defer srv.Close()
+
+	c := testClientFor(srv.URL)
+	orders, err := fetchOrderListPages(context.Background(), c, "year-2026", 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(orders) != 1 {
+		t.Fatalf("expected 1 order, got %d", len(orders))
+	}
+	if orders[0].OrderID != "408-1234567-1234567" {
+		t.Errorf("orderID = %q, want 408-1234567-1234567", orders[0].OrderID)
+	}
+	if orders[0].Currency != "INR" {
+		t.Errorf("currency = %q, want INR", orders[0].Currency)
+	}
+}

--- a/library/commerce/amazon-orders/internal/cli/auth_portable.go
+++ b/library/commerce/amazon-orders/internal/cli/auth_portable.go
@@ -19,7 +19,7 @@ import (
 // future format bump can be detected.
 type PortableSession struct {
 	Schema     string    `json:"schema"`  // "amazon-orders-session/v1"
-	Domain     string    `json:"domain"`  // .amazon.com
+	Domain     string    `json:"domain"`  // .amazon.com, .amazon.in, etc.
 	Cookies    string    `json:"cookies"` // semicolon-joined "k=v" pairs
 	ExportedAt time.Time `json:"exported_at"`
 	Source     string    `json:"source,omitempty"` // "chrome", "manual", "1password", etc.
@@ -108,9 +108,14 @@ inject into any other host via 'op read | auth import --stdin').`,
 			if src == "" {
 				src = "chrome"
 			}
+			domain, err := cookieDomainFromConfig(cfg)
+			if err != nil {
+				return configErr(fmt.Errorf("invalid base_url: %w", err))
+			}
+
 			session := PortableSession{
 				Schema:     "amazon-orders-session/v1",
-				Domain:     ".amazon.com",
+				Domain:     domain,
 				Cookies:    cookies,
 				ExportedAt: time.Now().UTC(),
 				Source:     src,
@@ -218,6 +223,7 @@ setup with 1Password" for the full roundtrip and refresh recipe.`,
 			}
 
 			var cookies string
+			var importedDomain string
 			if rawCookies || (blob[0] != '{' && blob[0] != '[') {
 				cookies = string(blob)
 			} else {
@@ -229,10 +235,18 @@ setup with 1Password" for the full roundtrip and refresh recipe.`,
 					return fmt.Errorf("session JSON has no cookies field")
 				}
 				cookies = session.Cookies
+				importedDomain = session.Domain
 			}
 			cfg, err := config.Load(flags.configPath)
 			if err != nil {
 				return configErr(err)
+			}
+			if importedDomain != "" {
+				domain, err := normalizeAmazonCookieDomain(importedDomain)
+				if err != nil {
+					return authErr(err)
+				}
+				cfg.BaseURL = baseURLForCookieDomain(domain)
 			}
 			if err := cfg.SaveTokens("", "", cookies, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving cookies: %w", err))

--- a/library/commerce/amazon-orders/internal/cli/doctor.go
+++ b/library/commerce/amazon-orders/internal/cli/doctor.go
@@ -100,7 +100,12 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					authConfigured = true
 					report["auth"] = "configured (browser session)"
 					report["auth_source"] = cfg.AuthSource
-					report["auth_domain"] = ".amazon.com"
+					domain, domainErr := cookieDomainFromConfig(cfg)
+					if domainErr != nil {
+						report["auth"] = fmt.Sprintf("error: invalid base_url: %s", domainErr)
+					} else {
+						report["auth_domain"] = domain
+					}
 					if proofOK, proofDetail := browserSessionProofStatus(cfg, header); proofOK {
 						report["browser_session_proof"] = "valid"
 						report["browser_session_proof_detail"] = proofDetail
@@ -320,10 +325,17 @@ func browserSessionProofStatus(cfg *config.Config, authHeader string) (bool, str
 	if proof.APIName != "amazon-orders" {
 		return false, "proof belongs to a different CLI"
 	}
-	if proof.CookieDomain != ".amazon.com" {
+	domain, err := cookieDomainFromConfig(cfg)
+	if err != nil {
+		return false, fmt.Sprintf("invalid base_url: %v", err)
+	}
+	if proof.CookieDomain != domain {
 		return false, "proof belongs to a different cookie domain"
 	}
-	if proof.ValidationPath != "/gp/your-account/order-history" {
+	if proof.ValidationPath == "/gp/your-account/order-history" {
+		return false, "proof was written against an older validation endpoint; re-run amazon-orders-pp-cli auth login --chrome to refresh it"
+	}
+	if proof.ValidationPath != "/your-orders/orders" {
 		return false, "proof was captured for a different validation endpoint"
 	}
 	if authHeader != "" && proof.CredentialFingerprint != doctorFingerprintCredential(authHeader) {

--- a/library/commerce/amazon-orders/internal/cli/novel_helpers.go
+++ b/library/commerce/amazon-orders/internal/cli/novel_helpers.go
@@ -42,6 +42,16 @@ func fetchOrderListPages(ctx context.Context, c *client.Client, timeFilter strin
 			}
 			break
 		}
+		// A logged-out/expired session is answered with HTTP 200 and an Amazon
+		// sign-in/claim page. On the first page that's an auth failure; surface
+		// it instead of rolling up an empty spend report. On later pages, stop
+		// and return what we have.
+		if ierr := parser.AuthInterstitialError(raw); ierr != nil {
+			if page == 0 {
+				return nil, ierr
+			}
+			break
+		}
 		listPage, perr := parser.ParseOrderList(raw)
 		if perr != nil {
 			return nil, perr

--- a/library/commerce/amazon-orders/internal/cli/orders_list.go
+++ b/library/commerce/amazon-orders/internal/cli/orders_list.go
@@ -51,6 +51,12 @@ func newOrdersListCmd(flags *rootFlags) *cobra.Command {
 				// We skip the generic extractHTMLResponse helper because Amazon does not
 				// embed a __NEXT_DATA__ blob; the order data lives in .order-card divs.
 				_ = htmlRequestParams // silence unused-warning while we keep the variable for parity with sibling endpoints
+				// A logged-out/expired session is answered with HTTP 200 and an
+				// Amazon sign-in/claim page, not a 4xx. Fail with a re-auth hint
+				// instead of parsing zero order cards and returning [].
+				if ierr := parser.AuthInterstitialError(data); ierr != nil {
+					return ierr
+				}
 				page, perr := parser.ParseOrderList(data)
 				if perr != nil {
 					return fmt.Errorf("parsing Amazon order list HTML: %w", perr)

--- a/library/commerce/amazon-orders/internal/client/client.go
+++ b/library/commerce/amazon-orders/internal/client/client.go
@@ -84,8 +84,20 @@ func (c *Client) GetWithHeaders(path string, params map[string]string, headers m
 	return result, err
 }
 
+// GetWithStatus performs a GET and returns the response body, HTTP status, and
+// error. Unlike Get it bypasses the response cache, so callers validating a
+// live browser session always observe the current server response (including a
+// sign-in/interstitial page served with HTTP 200).
+func (c *Client) GetWithStatus(path string, params map[string]string) (json.RawMessage, int, error) {
+	return c.do("GET", path, params, nil, nil)
+}
+
 func (c *Client) ProbeGet(path string) (int, error) {
-	_, status, err := c.do("GET", path, nil, nil, nil)
+	return c.ProbeGetWithParams(path, nil)
+}
+
+func (c *Client) ProbeGetWithParams(path string, params map[string]string) (int, error) {
+	_, status, err := c.do("GET", path, params, nil, nil)
 	return status, err
 }
 

--- a/library/commerce/amazon-orders/internal/parser/auth_interstitial.go
+++ b/library/commerce/amazon-orders/internal/parser/auth_interstitial.go
@@ -1,0 +1,90 @@
+package parser
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// titleRegex captures the contents of the first <title> element.
+var titleRegex = regexp.MustCompile(`(?is)<title[^>]*>(.*?)</title>`)
+
+// authInterstitialTitleMarkers are decisive <title> substrings (lowercased)
+// that an authenticated order page never carries. Amazon titles its
+// order-history page "Your Orders"; the sign-in, claim, robot-check and
+// identity-challenge pages title themselves differently.
+var authInterstitialTitleMarkers = []string{
+	"sign-in",
+	"sign in",
+	"signin",
+	"robot check",
+	"authentication required",
+	"captcha",
+}
+
+// DetectAuthInterstitial reports whether htmlBytes is an Amazon sign-in,
+// account-claim (/ax/claim), CAPTCHA, or identity-verification challenge page
+// served in place of the requested content. When true, reason is a short
+// human-readable description of which signal matched.
+//
+// Amazon publishes no buyer-side API; an expired or never-authenticated cookie
+// jar is answered with HTTP 200 and one of these interstitials rather than a
+// 4xx, so status-code checks alone cannot tell a logged-in session from a
+// logged-out one. Content detection is the only reliable signal available
+// without a final-redirect URL (the HTTP client does not surface one here).
+func DetectAuthInterstitial(htmlBytes []byte) (bool, string) {
+	if len(htmlBytes) == 0 {
+		return false, ""
+	}
+	body := string(htmlBytes)
+	lower := strings.ToLower(body)
+
+	// Title-based detection is the most reliable signal.
+	if m := titleRegex.FindStringSubmatch(body); len(m) > 1 {
+		title := strings.ToLower(strings.TrimSpace(m[1]))
+		for _, marker := range authInterstitialTitleMarkers {
+			if strings.Contains(title, marker) {
+				return true, "page title is " + strconv.Quote(strings.TrimSpace(m[1]))
+			}
+		}
+	}
+
+	// A full sign-in form: a password input alongside Amazon's auth-form
+	// markers. We require the password field so a stray "/ap/signin" href in a
+	// header nav can't trip detection on an authenticated page.
+	if strings.Contains(lower, `name="password"`) &&
+		(strings.Contains(lower, "ap_password") ||
+			strings.Contains(lower, "signinsubmit") ||
+			strings.Contains(lower, "/ap/signin")) {
+		return true, "response contains an Amazon sign-in form"
+	}
+
+	// The /ax/claim re-authentication interstitial.
+	if strings.Contains(lower, "/ax/claim") {
+		return true, "response is an Amazon account-claim interstitial (/ax/claim)"
+	}
+
+	// CAPTCHA / automated-traffic challenge.
+	if strings.Contains(lower, "captchacharacters") || strings.Contains(lower, "/errors/validatecaptcha") {
+		return true, "response is an Amazon CAPTCHA challenge"
+	}
+
+	// CVF / additional identity-verification challenge.
+	if strings.Contains(lower, "cvf-widget") || strings.Contains(lower, "auth-error-message-box") {
+		return true, "response is an Amazon identity-verification challenge"
+	}
+
+	return false, ""
+}
+
+// AuthInterstitialError returns a non-nil error describing the interstitial
+// when htmlBytes is an Amazon sign-in/claim/challenge page, and nil otherwise.
+// Callers fetching live HTML use it to fail loudly with a re-auth hint instead
+// of silently parsing zero orders out of a sign-in page.
+func AuthInterstitialError(htmlBytes []byte) error {
+	if ok, reason := DetectAuthInterstitial(htmlBytes); ok {
+		return fmt.Errorf("amazon returned a sign-in/interstitial page (%s); the browser session is not authenticated — run 'amazon-orders-pp-cli auth login --chrome' (or 'auth refresh') and retry", reason)
+	}
+	return nil
+}

--- a/library/commerce/amazon-orders/internal/parser/auth_interstitial_test.go
+++ b/library/commerce/amazon-orders/internal/parser/auth_interstitial_test.go
@@ -1,0 +1,91 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectAuthInterstitial(t *testing.T) {
+	tests := []struct {
+		name   string
+		html   string
+		want   bool
+		reason string // substring expected in reason when want is true
+	}{
+		{
+			name: "amazon sign-in title",
+			html: `<html><head><title>Amazon Sign-In</title></head><body>...</body></html>`,
+			want: true, reason: "Amazon Sign-In",
+		},
+		{
+			name: "ax/claim interstitial",
+			html: `<html><head><title>Amazon</title></head><body><form action="/ax/claim?arb=193cca18">...</form></body></html>`,
+			want: true, reason: "/ax/claim",
+		},
+		{
+			name: "sign-in form with password field",
+			html: `<html><head><title>Amazon</title></head><body><form action="/ap/signin"><input name="email"><input name="password" id="ap_password"></form></body></html>`,
+			want: true, reason: "sign-in form",
+		},
+		{
+			name: "robot check / captcha",
+			html: `<html><head><title>Robot Check</title></head><body><input id="captchacharacters"></body></html>`,
+			want: true, reason: "Robot Check",
+		},
+		{
+			name: "identity verification challenge",
+			html: `<html><head><title>Amazon</title></head><body><div id="cvf-widget"></div></body></html>`,
+			want: true, reason: "identity-verification",
+		},
+		{
+			name: "authenticated orders page is not an interstitial",
+			html: `<html><head><title>Amazon.in - Your Orders</title></head><body>
+				<div class="order-card js-order-card">ORDER PLACED May 5, 2026 TOTAL ₹1,234.56 ORDER # 408-1234567-1234567</div>
+				<a href="/ap/signin">Sign Out</a>
+			</body></html>`,
+			want: false,
+		},
+		{
+			name: "empty body",
+			html: ``,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reason := DetectAuthInterstitial([]byte(tt.html))
+			if got != tt.want {
+				t.Fatalf("DetectAuthInterstitial() = %v, want %v (reason=%q)", got, tt.want, reason)
+			}
+			if tt.want && tt.reason != "" && !strings.Contains(reason, tt.reason) {
+				t.Errorf("reason = %q, want it to contain %q", reason, tt.reason)
+			}
+			err := AuthInterstitialError([]byte(tt.html))
+			if tt.want && err == nil {
+				t.Errorf("AuthInterstitialError() = nil, want non-nil")
+			}
+			if !tt.want && err != nil {
+				t.Errorf("AuthInterstitialError() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// A real order page must still parse to non-empty orders after the
+// interstitial guard — detection must not false-positive on authenticated HTML.
+func TestDetectAuthInterstitial_DoesNotBreakRealOrderPage(t *testing.T) {
+	html := `<html><head><title>Your Orders</title></head><body>
+		<div class="order-card js-order-card">ORDER PLACED May 5, 2026 TOTAL $51.46 SHIP TO Jane ORDER # 111-1111111-1111111</div>
+	</body></html>`
+	if ok, reason := DetectAuthInterstitial([]byte(html)); ok {
+		t.Fatalf("real order page flagged as interstitial: %s", reason)
+	}
+	page, err := ParseOrderList([]byte(html))
+	if err != nil {
+		t.Fatalf("ParseOrderList: %v", err)
+	}
+	if len(page.Orders) != 1 {
+		t.Fatalf("expected 1 order, got %d", len(page.Orders))
+	}
+}

--- a/library/commerce/amazon-orders/internal/parser/orders_list.go
+++ b/library/commerce/amazon-orders/internal/parser/orders_list.go
@@ -100,13 +100,25 @@ func parseOrderCard(card *html.Node) OrderSummary {
 		}
 	}
 
-	// Total: first money string after "TOTAL" label, fall back to first $ in card.
+	// Total: first money string after "TOTAL" label, fall back to first currency-marked amount in card.
+	foundTotal := false
 	if i := strings.Index(strings.ToUpper(cardText), "TOTAL"); i >= 0 {
-		window := cardText[i:min(i+40, len(cardText))]
-		s.Total = ExtractMoney(window)
+		window := cardText[i:min(i+60, len(cardText))]
+		if total, currency, ok := ExtractMoneyWithCurrency(window); ok {
+			s.Total = total
+			foundTotal = true
+			if currency != "" {
+				s.Currency = currency
+			}
+		}
 	}
-	if s.Total == 0 {
-		s.Total = ExtractMoney(cardText)
+	if !foundTotal {
+		if total, currency, ok := ExtractMoneyWithCurrency(cardText); ok {
+			s.Total = total
+			if currency != "" {
+				s.Currency = currency
+			}
+		}
 	}
 
 	// Recipient: SHIP TO label.

--- a/library/commerce/amazon-orders/internal/parser/parser.go
+++ b/library/commerce/amazon-orders/internal/parser/parser.go
@@ -27,8 +27,9 @@ var orderIDRegex = regexp.MustCompile(`\b\d{3}-\d{7}-\d{7}\b|\bD\d{2}-\d{7}-\d{7
 // asinRegex extracts a 10-char Amazon Standard ID Number (ASIN).
 var asinRegex = regexp.MustCompile(`/dp/([A-Z0-9]{10})`)
 
-// moneyRegex matches USD-style money (e.g. "$1,234.56", "-$5.00").
-var moneyRegex = regexp.MustCompile(`-?\$\s*([0-9][0-9,]*\.\d{2})`)
+// moneyRegex matches currency-marked money across Amazon marketplaces (e.g.
+// "$1,234.56", "-₹1,234.56", "Rs. 999.00", "INR 2,500.00").
+var moneyRegex = regexp.MustCompile(`(?i)(-?)\s*(₹|rs\.?|inr|\$|£|€)\s*([0-9][0-9,]*(?:\.\d{2})?)`)
 
 // dateLikeRegex tolerates "May 5, 2026", "May 5", "Jan 1, 2026".
 var dateLikeRegex = regexp.MustCompile(`\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2}(?:,\s*\d{4})?\b`)
@@ -174,19 +175,44 @@ func ExtractASIN(url string) string {
 // ExtractMoney returns the first money value in text as a float (e.g. 51.46).
 // Returns 0 if no money string is found. Negative for negative amounts.
 func ExtractMoney(text string) float64 {
-	m := moneyRegex.FindStringSubmatch(text)
-	if len(m) < 2 {
+	v, _, ok := ExtractMoneyWithCurrency(text)
+	if !ok {
 		return 0
-	}
-	clean := strings.ReplaceAll(m[1], ",", "")
-	v, err := strconv.ParseFloat(clean, 64)
-	if err != nil {
-		return 0
-	}
-	if strings.HasPrefix(m[0], "-") {
-		v = -v
 	}
 	return v
+}
+
+// ExtractMoneyWithCurrency returns the first money value and detected ISO-ish
+// currency code. ok is false when no supported currency-marked amount exists.
+func ExtractMoneyWithCurrency(text string) (amount float64, currency string, ok bool) {
+	m := moneyRegex.FindStringSubmatch(text)
+	if len(m) < 4 {
+		return 0, "", false
+	}
+	clean := strings.ReplaceAll(m[3], ",", "")
+	v, err := strconv.ParseFloat(clean, 64)
+	if err != nil {
+		return 0, "", false
+	}
+	if m[1] == "-" {
+		v = -v
+	}
+	return v, currencyForMoneyToken(m[2]), true
+}
+
+func currencyForMoneyToken(token string) string {
+	switch strings.ToUpper(strings.TrimSpace(token)) {
+	case "₹", "RS", "RS.", "INR":
+		return "INR"
+	case "$":
+		return "USD"
+	case "£":
+		return "GBP"
+	case "€":
+		return "EUR"
+	default:
+		return ""
+	}
 }
 
 // ParseDate tolerates several Amazon date strings ("May 5, 2026", "May 5",

--- a/library/commerce/amazon-orders/internal/parser/parser_test.go
+++ b/library/commerce/amazon-orders/internal/parser/parser_test.go
@@ -47,6 +47,10 @@ func TestExtractMoney(t *testing.T) {
 		{"TOTAL $51.46 SHIP TO", 51.46},
 		{"$1,234.56", 1234.56},
 		{"-$5.00", -5.0},
+		{"TOTAL ₹1,234.56 SHIP TO", 1234.56},
+		{"TOTAL Rs. 999.00", 999.00},
+		{"TOTAL INR 2,500.00", 2500.00},
+		{"-₹5.00", -5.0},
 		{"no money here", 0},
 		{"$ 12.34 spaced", 12.34},
 	}
@@ -54,6 +58,28 @@ func TestExtractMoney(t *testing.T) {
 		got := ExtractMoney(tt.in)
 		if got != tt.want {
 			t.Errorf("ExtractMoney(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestExtractMoneyWithCurrency(t *testing.T) {
+	tests := []struct {
+		in           string
+		wantAmount   float64
+		wantCurrency string
+		wantOK       bool
+	}{
+		{"TOTAL ₹1,234.56", 1234.56, "INR", true},
+		{"TOTAL Rs. 999.00", 999.00, "INR", true},
+		{"TOTAL INR 2,500.00", 2500.00, "INR", true},
+		{"TOTAL $51.46", 51.46, "USD", true},
+		{"TOTAL £12.34", 12.34, "GBP", true},
+		{"no money", 0, "", false},
+	}
+	for _, tt := range tests {
+		gotAmount, gotCurrency, gotOK := ExtractMoneyWithCurrency(tt.in)
+		if gotOK != tt.wantOK || gotAmount != tt.wantAmount || gotCurrency != tt.wantCurrency {
+			t.Errorf("ExtractMoneyWithCurrency(%q) = (%v, %q, %v), want (%v, %q, %v)", tt.in, gotAmount, gotCurrency, gotOK, tt.wantAmount, tt.wantCurrency, tt.wantOK)
 		}
 	}
 }
@@ -145,6 +171,31 @@ func TestParseOrderListMinimal(t *testing.T) {
 	}
 	if len(o.ASINs) != 1 || o.ASINs[0] != "B0EXAMPLE1" {
 		t.Errorf("ASINs = %v, want [B0EXAMPLE1]", o.ASINs)
+	}
+}
+
+func TestParseOrderListINRTotalAndCurrency(t *testing.T) {
+	html := `<html><body>
+<div class="order-card js-order-card">
+  <span>ORDER PLACED</span><span>May 5, 2026</span>
+  <span>TOTAL</span><span>₹1,234.56</span>
+  <span>SHIP TO</span><span>Test User</span>
+  <span>ORDER # 111-1111111-1111111</span>
+</div>
+</body></html>`
+	page, err := ParseOrderList([]byte(html))
+	if err != nil {
+		t.Fatalf("ParseOrderList: %v", err)
+	}
+	if len(page.Orders) != 1 {
+		t.Fatalf("got %d orders, want 1", len(page.Orders))
+	}
+	o := page.Orders[0]
+	if o.Total != 1234.56 {
+		t.Errorf("Total = %v, want 1234.56", o.Total)
+	}
+	if o.Currency != "INR" {
+		t.Errorf("Currency = %q, want INR", o.Currency)
 	}
 }
 

--- a/library/commerce/amazon-orders/manifest.json
+++ b/library/commerce/amazon-orders/manifest.json
@@ -23,7 +23,7 @@
     "amazon_cookies": {
       "type": "string",
       "title": "Amazon buyer session",
-      "description": "Amazon does not publish a buyer-side API for order history. This CLI imports\ncookies from your logged-in Chrome / Firefox / Safari / Brave browser session,\nthen makes authenticated HTTPS GETs to the same HTML pages you see on\namazon.com. Log in to amazon.com in your browser, then run:\n\n  amazon-orders-pp-cli auth login --chrome\n\nCookies live under the .amazon.com domain. The CLI persists them locally and\nrefreshes the session-id cookie automatically when amazon.com rotates it.",
+      "description": "Amazon does not publish a buyer-side API for order history. This CLI imports cookies from your logged-in Chrome / Firefox / Safari / Brave browser session, then makes authenticated HTTPS GETs to the same HTML pages you see on your configured Amazon marketplace. Log in to that marketplace in your browser, then run:\n\n  amazon-orders-pp-cli auth login --chrome\n\nFor India or another non-US marketplace, pass the domain, e.g.:\n\n  amazon-orders-pp-cli auth login --chrome --domain amazon.in\n\nThe CLI persists cookies locally and refreshes the session-id cookie automatically when Amazon rotates it.",
       "sensitive": true
     }
   },


### PR DESCRIPTION
## Summary

Fixes Amazon Orders browser-cookie auth for non-US marketplaces such as `amazon.in`.

The CLI previously hardcoded `.amazon.com` across Chrome cookie discovery, auth refresh/status, browser-session proof validation, and portable session export. A user logged into `amazon.in` in Chrome had valid Amazon buyer cookies, but `auth login --chrome` still searched for `.amazon.com` and failed.

## Changes

- Derive the cookie domain from the configured Amazon base URL.
- Add `auth login --chrome --domain <marketplace>` for explicit regional login, e.g. `--domain amazon.in`.
- Persist the matching `base_url` when `--domain` is used, so later commands validate/fetch against the same marketplace.
- Make auth refresh, status, doctor, browser-session proofs, and portable session export/import respect the marketplace domain.
- Document the regional marketplace auth path in README/SKILL/manifest metadata.
- Record the generated-tree hand edit in `.printing-press-patches/marketplace-cookie-domain.json`.

## Validation

| Check | Result |
|---|---|
| Focused auth-domain tests | PASS |
| `go test ./...` from `library/commerce/amazon-orders` | PASS |
| `go vet ./...` from `library/commerce/amazon-orders` | PASS |
| `go build ./cmd/amazon-orders-pp-cli` | PASS |
| `auth login --chrome --domain amazon.in --dry-run` | PASS, reports `.amazon.in` |
| `AMAZON_ORDERS_BASE_URL=https://www.amazon.in auth login --chrome --dry-run` | PASS, reports `.amazon.in` |
| `verify_skill.py --dir library/commerce/amazon-orders` | PASS |

## Notes

This only fixes marketplace-aware auth/domain plumbing. Localized HTML/date parsing may still need follow-up fixes if a marketplace renders order history differently.
