### PR TITLE
fix(x-twitter): address article review follow-ups

### DIFF
--- a/library/social-and-messaging/x-twitter/internal/cli/articles_friendly.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_friendly.go
@@ -162,31 +162,39 @@ func printArticleMutationResponse(cmd *cobra.Command, flags *rootFlags, path str
 	return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
 }
 
+func printArticleMutationDryRun(cmd *cobra.Command, flags *rootFlags, path string, body map[string]any, extra map[string]any) error {
+	selectedProfile := flags.profileName
+	if selectedProfile == "" {
+		selectedProfile = "default"
+	}
+	previewValue := map[string]any{
+		"dry_run": true,
+		"meta": map[string]any{
+			"auth_lane":        "x_articles_cookie",
+			"selected_profile": selectedProfile,
+		},
+		"mutation": true,
+		"request": map[string]any{
+			"body":   body,
+			"method": "POST",
+			"path":   path,
+		},
+		"sent": false,
+	}
+	for key, value := range extra {
+		previewValue[key] = value
+	}
+	preview, err := json.Marshal(previewValue)
+	if err != nil {
+		return err
+	}
+	return printArticleMutationResponse(cmd, flags, path, preview, 0)
+}
+
 func runArticleGraphQLMutation(cmd *cobra.Command, flags *rootFlags, opName string, body map[string]any) error {
 	path := client.ArticleOpURL(opName)
 	if flags.dryRun {
-		selectedProfile := flags.profileName
-		if selectedProfile == "" {
-			selectedProfile = "default"
-		}
-		preview, err := json.Marshal(map[string]any{
-			"dry_run": true,
-			"meta": map[string]any{
-				"auth_lane":        "x_articles_cookie",
-				"selected_profile": selectedProfile,
-			},
-			"mutation": true,
-			"request": map[string]any{
-				"body":   body,
-				"method": "POST",
-				"path":   path,
-			},
-			"sent": false,
-		})
-		if err != nil {
-			return err
-		}
-		return printArticleMutationResponse(cmd, flags, path, preview, 0)
+		return printArticleMutationDryRun(cmd, flags, path, body, nil)
 	}
 	c, err := flags.newClient()
 	if err != nil {

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_friendly_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_friendly_test.go
@@ -104,3 +104,44 @@ func TestArticleFriendlyMutationDryRunDoesNotRequireAuth(t *testing.T) {
 		t.Fatalf("unexpected dry-run variables: %#v", vars)
 	}
 }
+
+func TestArticleCoverUploadDryRunUsesMutationEnvelope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("X_TWITTER_COOKIE_AUTH_TOKEN", "")
+	t.Setenv("X_TWITTER_COOKIE_CT0", "")
+	t.Setenv("X_TWITTER_BEARER_TOKEN", "")
+	t.Setenv("X_BEARER_TOKEN", "")
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"articles", "update-cover-media", "--id", "123", "--cover", "/tmp/cover.jpg", "--dry-run", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("dry-run cover update failed without auth: %v\n%s", err, out.String())
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(out.Bytes(), &envelope); err != nil {
+		t.Fatalf("dry-run output is not JSON: %v\n%s", err, out.String())
+	}
+	data, _ := envelope["data"].(map[string]any)
+	if data["sent"] != false || data["dry_run"] != true {
+		t.Fatalf("expected unsent dry-run preview, got %#v", data)
+	}
+	request, _ := data["request"].(map[string]any)
+	body, _ := request["body"].(map[string]any)
+	vars, _ := body["variables"].(map[string]any)
+	if vars["articleEntityId"] != "123" {
+		t.Fatalf("unexpected dry-run variables: %#v", vars)
+	}
+	coverMedia, _ := vars["coverMedia"].(map[string]any)
+	if coverMedia["media_id"] != "<uploaded-cover-media-id>" {
+		t.Fatalf("expected placeholder media id, got %#v", coverMedia)
+	}
+	upload, _ := data["would_upload"].(map[string]any)
+	if upload["path"] != "/tmp/cover.jpg" {
+		t.Fatalf("unexpected upload preview: %#v", upload)
+	}
+}

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
@@ -821,16 +821,9 @@ func extractInlineSpans(s string) (string, []inlineStyle, []linkSpan) {
 	out := strings.Builder{}
 	i := 0
 	for i < len(s) {
-		if s[i] == '`' {
-			end := strings.Index(s[i+1:], "`")
-			if end >= 0 {
-				inner := s[i+1 : i+1+end]
-				offset := utf16Len(out.String())
-				out.WriteString(inner)
-				ranges = append(ranges, inlineStyle{Offset: offset, Length: utf16Len(inner), Style: "CODE"})
-				i = i + 1 + end + 1
-				continue
-			}
+		if next, ok := consumeInlineCode(s, i, &out, &ranges); ok {
+			i = next
+			continue
 		}
 		// Bold first (**...**) so it doesn't get consumed as italic.
 		if i+2 <= len(s) && s[i:i+2] == "**" {
@@ -882,15 +875,15 @@ func extractInlineSpans(s string) (string, []inlineStyle, []linkSpan) {
 // consumes. Empty link text or empty url returns ok=false so the caller copies
 // the characters through as plain text.
 func parseInlineLinkAt(s string, i int) (inner string, linkURL string, advance int, ok bool) {
-	closeText := strings.Index(s[i+1:], "](")
+	closeText := findInlineLinkTextClose(s, i)
 	if closeText < 0 {
 		return "", "", 0, false
 	}
-	inner = s[i+1 : i+1+closeText]
+	inner = s[i+1 : closeText]
 	if strings.TrimSpace(inner) == "" {
 		return "", "", 0, false
 	}
-	urlStart := i + 1 + closeText + 2
+	urlStart := closeText + 2
 	// PATCH: balance nested parens so URLs like .../Rust_(programming_language)
 	// are not truncated at the inner ')' (Greptile P1 on PR #1141).
 	closeURL := -1
@@ -921,6 +914,40 @@ func parseInlineLinkAt(s string, i int) (inner string, linkURL string, advance i
 	return inner, linkURL, advance, true
 }
 
+func findInlineLinkTextClose(s string, open int) int {
+	depth := 0
+	for j := open + 1; j+1 < len(s); j++ {
+		switch s[j] {
+		case '[':
+			depth++
+		case ']':
+			if depth > 0 {
+				depth--
+				continue
+			}
+			if s[j+1] == '(' {
+				return j
+			}
+		}
+	}
+	return -1
+}
+
+func consumeInlineCode(s string, i int, out *strings.Builder, ranges *[]inlineStyle) (int, bool) {
+	if i >= len(s) || s[i] != '`' {
+		return i, false
+	}
+	end := strings.Index(s[i+1:], "`")
+	if end < 0 {
+		return i, false
+	}
+	inner := s[i+1 : i+1+end]
+	offset := utf16Len(out.String())
+	out.WriteString(inner)
+	*ranges = append(*ranges, inlineStyle{Offset: offset, Length: utf16Len(inner), Style: "CODE"})
+	return i + 1 + end + 1, true
+}
+
 // extractInlineStyles scans a string for **bold** and *italic* markers and
 // returns the cleaned text plus the inline_style_ranges that describe them.
 //
@@ -932,16 +959,9 @@ func extractInlineStyles(s string) (string, []inlineStyle) {
 	out := strings.Builder{}
 	i := 0
 	for i < len(s) {
-		if s[i] == '`' {
-			end := strings.Index(s[i+1:], "`")
-			if end >= 0 {
-				inner := s[i+1 : i+1+end]
-				offset := utf16Len(out.String())
-				out.WriteString(inner)
-				ranges = append(ranges, inlineStyle{Offset: offset, Length: utf16Len(inner), Style: "CODE"})
-				i = i + 1 + end + 1
-				continue
-			}
+		if next, ok := consumeInlineCode(s, i, &out, &ranges); ok {
+			i = next
+			continue
 		}
 		// Bold first (**...**) so it doesn't get consumed as italic.
 		if i+2 <= len(s) && s[i:i+2] == "**" {

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
@@ -74,6 +74,7 @@ func newNovelArticlesPublishMdCmd(flags *rootFlags) *cobra.Command {
 	var post bool
 	var draft bool
 	var updateID string
+	var replaceUnknownEntities bool
 	cmd := &cobra.Command{
 		Use:     "articles-publish-md <markdown-file>",
 		Short:   "Convert a markdown file to an X Article (preview by default; --draft or --post to write)",
@@ -137,10 +138,11 @@ func newNovelArticlesPublishMdCmd(flags *rootFlags) *cobra.Command {
 					},
 				}
 				result, err := updateMarkdownArticle(cmd.Context(), deps, articleUpdateOptions{
-					articleID:    strings.TrimSpace(updateID),
-					title:        parsed.Frontmatter.Title,
-					coverPath:    parsed.Frontmatter.Cover,
-					contentState: cs,
+					articleID:              strings.TrimSpace(updateID),
+					title:                  parsed.Frontmatter.Title,
+					coverPath:              parsed.Frontmatter.Cover,
+					contentState:           cs,
+					replaceUnknownEntities: replaceUnknownEntities,
 				})
 				if err != nil {
 					return classifyAPIError(err, flags)
@@ -202,6 +204,7 @@ func newNovelArticlesPublishMdCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&draft, "draft", false, "Create the article as a draft without publishing")
 	cmd.Flags().BoolVar(&post, "post", false, "Create and publish the article publicly (default: preview only)")
 	cmd.Flags().StringVar(&updateID, "update", "", "Update an existing draft article by rest_id instead of creating a new draft")
+	cmd.Flags().BoolVar(&replaceUnknownEntities, "replace-unknown-entities", false, "With --update, proceed even when the target draft contains entity types the converter cannot reproduce")
 	return cmd
 }
 

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
@@ -303,7 +303,7 @@ func unpublishArticleEntity(ctx context.Context, p articleGraphQLPoster, article
 // PATCH: Wire the X-specific Articles create/update/publish GraphQL sequence.
 func publishMarkdownArticle(ctx context.Context, flags *rootFlags, title string, coverPath string, contentState draftContentState, publish bool) (*publishedArticleResult, error) {
 	if strings.TrimSpace(title) == "" {
-		return nil, fmt.Errorf("frontmatter title is required when --post is set")
+		return nil, fmt.Errorf("frontmatter title is required when creating an article draft or post")
 	}
 	c, err := flags.newClient()
 	if err != nil {

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
@@ -329,6 +329,25 @@ func TestMarkdownBodyToDraftJSMultipleLinks(t *testing.T) {
 	}
 }
 
+func TestMarkdownBodyToDraftJSNestedBracketLinkText(t *testing.T) {
+	contentState := MarkdownBodyToDraftJS("[text [note](inner)](https://outer.example) done")
+
+	blk := contentState.Blocks[0]
+	if blk.Text != "text [note](inner) done" {
+		t.Fatalf("unexpected text: %q", blk.Text)
+	}
+	if len(blk.EntityRanges) != 1 || len(contentState.EntityMap) != 1 {
+		t.Fatalf("expected one outer link entity, got %d ranges / %d entities", len(blk.EntityRanges), len(contentState.EntityMap))
+	}
+	er := blk.EntityRanges[0]
+	if er["key"] != 0 || er["offset"] != 0 || er["length"] != 18 {
+		t.Fatalf("unexpected entity range: %#v", er)
+	}
+	if contentState.EntityMap[0].Value.Data["url"] != "https://outer.example" {
+		t.Fatalf("unexpected entity url: %#v", contentState.EntityMap[0].Value.Data["url"])
+	}
+}
+
 func TestMarkdownBodyToDraftJSLinkMultibyteOffsets(t *testing.T) {
 	// Two emoji (2 UTF-16 units each) + space = offset 5; link text
 	// "café ☕" = 6 UTF-16 units (é and ☕ are BMP, 1 unit each).

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
@@ -96,6 +96,31 @@ func TestArticlesPublishMdUpdateRejectsDraftFlag(t *testing.T) {
 	}
 }
 
+func TestArticlesPublishMdUpdateAcceptsReplaceUnknownEntitiesFlag(t *testing.T) {
+	dir := t.TempDir()
+	md := filepath.Join(dir, "article.md")
+	if err := os.WriteFile(md, []byte("---\ntitle: Dry Run\n---\n\nBody"), 0o600); err != nil {
+		t.Fatalf("write markdown: %v", err)
+	}
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"articles-publish-md", md, "--update", "123", "--replace-unknown-entities", "--dry-run", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected --replace-unknown-entities to be accepted on --update dry-run: %v\n%s", err, out.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("preview output is not JSON: %v\n%s", err, out.String())
+	}
+	if payload["article_id"] != "123" {
+		t.Fatalf("unexpected preview payload: %#v", payload)
+	}
+}
+
 func TestBindArticleMediaEntities(t *testing.T) {
 	contentState := MarkdownBodyToDraftJS("![one](./one.png)\n\n![two](./two.jpg)")
 	uploads := []string{}

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -118,6 +119,20 @@ func TestArticlesPublishMdUpdateAcceptsReplaceUnknownEntitiesFlag(t *testing.T) 
 	}
 	if payload["article_id"] != "123" {
 		t.Fatalf("unexpected preview payload: %#v", payload)
+	}
+}
+
+func TestPublishMarkdownArticleMissingTitleMessageCoversDraft(t *testing.T) {
+	var flags rootFlags
+	_, err := publishMarkdownArticle(context.Background(), &flags, "", "", MarkdownBodyToDraftJS("Body"), false)
+	if err == nil {
+		t.Fatalf("expected missing-title error")
+	}
+	if !strings.Contains(err.Error(), "draft or post") {
+		t.Fatalf("expected title error to cover draft creation, got %v", err)
+	}
+	if strings.Contains(err.Error(), "--post") {
+		t.Fatalf("title error should not mention only --post, got %v", err)
 	}
 }
 

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_set_cover.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_set_cover.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -10,6 +13,7 @@ import (
 )
 
 func newArticlesSetCoverCmd(flags *rootFlags) *cobra.Command {
+	var title string
 	cmd := &cobra.Command{
 		Use:     "set-cover <article-id> <image-file>",
 		Short:   "Upload an image and set it as an X Article cover",
@@ -37,7 +41,13 @@ func newArticlesSetCoverCmd(flags *rootFlags) *cobra.Command {
 					"media_category": "DraftTweetImage",
 				},
 			})
-			data, _, err := c.Post(cmd.Context(), client.ArticleOpURL("ArticleEntityUpdateCoverMedia"), body)
+			titleResolver := func() (string, error) {
+				if strings.TrimSpace(title) != "" {
+					return title, nil
+				}
+				return existingArticleTitle(cmd.Context(), c, args[0])
+			}
+			data, _, err := postCoverMediaWithMetadataHeal(cmd.Context(), c, args[0], body, titleResolver)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
@@ -49,5 +59,90 @@ func newArticlesSetCoverCmd(flags *rootFlags) *cobra.Command {
 			return json.NewEncoder(cmd.OutOrStdout()).Encode(result)
 		},
 	}
+	cmd.Flags().StringVar(&title, "title", "", "Article title to use if X needs ArticleMetadata before setting the cover; defaults to the existing title")
 	return cmd
+}
+
+func postCoverMediaWithMetadataHeal(ctx context.Context, p articleGraphQLPoster, articleID string, body map[string]any, titleResolver func() (string, error)) (json.RawMessage, int, error) {
+	path := client.ArticleOpURL("ArticleEntityUpdateCoverMedia")
+	data, statusCode, err := p.Post(ctx, path, body)
+	if err == nil || !isMissingArticleMetadataError(err) {
+		return data, statusCode, err
+	}
+	title, titleErr := titleResolver()
+	if titleErr != nil {
+		return nil, statusCode, fmt.Errorf("cover update hit Missing ArticleMetadata (code 214), and the existing title could not be resolved; pass --title to self-heal manually: %w", titleErr)
+	}
+	if strings.TrimSpace(title) == "" {
+		return nil, statusCode, fmt.Errorf("cover update hit Missing ArticleMetadata (code 214), and the article title is empty; pass --title to self-heal manually")
+	}
+	if err := updateArticleEntityTitle(ctx, p, articleID, title); err != nil {
+		return nil, statusCode, fmt.Errorf("cover update hit Missing ArticleMetadata (code 214), but self-heal update-title failed: %w", err)
+	}
+	return p.Post(ctx, path, body)
+}
+
+func isMissingArticleMetadataError(err error) bool {
+	var apiErr *client.APIError
+	body := err.Error()
+	if errors.As(err, &apiErr) {
+		body = apiErr.Body
+	}
+	body = strings.ToLower(body)
+	return strings.Contains(body, "articlemetadata") && strings.Contains(body, "214")
+}
+
+func existingArticleTitle(ctx context.Context, c *client.Client, articleID string) (string, error) {
+	for _, lifecycle := range []string{"Draft", "Published"} {
+		raw, err := fetchArticleSlice(ctx, c, lifecycle)
+		if err != nil {
+			return "", err
+		}
+		if title, found := articleTitleFromSlice(raw, articleID); found {
+			return title, nil
+		}
+	}
+	return "", fmt.Errorf("article %s not found in your Draft or Published articles", articleID)
+}
+
+func articleTitleFromSlice(raw json.RawMessage, articleID string) (string, bool) {
+	var response struct {
+		Data struct {
+			User struct {
+				Result struct {
+					Slice struct {
+						Items []struct {
+							Results struct {
+								Result map[string]any `json:"result"`
+							} `json:"article_entity_results"`
+						} `json:"items"`
+					} `json:"articles_article_mixer_slice"`
+				} `json:"result"`
+			} `json:"user"`
+		} `json:"data"`
+	}
+	if json.Unmarshal(raw, &response) != nil {
+		return "", false
+	}
+	for _, item := range response.Data.User.Result.Slice.Items {
+		article := item.Results.Result
+		if id, _ := article["rest_id"].(string); id == articleID {
+			return articleTitleField(article), true
+		}
+	}
+	return "", false
+}
+
+func articleTitleField(article map[string]any) string {
+	if title, _ := article["title"].(string); strings.TrimSpace(title) != "" {
+		return title
+	}
+	for _, value := range article {
+		if nested, ok := value.(map[string]any); ok {
+			if title := articleTitleField(nested); strings.TrimSpace(title) != "" {
+				return title
+			}
+		}
+	}
+	return ""
 }

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_set_cover_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_set_cover_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/internal/client"
+)
+
+type setCoverPoster struct {
+	calls         []fakePostCall
+	coverFailures int
+}
+
+func (f *setCoverPoster) Post(_ context.Context, path string, body any) (json.RawMessage, int, error) {
+	op := path[strings.LastIndex(path, "/")+1:]
+	m, _ := body.(map[string]any)
+	f.calls = append(f.calls, fakePostCall{op: op, body: m})
+	if op == "ArticleEntityUpdateCoverMedia" && f.coverFailures > 0 {
+		f.coverFailures--
+		return nil, http.StatusUnprocessableEntity, &client.APIError{
+			Method:     http.MethodPost,
+			Path:       path,
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       `{"errors":[{"message":"Missing ArticleMetadata","code":214}]}`,
+		}
+	}
+	return json.RawMessage(`{"ok":true}`), http.StatusOK, nil
+}
+
+func TestSetCoverSelfHealsMissingArticleMetadata(t *testing.T) {
+	poster := &setCoverPoster{coverFailures: 1}
+	body := articleOpRequestBody("ArticleEntityUpdateCoverMedia", map[string]any{
+		"articleEntityId": "123",
+		"coverMedia":      map[string]any{"media_id": "media-1", "media_category": "DraftTweetImage"},
+	})
+
+	data, status, err := postCoverMediaWithMetadataHeal(context.Background(), poster, "123", body, func() (string, error) {
+		return "Existing Title", nil
+	})
+	if err != nil {
+		t.Fatalf("expected self-heal retry to succeed: %v", err)
+	}
+	if status != http.StatusOK || string(data) != `{"ok":true}` {
+		t.Fatalf("unexpected retry response status=%d data=%s", status, data)
+	}
+	wantOps := []string{"ArticleEntityUpdateCoverMedia", "ArticleEntityUpdateTitle", "ArticleEntityUpdateCoverMedia"}
+	if got := postOps(poster.calls); strings.Join(got, ",") != strings.Join(wantOps, ",") {
+		t.Fatalf("ops = %v, want %v", got, wantOps)
+	}
+	titleVars, _ := poster.calls[1].body["variables"].(map[string]any)
+	if titleVars["articleEntityId"] != "123" || titleVars["title"] != "Existing Title" {
+		t.Fatalf("unexpected title variables: %#v", titleVars)
+	}
+}
+
+func TestSetCoverMissingArticleMetadataNeedsResolvableTitle(t *testing.T) {
+	poster := &setCoverPoster{coverFailures: 1}
+	body := articleOpRequestBody("ArticleEntityUpdateCoverMedia", map[string]any{"articleEntityId": "123"})
+
+	_, _, err := postCoverMediaWithMetadataHeal(context.Background(), poster, "123", body, func() (string, error) {
+		return "", fmt.Errorf("not found")
+	})
+	if err == nil || !strings.Contains(err.Error(), "pass --title") {
+		t.Fatalf("expected --title guidance, got %v", err)
+	}
+}
+
+func TestIsMissingArticleMetadataError(t *testing.T) {
+	err := &client.APIError{
+		Method:     http.MethodPost,
+		Path:       "/graphql/ArticleEntityUpdateCoverMedia",
+		StatusCode: http.StatusUnprocessableEntity,
+		Body:       `{"errors":[{"message":"Missing ArticleMetadata","code":214}]}`,
+	}
+	if !isMissingArticleMetadataError(err) {
+		t.Fatalf("expected Missing ArticleMetadata code 214 to be recognized")
+	}
+	if isMissingArticleMetadataError(fmt.Errorf(`{"errors":[{"message":"Missing ArticleMetadata","code":215}]}`)) {
+		t.Fatalf("unexpected match for non-214 metadata error")
+	}
+}
+
+func TestArticleTitleFromSliceFindsNestedMetadataTitle(t *testing.T) {
+	raw := json.RawMessage(`{"data":{"user":{"result":{"articles_article_mixer_slice":{"items":[{"article_entity_results":{"result":{"rest_id":"123","metadata":{"title":"Existing Title"}}}}]}}}}}`)
+	title, found := articleTitleFromSlice(raw, "123")
+	if !found || title != "Existing Title" {
+		t.Fatalf("title=%q found=%v, want Existing Title true", title, found)
+	}
+}
+
+func postOps(calls []fakePostCall) []string {
+	ops := make([]string, 0, len(calls))
+	for _, call := range calls {
+		ops = append(ops, call.op)
+	}
+	return ops
+}

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_update_cover_media.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_update_cover_media.go
@@ -40,14 +40,16 @@ func newArticlesUpdateCoverMediaCmd(flags *rootFlags) *cobra.Command {
 						return err
 					}
 					if flags.dryRun {
-						preview := map[string]any{
-							"dry_run":       true,
-							"article_id":    articleID,
-							"cover":         coverPath,
-							"would_upload":  true,
-							"then_mutation": "ArticleEntityUpdateCoverMedia",
+						body, err := articleUpdateCoverRequestBody(articleID, "<uploaded-cover-media-id>")
+						if err != nil {
+							return err
 						}
-						return json.NewEncoder(cmd.OutOrStdout()).Encode(preview)
+						return printArticleMutationDryRun(cmd, flags, client.ArticleOpURL("ArticleEntityUpdateCoverMedia"), body, map[string]any{
+							"would_upload": map[string]any{
+								"media_category": "DraftTweetImage",
+								"path":           coverPath,
+							},
+						})
 					}
 					c, err := flags.newClient()
 					if err != nil {

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_update_md.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_update_md.go
@@ -179,7 +179,7 @@ func updateMarkdownArticle(ctx context.Context, deps articleUpdateDeps, opts art
 			opts.articleID, strings.Join(scan.unknownTypes, ", "))
 	}
 	if scan.lifecycle == "Published" && !opts.republish {
-		return nil, fmt.Errorf("article %s is published; pass --republish to run Unpublish -> UpdateContent -> Publish (it is briefly unpublished), or edit a draft instead", opts.articleID)
+		return nil, fmt.Errorf("article %s is published; use `articles update-md <markdown-file> --article-id %s --republish` to run Unpublish -> UpdateContent -> Publish (it is briefly unpublished), or edit a draft instead", opts.articleID, opts.articleID)
 	}
 
 	if opts.republish && scan.lifecycle != "Published" {

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_update_md.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_update_md.go
@@ -245,7 +245,7 @@ func updateMarkdownArticle(ctx context.Context, deps articleUpdateDeps, opts art
 	if opts.republish {
 		publishData, err := publishArticleEntity(ctx, deps.post, opts.articleID)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("article %s was updated but final publish failed (%w); it is left UNPUBLISHED, re-publish it in the composer or retry `articles update-md --article-id %s --republish`", opts.articleID, err, opts.articleID)
 		}
 		articleID := opts.articleID
 		if publishedID := articleIDFromPublishResponse(publishData); publishedID != "" {

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_update_md_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_update_md_test.go
@@ -385,8 +385,8 @@ func TestUpdateMarkdownArticlePublishedRequiresRepublish(t *testing.T) {
 		articleID:    "111",
 		contentState: MarkdownBodyToDraftJS("body"),
 	})
-	if err == nil || !strings.Contains(err.Error(), "--republish") {
-		t.Fatalf("expected published-article refusal advising --republish, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "articles update-md <markdown-file> --article-id 111 --republish") {
+		t.Fatalf("expected published-article refusal to name update-md --republish, got %v", err)
 	}
 	if len(poster.calls) != 0 {
 		t.Fatalf("expected no mutations, got %v", poster.ops())

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_update_md_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_update_md_test.go
@@ -450,3 +450,26 @@ func TestUpdateMarkdownArticleRepublishRestoresOnFailure(t *testing.T) {
 		t.Fatalf("expected restore publish after failure, got %v", poster.ops())
 	}
 }
+
+func TestUpdateMarkdownArticleRepublishFinalPublishFailureHasContext(t *testing.T) {
+	poster := &fakeArticlePoster{fail: map[string]error{"ArticleEntityPublish": fmt.Errorf("publish down")}}
+	deps := testDeps(t, poster, "444", "Published")
+
+	_, err := updateMarkdownArticle(context.Background(), deps, articleUpdateOptions{
+		articleID:    "444",
+		contentState: MarkdownBodyToDraftJS("body"),
+		republish:    true,
+	})
+	if err == nil {
+		t.Fatalf("expected final publish failure")
+	}
+	for _, want := range []string{"was updated but final publish failed", "left UNPUBLISHED", "articles update-md --article-id 444 --republish"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
+	}
+	wantOps := []string{"ArticleEntityUnpublish", "ArticleEntityUpdateContent", "ArticleEntityPublish"}
+	if strings.Join(poster.ops(), ",") != strings.Join(wantOps, ",") {
+		t.Fatalf("expected final publish failure after update, got %v", poster.ops())
+	}
+}


### PR DESCRIPTION
## Summary

- Follow-up to merged PR #1213 for x-twitter Article review findings that landed after the main public PR merged.
- Keeps the public `x-twitter-pp-cli` aligned with the private CLI branch fixes without widening the feature scope.

## Published CLI Metadata

**API:** `x-twitter` | **Category:** `social-and-messaging` | **Press version:** `4.20.1`  
**Spec:** `library/social-and-messaging/x-twitter/.printing-press.json`  
**Required env:** unchanged. Public X API lanes still use the existing OAuth/app env; Article create/update/list/delete uses browser cookie auth from `~/.config/x-twitter-pp-cli/cookies.json`.

## What Changed

- Adds `articles-publish-md --replace-unknown-entities` for the `--update <article_id>` lane so the unknown-entity preflight message points to a flag the command actually accepts.
- Normalizes `articles update-cover-media --id <article_id> --cover <file> --dry-run --json` to the same mutation dry-run envelope as `--media-id`, including `sent:false`, `meta.auth_lane`, and `request.body.variables`.
- Refactors inline-code parsing into one helper shared by both inline passes.
- Makes inline link parsing account for nested bracket pairs so compound link text does not truncate at the first inner `](`.
- Clarifies Article update error messages: missing frontmatter title covers draft creation, final republish failure says the article was updated but left unpublished, and published-article refusal points `articles-publish-md --update` callers to `articles update-md <markdown-file> --article-id <id> --republish`.
- Makes standalone `articles set-cover` self-heal Missing ArticleMetadata (code 214): it can call `ArticleEntityUpdateTitle` using `--title` or the existing article title, then retry the cover mutation once.

## CLI Shape

```bash
$ x-twitter-pp-cli articles-publish-md --help
Usage:
  x-twitter-pp-cli articles-publish-md <markdown-file> [flags]

Key flags:
      --update string              Update an existing draft article by rest_id instead of creating a new draft
      --replace-unknown-entities   With --update, proceed even when the target draft contains entity types the converter cannot reproduce
      --dry-run                    Show request without sending
      --json                       Output as JSON
```

```bash
-twitter-pp-cli articles set-cover --help
Usage:
  x-twitter-pp-cli articles set-cover <article-id> <image-file> [flags]

Key flags:
      --title string   Article title to use if X needs ArticleMetadata before setting the cover; defaults to the existing title
```

```bash
-twitter-pp-cli articles update-cover-media --help
Friendly flags:
      --id string         Article rest_id to update
      --media-id string   Uploaded media id to set as the cover
      --cover string      Image file to upload and set as the cover
```

```bash
$ x-twitter-pp-cli articles update-cover-media --id 123 --cover ./cover.jpg --dry-run --json
{
  "dry_run": true,
  "data": {
    "sent": false,
    "meta": { "auth_lane": "x_articles_cookie" },
    "request": {
      "method": "POST",
      "body": {
        "variables": {
          "articleEntityId": "123",
          "coverMedia": { "media_id": "<uploaded-cover-media-id>" }
        }
      }
    },
    "would_upload": { "path": "./cover.jpg", "media_category": "DraftTweetImage" }
  }
}
```

Novel command shapes in this follow-up:

- `articles-publish-md --update <article_id> --replace-unknown-entities`
- `articles update-cover-media --id <article_id> --cover <file> --dry-run --json` now uses the standard mutation dry-run envelope
- `articles set-cover <article_id> <image-file> [--title <title>]` self-heals Missing ArticleMetadata code 214 before retrying cover

## What This CLI Does

`x-twitter-pp-cli` is the Printing Press-generated command-line interface for X/Twitter workflows. It mirrors the official X v2 API and adds curated agent-native workflows for timelines, posts, bookmarks, analytics, account snapshots, threads, and long-form X Articles.

This follow-up only tightens the browser-cookie-backed X Articles lane after the main Article ergonomics patch merged: markdown update preflight, friendly mutation dry-runs, markdown inline conversion, and actionable failure messages.

## Manuscripts

- [Research Brief](./library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/research/)
- [Shipcheck Results](./library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/proofs/)

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/social-and-messaging/x-twitter/`
- [x] `go build ./...` from `library/social-and-messaging/x-twitter`
- [x] `go vet ./...` from `library/social-and-messaging/x-twitter`
- [x] `go test ./...` from `library/social-and-messaging/x-twitter`
- [x] `govulncheck ./...` from `library/social-and-messaging/x-twitter`
- [x] `go run ./tools/generate-skills/main.go` not needed; `library/**/SKILL.md` unchanged in this follow-up
- [x] `git diff --check`

## Gaps / Follow-Up

- No live X writes were performed during validation.
- This PR is intentionally a narrow public follow-up to #1213; the private CLI PR tracks private branch install evidence separately.