### PR TITLE
fix(ci): require targeted release artifact dispatch

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -9,7 +9,7 @@ name: Build CLI release artifacts
 # so each push to main rebuilds and the URLs stay stable forever.
 #
 # Triggers:
-#   - workflow_dispatch (manual): rebuild a specific CLI or "all"
+#   - workflow_dispatch (manual): rebuild a specific CLI
 #   - push to main on library/** (excluding build/): rebuild affected CLIs
 #
 # Auth: requires GENERATOR_READ_TOKEN (fine-grained PAT with Contents:read on
@@ -21,9 +21,8 @@ on:
   workflow_dispatch:
     inputs:
       cli:
-        description: 'CLI to rebuild as <category>/<slug>, or "all" for every CLI in the library'
-        required: false
-        default: ''
+        description: 'CLI to rebuild as <category>/<slug>'
+        required: true
   push:
     branches: [main]
     paths:
@@ -71,14 +70,20 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            if [ -z "$INPUT_CLI" ] || [ "$INPUT_CLI" = "all" ]; then
-              affected=$(find library -mindepth 2 -maxdepth 2 -type d \
-                | sed 's|library/||' \
-                | sort -u \
-                | jq -R . | jq -s -c .)
-            else
-              affected=$(printf '%s' "$INPUT_CLI" | jq -R . | jq -s -c .)
+            if [ -z "$INPUT_CLI" ]; then
+              echo "::error::No CLI target provided. Specify a target with cli=<category>/<slug>, for example cli=media-and-entertainment/substack."
+              exit 1
             fi
+            if [ "$INPUT_CLI" = "all" ]; then
+              total=$(find library -mindepth 2 -maxdepth 2 -type d | wc -l | tr -d ' ')
+              echo "::error::Manual all-CLI rebuilds would expand to ${total} targets and exceed GitHub Actions' 256-combination matrix limit. Re-run with a specific CLI, for example cli=media-and-entertainment/substack."
+              exit 1
+            fi
+            if [ ! -d "library/$INPUT_CLI" ]; then
+              echo "::error::Unknown CLI target '${INPUT_CLI}'. Expected a path like media-and-entertainment/substack under library/."
+              exit 1
+            fi
+            affected=$(printf '%s' "$INPUT_CLI" | jq -R . | jq -s -c .)
           else
             # Push event: diff against parent commit. The all-zeros sentinel
             # appears for initial branch pushes; fall back to HEAD^ then to


### PR DESCRIPTION
## Summary

Manual release-artifact dispatches no longer fail opaquely at workflow expansion time when the input is left blank. The workflow now requires a specific `category/slug` target and rejects blank or `all` dispatches before GitHub tries to create an oversized matrix for the full 257-CLI catalog.

This keeps targeted validation runs, such as `media-and-entertainment/substack`, on the normal bundle/build/release path while making full-catalog rebuilds an explicit future sharding problem instead of a broken manual default.

## Validation

- `git diff --check`
- `actionlint .github/workflows/build-mcpb.yml`
- `/tmp/ppl-supply-chain-venv/bin/python .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`
- `/tmp/ppl-supply-chain-venv/bin/python -m unittest scan_test`
- Shell simulation: blank input exits before matrix creation with `257 targets`
- Shell simulation: `media-and-entertainment/substack` produces `affected=["media-and-entertainment/substack"] count=1`

## Post-Deploy Monitoring & Validation

After merge, manually dispatch `Build CLI release artifacts` with `cli=media-and-entertainment/substack` to validate the original MCPB toolchain path. Healthy signal: detect reports one affected CLI, bundle jobs set up Go `1.26.4`, `Install cli-printing-press` succeeds, and bundle/build/release jobs complete or report per-app artifact gates. Failure signal: detect rejects the specific target, matrix expansion fails before jobs are created, or bundle jobs still fail before `Bundle MCPB`. Owner: PR author during the first post-merge targeted dispatch.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
