### PR TITLE
fix(substack): report substituted publication URLs

### DIFF
--- a/library/media-and-entertainment/substack/.printing-press-patches/publication-error-url-reporting.json
+++ b/library/media-and-entertainment/substack/.printing-press-patches/publication-error-url-reporting.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "publication-error-url-reporting",
+  "applied_at": "2026-06-16",
+  "base_run_id": "20260531-014452",
+  "base_printing_press_version": "4.19.0",
+  "summary": "HTTP error diagnostics for publication-scoped endpoints must report the substituted request URL, not the raw {publication} template.",
+  "reason": "The live request path correctly substitutes --subdomain, but API errors previously displayed the generated template string, making agents and users believe the CLI was still calling https://{publication}.substack.com.",
+  "files": [
+    "internal/client/client.go",
+    "internal/client/client_test.go"
+  ],
+  "validated_outcome": "A client regression test verifies 403 errors from https://{publication}.substack.com/api/v1/drafts report https://trevinsays.substack.com/api/v1/drafts."
+}

--- a/library/media-and-entertainment/substack/internal/client/client.go
+++ b/library/media-and-entertainment/substack/internal/client/client.go
@@ -20,9 +20,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
+
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/config"
-	"time"
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
@@ -569,7 +570,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return nil, 0, ctxErr
 			}
-			lastErr = fmt.Errorf("%s %s: %w", method, c.displayURL(path, authHeader), c.maskError(err, authHeader))
+			lastErr = fmt.Errorf("%s %s: %w", method, c.displayURL(targetURL, authHeader), c.maskError(err, authHeader))
 			continue
 		}
 
@@ -605,7 +606,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 
 		apiErr := &APIError{
 			Method:     method,
-			Path:       c.displayURL(path, authHeader),
+			Path:       c.displayURL(targetURL, authHeader),
 			StatusCode: resp.StatusCode,
 			Body:       c.maskCredentialText(truncateBody(respBody), authHeader),
 		}

--- a/library/media-and-entertainment/substack/internal/client/client_test.go
+++ b/library/media-and-entertainment/substack/internal/client/client_test.go
@@ -5,9 +5,15 @@ package client
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/config"
 )
 
 func TestTruncateBody(t *testing.T) {
@@ -69,4 +75,51 @@ func TestTruncateBody_UTF8RuneAtBoundary(t *testing.T) {
 	if want := 4094 + 3; len(got) != want {
 		t.Fatalf("len = %d, want %d (partial rune should be dropped, not replaced)", len(got), want)
 	}
+}
+
+func TestAPIErrorReportsSubstitutedAbsoluteURL(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		BaseURL: "https://substack.com/api/v1",
+		TemplateVars: map[string]string{
+			"publication": "trevinsays",
+		},
+	}
+	c := New(cfg, 0, 0)
+	c.NoCache = true
+	var requested string
+	c.HTTPClient.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requested = req.URL.String()
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("Not authorized")),
+			Request:    req,
+		}, nil
+	})
+
+	_, err := c.Get(context.Background(), "https://{publication}.substack.com/api/v1/drafts", nil)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error type = %T, want *APIError", err)
+	}
+	if requested != "https://trevinsays.substack.com/api/v1/drafts" {
+		t.Fatalf("requested URL = %q, want substituted publication URL", requested)
+	}
+	if strings.Contains(apiErr.Path, "{publication}") {
+		t.Fatalf("APIError.Path = %q, still contains unresolved publication placeholder", apiErr.Path)
+	}
+	if got, want := apiErr.Path, "https://trevinsays.substack.com/api/v1/drafts"; got != want {
+		t.Fatalf("APIError.Path = %q, want %q", got, want)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }


### PR DESCRIPTION
## Summary

Substack publication-scoped read commands now report the actual substituted publication URL when the live API returns an error. The request already went to `trevinsays.substack.com`, but the error object kept the generated template path, so users saw misleading failures against `https://{publication}.substack.com/...` after passing `--subdomain`.

This fixes the remaining confusion from mvanhorn/printing-press-library#1223: `drafts list`, `tags list`, and `posts list-published` can still surface auth/permission errors, but those errors now identify the real host that was contacted.

Fixes mvanhorn/printing-press-library#1223

## Validation

- `go test ./...` from `library/media-and-entertainment/substack`
- `go vet ./...` from `library/media-and-entertainment/substack`
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/media-and-entertainment/substack`
- Live read smoke checks now report `https://trevinsays.substack.com/...` instead of `https://{publication}.substack.com/...` for:
  - `drafts list --subdomain trevinsays --data-source live --no-cache`
  - `tags list --subdomain trevinsays --data-source live --no-cache`
  - `posts list-published --subdomain trevinsays --data-source live --no-cache`

## Post-Deploy Monitoring & Validation

After merge and release-ledger automation, install/update `substack-pp-cli` and rerun the three issue-comment commands with a valid publication subdomain. Healthy signal: any API error names `https://<subdomain>.substack.com/...`; failure signal: an error still contains `https://{publication}.substack.com/...`. Owner: PR author during the first post-merge Substack release validation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
