### PR TITLE
fix(ankiweb): correct README byline handle to paulbockewitz

### DIFF
--- a/library/education/ankiweb/README.md
+++ b/library/education/ankiweb/README.md
@@ -6,7 +6,7 @@ Every existing Anki CLI wraps the desktop AnkiConnect add-on; none touches ankiw
 
 Learn more at [AnkiWeb](https://ankiweb.net).
 
-Created by [@paulb](https://github.com/paulb) (Paul Bockewitz).
+Created by [@paulbockewitz](https://github.com/paulbockewitz) (Paul Bockewitz).
 Contributors: [@tmchow](https://github.com/tmchow) (Trevin Chow).
 
 ## Install


### PR DESCRIPTION
## ankiweb — README byline handle fix

Companion to #1209 (the attribution-only manifest fix). That PR corrects the catalog
byline via the manifest `printer` field, which `generate-registry` regenerates post-merge.
But the **per-CLI README byline** is committed content that is *not* regenerated, so it
needs its own edit:

```diff
-Created by [@paulb](https://github.com/paulb) (Paul Bockewitz).
+Created by [@paulbockewitz](https://github.com/paulbockewitz) (Paul Bockewitz).
```

Display name unchanged; only the `@paulb` handle/link is corrected.

**Why a separate PR from #1209:** the `verify-attribution` guard rejects a PR that changes
manifest attribution fields *and* a surface file (README) together — attribution
corrections must be isolated. This PR is surface-only (no manifest/attribution change), so
it passes the guard cleanly. Verified locally against `main`.
