### PR TITLE
fix: resolve publication URL in Substack dry-run JSON

### DIFF
--- a/library/media-and-entertainment/substack/.printing-press-patches/dry-run-json-publication-url.json
+++ b/library/media-and-entertainment/substack/.printing-press-patches/dry-run-json-publication-url.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "dry-run-json-publication-url",
+  "applied_at": "2026-06-16",
+  "base_run_id": "20260531-014452",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Substack draft create dry-run JSON output reports the resolved publication URL instead of the raw {publication} template.",
+  "reason": "The dry-run request preview on stderr used the resolved --subdomain host, but the machine-readable JSON envelope reused the template path, making agents believe the CLI would call https://{publication}.substack.com/api/v1/drafts.",
+  "files": [
+    "internal/client/client.go",
+    "internal/cli/drafts_create.go",
+    "internal/cli/publication_paths_test.go"
+  ],
+  "validated_outcome": "A CLI-level regression test executes drafts create --subdomain trevinsays --dry-run --agent and verifies stdout path is https://trevinsays.substack.com/api/v1/drafts, with no live request sent."
+}

--- a/library/media-and-entertainment/substack/internal/cli/drafts_create.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_create.go
@@ -164,6 +164,10 @@ Second paragraph."
 			}
 
 			path := publicationAPIPath("/drafts")
+			displayPath := path
+			if resolvedPath, err := c.DisplayURLForPath(path); err == nil {
+				displayPath = resolvedPath
+			}
 			var body map[string]any
 
 			if stdinBody {
@@ -305,7 +309,7 @@ Second paragraph."
 				envelope := map[string]any{
 					"action":   "post",
 					"resource": "drafts",
-					"path":     path,
+					"path":     displayPath,
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300,
 				}

--- a/library/media-and-entertainment/substack/internal/cli/drafts_create.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_create.go
@@ -168,6 +168,8 @@ Second paragraph."
 			if resolvedPath, err := c.DisplayURLForPath(path); err == nil {
 				displayPath = resolvedPath
 			}
+			// DisplayURLForPath uses the same template resolution as c.Post below; if it
+			// fails, c.Post will return that error before printing the JSON envelope.
 			var body map[string]any
 
 			if stdinBody {

--- a/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
+++ b/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
@@ -3,6 +3,9 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -23,6 +26,43 @@ func TestPublicationAPIPath(t *testing.T) {
 	want := "https://{publication}.substack.com/api/v1/drafts"
 	if got != want {
 		t.Fatalf("publicationAPIPath = %q, want %q", got, want)
+	}
+}
+
+func TestDraftCreateDryRunJSONReportsResolvedPublicationURL(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"--subdomain", "trevinsays",
+		"drafts", "create",
+		"--title", "CLI verification dry-run",
+		"--body", "Verification only.",
+		"--dry-run",
+		"--agent",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute dry-run: %v; stderr=%s", err, stderr.String())
+	}
+	var envelope struct {
+		Path   string `json:"path"`
+		DryRun bool   `json:"dry_run"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &envelope); err != nil {
+		t.Fatalf("parse stdout JSON %q: %v", stdout.String(), err)
+	}
+	if !envelope.DryRun {
+		t.Fatalf("dry_run = false, want true; stdout=%s", stdout.String())
+	}
+	if strings.Contains(envelope.Path, "{publication}") {
+		t.Fatalf("path = %q, still contains unresolved publication placeholder", envelope.Path)
+	}
+	if got, want := envelope.Path, "https://trevinsays.substack.com/api/v1/drafts"; got != want {
+		t.Fatalf("path = %q, want %q", got, want)
 	}
 }
 

--- a/library/media-and-entertainment/substack/internal/client/client.go
+++ b/library/media-and-entertainment/substack/internal/client/client.go
@@ -681,6 +681,26 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	return json.RawMessage(`{"dry_run": true}`), 0, nil
 }
 
+// DisplayURLForPath resolves the same endpoint template variables the request
+// path uses and returns the URL shape safe for user-facing diagnostics.
+func (c *Client) DisplayURLForPath(path string) (string, error) {
+	var endpointVars map[string]string
+	if c.Config != nil {
+		endpointVars = c.Config.TemplateVars
+	}
+	var targetURL string
+	var err error
+	if isAbsoluteURL(path) {
+		targetURL, err = buildURL("", path, endpointVars)
+	} else {
+		targetURL, err = buildURL(c.BaseURL, path, endpointVars)
+	}
+	if err != nil {
+		return "", err
+	}
+	return c.displayURL(targetURL, ""), nil
+}
+
 func (c *Client) ConfiguredTimeout() time.Duration {
 	if c.HTTPClient != nil && c.HTTPClient.Timeout > 0 {
 		return c.HTTPClient.Timeout


### PR DESCRIPTION
## Bug

`substack-pp-cli drafts create --subdomain <pub> --dry-run --agent` printed the resolved request preview on stderr, but the machine-readable JSON envelope still reported the raw template path:

```json
"path": "https://{publication}.substack.com/api/v1/drafts"
```

Agents consuming stdout could therefore think the CLI was still targeting the unresolved template URL even though the dry-run request preview was correct.

## Fix

- Added a client display helper that resolves endpoint template variables the same way request construction does.
- Updated the Substack draft-create JSON envelope to use that resolved display URL for `path`.
- Added patch metadata so this generated-tree repair is preserved across future reprints.

## Tests run

```bash
go test ./internal/cli ./internal/client -run 'TestDraftCreateDryRunJSONReportsResolvedPublicationURL|TestAPIErrorReportsSubstitutedAbsoluteURL|TestPublicationAPIPath|TestSyncResourcePathPublicationScopedResourcesUsePublicationHost' -count=1
go test ./internal/cli ./internal/client -count=1
go build ./cmd/substack-pp-cli
SUBSTACK_CONFIG=$(mktemp -t substack-pp-cli-config.XXXXXX.toml) ./substack-pp-cli drafts create --subdomain trevinsays --title 'CLI verification dry-run' --body 'Verification only.' --dry-run --agent
# stdout path: https://trevinsays.substack.com/api/v1/drafts
# stderr preview: POST https://trevinsays.substack.com/api/v1/drafts
go test ./... -count=1
python3 .github/scripts/verify-publish-package/verify_publish_package.py --base-ref origin/main
```

## Safety

The regression executes `drafts create` only with `--dry-run --agent`; the client dry-run path returns before sending a live HTTP request, and the smoke run confirmed `(dry run - no request sent)` while stdout reported the resolved publication URL.
