### PR TITLE
fix(x-twitter): improve article agent ergonomics

### DIFF
--- a/library/social-and-messaging/x-twitter/.printing-press-patches/x-twitter-article-agent-ergonomics.json
+++ b/library/social-and-messaging/x-twitter/.printing-press-patches/x-twitter-article-agent-ergonomics.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 2,
+  "id": "x-twitter-article-agent-ergonomics",
+  "applied_at": "2026-06-15",
+  "base_run_id": "20260603-230951",
+  "base_printing_press_version": "4.20.1",
+  "summary": "Preserve agent-safe X Articles management surfaces: markdown update-in-place, friendly mutation flags, cookie user-id identity, and lossless basic inline markdown.",
+  "reason": "Real article authoring sessions showed agents were forced to create duplicate drafts or hand-craft GraphQL variables, while doctor over-emphasized OAuth2 user-context warnings for cookie-lane Article writes. A regen must keep Articles create/update/delete on the browser-cookie lane and keep markdown links/code/headings from leaking raw syntax into Draft.js output.",
+  "files": [
+    "internal/client/cookies.go",
+    "internal/cli/account_snapshot_workflow.go",
+    "internal/cli/articles_delete.go",
+    "internal/cli/articles_friendly.go",
+    "internal/cli/articles_publish_md.go",
+    "internal/cli/articles_update_content.go",
+    "internal/cli/articles_update_cover_media.go",
+    "internal/cli/articles_update_md.go",
+    "internal/cli/articles_update_title.go",
+    "internal/cli/doctor.go"
+  ],
+  "validated_outcome": "go test ./... passed; local dry-run previews showed LINK entities, CODE inline style, downgraded h3 headings, --update preview, and friendly Article GraphQL request bodies without posting to X."
+}

--- a/library/social-and-messaging/x-twitter/README.md
+++ b/library/social-and-messaging/x-twitter/README.md
@@ -280,12 +280,13 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   x-twitter-pp-cli thread compose ./update.md
   ```
-- **`articles-publish-md`** — Parse a markdown file with YAML frontmatter into the Draft.js content_state JSON X's Articles editor accepts; previews by default; --draft saves a draft, --post publishes publicly.
+- **`articles-publish-md`** — Parse a markdown file with YAML frontmatter into the Draft.js content_state JSON X's Articles editor accepts; previews by default; --draft creates a new draft, --update edits an existing draft, --post publishes publicly.
 
-  _The only programmatic way to author a long-form X Article from a document; preview and --draft keep it private until you explicitly --post._
+  _The only programmatic way to author a long-form X Article from a document; preview, --draft, and --update keep it private until you explicitly --post._
 
   ```bash
   x-twitter-pp-cli articles-publish-md ./post.md
+  x-twitter-pp-cli articles-publish-md ./post.md --update 1750000000000000000
   ```
 
 ## Recipes

--- a/library/social-and-messaging/x-twitter/SKILL.md
+++ b/library/social-and-messaging/x-twitter/SKILL.md
@@ -144,14 +144,15 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   x-twitter-pp-cli thread compose ./update.md
   ```
-- **`articles-publish-md`** — Parse a markdown file with YAML frontmatter into the Draft.js content_state JSON X's Articles editor accepts; previews by default; --draft saves a draft, --post publishes publicly.
+- **`articles-publish-md`** — Parse a markdown file with YAML frontmatter into the Draft.js content_state JSON X's Articles editor accepts; previews by default; --draft creates a new draft, --update edits an existing draft, --post publishes publicly.
 
-  _The only programmatic way to author a long-form X Article from a document; preview and --draft keep it private until you explicitly --post._
+  _The only programmatic way to author a long-form X Article from a document; preview, --draft, and --update keep it private until you explicitly --post._
 
-  The converter supports paragraphs, `#`/`##` headers, lists, blockquotes, fenced code blocks, tables, dividers, image lines (`![alt](path)`), standalone tweet URLs (native embeds), bold/italic inline styles (including inside blockquotes), and `[text](url)` inline links, which become real LINK entities (working hyperlinks) in the article. Lines that are HTML comments (`<!-- ... -->`) are stripped and never ship as article text.
+  The converter supports paragraphs, `#`/`##` headers (`###` and deeper are downgraded to `##`), lists, blockquotes, fenced code blocks, tables, dividers, image lines (`![alt](path)`), standalone tweet URLs (native embeds), bold/italic/code inline styles (including inside blockquotes), and `[text](url)` inline links, which become real LINK entities (working hyperlinks) in the article. Lines that are HTML comments (`<!-- ... -->`) are stripped and never ship as article text.
 
   ```bash
   x-twitter-pp-cli articles-publish-md ./post.md
+  x-twitter-pp-cli articles-publish-md ./post.md --update 1750000000000000000
   ```
 - **`articles update-md`** — Update an existing X Article draft in place from a markdown file: title (frontmatter), body, links, and new inline images, all in one command. Find the article id via `articles list --agent`.
 

--- a/library/social-and-messaging/x-twitter/internal/cli/account_snapshot_workflow.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/account_snapshot_workflow.go
@@ -3,9 +3,11 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/internal/client"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +26,70 @@ func newNovelAccountCmd(flags *rootFlags) *cobra.Command {
 		RunE:        parentNoSubcommandRunE(flags),
 	}
 	cmd.AddCommand(newNovelAccountSnapshotCmd(flags))
+	cmd.AddCommand(newNovelAccountWhoamiCmd(flags))
+	return cmd
+}
+
+func newNovelAccountWhoamiCmd(flags *rootFlags) *cobra.Command {
+	var live bool
+	cmd := &cobra.Command{
+		Use:   "whoami",
+		Short: "Show the signed-in account identity available to this CLI",
+		Long:  "Shows the X Articles cookie user id from captured browser cookies. With --live, also probes /2/users/me using OAuth2 user-context auth.",
+		Example: `  x-twitter-pp-cli account whoami --agent
+  x-twitter-pp-cli account whoami --live --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result := map[string]any{
+				"x_articles_cookie": map[string]any{
+					"status": "missing",
+				},
+			}
+			if cookies, err := client.LoadCookieAuth(); err == nil {
+				cookieLane := map[string]any{"status": "ok"}
+				if userID := cookies.ArticleUserID(); userID != "" {
+					cookieLane["user_id"] = userID
+				}
+				result["x_articles_cookie"] = cookieLane
+			} else {
+				result["x_articles_cookie"].(map[string]any)["error"] = err.Error()
+			}
+			if live {
+				c, err := flags.newClient()
+				if err != nil {
+					return err
+				}
+				body, err := c.GetNoCache(cmd.Context(), "/2/users/me", nil)
+				if err != nil {
+					result["oauth2_user_context"] = map[string]any{
+						"status": "error",
+						"error":  err.Error(),
+					}
+				} else if user := userSummaryFromMeProbe(body); len(user) > 0 {
+					result["oauth2_user_context"] = map[string]any{
+						"status": "ok",
+						"user":   user,
+					}
+				} else {
+					result["oauth2_user_context"] = map[string]any{"status": "unknown"}
+				}
+			}
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(result)
+			}
+			cookieLane, _ := result["x_articles_cookie"].(map[string]any)
+			if userID, _ := cookieLane["user_id"].(string); userID != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "X Articles cookie user id: %s\n", userID)
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "X Articles cookie user id: unavailable\n")
+			}
+			if oauthLane, _ := result["oauth2_user_context"].(map[string]any); len(oauthLane) > 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "OAuth2 user-context: %v\n", oauthLane["status"])
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&live, "live", false, "Also probe /2/users/me with OAuth2 user-context auth")
 	return cmd
 }
 

--- a/library/social-and-messaging/x-twitter/internal/cli/account_whoami_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/account_whoami_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAccountWhoamiReportsCookieUserID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("X_BEARER_TOKEN", "")
+	t.Setenv("X_OAUTH2_USER_TOKEN", "")
+	dir := filepath.Join(home, ".config", "x-twitter-pp-cli")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir cookies dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cookies.json"), []byte(`{"auth_token":"a","ct0":"c","web_bearer":"w","twid":"u%3D98765"}`), 0o600); err != nil {
+		t.Fatalf("write cookies: %v", err)
+	}
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"account", "whoami", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("account whoami failed: %v\n%s", err, out.String())
+	}
+
+	var payload map[string]map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	cookieLane := payload["x_articles_cookie"]
+	if cookieLane["status"] != "ok" || cookieLane["user_id"] != "98765" {
+		t.Fatalf("unexpected cookie lane: %#v", cookieLane)
+	}
+}

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_delete.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_delete.go
@@ -16,6 +16,7 @@ import (
 
 func newArticlesDeleteCmd(flags *rootFlags) *cobra.Command {
 	var flagData string
+	var articleID string
 	var bodyQueryId string
 	var bodyVariables string
 	var stdinBody bool
@@ -26,6 +27,14 @@ func newArticlesDeleteCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  x-twitter-pp-cli articles delete --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000",
 		Annotations: map[string]string{"pp:endpoint": "articles.delete", "pp:method": "POST", "pp:path": "/i/api/graphql/e4lWqB6m2TA8Fn_j9L9xEA/ArticleEntityDelete"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			friendly := cmd.Flags().Changed("id")
+			if friendly {
+				body, err := articleDeleteRequestBody(articleID)
+				if err != nil {
+					return err
+				}
+				return runArticleGraphQLMutation(cmd, flags, "ArticleEntityDelete", body)
+			}
 			if !cmd.Flags().Changed("data") && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "data")
 			}
@@ -135,6 +144,7 @@ func newArticlesDeleteCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagData, "data", "", "")
+	cmd.Flags().StringVar(&articleID, "id", "", "Article rest_id to delete")
 	cmd.Flags().StringVar(&bodyQueryId, "query-id", "", "")
 	cmd.Flags().StringVar(&bodyVariables, "variables", "", "")
 	cmd.Flags().BoolVar(&stdinBody, "stdin", false, "Read request body as JSON from stdin")

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_friendly.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_friendly.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/internal/client"
+	"github.com/spf13/cobra"
+)
+
+func articleIDFlag(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", usageErr(fmt.Errorf("--id is required"))
+	}
+	return id, nil
+}
+
+func articleDeleteRequestBody(articleID string) (map[string]any, error) {
+	articleID, err := articleIDFlag(articleID)
+	if err != nil {
+		return nil, err
+	}
+	return articleOpRequestBody("ArticleEntityDelete", map[string]any{
+		"articleEntityId": articleID,
+	}), nil
+}
+
+func articleUpdateTitleRequestBody(articleID string, title string) (map[string]any, error) {
+	articleID, err := articleIDFlag(articleID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(title) == "" {
+		return nil, usageErr(fmt.Errorf("--title is required"))
+	}
+	return articleOpRequestBody("ArticleEntityUpdateTitle", map[string]any{
+		"articleEntityId": articleID,
+		"title":           title,
+	}), nil
+}
+
+func articleUpdateCoverRequestBody(articleID string, mediaID string) (map[string]any, error) {
+	articleID, err := articleIDFlag(articleID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(mediaID) == "" {
+		return nil, usageErr(fmt.Errorf("--media-id is required unless --cover is supplied"))
+	}
+	return articleOpRequestBody("ArticleEntityUpdateCoverMedia", map[string]any{
+		"articleEntityId": articleID,
+		"coverMedia": map[string]any{
+			"media_id":       strings.TrimSpace(mediaID),
+			"media_category": "DraftTweetImage",
+		},
+	}), nil
+}
+
+func articleUpdateContentRequestBody(articleID string, contentState draftContentState) (map[string]any, error) {
+	articleID, err := articleIDFlag(articleID)
+	if err != nil {
+		return nil, err
+	}
+	return articleOpRequestBody("ArticleEntityUpdateContent", map[string]any{
+		"content_state":  articleContentStateRequest(contentState),
+		"article_entity": articleID,
+	}), nil
+}
+
+func readArticleContentStateFile(path string) (draftContentState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return draftContentState{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	return parseArticleContentStateJSON(data)
+}
+
+func parseArticleContentStateJSON(data []byte) (draftContentState, error) {
+	var outer map[string]json.RawMessage
+	if err := json.Unmarshal(data, &outer); err == nil {
+		if nested, ok := outer["content_state"]; ok {
+			data = nested
+		}
+	}
+	var raw struct {
+		Blocks         []draftBlock  `json:"blocks"`
+		EntityMap      []draftEntity `json:"entityMap"`
+		EntityMapSnake []draftEntity `json:"entity_map"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return draftContentState{}, fmt.Errorf("parse content_state JSON: %w", err)
+	}
+	entityMap := raw.EntityMap
+	if entityMap == nil {
+		entityMap = raw.EntityMapSnake
+	}
+	return draftContentState{
+		Blocks:    raw.Blocks,
+		EntityMap: entityMap,
+	}, nil
+}
+
+func printArticleMutationResponse(cmd *cobra.Command, flags *rootFlags, path string, data json.RawMessage, statusCode int) error {
+	if wantsHumanTable(cmd.OutOrStdout(), flags) {
+		var items []map[string]any
+		if json.Unmarshal(data, &items) == nil && len(items) > 0 {
+			if err := printAutoTable(cmd.OutOrStdout(), items); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: table rendering failed, falling back to JSON: %v\n", err)
+			} else {
+				return nil
+			}
+		} else {
+			var wrapped struct {
+				Data []map[string]any `json:"data"`
+			}
+			if json.Unmarshal(data, &wrapped) == nil && len(wrapped.Data) > 0 {
+				if err := printAutoTable(cmd.OutOrStdout(), wrapped.Data); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: table rendering failed, falling back to JSON: %v\n", err)
+				} else {
+					return nil
+				}
+			}
+		}
+	}
+	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+		if flags.quiet {
+			return nil
+		}
+		filtered := data
+		if flags.selectFields != "" {
+			filtered = filterFields(filtered, flags.selectFields)
+		} else if flags.compact {
+			filtered = compactFields(filtered)
+		}
+		envelope := map[string]any{
+			"action":   "post",
+			"resource": "articles",
+			"path":     path,
+			"status":   statusCode,
+			"success":  statusCode >= 200 && statusCode < 300,
+		}
+		if flags.dryRun {
+			envelope["dry_run"] = true
+			envelope["status"] = 0
+			envelope["success"] = false
+		}
+		if len(filtered) > 0 {
+			var parsed any
+			if err := json.Unmarshal(filtered, &parsed); err == nil {
+				envelope["data"] = parsed
+			}
+		}
+		envelopeJSON, err := json.Marshal(envelope)
+		if err != nil {
+			return err
+		}
+		return printOutput(cmd.OutOrStdout(), json.RawMessage(envelopeJSON), true)
+	}
+	return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+}
+
+func runArticleGraphQLMutation(cmd *cobra.Command, flags *rootFlags, opName string, body map[string]any) error {
+	c, err := flags.newClient()
+	if err != nil {
+		return err
+	}
+	path := client.ArticleOpURL(opName)
+	data, statusCode, err := c.Post(cmd.Context(), path, body)
+	if err != nil {
+		return classifyAPIError(err, flags)
+	}
+	return printArticleMutationResponse(cmd, flags, path, data, statusCode)
+}

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_friendly.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_friendly.go
@@ -163,11 +163,35 @@ func printArticleMutationResponse(cmd *cobra.Command, flags *rootFlags, path str
 }
 
 func runArticleGraphQLMutation(cmd *cobra.Command, flags *rootFlags, opName string, body map[string]any) error {
+	path := client.ArticleOpURL(opName)
+	if flags.dryRun {
+		selectedProfile := flags.profileName
+		if selectedProfile == "" {
+			selectedProfile = "default"
+		}
+		preview, err := json.Marshal(map[string]any{
+			"dry_run": true,
+			"meta": map[string]any{
+				"auth_lane":        "x_articles_cookie",
+				"selected_profile": selectedProfile,
+			},
+			"mutation": true,
+			"request": map[string]any{
+				"body":   body,
+				"method": "POST",
+				"path":   path,
+			},
+			"sent": false,
+		})
+		if err != nil {
+			return err
+		}
+		return printArticleMutationResponse(cmd, flags, path, preview, 0)
+	}
 	c, err := flags.newClient()
 	if err != nil {
 		return err
 	}
-	path := client.ArticleOpURL(opName)
 	data, statusCode, err := c.Post(cmd.Context(), path, body)
 	if err != nil {
 		return classifyAPIError(err, flags)

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_friendly_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_friendly_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -65,5 +66,41 @@ func TestArticleUpdateContentRequestBodyFromPreviewContentState(t *testing.T) {
 	if _, ok := requestState["entity_map"].([]draftEntity); !ok {
 		encoded, _ := json.Marshal(requestState)
 		t.Fatalf("expected snake_case entity_map in request state, got %s", encoded)
+	}
+}
+
+func TestArticleFriendlyMutationDryRunDoesNotRequireAuth(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("X_TWITTER_COOKIE_AUTH_TOKEN", "")
+	t.Setenv("X_TWITTER_COOKIE_CT0", "")
+	t.Setenv("X_TWITTER_BEARER_TOKEN", "")
+	t.Setenv("X_BEARER_TOKEN", "")
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"articles", "delete", "--id", "123", "--dry-run", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("dry-run friendly delete failed without auth: %v\n%s", err, out.String())
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(out.Bytes(), &envelope); err != nil {
+		t.Fatalf("dry-run output is not JSON: %v\n%s", err, out.String())
+	}
+	data, _ := envelope["data"].(map[string]any)
+	if data["sent"] != false || data["dry_run"] != true {
+		t.Fatalf("expected unsent dry-run preview, got %#v", data)
+	}
+	request, _ := data["request"].(map[string]any)
+	if request["method"] != "POST" {
+		t.Fatalf("unexpected request preview: %#v", request)
+	}
+	body, _ := request["body"].(map[string]any)
+	vars, _ := body["variables"].(map[string]any)
+	if vars["articleEntityId"] != "123" {
+		t.Fatalf("unexpected dry-run variables: %#v", vars)
 	}
 }

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_friendly_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_friendly_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestArticleFriendlyRequestBodies(t *testing.T) {
+	deleteBody, err := articleDeleteRequestBody("111")
+	if err != nil {
+		t.Fatalf("delete body: %v", err)
+	}
+	deleteVars, _ := deleteBody["variables"].(map[string]any)
+	if deleteVars["articleEntityId"] != "111" {
+		t.Fatalf("unexpected delete variables: %#v", deleteVars)
+	}
+	if deleteBody["queryId"] == "" {
+		t.Fatalf("expected delete queryId")
+	}
+
+	titleBody, err := articleUpdateTitleRequestBody("222", "New")
+	if err != nil {
+		t.Fatalf("title body: %v", err)
+	}
+	titleVars, _ := titleBody["variables"].(map[string]any)
+	if titleVars["articleEntityId"] != "222" || titleVars["title"] != "New" {
+		t.Fatalf("unexpected title variables: %#v", titleVars)
+	}
+
+	coverBody, err := articleUpdateCoverRequestBody("333", "media-1")
+	if err != nil {
+		t.Fatalf("cover body: %v", err)
+	}
+	coverVars, _ := coverBody["variables"].(map[string]any)
+	coverMedia, _ := coverVars["coverMedia"].(map[string]any)
+	if coverVars["articleEntityId"] != "333" || coverMedia["media_id"] != "media-1" || coverMedia["media_category"] != "DraftTweetImage" {
+		t.Fatalf("unexpected cover variables: %#v", coverVars)
+	}
+}
+
+func TestArticleUpdateContentRequestBodyFromPreviewContentState(t *testing.T) {
+	raw := []byte(`{
+		"content_state": {
+			"blocks": [
+				{"data":{},"text":"Hello","key":"abcde","type":"unstyled","entity_ranges":[],"inline_style_ranges":[]}
+			],
+			"entityMap": [
+				{"key":"0","value":{"data":{"url":"https://example.com"},"type":"LINK","mutability":"Mutable"}}
+			]
+		}
+	}`)
+	cs, err := parseArticleContentStateJSON(raw)
+	if err != nil {
+		t.Fatalf("parse content state: %v", err)
+	}
+	body, err := articleUpdateContentRequestBody("444", cs)
+	if err != nil {
+		t.Fatalf("content body: %v", err)
+	}
+	vars, _ := body["variables"].(map[string]any)
+	if vars["article_entity"] != "444" {
+		t.Fatalf("unexpected article_entity: %#v", vars)
+	}
+	requestState, _ := vars["content_state"].(map[string]any)
+	if _, ok := requestState["entity_map"].([]draftEntity); !ok {
+		encoded, _ := json.Marshal(requestState)
+		t.Fatalf("expected snake_case entity_map in request state, got %s", encoded)
+	}
+}

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
@@ -102,6 +102,9 @@ func newNovelArticlesPublishMdCmd(flags *rootFlags) *cobra.Command {
 				if post {
 					return usageErr(fmt.Errorf("--update cannot be combined with --post; use `articles update-md --article-id %s --republish` for published articles", strings.TrimSpace(updateID)))
 				}
+				if draft {
+					return usageErr(fmt.Errorf("--update cannot be combined with --draft; --update already targets an existing draft (id %s); drop --draft", strings.TrimSpace(updateID)))
+				}
 				payload := map[string]any{
 					"article_id":    strings.TrimSpace(updateID),
 					"title":         parsed.Frontmatter.Title,
@@ -817,7 +820,7 @@ func extractInlineSpans(s string) (string, []inlineStyle, []linkSpan) {
 	for i < len(s) {
 		if s[i] == '`' {
 			end := strings.Index(s[i+1:], "`")
-			if end > 0 {
+			if end >= 0 {
 				inner := s[i+1 : i+1+end]
 				offset := utf16Len(out.String())
 				out.WriteString(inner)
@@ -928,7 +931,7 @@ func extractInlineStyles(s string) (string, []inlineStyle) {
 	for i < len(s) {
 		if s[i] == '`' {
 			end := strings.Index(s[i+1:], "`")
-			if end > 0 {
+			if end >= 0 {
 				inner := s[i+1 : i+1+end]
 				offset := utf16Len(out.String())
 				out.WriteString(inner)

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
@@ -7,8 +7,8 @@
 // paragraph, header-one, header-two, unordered-list-item, ordered-list-item,
 // blockquote, fenced code blocks, markdown table blocks, markdown image blocks,
 // tweet embeds, dividers, plus bold/italic inline styles and [text](url)
-// inline links (LINK entities). HTML comment lines are stripped. Cover image
-// uses the captured upload + UpdateCoverMedia flow.
+// inline links (LINK entities), and inline `code` spans. HTML comment lines
+// are stripped. Cover image uses the captured upload + UpdateCoverMedia flow.
 
 package cli
 
@@ -73,19 +73,20 @@ type draftEntityValue struct {
 func newNovelArticlesPublishMdCmd(flags *rootFlags) *cobra.Command {
 	var post bool
 	var draft bool
+	var updateID string
 	cmd := &cobra.Command{
 		Use:     "articles-publish-md <markdown-file>",
 		Short:   "Convert a markdown file to an X Article (preview by default; --draft or --post to write)",
-		Long:    "Parses frontmatter (title, cover, tags) and body, converts the body to the Draft.js content_state JSON X's Articles editor accepts. Previews the payload by default (no API call); pass --draft to save a draft (not published) or --post to create and publish the article publicly.",
-		Example: "  x-twitter-pp-cli articles-publish-md draft.md",
+		Long:    "Parses frontmatter (title, cover, tags) and body, converts the body to the Draft.js content_state JSON X's Articles editor accepts. Previews the payload by default (no API call); pass --draft to save a new draft, --post to create and publish publicly, or --update <article_id> to update an existing draft in place.",
+		Example: "  x-twitter-pp-cli articles-publish-md draft.md\n  x-twitter-pp-cli articles-publish-md draft.md --update 1750000000000000000",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Dry-run probes call with no file arg: short-circuit before the
-			// required-arg check so verify can exercise the command cleanly.
-			if dryRunOK(flags) {
-				return nil
-			}
 			if len(args) == 0 {
+				// Dry-run probes call with no file arg: short-circuit before the
+				// required-arg check so verify can exercise the command cleanly.
+				if dryRunOK(flags) {
+					return nil
+				}
 				return cmd.Help()
 			}
 			data, err := os.ReadFile(args[0])
@@ -97,6 +98,56 @@ func newNovelArticlesPublishMdCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			cs := MarkdownBodyToDraftJS(parsed.Body)
+			if strings.TrimSpace(updateID) != "" {
+				if post {
+					return usageErr(fmt.Errorf("--update cannot be combined with --post; use `articles update-md --article-id %s --republish` for published articles", strings.TrimSpace(updateID)))
+				}
+				payload := map[string]any{
+					"article_id":    strings.TrimSpace(updateID),
+					"title":         parsed.Frontmatter.Title,
+					"cover":         parsed.Frontmatter.Cover,
+					"content_state": cs,
+				}
+				if flags.dryRun {
+					enc := json.NewEncoder(cmd.OutOrStdout())
+					if !flags.asJSON {
+						fmt.Fprintln(cmd.OutOrStdout(), "── Article update payload (dry-run, no API call) ──")
+						enc.SetIndent("", "  ")
+					}
+					return enc.Encode(payload)
+				}
+				if os.Getenv("PRINTING_PRESS_VERIFY") == "1" {
+					fmt.Fprintln(cmd.OutOrStdout(), "verify-env: skipping article update")
+					return nil
+				}
+				c, err := flags.newClient()
+				if err != nil {
+					return err
+				}
+				deps := articleUpdateDeps{
+					post: c,
+					fetchSlice: func(ctx context.Context, lifecycle string) (json.RawMessage, error) {
+						return fetchArticleSlice(ctx, c, lifecycle)
+					},
+					uploadImage: func(p string) (string, error) {
+						return c.UploadArticleImage(cmd.Context(), p)
+					},
+				}
+				result, err := updateMarkdownArticle(cmd.Context(), deps, articleUpdateOptions{
+					articleID:    strings.TrimSpace(updateID),
+					title:        parsed.Frontmatter.Title,
+					coverPath:    parsed.Frontmatter.Cover,
+					contentState: cs,
+				})
+				if err != nil {
+					return classifyAPIError(err, flags)
+				}
+				if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+					return json.NewEncoder(cmd.OutOrStdout()).Encode(result)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "updated draft article %s\n%s\n", result.ArticleID, result.URL)
+				return nil
+			}
 			payload := map[string]any{
 				"title":         parsed.Frontmatter.Title,
 				"cover":         parsed.Frontmatter.Cover,
@@ -147,6 +198,7 @@ func newNovelArticlesPublishMdCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&draft, "draft", false, "Create the article as a draft without publishing")
 	cmd.Flags().BoolVar(&post, "post", false, "Create and publish the article publicly (default: preview only)")
+	cmd.Flags().StringVar(&updateID, "update", "", "Update an existing draft article by rest_id instead of creating a new draft")
 	return cmd
 }
 
@@ -432,14 +484,15 @@ func parseFrontmatter(yamlSrc string, fm *articleFrontmatter) {
 }
 
 // MarkdownBodyToDraftJS converts a markdown body to a Draft.js content_state.
-// Supports: paragraph, header-one (# ), header-two (## ), unordered-list-item,
+// Supports: paragraph, header-one (# ), header-two (## and deeper headings),
 // ordered-list-item, blockquote, markdown image lines, standalone tweet URLs,
 // standalone dividers (---), markdown tables, plus inline bold (**...**) and
-// italic (*...*). Fenced code blocks and markdown tables are emitted as X
-// Articles MARKDOWN entities bound to atomic Draft.js blocks. Image lines are
-// emitted as placeholder MEDIA entities in dry-run output, then rebound to
-// uploaded media IDs before live publish. Setext headings are intentionally
-// unsupported; use ## for header-two because --- is reserved for dividers.
+// italic (*...*) and code (`...`). Fenced code blocks and markdown tables are
+// emitted as X Articles MARKDOWN entities bound to atomic Draft.js blocks.
+// Image lines are emitted as placeholder MEDIA entities in dry-run output, then
+// rebound to uploaded media IDs before live publish. Setext headings are
+// intentionally unsupported; use ## for header-two because --- is reserved for
+// dividers.
 func MarkdownBodyToDraftJS(md string) draftContentState {
 	cs := draftContentState{}
 	lines := strings.Split(md, "\n")
@@ -501,6 +554,13 @@ func MarkdownBodyToDraftJS(md string) draftContentState {
 		case strings.HasPrefix(trim, "## "):
 			blk.Type = "header-two"
 			blk.Text = strings.TrimSpace(trim[3:])
+		case strings.HasPrefix(trim, "###"):
+			if headingText, ok := downgradeMarkdownHeading(trim); ok {
+				blk.Type = "header-two"
+				blk.Text = headingText
+			} else {
+				blk.Text = trim
+			}
 		case strings.HasPrefix(trim, "> "):
 			blk.Type = "blockquote"
 			blk.Text = strings.TrimSpace(trim[2:])
@@ -717,6 +777,24 @@ func splitMarkdownTableRow(line string) []string {
 	return strings.Split(trimmed, "|")
 }
 
+func downgradeMarkdownHeading(line string) (string, bool) {
+	hashes := 0
+	for hashes < len(line) && line[hashes] == '#' {
+		hashes++
+	}
+	if hashes < 3 {
+		return "", false
+	}
+	if hashes >= len(line) || line[hashes] != ' ' {
+		return "", false
+	}
+	text := strings.TrimSpace(line[hashes+1:])
+	if text == "" {
+		return "", false
+	}
+	return text, true
+}
+
 // linkSpan describes one [text](url) span found by extractInlineSpans, with
 // Offset/Length in UTF-16 code units over the cleaned block text.
 type linkSpan struct {
@@ -737,6 +815,17 @@ func extractInlineSpans(s string) (string, []inlineStyle, []linkSpan) {
 	out := strings.Builder{}
 	i := 0
 	for i < len(s) {
+		if s[i] == '`' {
+			end := strings.Index(s[i+1:], "`")
+			if end > 0 {
+				inner := s[i+1 : i+1+end]
+				offset := utf16Len(out.String())
+				out.WriteString(inner)
+				ranges = append(ranges, inlineStyle{Offset: offset, Length: utf16Len(inner), Style: "CODE"})
+				i = i + 1 + end + 1
+				continue
+			}
+		}
 		// Bold first (**...**) so it doesn't get consumed as italic.
 		if i+2 <= len(s) && s[i:i+2] == "**" {
 			end := strings.Index(s[i+2:], "**")
@@ -837,6 +926,17 @@ func extractInlineStyles(s string) (string, []inlineStyle) {
 	out := strings.Builder{}
 	i := 0
 	for i < len(s) {
+		if s[i] == '`' {
+			end := strings.Index(s[i+1:], "`")
+			if end > 0 {
+				inner := s[i+1 : i+1+end]
+				offset := utf16Len(out.String())
+				out.WriteString(inner)
+				ranges = append(ranges, inlineStyle{Offset: offset, Length: utf16Len(inner), Style: "CODE"})
+				i = i + 1 + end + 1
+				continue
+			}
+		}
 		// Bold first (**...**) so it doesn't get consumed as italic.
 		if i+2 <= len(s) && s[i:i+2] == "**" {
 			end := strings.Index(s[i+2:], "**")

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -70,6 +71,28 @@ func TestArticlesPublishMdUpdateDryRunWithFilePrintsPreview(t *testing.T) {
 	}
 	if payload["article_id"] != "123" || payload["title"] != "Dry Run" || payload["cover"] != "./cover.jpg" {
 		t.Fatalf("unexpected preview payload: %#v", payload)
+	}
+}
+
+func TestArticlesPublishMdUpdateRejectsDraftFlag(t *testing.T) {
+	dir := t.TempDir()
+	md := filepath.Join(dir, "article.md")
+	if err := os.WriteFile(md, []byte("---\ntitle: Dry Run\n---\n\nBody"), 0o600); err != nil {
+		t.Fatalf("write markdown: %v", err)
+	}
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"articles-publish-md", md, "--update", "123", "--draft"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected --update --draft to fail")
+	}
+	if !strings.Contains(err.Error(), "--update cannot be combined with --draft") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -357,6 +380,22 @@ func TestMarkdownBodyToDraftJSInlineCode(t *testing.T) {
 	}
 	style := blk.InlineStyleRanges[0]
 	if style.Offset != 4 || style.Length != 16 || style.Style != "CODE" {
+		t.Fatalf("unexpected CODE style range: %#v", style)
+	}
+}
+
+func TestMarkdownBodyToDraftJSEmptyInlineCode(t *testing.T) {
+	contentState := MarkdownBodyToDraftJS("Run `` now")
+
+	blk := contentState.Blocks[0]
+	if blk.Text != "Run  now" {
+		t.Fatalf("unexpected text: %q", blk.Text)
+	}
+	if len(blk.InlineStyleRanges) != 1 {
+		t.Fatalf("expected one empty inline code style, got %d", len(blk.InlineStyleRanges))
+	}
+	style := blk.InlineStyleRanges[0]
+	if style.Offset != 4 || style.Length != 0 || style.Style != "CODE" {
 		t.Fatalf("unexpected CODE style range: %#v", style)
 	}
 }

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 )
@@ -38,6 +42,34 @@ func TestMarkdownBodyToDraftJSImageLine(t *testing.T) {
 	}
 	if entity.Value.Data["alt_text"] != "body alt" {
 		t.Fatalf("expected alt_text to be retained, got %#v", entity.Value.Data["alt_text"])
+	}
+}
+
+func TestArticlesPublishMdUpdateDryRunWithFilePrintsPreview(t *testing.T) {
+	dir := t.TempDir()
+	md := filepath.Join(dir, "article.md")
+	if err := os.WriteFile(md, []byte("---\ntitle: Dry Run\ncover: ./cover.jpg\n---\n\nBody"), 0o600); err != nil {
+		t.Fatalf("write markdown: %v", err)
+	}
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"articles-publish-md", md, "--update", "123", "--dry-run", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("articles-publish-md dry-run failed: %v\n%s", err, out.String())
+	}
+	if out.Len() == 0 {
+		t.Fatalf("expected dry-run preview output")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("preview output is not JSON: %v\n%s", err, out.String())
+	}
+	if payload["article_id"] != "123" || payload["title"] != "Dry Run" || payload["cover"] != "./cover.jpg" {
+		t.Fatalf("unexpected preview payload: %#v", payload)
 	}
 }
 
@@ -310,6 +342,36 @@ func TestMarkdownBodyToDraftJSBoldInBlockquote(t *testing.T) {
 	style := blk.InlineStyleRanges[0]
 	if style.Offset != 0 || style.Length != 10 || style.Style != "Bold" {
 		t.Fatalf("unexpected style range: %#v", style)
+	}
+}
+
+func TestMarkdownBodyToDraftJSInlineCode(t *testing.T) {
+	contentState := MarkdownBodyToDraftJS("Run `x-twitter-pp-cli` now")
+
+	blk := contentState.Blocks[0]
+	if blk.Text != "Run x-twitter-pp-cli now" {
+		t.Fatalf("unexpected text: %q", blk.Text)
+	}
+	if len(blk.InlineStyleRanges) != 1 {
+		t.Fatalf("expected one inline code style, got %d", len(blk.InlineStyleRanges))
+	}
+	style := blk.InlineStyleRanges[0]
+	if style.Offset != 4 || style.Length != 16 || style.Style != "CODE" {
+		t.Fatalf("unexpected CODE style range: %#v", style)
+	}
+}
+
+func TestMarkdownBodyToDraftJSDowngradesDeepHeadings(t *testing.T) {
+	contentState := MarkdownBodyToDraftJS("### Third\n\n#### Fourth")
+
+	if len(contentState.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(contentState.Blocks))
+	}
+	for i, want := range []string{"Third", "Fourth"} {
+		blk := contentState.Blocks[i]
+		if blk.Type != "header-two" || blk.Text != want {
+			t.Fatalf("block %d = %q/%q, want header-two/%q", i, blk.Type, blk.Text, want)
+		}
 	}
 }
 

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_update_content.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_update_content.go
@@ -16,6 +16,9 @@ import (
 
 func newArticlesUpdateContentCmd(flags *rootFlags) *cobra.Command {
 	var flagData string
+	var articleID string
+	var markdownPath string
+	var contentStatePath string
 	var bodyFeatures string
 	var bodyQueryId string
 	var bodyVariables string
@@ -27,6 +30,38 @@ func newArticlesUpdateContentCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  x-twitter-pp-cli articles update-content --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000",
 		Annotations: map[string]string{"pp:endpoint": "articles.update_content", "pp:method": "POST", "pp:path": "/i/api/graphql/M7N2FrPrlOmu-YrVIBxFnQ/ArticleEntityUpdateContent"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			friendly := cmd.Flags().Changed("id") || cmd.Flags().Changed("md") || cmd.Flags().Changed("content-state")
+			if friendly {
+				if cmd.Flags().Changed("md") && cmd.Flags().Changed("content-state") {
+					return usageErr(fmt.Errorf("use only one of --md or --content-state"))
+				}
+				var cs draftContentState
+				switch {
+				case cmd.Flags().Changed("md"):
+					data, err := os.ReadFile(markdownPath)
+					if err != nil {
+						return fmt.Errorf("read %s: %w", markdownPath, err)
+					}
+					parsed, err := ParseArticleMarkdown(string(data))
+					if err != nil {
+						return err
+					}
+					cs = MarkdownBodyToDraftJS(parsed.Body)
+				case cmd.Flags().Changed("content-state"):
+					var err error
+					cs, err = readArticleContentStateFile(contentStatePath)
+					if err != nil {
+						return err
+					}
+				default:
+					return usageErr(fmt.Errorf("one of --md or --content-state is required with --id"))
+				}
+				body, err := articleUpdateContentRequestBody(articleID, cs)
+				if err != nil {
+					return err
+				}
+				return runArticleGraphQLMutation(cmd, flags, "ArticleEntityUpdateContent", body)
+			}
 			if !cmd.Flags().Changed("data") && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "data")
 			}
@@ -146,6 +181,9 @@ func newArticlesUpdateContentCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagData, "data", "", "")
+	cmd.Flags().StringVar(&articleID, "id", "", "Article rest_id to update")
+	cmd.Flags().StringVar(&markdownPath, "md", "", "Markdown file to convert and send as the replacement content_state")
+	cmd.Flags().StringVar(&contentStatePath, "content-state", "", "Draft.js content_state JSON file to send as the replacement body")
 	cmd.Flags().StringVar(&bodyFeatures, "features", "", "")
 	cmd.Flags().StringVar(&bodyQueryId, "query-id", "", "")
 	cmd.Flags().StringVar(&bodyVariables, "variables", "", "")

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_update_cover_media.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_update_cover_media.go
@@ -16,6 +16,9 @@ import (
 
 func newArticlesUpdateCoverMediaCmd(flags *rootFlags) *cobra.Command {
 	var flagData string
+	var articleID string
+	var coverPath string
+	var mediaID string
 	var bodyFeatures string
 	var bodyQueryId string
 	var bodyVariables string
@@ -27,6 +30,50 @@ func newArticlesUpdateCoverMediaCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  x-twitter-pp-cli articles update-cover-media --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000",
 		Annotations: map[string]string{"pp:endpoint": "articles.update_cover_media", "pp:method": "POST", "pp:path": "/i/api/graphql/Es8InPh7mEkK9PxclxFAVQ/ArticleEntityUpdateCoverMedia"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			friendly := cmd.Flags().Changed("id") || cmd.Flags().Changed("media-id") || cmd.Flags().Changed("cover")
+			if friendly {
+				if cmd.Flags().Changed("media-id") && cmd.Flags().Changed("cover") {
+					return usageErr(fmt.Errorf("use only one of --media-id or --cover"))
+				}
+				if cmd.Flags().Changed("cover") {
+					if _, err := articleIDFlag(articleID); err != nil {
+						return err
+					}
+					if flags.dryRun {
+						preview := map[string]any{
+							"dry_run":       true,
+							"article_id":    articleID,
+							"cover":         coverPath,
+							"would_upload":  true,
+							"then_mutation": "ArticleEntityUpdateCoverMedia",
+						}
+						return json.NewEncoder(cmd.OutOrStdout()).Encode(preview)
+					}
+					c, err := flags.newClient()
+					if err != nil {
+						return err
+					}
+					uploaded, err := c.UploadArticleImage(cmd.Context(), coverPath)
+					if err != nil {
+						return classifyAPIError(err, flags)
+					}
+					body, err := articleUpdateCoverRequestBody(articleID, uploaded)
+					if err != nil {
+						return err
+					}
+					path := client.ArticleOpURL("ArticleEntityUpdateCoverMedia")
+					data, statusCode, err := c.Post(cmd.Context(), path, body)
+					if err != nil {
+						return classifyAPIError(err, flags)
+					}
+					return printArticleMutationResponse(cmd, flags, path, data, statusCode)
+				}
+				body, err := articleUpdateCoverRequestBody(articleID, mediaID)
+				if err != nil {
+					return err
+				}
+				return runArticleGraphQLMutation(cmd, flags, "ArticleEntityUpdateCoverMedia", body)
+			}
 			if !cmd.Flags().Changed("data") && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "data")
 			}
@@ -146,6 +193,9 @@ func newArticlesUpdateCoverMediaCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagData, "data", "", "")
+	cmd.Flags().StringVar(&articleID, "id", "", "Article rest_id to update")
+	cmd.Flags().StringVar(&mediaID, "media-id", "", "Uploaded media id to set as the cover")
+	cmd.Flags().StringVar(&coverPath, "cover", "", "Image file to upload and set as the cover")
 	cmd.Flags().StringVar(&bodyFeatures, "features", "", "")
 	cmd.Flags().StringVar(&bodyQueryId, "query-id", "", "")
 	cmd.Flags().StringVar(&bodyVariables, "variables", "", "")

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_update_md.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_update_md.go
@@ -49,17 +49,19 @@ type articleUpdateDeps struct {
 type articleUpdateOptions struct {
 	articleID              string
 	title                  string
+	coverPath              string
 	contentState           draftContentState
 	republish              bool
 	replaceUnknownEntities bool
 }
 
 type articleUpdateResult struct {
-	ArticleID   string `json:"article_id"`
-	URL         string `json:"url"`
-	Title       string `json:"title,omitempty"`
-	Lifecycle   string `json:"lifecycle"`
-	Republished bool   `json:"republished"`
+	ArticleID    string `json:"article_id"`
+	URL          string `json:"url"`
+	Title        string `json:"title,omitempty"`
+	CoverMediaID string `json:"cover_media_id,omitempty"`
+	Lifecycle    string `json:"lifecycle"`
+	Republished  bool   `json:"republished"`
 }
 
 func newArticlesUpdateMdCmd(flags *rootFlags) *cobra.Command {
@@ -69,8 +71,8 @@ func newArticlesUpdateMdCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update-md <markdown-file>",
 		Short: "Update an existing X Article draft in place from a markdown file (replaces the whole body)",
-		Long: "Parses frontmatter (title) and body, converts the body to Draft.js content_state, uploads any new inline images, " +
-			"and rewrites the target draft via ArticleEntityUpdateTitle + ArticleEntityUpdateContent.\n\n" +
+		Long: "Parses frontmatter (title, cover) and body, converts the body to Draft.js content_state, uploads any new inline images, " +
+			"and rewrites the target draft via ArticleEntityUpdateTitle + ArticleEntityUpdateContent + ArticleEntityUpdateCoverMedia when cover is present.\n\n" +
 			"WARNING: this REPLACES THE ENTIRE BODY of the target draft. Anything added in the composer that the markdown " +
 			"converter cannot reproduce (polls, composer-only embeds, unknown entity types) is destroyed by the update. The " +
 			"command preflights the draft's content_state and refuses when it finds such entity types unless " +
@@ -101,6 +103,7 @@ func newArticlesUpdateMdCmd(flags *rootFlags) *cobra.Command {
 				payload := map[string]any{
 					"article_id":    articleID,
 					"title":         parsed.Frontmatter.Title,
+					"cover":         parsed.Frontmatter.Cover,
 					"content_state": cs,
 				}
 				enc := json.NewEncoder(cmd.OutOrStdout())
@@ -133,6 +136,7 @@ func newArticlesUpdateMdCmd(flags *rootFlags) *cobra.Command {
 			result, err := updateMarkdownArticle(cmd.Context(), deps, articleUpdateOptions{
 				articleID:              articleID,
 				title:                  parsed.Frontmatter.Title,
+				coverPath:              parsed.Frontmatter.Cover,
 				contentState:           cs,
 				republish:              republish,
 				replaceUnknownEntities: replaceUnknownEntities,
@@ -219,11 +223,24 @@ func updateMarkdownArticle(ctx context.Context, deps articleUpdateDeps, opts art
 		return nil, restoreOnErr(err)
 	}
 
+	var coverMediaID string
+	if strings.TrimSpace(opts.coverPath) != "" {
+		mediaID, err := deps.uploadImage(opts.coverPath)
+		if err != nil {
+			return nil, restoreOnErr(err)
+		}
+		coverMediaID = mediaID
+		if err := updateArticleEntityCoverMedia(ctx, deps.post, opts.articleID, mediaID); err != nil {
+			return nil, restoreOnErr(err)
+		}
+	}
+
 	result := &articleUpdateResult{
-		ArticleID: opts.articleID,
-		URL:       "https://x.com/compose/article/edit/" + opts.articleID,
-		Title:     opts.title,
-		Lifecycle: "Draft",
+		ArticleID:    opts.articleID,
+		URL:          "https://x.com/compose/article/edit/" + opts.articleID,
+		Title:        opts.title,
+		CoverMediaID: coverMediaID,
+		Lifecycle:    "Draft",
 	}
 	if opts.republish {
 		publishData, err := publishArticleEntity(ctx, deps.post, opts.articleID)

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_update_md_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_update_md_test.go
@@ -203,6 +203,43 @@ func TestUpdateMarkdownArticleUploadsNewImages(t *testing.T) {
 	}
 }
 
+func TestUpdateMarkdownArticleUpdatesCoverWhenPresent(t *testing.T) {
+	poster := &fakeArticlePoster{}
+	deps := testDeps(t, poster, "111", "Draft")
+	uploads := []string{}
+	deps.uploadImage = func(path string) (string, error) {
+		uploads = append(uploads, path)
+		return "media-cover", nil
+	}
+
+	result, err := updateMarkdownArticle(context.Background(), deps, articleUpdateOptions{
+		articleID:    "111",
+		coverPath:    "./cover.jpg",
+		contentState: MarkdownBodyToDraftJS("Updated"),
+	})
+	if err != nil {
+		t.Fatalf("updateMarkdownArticle returned error: %v", err)
+	}
+	if strings.Join(uploads, ",") != "./cover.jpg" {
+		t.Fatalf("expected cover upload only, got %#v", uploads)
+	}
+	wantOps := []string{"ArticleEntityUpdateContent", "ArticleEntityUpdateCoverMedia"}
+	if strings.Join(poster.ops(), ",") != strings.Join(wantOps, ",") {
+		t.Fatalf("unexpected call sequence: %v", poster.ops())
+	}
+	coverVars, _ := poster.calls[1].body["variables"].(map[string]any)
+	if coverVars["articleEntityId"] != "111" {
+		t.Fatalf("unexpected cover variables: %#v", coverVars)
+	}
+	coverMedia, _ := coverVars["coverMedia"].(map[string]any)
+	if coverMedia["media_id"] != "media-cover" || coverMedia["media_category"] != "DraftTweetImage" {
+		t.Fatalf("unexpected coverMedia: %#v", coverMedia)
+	}
+	if result.CoverMediaID != "media-cover" {
+		t.Fatalf("CoverMediaID = %q, want media-cover", result.CoverMediaID)
+	}
+}
+
 func TestUpdateMarkdownArticleMissingArticleID(t *testing.T) {
 	poster := &fakeArticlePoster{}
 	fetchCalls := 0

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_update_title.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_update_title.go
@@ -16,6 +16,8 @@ import (
 
 func newArticlesUpdateTitleCmd(flags *rootFlags) *cobra.Command {
 	var flagData string
+	var articleID string
+	var title string
 	var bodyFeatures string
 	var bodyQueryId string
 	var bodyVariables string
@@ -27,6 +29,14 @@ func newArticlesUpdateTitleCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  x-twitter-pp-cli articles update-title --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000",
 		Annotations: map[string]string{"pp:endpoint": "articles.update_title", "pp:method": "POST", "pp:path": "/i/api/graphql/x75E2ABzm8_mGTg1bz8hcA/ArticleEntityUpdateTitle"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			friendly := cmd.Flags().Changed("id") || cmd.Flags().Changed("title")
+			if friendly {
+				body, err := articleUpdateTitleRequestBody(articleID, title)
+				if err != nil {
+					return err
+				}
+				return runArticleGraphQLMutation(cmd, flags, "ArticleEntityUpdateTitle", body)
+			}
 			if !cmd.Flags().Changed("data") && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "data")
 			}
@@ -146,6 +156,8 @@ func newArticlesUpdateTitleCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagData, "data", "", "")
+	cmd.Flags().StringVar(&articleID, "id", "", "Article rest_id to update")
+	cmd.Flags().StringVar(&title, "title", "", "New article title")
 	cmd.Flags().StringVar(&bodyFeatures, "features", "", "")
 	cmd.Flags().StringVar(&bodyQueryId, "query-id", "", "")
 	cmd.Flags().StringVar(&bodyVariables, "variables", "", "")

--- a/library/social-and-messaging/x-twitter/internal/cli/doctor.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/doctor.go
@@ -129,9 +129,12 @@ func cookieAuthLane() map[string]any {
 		return authLane("missing", "cookies.json", "capture X Articles cookies with `x-twitter-pp-cli auth login --chrome`; this does not configure v2 API OAuth2 user-context auth")
 	}
 	lane := authLane("ok", "cookies.json", "")
-	if cookies.ArticleUserID() != "" {
+	if userID := cookies.ArticleUserID(); userID != "" {
 		lane["user_id_present"] = true
+		lane["user_id"] = userID
 	}
+	lane["write_capability"] = "ok: Articles create/update/title/cover/delete writes use browser cookies; X_OAUTH2_USER_TOKEN is only needed for v2 API user-context writes"
+	lane["capabilities"] = []string{"articles.list", "articles.create-draft", "articles.update-content", "articles.update-title", "articles.update-cover-media", "articles.delete", "articles.publish", "articles.unpublish", "articles.upload-media"}
 	return lane
 }
 
@@ -791,6 +794,12 @@ func renderAuthLaneReport(w io.Writer, lanes map[string]any) {
 		}
 		if hint, _ := lane["hint"].(string); hint != "" {
 			fmt.Fprintf(w, "      hint: %s\n", hint)
+		}
+		if capability, _ := lane["write_capability"].(string); capability != "" {
+			fmt.Fprintf(w, "      write_capability: %s\n", capability)
+		}
+		if userID, _ := lane["user_id"].(string); userID != "" {
+			fmt.Fprintf(w, "      user_id: %s\n", userID)
 		}
 	}
 }

--- a/library/social-and-messaging/x-twitter/internal/cli/doctor_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/doctor_test.go
@@ -127,6 +127,13 @@ oauth2_user_token = "user"
 			t.Fatalf("%s status = %q, want ok (report=%#v)", key, got, report["auth_lanes"])
 		}
 	}
+	cookieLane := laneFromReport(t, report, "x_articles_cookie")
+	if got, _ := cookieLane["write_capability"].(string); !strings.Contains(got, "Articles create/update/title/cover/delete writes") {
+		t.Fatalf("cookie lane write capability missing or vague: %#v", cookieLane)
+	}
+	if got, _ := cookieLane["user_id"].(string); got != "123" {
+		t.Fatalf("cookie lane user_id = %q, want 123", got)
+	}
 }
 
 func TestDoctorReportsProfileUserAndScopeMetadata(t *testing.T) {

--- a/library/social-and-messaging/x-twitter/internal/cli/root.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/root.go
@@ -160,7 +160,7 @@ Highlights (not in the official API docs):
   • timeline export   Export account or query timelines as markdown, JSON, or JSONL for research and archives.
   • thread show   Rebuild a full conversation thread from your locally synced posts — ordered and depth-tagged — without re-spending API read credits.
   • thread compose   Split a markdown file into a numbered, 280-char-packed self-reply thread; prints by default and only posts with --post.
-  • articles-publish-md   Parse a markdown file with YAML frontmatter into the Draft.js content_state JSON X's Articles editor accepts; previews by default; --draft saves a draft, --post publishes publicly.
+  • articles-publish-md   Parse a markdown file with YAML frontmatter into Draft.js; preview by default, --draft creates, --update edits an existing draft, --post publishes.
 
 Agent mode: add --agent to any command for JSON output + non-interactive mode.
 Health check: run 'x-twitter-pp-cli doctor' to verify auth and connectivity.

--- a/library/social-and-messaging/x-twitter/internal/client/cookies.go
+++ b/library/social-and-messaging/x-twitter/internal/client/cookies.go
@@ -72,8 +72,8 @@ func userIDFromTWID(twid string) string {
 		twid = decoded
 	}
 	twid = strings.Trim(twid, `"`)
-	twid = strings.TrimPrefix(twid, "u%3D")
 	twid = strings.TrimPrefix(twid, "u=")
+	twid = strings.TrimPrefix(twid, "u%3D")
 	if twid == "" {
 		return ""
 	}

--- a/library/social-and-messaging/x-twitter/internal/client/cookies.go
+++ b/library/social-and-messaging/x-twitter/internal/client/cookies.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type cookieAuth struct {
@@ -25,6 +26,7 @@ type cookieAuth struct {
 	CT0        string `json:"ct0"`
 	WebBearer  string `json:"web_bearer"`
 	UserID     string `json:"user_id"`
+	TWID       string `json:"twid"`
 	CapturedAt string `json:"captured_at"`
 }
 
@@ -55,7 +57,32 @@ func (c *cookieAuth) ArticleUserID() string {
 	if c == nil {
 		return ""
 	}
-	return c.UserID
+	if c.UserID != "" {
+		return c.UserID
+	}
+	return userIDFromTWID(c.TWID)
+}
+
+func userIDFromTWID(twid string) string {
+	twid = strings.TrimSpace(twid)
+	if twid == "" {
+		return ""
+	}
+	if decoded, err := url.QueryUnescape(twid); err == nil {
+		twid = decoded
+	}
+	twid = strings.Trim(twid, `"`)
+	twid = strings.TrimPrefix(twid, "u%3D")
+	twid = strings.TrimPrefix(twid, "u=")
+	if twid == "" {
+		return ""
+	}
+	for _, r := range twid {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return twid
 }
 
 // applyCookieAuth attaches Source B auth headers to req. Used for hosts

--- a/library/social-and-messaging/x-twitter/internal/client/cookies_test.go
+++ b/library/social-and-messaging/x-twitter/internal/client/cookies_test.go
@@ -1,0 +1,14 @@
+package client
+
+import "testing"
+
+func TestCookieAuthArticleUserIDFallsBackToTWID(t *testing.T) {
+	c := &cookieAuth{TWID: `"u%3D1234567890"`}
+	if got := c.ArticleUserID(); got != "1234567890" {
+		t.Fatalf("ArticleUserID() = %q, want 1234567890", got)
+	}
+	c.UserID = "999"
+	if got := c.ArticleUserID(); got != "999" {
+		t.Fatalf("ArticleUserID() should prefer user_id, got %q", got)
+	}
+}


### PR DESCRIPTION
## x-twitter

Improves the X Articles workflow for agent use without publishing or posting to X during validation.

### What changed

- Added `articles-publish-md --update <article_id>` to update an existing draft instead of creating a duplicate.
- Added friendly `--id` paths for `articles delete`, `update-title`, `update-content`, and `update-cover-media`, including `--md`, `--content-state`, `--title`, `--media-id`, and `--cover` where applicable.
- Added `account whoami` and cookie `twid` fallback parsing so agents can surface the signed-in Articles user id.
- Improved the markdown converter: `[text](url)` remains LINK entities, inline backticks become Draft.js `CODE`, and `###`/deeper headings downgrade to `header-two` instead of leaking literal markdown.
- Clarified `doctor` to report the X Articles cookie lane's write capability separately from OAuth2 user-context warnings.
- Recorded the library-side customization in `.printing-press-patches/x-twitter-article-agent-ergonomics.json`.

### Verification

| Check | Result |
|---|---|
| `go test ./...` from `library/social-and-messaging/x-twitter` | PASS |
| `go vet ./...` from `library/social-and-messaging/x-twitter` | PASS |
| `go build -o /tmp/x-twitter-pp-cli-amend ./cmd/x-twitter-pp-cli` | PASS |
| `git diff --check` | PASS |
| Dry-run `articles-publish-md` before/after preview | PASS: old binary leaked `###`, links, and backticks as literal text; amended binary emits `header-two`, LINK entity ranges, and `CODE` inline style |
| Dry-run friendly Article mutation commands | PASS: emitted expected GraphQL variables for update-title, update-content, update-cover-media, and delete |
| Fake-cookie `account whoami --json` smoke test | PASS |

### Risk / approval boundary

- No live X write, post, publish, delete, upload, or update call was sent during testing. All Article mutation validation used `--dry-run` or unit fakes.
- The installed `~/go/bin/x-twitter-pp-cli` binary was not overwritten.
- This patch was made in a fresh public-library clone at `~/printing-press/.publish-repo-amend-x-twitter-20260615`; it is not applied to `~/printing-press/.publish-repo-private`.

### Completion Gate

- Artifact: this PR branch, `fix/x-twitter-article-agent-ergonomics`, commit `182309ff0`.
- Evidence: tests, vet, build, diff check, and dry-run previews listed above.
- Residual risk: live X Article GraphQL behavior still depends on current operation hashes and live cookie validity; this patch reuses the existing `ArticleOpURL`/`ArticleOpQueryID` runtime resolution.
- Approval boundary: ready for review; merge/publish remains with maintainers.
