### PR TITLE
fix(substack): honor publication subdomain for drafts

### DIFF
--- a/library/media-and-entertainment/substack/.printing-press-patches/subdomain-publication-routing.json
+++ b/library/media-and-entertainment/substack/.printing-press-patches/subdomain-publication-routing.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 2,
+  "id": "subdomain-publication-routing",
+  "applied_at": "2026-06-15",
+  "base_run_id": "20260531-014452",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Publication-scoped Substack commands must accept --subdomain and route through the {publication}.substack.com host.",
+  "reason": "The published draft authoring help documented --subdomain, but Cobra never registered the flag; hand-authored draft commands and sync refresh paths also used relative /drafts-style paths, so SUBSTACK_PUBLICATION could not steer those requests to the publication host.",
+  "files": [
+    "internal/cli/root.go",
+    "internal/cli/publication_paths.go",
+    "internal/cli/drafts_create.go",
+    "internal/cli/drafts_update.go",
+    "internal/cli/drafts_schedule.go",
+    "internal/cli/sync.go",
+    "internal/cli/publication_paths_test.go",
+    "internal/cli/sync_publication_context_test.go",
+    "internal/config/config.go",
+    "internal/config/substack_publication.go",
+    "internal/config/substack_publication_test.go"
+  ],
+  "validated_outcome": "Regression tests verify --subdomain is registered, invalid host-like values are rejected, and sync resource paths use https://{publication}.substack.com/api/v1."
+}

--- a/library/media-and-entertainment/substack/internal/cli/drafts_create.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_create.go
@@ -149,7 +149,7 @@ Second paragraph."
 		Annotations: map[string]string{
 			"pp:endpoint":  "drafts.create",
 			"pp:method":    "POST",
-			"pp:path":      "/drafts",
+			"pp:path":      "https://{publication}.substack.com/api/v1/drafts",
 			"pp:novel-ext": "full-field-coverage",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -163,7 +163,7 @@ Second paragraph."
 				return err
 			}
 
-			path := "/drafts"
+			path := publicationAPIPath("/drafts")
 			var body map[string]any
 
 			if stdinBody {

--- a/library/media-and-entertainment/substack/internal/cli/drafts_schedule.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_schedule.go
@@ -55,7 +55,7 @@ Requires --subdomain <publication-subdomain>.`,
 		Annotations: map[string]string{
 			"pp:endpoint": "drafts.schedule",
 			"pp:method":   "POST",
-			"pp:path":     "/drafts/{id}/scheduled_release",
+			"pp:path":     "https://{publication}.substack.com/api/v1/drafts/{id}/scheduled_release",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -73,7 +73,7 @@ Requires --subdomain <publication-subdomain>.`,
 				return usageErr(err)
 			}
 
-			path := "/drafts/" + args[0] + "/scheduled_release"
+			path := publicationAPIPath("/drafts/" + args[0] + "/scheduled_release")
 			body := map[string]any{
 				"trigger_at":    triggerAt.UTC().Format(time.RFC3339),
 				"post_audience": postAudience,

--- a/library/media-and-entertainment/substack/internal/cli/drafts_update.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_update.go
@@ -62,7 +62,7 @@ full field list.`,
 		Annotations: map[string]string{
 			"pp:endpoint":  "drafts.update",
 			"pp:method":    "PUT",
-			"pp:path":      "/drafts/{id}",
+			"pp:path":      "https://{publication}.substack.com/api/v1/drafts/{id}",
 			"pp:novel-ext": "full-field-coverage",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -74,7 +74,7 @@ full field list.`,
 				return err
 			}
 
-			path := "/drafts/{id}"
+			path := publicationAPIPath("/drafts/{id}")
 			path = replacePathParam(path, "id", args[0])
 			var body map[string]any
 

--- a/library/media-and-entertainment/substack/internal/cli/publication_paths.go
+++ b/library/media-and-entertainment/substack/internal/cli/publication_paths.go
@@ -1,0 +1,11 @@
+// Copyright 2026 Chirantan Rajhans and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored: Substack publication-scoped endpoints must route through the
+// publication host so {publication} can be substituted from --subdomain or env.
+
+package cli
+
+const substackPublicationAPIBase = "https://{publication}.substack.com/api/v1"
+
+func publicationAPIPath(path string) string {
+	return substackPublicationAPIBase + path
+}

--- a/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
+++ b/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Chirantan Rajhans and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRootCmdRegistersSubdomainFlag(t *testing.T) {
+	t.Parallel()
+
+	root := RootCmd()
+	if root.PersistentFlags().Lookup("subdomain") == nil {
+		t.Fatal("root command must expose --subdomain for publication-scoped endpoints")
+	}
+}
+
+func TestPublicationAPIPath(t *testing.T) {
+	t.Parallel()
+
+	got := publicationAPIPath("/drafts")
+	want := "https://{publication}.substack.com/api/v1/drafts"
+	if got != want {
+		t.Fatalf("publicationAPIPath = %q, want %q", got, want)
+	}
+}
+
+func TestSyncResourcePathPublicationScopedResourcesUsePublicationHost(t *testing.T) {
+	t.Parallel()
+
+	for _, resource := range []string{"drafts", "posts", "posts-published", "posts-ranked", "sections", "subs", "tags"} {
+		resource := resource
+		t.Run(resource, func(t *testing.T) {
+			t.Parallel()
+			got, err := syncResourcePath(resource)
+			if err != nil {
+				t.Fatalf("syncResourcePath returned error: %v", err)
+			}
+			if got == "" || got[0] == '/' {
+				t.Fatalf("syncResourcePath(%q) = %q, want publication host URL", resource, got)
+			}
+			if !strings.HasPrefix(got, substackPublicationAPIBase) {
+				t.Fatalf("syncResourcePath(%q) = %q, want %q prefix", resource, got, substackPublicationAPIBase)
+			}
+		})
+	}
+}

--- a/library/media-and-entertainment/substack/internal/cli/root.go
+++ b/library/media-and-entertainment/substack/internal/cli/root.go
@@ -12,9 +12,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/config"
+	"github.com/spf13/cobra"
 )
 
 var version = "2026.6.1"
@@ -40,6 +40,7 @@ type rootFlags struct {
 	selectFields        string
 	configPath          string
 	profileName         string
+	subdomain           string
 	deliverSpec         string
 	timeout             time.Duration
 	rateLimit           float64
@@ -187,6 +188,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.PersistentFlags().StringVar(&flags.dataSource, "data-source", "auto", "Data source for read commands: auto (live with local fallback), live (API only), local (synced data only)")
 	rootCmd.PersistentFlags().DurationVar(&flags.maxAge, "max-age", 30*time.Minute, "Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables")
 	rootCmd.PersistentFlags().StringVar(&flags.profileName, "profile", "", "Apply values from a saved profile (see 'substack-pp-cli profile list')")
+	rootCmd.PersistentFlags().StringVar(&flags.subdomain, "subdomain", "", "Publication subdomain for {publication}.substack.com endpoints (overrides SUBSTACK_PUBLICATION)")
 	rootCmd.PersistentFlags().StringVar(&flags.deliverSpec, "deliver", "", "Route output to a sink: stdout (default), file:<path>, webhook:<url>")
 	rootCmd.PersistentFlags().Float64Var(&flags.rateLimit, "rate-limit", 0, "Max requests per second (0 to disable)")
 
@@ -311,6 +313,9 @@ func (f *rootFlags) newClient() (*client.Client, error) {
 	cfg, err := config.Load(f.configPath)
 	if err != nil {
 		return nil, configErr(err)
+	}
+	if err := cfg.SetPublication(f.subdomain); err != nil {
+		return nil, usageErr(err)
 	}
 	c := client.New(cfg, f.timeout, f.rateLimit)
 	c.DryRun = f.dryRun

--- a/library/media-and-entertainment/substack/internal/cli/sync.go
+++ b/library/media-and-entertainment/substack/internal/cli/sync.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
 	"io"
 	"net/url"
 	"os"
@@ -16,12 +15,14 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/client"
-	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/cliutil"
-	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/store"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/cliutil"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/store"
+	"github.com/spf13/cobra"
 )
 
 // unresolvedPathKeyRE matches `{key}` placeholders left in a sync path
@@ -148,6 +149,15 @@ Resource scoping:
 				for k, v := range pathContext {
 					if !endpointTemplateVarSet[k] {
 						fmt.Fprintf(os.Stderr, "warning: --path-context key %q is not a known endpoint placeholder; this value will not be substituted into any request path\n", k)
+					}
+					if k == "publication" {
+						if flags.subdomain != "" && v != flags.subdomain {
+							return usageErr(fmt.Errorf("--path-context publication cannot override --subdomain; pass one publication binding"))
+						}
+						if err := c.Config.SetPublication(v); err != nil {
+							return usageErr(fmt.Errorf("--path-context publication: %w", err))
+						}
+						continue
 					}
 					c.Config.TemplateVars[k] = v
 				}
@@ -1267,16 +1277,16 @@ func knownSyncResourceNames() []string {
 func syncResourcePath(resource string) (string, error) {
 	paths := map[string]string{
 		"categories":      "/categories",
-		"drafts":          "/drafts",
+		"drafts":          publicationAPIPath("/drafts"),
 		"inbox":           "/reader/feed",
 		"inbox-posts":     "/reader/posts",
-		"posts":           "/archive",
-		"posts-published": "/post_management/published",
-		"posts-ranked":    "/publication/users/ranked",
+		"posts":           publicationAPIPath("/archive"),
+		"posts-published": publicationAPIPath("/post_management/published"),
+		"posts-ranked":    publicationAPIPath("/publication/users/ranked"),
 		"profiles":        "/handle/options",
-		"sections":        "/subscriptions",
-		"subs":            "/publication/users",
-		"tags":            "/publication/post-tag",
+		"sections":        publicationAPIPath("/subscriptions"),
+		"subs":            publicationAPIPath("/publication/users"),
+		"tags":            publicationAPIPath("/publication/post-tag"),
 	}
 	if p, ok := paths[resource]; ok {
 		return p, nil

--- a/library/media-and-entertainment/substack/internal/cli/sync_publication_context_test.go
+++ b/library/media-and-entertainment/substack/internal/cli/sync_publication_context_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Chirantan Rajhans and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSyncRejectsPublicationPathContextOverrideOfSubdomain(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+
+	root := RootCmd()
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"--subdomain", "trevinsays",
+		"sync",
+		"--path-context", "publication=otherpub",
+		"--resources", "drafts",
+		"--latest-only",
+	})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("sync accepted --path-context publication override of --subdomain")
+	}
+	if !strings.Contains(err.Error(), "cannot override --subdomain") {
+		t.Fatalf("error = %q, want override guidance", err)
+	}
+}
+
+func TestSyncRejectsInvalidPublicationPathContext(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+
+	root := RootCmd()
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"sync",
+		"--path-context", "publication=trevinsays.evil.test",
+		"--resources", "drafts",
+		"--latest-only",
+	})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("sync accepted invalid --path-context publication value")
+	}
+	if !strings.Contains(err.Error(), "single DNS label") {
+		t.Fatalf("error = %q, want single-label guidance", err)
+	}
+}

--- a/library/media-and-entertainment/substack/internal/config/config.go
+++ b/library/media-and-entertainment/substack/internal/config/config.go
@@ -89,8 +89,10 @@ func Load(configPath string) (*Config, error) {
 		cfg.TemplateVars = map[string]string{}
 	}
 	verifyMode := os.Getenv("PRINTING_PRESS_VERIFY") == "1"
-	if v := strings.TrimSpace(os.Getenv("SUBSTACK_PUBLICATION")); validPublicationLabel(v) {
-		cfg.TemplateVars["publication"] = v
+	if v := strings.TrimSpace(os.Getenv("SUBSTACK_PUBLICATION")); v != "" {
+		if err := cfg.SetPublication(v); err != nil {
+			return nil, fmt.Errorf("SUBSTACK_PUBLICATION: %w", err)
+		}
 	} else if verifyMode {
 		cfg.TemplateVars["publication"] = "publication_placeholder"
 	}

--- a/library/media-and-entertainment/substack/internal/config/substack_publication.go
+++ b/library/media-and-entertainment/substack/internal/config/substack_publication.go
@@ -3,6 +3,28 @@
 
 package config
 
+import (
+	"fmt"
+	"strings"
+)
+
+// SetPublication validates and stores the publication subdomain used to fill
+// {publication} in publication-scoped Substack endpoints.
+func (c *Config) SetPublication(subdomain string) error {
+	subdomain = strings.TrimSpace(subdomain)
+	if subdomain == "" {
+		return nil
+	}
+	if !validPublicationLabel(subdomain) {
+		return fmt.Errorf("invalid publication subdomain %q: use a single DNS label such as mypub", subdomain)
+	}
+	if c.TemplateVars == nil {
+		c.TemplateVars = map[string]string{}
+	}
+	c.TemplateVars["publication"] = subdomain
+	return nil
+}
+
 // validPublicationLabel reports whether s is a single DNS label safe to
 // substitute into the {publication}.substack.com Creator host. The publication
 // is always one subdomain label; rejecting punctuation (/, @, :, ., %, …) stops

--- a/library/media-and-entertainment/substack/internal/config/substack_publication_test.go
+++ b/library/media-and-entertainment/substack/internal/config/substack_publication_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Chirantan Rajhans and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetPublication(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{}
+	if err := cfg.SetPublication("trevinsays"); err != nil {
+		t.Fatalf("SetPublication returned error: %v", err)
+	}
+	if got := cfg.TemplateVars["publication"]; got != "trevinsays" {
+		t.Fatalf("TemplateVars[publication] = %q, want %q", got, "trevinsays")
+	}
+}
+
+func TestSetPublicationRejectsHostInjection(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{}
+	if err := cfg.SetPublication("trevinsays.evil.test"); err == nil {
+		t.Fatal("SetPublication accepted a multi-label host")
+	}
+	if _, ok := cfg.TemplateVars["publication"]; ok {
+		t.Fatal("invalid publication should not be stored")
+	}
+}
+
+func TestLoadRejectsInvalidPublicationEnv(t *testing.T) {
+	t.Setenv("SUBSTACK_PUBLICATION", "trevinsays.evil.test")
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+
+	_, err := Load("")
+	if err == nil {
+		t.Fatal("Load accepted invalid SUBSTACK_PUBLICATION")
+	}
+	if !strings.Contains(err.Error(), "SUBSTACK_PUBLICATION") {
+		t.Fatalf("error = %q, want SUBSTACK_PUBLICATION context", err)
+	}
+	if !strings.Contains(err.Error(), "single DNS label") {
+		t.Fatalf("error = %q, want actionable single-label guidance", err)
+	}
+}


### PR DESCRIPTION
## Summary

Substack draft authoring now follows the documented publication binding: `drafts create --subdomain trevinsays ... --dry-run` previews `POST https://trevinsays.substack.com/api/v1/drafts` instead of rejecting the flag or falling back to `https://substack.com/api/v1/drafts`.

The fix registers `--subdomain` as a root override for the existing `{publication}` template variable, rejects host-like values such as `trevinsays.evil.test`, and routes the hand-authored draft create/update/schedule paths plus publication-scoped sync refresh paths through `https://{publication}.substack.com/api/v1`. That keeps the CLI help, env-based `SUBSTACK_PUBLICATION` path, and one-off flag override consistent for agents.

Fixes #1223.

## Validation

- `go test ./...` from `library/media-and-entertainment/substack`
- `go vet ./...` from `library/media-and-entertainment/substack`
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/media-and-entertainment/substack`
- `substack-pp-cli drafts create --subdomain trevinsays --title ... --body ... --dry-run --agent` via `go run`
- `SUBSTACK_PUBLICATION=trevinsays substack-pp-cli drafts list --dry-run --agent` via `go run`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
