### PR TITLE
fix(ci): bump workflow Go toolchain

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           # Public library is a monorepo with per-CLI go.mod under library/<cat>/<slug>/.
           # Point setup-go at this matrix entry's go.sum so its module cache is keyed
           # correctly. Without this, setup-go warns "Dependencies file is not found".
@@ -230,7 +230,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache-dependency-path: library/${{ matrix.target }}/go.sum
       - name: Build CLI binary
         env:

--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           # Audit walks every CLI; no single go.sum to key the module cache on,
           # and the cache hit-rate would be near zero anyway (every CLI's go.sum
           # differs). Disable caching to silence the "Dependencies file is not

--- a/.github/workflows/generate-registry.yml
+++ b/.github/workflows/generate-registry.yml
@@ -62,7 +62,7 @@ jobs:
           token: ${{ secrets.ADMIN_PUSH_PAT }}
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
       - name: Run generator
         run: go run ./tools/generate-registry/main.go
       - name: Commit if changed

--- a/.github/workflows/update-cli-release-ledger.yml
+++ b/.github/workflows/update-cli-release-ledger.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
       - name: Resolve release metadata
         id: meta
         env:

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -257,7 +257,7 @@ jobs:
       # binary that will run after merge.
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Validate registry source descriptions
         # Reject PRs whose .printing-press.json + .goreleaser.yaml sources would


### PR DESCRIPTION
## Summary

MCPB release artifact jobs can install `cli-printing-press@latest` again. The workflow fleet now uses Go `1.26.4`, matching the minimum version required by `cli-printing-press/v4 v4.24.0`, instead of failing under `GOTOOLCHAIN=local` on Go `1.26.3` before bundling starts.

## Validation

- `git diff --check`
- `/tmp/ppl-supply-chain-venv/bin/python .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`
- `/tmp/ppl-supply-chain-venv/bin/python -m unittest scan_test`

## Post-Deploy Monitoring & Validation

Watch the next `Build CLI release artifacts` run, or rerun the failed run after merge, and confirm the MCPB bundle matrix reaches `Bundle MCPB` instead of failing at `Install cli-printing-press`. Healthy signal: `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` completes on all bundle platforms. Failure signal: any bundle job still reports a Go version mismatch or exits before the `Bundle MCPB` step. Owner: PR author during the first post-merge release-artifact run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
