### PR TITLE
fix(substack): route writer endpoints globally

### DIFF
--- a/library/media-and-entertainment/substack/.printing-press-patches/writer-global-endpoints.json
+++ b/library/media-and-entertainment/substack/.printing-press-patches/writer-global-endpoints.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 2,
+  "id": "writer-global-endpoints",
+  "applied_at": "2026-06-16",
+  "base_run_id": "20260531-014452",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Authenticated Substack writer mutations use global substack.com API routes with publication_id instead of publication-host routes when that is the working writer contract.",
+  "reason": "Live author sessions can read/write drafts and upload images through https://substack.com/api/v1 with a numeric publication_id, while publication-host writer routes return 403 or 404 for the same valid session.",
+  "files": [
+    "internal/cli/drafts_create.go",
+    "internal/cli/promoted_images.go",
+    "internal/cli/root.go",
+    "internal/cli/writer_endpoints.go",
+    "internal/config/config.go",
+    "internal/cli/publication_paths_test.go"
+  ],
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1239"
+}

--- a/library/media-and-entertainment/substack/internal/cli/drafts_create.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_create.go
@@ -149,7 +149,7 @@ Second paragraph."
 		Annotations: map[string]string{
 			"pp:endpoint":  "drafts.create",
 			"pp:method":    "POST",
-			"pp:path":      "https://{publication}.substack.com/api/v1/drafts",
+			"pp:path":      "https://substack.com/api/v1/drafts?publication_id={publication_id}",
 			"pp:novel-ext": "full-field-coverage",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -163,13 +163,17 @@ Second paragraph."
 				return err
 			}
 
-			path := publicationAPIPath("/drafts")
-			displayPath := path
-			if resolvedPath, err := c.DisplayURLForPath(path); err == nil {
-				displayPath = resolvedPath
+			path := globalAPIPath("/drafts")
+			publicationID, err := writerPublicationID(cmd.Context(), c, flags)
+			if err != nil {
+				return err
 			}
-			// DisplayURLForPath uses the same template resolution as c.Post below; if it
-			// fails, c.Post will return that error before printing the JSON envelope.
+			params := map[string]string{"publication_id": publicationID}
+			displayPath := globalAPIPathWithParams("/drafts", params)
+			// c.PostWithParams resolves the same global writer endpoint below. In
+			// dry-run mode writerPublicationID returns a placeholder instead of
+			// performing a live profile lookup, so the displayed route remains
+			// accurate without creating a network side effect.
 			var body map[string]any
 
 			if stdinBody {
@@ -292,7 +296,7 @@ Second paragraph."
 				}
 			}
 
-			data, statusCode, err := c.Post(cmd.Context(), path, body)
+			data, statusCode, err := c.PostWithParams(cmd.Context(), path, params, body)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/library/media-and-entertainment/substack/internal/cli/promoted_images.go
+++ b/library/media-and-entertainment/substack/internal/cli/promoted_images.go
@@ -19,7 +19,7 @@ func newImagesPromotedCmd(flags *rootFlags) *cobra.Command {
 		Short:       "Upload an image; returns CDN URL. Body is data-URI JSON.",
 		Long:        "Upload an image; returns CDN URL. Body is data-URI JSON.",
 		Example:     "  substack-pp-cli images --image example-value",
-		Annotations: map[string]string{"pp:endpoint": "images.upload", "pp:method": "POST", "pp:path": "https://{publication}.substack.com/api/v1/image"},
+		Annotations: map[string]string{"pp:endpoint": "images.upload", "pp:method": "POST", "pp:path": "https://substack.com/api/v1/image"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Bare invocation of a command with a required flag/body prints help
 			// instead of pflag's terse "required flag not set" error. Optional-
@@ -36,7 +36,7 @@ func newImagesPromotedCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			path := "https://{publication}.substack.com/api/v1/image"
+			path := globalAPIPath("/image")
 			params := map[string]string{}
 			// HasStore + non-GET falls through to a live API call here
 			// rather than through resolveRead (GET-only internally); a

--- a/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
+++ b/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
@@ -8,8 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
+
+var processStderrMu sync.Mutex
 
 func TestRootCmdRegistersSubdomainFlag(t *testing.T) {
 	t.Parallel()
@@ -71,8 +74,7 @@ func TestDraftCreateDryRunJSONReportsGlobalWriterURL(t *testing.T) {
 func TestImagesDryRunUsesGlobalUploadEndpoint(t *testing.T) {
 	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
 
-	stderr, restore := captureProcessStderr(t)
-	defer restore()
+	restoreStderr := captureProcessStderr(t)
 
 	root := RootCmd()
 	var stdout, cmdStderr bytes.Buffer
@@ -87,9 +89,10 @@ func TestImagesDryRunUsesGlobalUploadEndpoint(t *testing.T) {
 	})
 
 	if err := root.Execute(); err != nil {
-		t.Fatalf("execute dry-run: %v; cmd stderr=%s; process stderr=%s", err, cmdStderr.String(), stderr())
+		got := restoreStderr()
+		t.Fatalf("execute dry-run: %v; cmd stderr=%s; process stderr=%s", err, cmdStderr.String(), got)
 	}
-	got := stderr()
+	got := restoreStderr()
 	if !strings.Contains(got, "POST https://substack.com/api/v1/image") {
 		t.Fatalf("stderr = %q, want global image upload endpoint", got)
 	}
@@ -143,11 +146,24 @@ func TestPublicationIDFromProfileMatchesPrimaryPublication(t *testing.T) {
 	}
 }
 
-func captureProcessStderr(t *testing.T) (func() string, func()) {
+func TestPublicationIDFromProfilePrefersPublicationID(t *testing.T) {
+	raw := []byte(`{"publicationUsers":[{"id":111,"publication_id":7019888,"subdomain":"trevinsays"}]}`)
+	got, err := publicationIDFromProfile(raw, "trevinsays")
+	if err != nil {
+		t.Fatalf("publicationIDFromProfile returned error: %v", err)
+	}
+	if got != "7019888" {
+		t.Fatalf("publication id = %q, want publication_id 7019888 instead of row id 111", got)
+	}
+}
+
+func captureProcessStderr(t *testing.T) func() string {
 	t.Helper()
+	processStderrMu.Lock()
 	old := os.Stderr
 	r, w, err := os.Pipe()
 	if err != nil {
+		processStderrMu.Unlock()
 		t.Fatalf("pipe stderr: %v", err)
 	}
 	os.Stderr = w
@@ -157,13 +173,14 @@ func captureProcessStderr(t *testing.T) (func() string, func()) {
 		_, _ = buf.ReadFrom(r)
 		close(done)
 	}()
-	restore := func() {
+	return func() string {
 		_ = w.Close()
 		os.Stderr = old
 		<-done
 		_ = r.Close()
+		processStderrMu.Unlock()
+		return buf.String()
 	}
-	return buf.String, restore
 }
 
 func TestSyncResourcePathPublicationScopedResourcesUsePublicationHost(t *testing.T) {

--- a/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
+++ b/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
@@ -127,8 +127,8 @@ func TestDraftCreateDryRunWithoutPublicationIDDoesNotLookupLiveProfile(t *testin
 	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &envelope); err != nil {
 		t.Fatalf("parse stdout JSON %q: %v", stdout.String(), err)
 	}
-	if !strings.HasPrefix(envelope.Path, "https://substack.com/api/v1/drafts?publication_id=") {
-		t.Fatalf("path = %q, want global dry-run drafts route", envelope.Path)
+	if got, want := envelope.Path, "https://substack.com/api/v1/drafts?publication_id=dry-run-placeholder"; got != want {
+		t.Fatalf("path = %q, want %q", got, want)
 	}
 	if strings.Contains(envelope.Path, "trevinsays.substack.com") {
 		t.Fatalf("path = %q, should not use publication host", envelope.Path)

--- a/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
+++ b/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,7 +30,7 @@ func TestPublicationAPIPath(t *testing.T) {
 	}
 }
 
-func TestDraftCreateDryRunJSONReportsResolvedPublicationURL(t *testing.T) {
+func TestDraftCreateDryRunJSONReportsGlobalWriterURL(t *testing.T) {
 	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
 
 	root := RootCmd()
@@ -38,6 +39,7 @@ func TestDraftCreateDryRunJSONReportsResolvedPublicationURL(t *testing.T) {
 	root.SetErr(&stderr)
 	root.SetArgs([]string{
 		"--subdomain", "trevinsays",
+		"--publication-id", "7019888",
 		"drafts", "create",
 		"--title", "CLI verification dry-run",
 		"--body", "Verification only.",
@@ -58,12 +60,110 @@ func TestDraftCreateDryRunJSONReportsResolvedPublicationURL(t *testing.T) {
 	if !envelope.DryRun {
 		t.Fatalf("dry_run = false, want true; stdout=%s", stdout.String())
 	}
-	if strings.Contains(envelope.Path, "{publication}") {
-		t.Fatalf("path = %q, still contains unresolved publication placeholder", envelope.Path)
+	if strings.Contains(envelope.Path, "trevinsays.substack.com") || strings.Contains(envelope.Path, "{publication}") {
+		t.Fatalf("path = %q, want global writer endpoint without publication host", envelope.Path)
 	}
-	if got, want := envelope.Path, "https://trevinsays.substack.com/api/v1/drafts"; got != want {
+	if got, want := envelope.Path, "https://substack.com/api/v1/drafts?publication_id=7019888"; got != want {
 		t.Fatalf("path = %q, want %q", got, want)
 	}
+}
+
+func TestImagesDryRunUsesGlobalUploadEndpoint(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+
+	stderr, restore := captureProcessStderr(t)
+	defer restore()
+
+	root := RootCmd()
+	var stdout, cmdStderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&cmdStderr)
+	root.SetArgs([]string{
+		"--subdomain", "trevinsays",
+		"images",
+		"--image", "data:image/png;base64,AAAA",
+		"--dry-run",
+		"--agent",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute dry-run: %v; cmd stderr=%s; process stderr=%s", err, cmdStderr.String(), stderr())
+	}
+	got := stderr()
+	if !strings.Contains(got, "POST https://substack.com/api/v1/image") {
+		t.Fatalf("stderr = %q, want global image upload endpoint", got)
+	}
+	if strings.Contains(got, "trevinsays.substack.com") || strings.Contains(got, "{publication}") {
+		t.Fatalf("stderr = %q, should not use publication-host image endpoint", got)
+	}
+}
+
+func TestDraftCreateDryRunWithoutPublicationIDDoesNotLookupLiveProfile(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+	t.Setenv("SUBSTACK_BASE_URL", "http://127.0.0.1:1")
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"--subdomain", "trevinsays",
+		"drafts", "create",
+		"--title", "CLI verification dry-run",
+		"--body", "Verification only.",
+		"--dry-run",
+		"--agent",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute dry-run without publication id should not perform live lookup: %v; stderr=%s", err, stderr.String())
+	}
+	var envelope struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &envelope); err != nil {
+		t.Fatalf("parse stdout JSON %q: %v", stdout.String(), err)
+	}
+	if !strings.HasPrefix(envelope.Path, "https://substack.com/api/v1/drafts?publication_id=") {
+		t.Fatalf("path = %q, want global dry-run drafts route", envelope.Path)
+	}
+	if strings.Contains(envelope.Path, "trevinsays.substack.com") {
+		t.Fatalf("path = %q, should not use publication host", envelope.Path)
+	}
+}
+
+func TestPublicationIDFromProfileMatchesPrimaryPublication(t *testing.T) {
+	raw := []byte(`{"primaryPublication":{"id":7019888,"subdomain":"trevinsays","custom_domain":"trevinsays.com"}}`)
+	got, err := publicationIDFromProfile(raw, "trevinsays")
+	if err != nil {
+		t.Fatalf("publicationIDFromProfile returned error: %v", err)
+	}
+	if got != "7019888" {
+		t.Fatalf("publication id = %q, want 7019888", got)
+	}
+}
+
+func captureProcessStderr(t *testing.T) (func() string, func()) {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = w
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = buf.ReadFrom(r)
+		close(done)
+	}()
+	restore := func() {
+		_ = w.Close()
+		os.Stderr = old
+		<-done
+		_ = r.Close()
+	}
+	return buf.String, restore
 }
 
 func TestSyncResourcePathPublicationScopedResourcesUsePublicationHost(t *testing.T) {

--- a/library/media-and-entertainment/substack/internal/cli/root.go
+++ b/library/media-and-entertainment/substack/internal/cli/root.go
@@ -41,6 +41,7 @@ type rootFlags struct {
 	configPath          string
 	profileName         string
 	subdomain           string
+	publicationID       string
 	deliverSpec         string
 	timeout             time.Duration
 	rateLimit           float64
@@ -189,6 +190,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.PersistentFlags().DurationVar(&flags.maxAge, "max-age", 30*time.Minute, "Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables")
 	rootCmd.PersistentFlags().StringVar(&flags.profileName, "profile", "", "Apply values from a saved profile (see 'substack-pp-cli profile list')")
 	rootCmd.PersistentFlags().StringVar(&flags.subdomain, "subdomain", "", "Publication subdomain for {publication}.substack.com endpoints (overrides SUBSTACK_PUBLICATION)")
+	rootCmd.PersistentFlags().StringVar(&flags.publicationID, "publication-id", "", "Numeric publication_id for global writer endpoints (overrides SUBSTACK_PUBLICATION_ID)")
 	rootCmd.PersistentFlags().StringVar(&flags.deliverSpec, "deliver", "", "Route output to a sink: stdout (default), file:<path>, webhook:<url>")
 	rootCmd.PersistentFlags().Float64Var(&flags.rateLimit, "rate-limit", 0, "Max requests per second (0 to disable)")
 

--- a/library/media-and-entertainment/substack/internal/cli/writer_endpoints.go
+++ b/library/media-and-entertainment/substack/internal/cli/writer_endpoints.go
@@ -13,7 +13,7 @@ import (
 )
 
 const substackGlobalAPIBase = "https://substack.com/api/v1"
-const dryRunPublicationIDPlaceholder = "<resolved-at-runtime>"
+const dryRunPublicationIDPlaceholder = "dry-run-placeholder"
 
 func globalAPIPath(path string) string {
 	return substackGlobalAPIBase + path

--- a/library/media-and-entertainment/substack/internal/cli/writer_endpoints.go
+++ b/library/media-and-entertainment/substack/internal/cli/writer_endpoints.go
@@ -126,9 +126,9 @@ func publicationIDFromProfile(raw []byte, subdomain string) (string, error) {
 			if !ok {
 				continue
 			}
-			id := jsonNumberString(pub["id"])
+			id := jsonNumberString(pub["publication_id"])
 			if id == "" {
-				id = jsonNumberString(pub["publication_id"])
+				id = jsonNumberString(pub["id"])
 			}
 			if id != "" && publicationMatchesSubdomain(pub, wantSubdomain) {
 				return id, nil

--- a/library/media-and-entertainment/substack/internal/cli/writer_endpoints.go
+++ b/library/media-and-entertainment/substack/internal/cli/writer_endpoints.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Chirantan Rajhans and contributors. Licensed under Apache-2.0. See LICENSE.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/client"
+)
+
+const substackGlobalAPIBase = "https://substack.com/api/v1"
+const dryRunPublicationIDPlaceholder = "<resolved-at-runtime>"
+
+func globalAPIPath(path string) string {
+	return substackGlobalAPIBase + path
+}
+
+func globalAPIPathWithParams(path string, params map[string]string) string {
+	if len(params) == 0 {
+		return globalAPIPath(path)
+	}
+	q := url.Values{}
+	for k, v := range params {
+		if v != "" {
+			q.Set(k, v)
+		}
+	}
+	if encoded := q.Encode(); encoded != "" {
+		return globalAPIPath(path) + "?" + encoded
+	}
+	return globalAPIPath(path)
+}
+
+func writerPublicationID(ctx context.Context, c *client.Client, flags *rootFlags) (string, error) {
+	if id := strings.TrimSpace(flags.publicationID); id != "" {
+		if !validPublicationID(id) {
+			return "", fmt.Errorf("invalid --publication-id %q: use the numeric Substack publication_id", id)
+		}
+		return id, nil
+	}
+	if id := strings.TrimSpace(os.Getenv("SUBSTACK_PUBLICATION_ID")); id != "" {
+		if !validPublicationID(id) {
+			return "", fmt.Errorf("invalid SUBSTACK_PUBLICATION_ID %q: use the numeric Substack publication_id", id)
+		}
+		return id, nil
+	}
+	if c != nil && c.Config != nil {
+		if id, ok := firstPublicationID(c.Config.TemplateVars["publication_id"]); ok {
+			return id, nil
+		}
+	}
+	if flags.dryRun {
+		return dryRunPublicationIDPlaceholder, nil
+	}
+	id, err := resolveWriterPublicationIDFromProfile(ctx, c, flags.subdomain)
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func firstPublicationID(candidates ...string) (string, bool) {
+	for _, candidate := range candidates {
+		id := strings.TrimSpace(candidate)
+		if id == "" {
+			continue
+		}
+		if !validPublicationID(id) {
+			continue
+		}
+		return id, true
+	}
+	return "", false
+}
+
+func validPublicationID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func resolveWriterPublicationIDFromProfile(ctx context.Context, c *client.Client, subdomain string) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("could not resolve publication_id: client is nil")
+	}
+	raw, err := c.Get(ctx, "/user/profile/self", nil)
+	if err != nil {
+		return "", fmt.Errorf("resolving publication_id via /user/profile/self: %w", err)
+	}
+	id, err := publicationIDFromProfile(raw, subdomain)
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func publicationIDFromProfile(raw []byte, subdomain string) (string, error) {
+	var profile map[string]any
+	if err := json.Unmarshal(raw, &profile); err != nil {
+		return "", fmt.Errorf("parsing /user/profile/self response: %w", err)
+	}
+	wantSubdomain := strings.TrimSpace(strings.ToLower(subdomain))
+	if pub, ok := profile["primaryPublication"].(map[string]any); ok {
+		id := jsonNumberString(pub["id"])
+		if id != "" && publicationMatchesSubdomain(pub, wantSubdomain) {
+			return id, nil
+		}
+	}
+	for _, key := range []string{"publications", "publicationUsers"} {
+		items, ok := profile[key].([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range items {
+			pub, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			id := jsonNumberString(pub["id"])
+			if id == "" {
+				id = jsonNumberString(pub["publication_id"])
+			}
+			if id != "" && publicationMatchesSubdomain(pub, wantSubdomain) {
+				return id, nil
+			}
+		}
+	}
+	if wantSubdomain == "" {
+		return "", fmt.Errorf("could not infer publication_id from /user/profile/self; pass --publication-id or set SUBSTACK_PUBLICATION_ID")
+	}
+	return "", fmt.Errorf("could not infer publication_id for subdomain %q from /user/profile/self; pass --publication-id or set SUBSTACK_PUBLICATION_ID", subdomain)
+}
+
+func publicationMatchesSubdomain(pub map[string]any, wantSubdomain string) bool {
+	if wantSubdomain == "" {
+		return true
+	}
+	for _, key := range []string{"subdomain", "custom_domain"} {
+		got := strings.TrimSpace(strings.ToLower(jsonNumberString(pub[key])))
+		if got == "" {
+			continue
+		}
+		if got == wantSubdomain || strings.TrimSuffix(got, ".substack.com") == wantSubdomain {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonNumberString(v any) string {
+	switch x := v.(type) {
+	case string:
+		return strings.TrimSpace(x)
+	case float64:
+		if x == float64(int64(x)) {
+			return fmt.Sprintf("%d", int64(x))
+		}
+	}
+	return ""
+}

--- a/library/media-and-entertainment/substack/internal/config/config.go
+++ b/library/media-and-entertainment/substack/internal/config/config.go
@@ -96,6 +96,9 @@ func Load(configPath string) (*Config, error) {
 	} else if verifyMode {
 		cfg.TemplateVars["publication"] = "publication_placeholder"
 	}
+	if v := strings.TrimSpace(os.Getenv("SUBSTACK_PUBLICATION_ID")); v != "" {
+		cfg.TemplateVars["publication_id"] = v
+	}
 	return cfg, nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #1239.

Routes Substack authenticated writer mutations through the global API surface that works for author sessions:

- `drafts create` now posts to `https://substack.com/api/v1/drafts?publication_id=<id>` instead of `https://{publication}.substack.com/api/v1/drafts` when the publication ID is known or resolvable.
- `images` now uploads to `https://substack.com/api/v1/image` instead of the publication-host image route.
- Adds `--publication-id` / `SUBSTACK_PUBLICATION_ID` as an explicit non-live resolution path for agents and dry-runs.
- For non-dry-run draft creation without an explicit ID, resolves the numeric publication ID from `/user/profile/self`; dry-run uses a placeholder and does not perform that live lookup.
- Records the generated-library hand edit in `.printing-press-patches/writer-global-endpoints.json`.

## Source-of-truth note

This is a published-library repair under `library/media-and-entertainment/substack/`, which the repo AGENTS.md says to patch here first for a real shipped CLI defect. The patch metadata captures the behavior a future `cli-printing-press` regen must preserve. If this same writer-endpoint routing pattern is generated elsewhere, the follow-up belongs in `mvanhorn/cli-printing-press`; I did not find another published CLI manifestation in this repo.

## Verification

From `library/media-and-entertainment/substack`:

```bash
go test ./...
```

Result: all Substack module packages passed (`internal/cli`, `internal/client`, `internal/cliutil`, `internal/config`, `internal/mcp`, `internal/mcp/cobratree`, `internal/notebuilder`, `internal/store`; command/internal cache/types packages have no tests).

From repo root:

```bash
python3 .github/scripts/verify-publish-package/verify_publish_package.py --base-ref origin/main
python3 .github/scripts/verify-skill/verify_skill.py --dir library/media-and-entertainment/substack
```

Results:

- `Publish-package verifier passed.`
- `✓ All checks passed (skill-guard-literals, flag-names, flag-commands, positional-args, unknown-command)`

Dry-run smoke checks (no live request sent):

```bash
go run ./cmd/substack-pp-cli --config /tmp/substack-missing-test.toml --subdomain trevinsays --publication-id 7019888 drafts create --title 'CLI verification dry-run' --body 'Verification only.' --dry-run --agent
```

Output included `"path": "https://substack.com/api/v1/drafts?publication_id=7019888"`; stderr showed `(dry run - no request sent)`.

```bash
go run ./cmd/substack-pp-cli --config /tmp/substack-missing-test.toml --subdomain trevinsays images --image 'data:image/png;base64,AAAA' --dry-run --agent
```

stderr showed `POST https://substack.com/api/v1/image` and `(dry run - no request sent)`.

Note: I also intentionally tried `go test ./...` from repo root; it fails because the repo root is not a Go module (`pattern ./...: directory prefix . does not contain main module or its selected dependencies`). The Substack module-level command above is the relevant Go test.

## Greptile

Draft PR opened; Greptile review not available at PR creation time. I will read it with the repo helper once the bot posts.

## Risks / follow-up

- Non-dry-run draft creation now performs one profile lookup when no explicit `--publication-id` / `SUBSTACK_PUBLICATION_ID` is supplied. Dry-runs do not do that lookup.
- The generator/source repo should preserve this routing on the next Substack reprint; this PR records the behavior in the published-library patch metadata.
