### PR TITLE
fix(yahoo-finance): pass positional args as bare values, not --flag pairs

### DIFF
--- a/library/commerce/yahoo-finance/internal/mcp/cobratree/positional.go
+++ b/library/commerce/yahoo-finance/internal/mcp/cobratree/positional.go
@@ -1,0 +1,38 @@
+// Local patch: fix positional argument handling in cobratree shell-out tools.
+// Filed for upstream: cobratree walker passes positional args as --flag value,
+// but cobra commands expect them as bare positional values (e.g. `search TSLA`
+// not `search --query TSLA`). This file adds the extraction and routing logic.
+
+package cobratree
+
+import "regexp"
+
+var positionalNameRe = regexp.MustCompile(`<([^>]+)>`)
+
+// parsePositionalArgNames extracts required positional argument names from a
+// cobra Use string. Returns nil for variadic commands (repeated names or "...")
+// so the caller falls back to the generic "args" field instead.
+//
+// Examples:
+//
+//	"search <query> [flags]"           -> ["query"]
+//	"sparkline <symbol>"               -> ["symbol"]
+//	"compare <symbol> <symbol> [...]"  -> nil  (variadic, repeated name)
+func parsePositionalArgNames(use string) []string {
+	matches := positionalNameRe.FindAllStringSubmatch(use, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	// Variadic: repeated positional name or explicit "..." → fall back to args.
+	seen := make(map[string]bool, len(matches))
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		name := m[1]
+		if seen[name] {
+			return nil // duplicate → variadic command
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
+}

--- a/library/commerce/yahoo-finance/internal/mcp/cobratree/positional.go
+++ b/library/commerce/yahoo-finance/internal/mcp/cobratree/positional.go
@@ -5,31 +5,44 @@
 
 package cobratree
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 var positionalNameRe = regexp.MustCompile(`<([^>]+)>`)
 
 // parsePositionalArgNames extracts required positional argument names from a
-// cobra Use string. Returns nil for variadic commands (repeated names or "...")
-// so the caller falls back to the generic "args" field instead.
+// cobra Use string. Returns nil for variadic commands so the caller falls back
+// to the generic "args" field instead.
+//
+// Variadic signals:
+//   - repeated positional name: "compare <symbol> <symbol> [...]"
+//   - name ending in "...":     "gather <file...>"
+//   - explicit "[...]" token:   "cmd <a> <b> [...]"
 //
 // Examples:
 //
 //	"search <query> [flags]"           -> ["query"]
 //	"sparkline <symbol>"               -> ["symbol"]
+//	"fx <from> <to>"                   -> ["from", "to"]
 //	"compare <symbol> <symbol> [...]"  -> nil  (variadic, repeated name)
+//	"gather <file...>"                 -> nil  (variadic, ellipsis name)
+//	"cmd <a> <b> [...]"                -> nil  (variadic, explicit [...])
 func parsePositionalArgNames(use string) []string {
+	if strings.Contains(use, "[...]") {
+		return nil
+	}
 	matches := positionalNameRe.FindAllStringSubmatch(use, -1)
 	if len(matches) == 0 {
 		return nil
 	}
-	// Variadic: repeated positional name or explicit "..." → fall back to args.
 	seen := make(map[string]bool, len(matches))
 	names := make([]string, 0, len(matches))
 	for _, m := range matches {
 		name := m[1]
-		if seen[name] {
-			return nil // duplicate → variadic command
+		if seen[name] || strings.HasSuffix(name, "...") {
+			return nil // variadic command
 		}
 		seen[name] = true
 		names = append(names, name)

--- a/library/commerce/yahoo-finance/internal/mcp/cobratree/positional_test.go
+++ b/library/commerce/yahoo-finance/internal/mcp/cobratree/positional_test.go
@@ -1,0 +1,44 @@
+package cobratree
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePositionalArgNames(t *testing.T) {
+	cases := []struct {
+		name string
+		use  string
+		want []string
+	}{
+		// Normal fixed-positional commands.
+		{"single positional", "sparkline <symbol>", []string{"symbol"}},
+		{"two positionals", "fx <from> <to>", []string{"from", "to"}},
+		{"positional with flags section", "search <query> [flags]", []string{"query"}},
+
+		// No positionals.
+		{"no positionals", "health [flags]", nil},
+		{"no angle brackets", "version", nil},
+
+		// Variadic: repeated name → nil.
+		{"repeated name", "compare <symbol> <symbol>", nil},
+		{"repeated name with ellipsis token", "compare <symbol> <symbol> [...]", nil},
+
+		// Variadic: name ends in "..." → nil.
+		{"ellipsis name", "gather <file...>", nil},
+		{"ellipsis name mixed", "send <dest> <file...>", nil},
+
+		// Variadic: explicit "[...]" token → nil.
+		{"explicit ellipsis token", "cmd <a> <b> [...]", nil},
+		{"explicit ellipsis unique names", "fetch <symbol> [...]", nil},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := parsePositionalArgNames(tc.use)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parsePositionalArgNames(%q) = %v, want %v", tc.use, got, tc.want)
+			}
+		})
+	}
+}

--- a/library/commerce/yahoo-finance/internal/mcp/cobratree/shellout.go
+++ b/library/commerce/yahoo-finance/internal/mcp/cobratree/shellout.go
@@ -16,16 +16,29 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.ToolHandlerFunc {
+func shellOutToCLI(cliPath func() (string, error), commandPath []string, positionalNames []string) server.ToolHandlerFunc {
 	lookupPath, lookupErr := cliPath()
 	prefixArgs := append([]string{}, commandPath...)
+	// Build a set for O(1) lookup when filtering flags.
+	positionalSet := make(map[string]bool, len(positionalNames))
+	for _, p := range positionalNames {
+		positionalSet[p] = true
+	}
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 		if lookupErr != nil {
 			return mcplib.NewToolResultError(fmt.Sprintf("companion CLI binary not found: %v\nTried sibling lookup, YAHOO_FINANCE_CLI_PATH env var, and PATH.", lookupErr)), nil
 		}
 		args := req.GetArguments()
 		finalArgs := append([]string{}, prefixArgs...)
-		finalArgs = append(finalArgs, cliArgsFromMCP(args)...)
+		// Add flag args first, skipping keys that are positional params.
+		finalArgs = append(finalArgs, cliArgsFromMCPFiltered(args, positionalSet)...)
+		// Append positional values in declared order (bare, no -- prefix).
+		for _, name := range positionalNames {
+			if v, ok := args[name].(string); ok && v != "" {
+				finalArgs = append(finalArgs, v)
+			}
+		}
+		// Legacy free-form "args" field for commands with no named positionals.
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {
 			tokens := SplitShellArgs(raw)
 			for _, t := range tokens {
@@ -57,6 +70,49 @@ var blockedRootFlags = map[string]bool{
 	"deliver":  true,
 	"profile":  true,
 	"token":    true,
+}
+
+// cliArgsFromMCPFiltered converts MCP arguments to CLI --flag value pairs,
+// skipping keys in the skip set (used to exclude positional arg names that
+// must be passed as bare values, not flags).
+func cliArgsFromMCPFiltered(args map[string]any, skip map[string]bool) []string {
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		if !blockedRootFlags[k] && !skip[k] {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	var out []string
+	for _, k := range keys {
+		v := args[k]
+		switch tv := v.(type) {
+		case bool:
+			if tv {
+				out = append(out, "--"+k)
+			}
+		case float64:
+			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+		case string:
+			if tv != "" {
+				out = append(out, "--"+k, tv)
+			}
+		case []any:
+			if len(tv) > 0 {
+				parts := make([]string, 0, len(tv))
+				for _, item := range tv {
+					parts = append(parts, fmt.Sprintf("%v", item))
+				}
+				out = append(out, "--"+k, strings.Join(parts, ","))
+			}
+		default:
+			if v != nil {
+				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+			}
+		}
+	}
+	return out
 }
 
 func cliArgsFromMCP(args map[string]any) []string {

--- a/library/commerce/yahoo-finance/internal/mcp/cobratree/shellout.go
+++ b/library/commerce/yahoo-finance/internal/mcp/cobratree/shellout.go
@@ -36,12 +36,14 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, positio
 		// Reject flag-like values so an MCP client cannot inject CLI flags
 		// through positional parameters (same guard as the "args" field).
 		for _, name := range positionalNames {
-			if v, ok := args[name].(string); ok && v != "" {
-				if strings.HasPrefix(v, "-") {
-					return mcplib.NewToolResultError(fmt.Sprintf("flag-like argument %q not allowed for positional parameter %q; pass a plain value instead", v, name)), nil
-				}
-				finalArgs = append(finalArgs, v)
+			v, _ := args[name].(string)
+			if strings.TrimSpace(v) == "" {
+				return mcplib.NewToolResultError(fmt.Sprintf("positional parameter %q is required but was empty or missing", name)), nil
 			}
+			if strings.HasPrefix(v, "-") {
+				return mcplib.NewToolResultError(fmt.Sprintf("flag-like argument %q not allowed for positional parameter %q; pass a plain value instead", v, name)), nil
+			}
+			finalArgs = append(finalArgs, v)
 		}
 		// Legacy free-form "args" field for commands with no named positionals.
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {

--- a/library/commerce/yahoo-finance/internal/mcp/cobratree/shellout.go
+++ b/library/commerce/yahoo-finance/internal/mcp/cobratree/shellout.go
@@ -33,8 +33,13 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, positio
 		// Add flag args first, skipping keys that are positional params.
 		finalArgs = append(finalArgs, cliArgsFromMCPFiltered(args, positionalSet)...)
 		// Append positional values in declared order (bare, no -- prefix).
+		// Reject flag-like values so an MCP client cannot inject CLI flags
+		// through positional parameters (same guard as the "args" field).
 		for _, name := range positionalNames {
 			if v, ok := args[name].(string); ok && v != "" {
+				if strings.HasPrefix(v, "-") {
+					return mcplib.NewToolResultError(fmt.Sprintf("flag-like argument %q not allowed for positional parameter %q; pass a plain value instead", v, name)), nil
+				}
 				finalArgs = append(finalArgs, v)
 			}
 		}
@@ -79,46 +84,6 @@ func cliArgsFromMCPFiltered(args map[string]any, skip map[string]bool) []string 
 	keys := make([]string, 0, len(args))
 	for k := range args {
 		if !blockedRootFlags[k] && !skip[k] {
-			keys = append(keys, k)
-		}
-	}
-	sort.Strings(keys)
-
-	var out []string
-	for _, k := range keys {
-		v := args[k]
-		switch tv := v.(type) {
-		case bool:
-			if tv {
-				out = append(out, "--"+k)
-			}
-		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
-		case string:
-			if tv != "" {
-				out = append(out, "--"+k, tv)
-			}
-		case []any:
-			if len(tv) > 0 {
-				parts := make([]string, 0, len(tv))
-				for _, item := range tv {
-					parts = append(parts, fmt.Sprintf("%v", item))
-				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
-			}
-		default:
-			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
-			}
-		}
-	}
-	return out
-}
-
-func cliArgsFromMCP(args map[string]any) []string {
-	keys := make([]string, 0, len(args))
-	for k := range args {
-		if !blockedRootFlags[k] {
 			keys = append(keys, k)
 		}
 	}

--- a/library/commerce/yahoo-finance/internal/mcp/cobratree/shellout_test.go
+++ b/library/commerce/yahoo-finance/internal/mcp/cobratree/shellout_test.go
@@ -41,14 +41,14 @@ func TestSplitShellArgs(t *testing.T) {
 	}
 }
 
-// TestCliArgsFromMCP_BlocksRootFlags pins the structured-parameter half of
+// TestCliArgsFromMCPFiltered_BlocksRootFlags pins the structured-parameter half of
 // the control-plane-injection guard: even when an MCP client wraps the
 // flag in the structured args map (instead of the free-form "args"
 // string), the root flags listed in blockedRootFlags must be dropped
 // before they reach exec.CommandContext. A regression here would let a
 // caller redirect --base-url, swap --token, switch --client filesystems, or
 // load a malicious --config.
-func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
+func TestCliArgsFromMCPFiltered_BlocksRootFlags(t *testing.T) {
 	in := map[string]any{
 		"args":     "contacts",
 		"base-url": "https://evil.example.com",
@@ -60,39 +60,39 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		// Allowed per-command flag passes through.
 		"limit": float64(10),
 	}
-	got := cliArgsFromMCP(in)
+	got := cliArgsFromMCPFiltered(in, nil)
 	want := []string{"--limit", "10"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
+		t.Fatalf("cliArgsFromMCPFiltered dropped/kept wrong keys: got %v, want %v", got, want)
 	}
 	for _, blocked := range []string{"--base-url", "--client", "--config", "--deliver", "--profile", "--token", "--args"} {
 		for _, tok := range got {
 			if tok == blocked {
-				t.Errorf("blocked flag %q leaked through cliArgsFromMCP", blocked)
+				t.Errorf("blocked flag %q leaked through cliArgsFromMCPFiltered", blocked)
 			}
 		}
 	}
 }
 
-// TestCliArgsFromMCP_AllowsPerCommandFlags is the don't-overcorrect half:
+// TestCliArgsFromMCPFiltered_AllowsPerCommandFlags is the don't-overcorrect half:
 // any flag NOT in blockedRootFlags must still pass through, including
 // strings, bools, numbers, and []any. Without this, a tightening change
 // to the blocklist that accidentally drops legitimate per-command flags
-// would silently break every MCP-driven command. cliArgsFromMCP also
+// would silently break every MCP-driven command. cliArgsFromMCPFiltered also
 // guarantees sorted-key output (so generated commands see deterministic
 // argv ordering); compare directly to catch a regression in either the
 // blocklist or the sort.
-func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
+func TestCliArgsFromMCPFiltered_AllowsPerCommandFlags(t *testing.T) {
 	in := map[string]any{
 		"query":   "alpha",
 		"verbose": true,
 		"limit":   float64(25),
 		"tags":    []any{"a", "b"},
 	}
-	got := cliArgsFromMCP(in)
+	got := cliArgsFromMCPFiltered(in, nil)
 	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
+		t.Fatalf("cliArgsFromMCPFiltered per-command passthrough: got %v, want %v", got, want)
 	}
 }
 

--- a/library/commerce/yahoo-finance/internal/mcp/cobratree/walker.go
+++ b/library/commerce/yahoo-finance/internal/mcp/cobratree/walker.go
@@ -32,13 +32,21 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		}
 		options := []mcplib.ToolOption{mcplib.WithDescription(descriptionFor(cmd))}
 		options = append(options, toolOptionsForFlags(cmd)...)
-		if commandTakesArgs(cmd) {
-			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
+		// Extract named positional args from Use string (e.g. "search <query>")
+		// and register them as typed MCP params instead of the catch-all "args".
+		positionalNames := parsePositionalArgNames(cmd.Use)
+		for _, name := range positionalNames {
+			options = append(options, mcplib.WithString(name, mcplib.Required(), mcplib.Description("Positional argument: "+name)))
+		}
+		// Keep generic "args" for commands with no named positionals (including
+		// variadic commands where parsePositionalArgNames returns nil).
+		if len(positionalNames) == 0 && commandTakesArgs(cmd) {
+			options = append(options, mcplib.WithString("args", mcplib.Description("Space-separated positional arguments (e.g. \"TSLA AAPL NVDA\" for variadic symbol lists).")))
 		}
 		if isMCPReadOnly(cmd) {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, positionalNames))
 	})
 }
 


### PR DESCRIPTION
cobratree's shellOutToCLI converted all MCP parameters to --flag value pairs, including positional arguments. Commands like `sparkline <symbol>` and `fx <from> <to>` received `--symbol TSLA` and `--from USD` instead of bare positional values, causing "unknown flag" errors.

Changes:
- Add positional.go: parses <name> tokens from cobra Use strings; returns nil for variadic commands (repeated names) so they fall back to the generic "args" field
- walker.go: register named MCP params for each positional arg with Required(); keep generic "args" only for variadic/no-positional cmds
- shellout.go: add cliArgsFromMCPFiltered that skips positional param keys; append positional values as bare args in declared order

Before: sparkline {"symbol":"TSLA"} → `sparkline --symbol TSLA` → error
After:  sparkline {"symbol":"TSLA"} → `sparkline TSLA`           → works

Variadic commands (compare <symbol> <symbol> [...]) correctly fall back to the "args" field: compare {"args":"TSLA AAPL NVDA"} → works.

## Summary

- 

## Published CLI Metadata

Use this section for Printing Press library publishes. Delete it only when the
PR does not add or modify `library/<category>/<slug>/`.

**API:** `<slug>` | **Category:** `<category>` | **Press version:** `<version>`
**Spec:** `<spec_url or spec.yaml>`  
**Required env:** `<none or env vars>`

## What Changed

- 

## CLI Shape

```bash
$ <cli-name> --help
<paste high-signal help output>
```

## What This CLI Does

<Use the first 2-3 README paragraphs or a concise equivalent.>

## Manuscripts

- [Research Brief](./library/<category>/<slug>/.manuscripts/<run-id>/research/)
- [Shipcheck Results](./library/<category>/<slug>/.manuscripts/<run-id>/proofs/)

## Validation

- [ ] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/<category>/<slug>/`
- [ ] `go build ./...` from the touched CLI root
- [ ] `go vet ./...` from the touched CLI root
- [ ] `go test ./...` from the touched CLI root
- [ ] `govulncheck ./...` from the touched CLI root
- [ ] `go run ./tools/generate-skills/main.go` when `library/**/SKILL.md` changed
- [ ] `git diff --check`

## Gaps / Follow-Up

- 
