### PR TITLE
fix(gitignore): allow *-pp-mcp source dirs in library (mirror *-pp-cli negation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *-pp-cli-[0-9]*
 # But allow CLI source directories in the library
 !library/**/*-pp-cli/
+!library/**/*-pp-mcp/
 *.exe
 *.test
 *.out


### PR DESCRIPTION
## Problem

The root `.gitignore` ignores built CLI binaries with `*-pp-cli` and `*-pp-mcp` (lines 2-3), then re-allows the **source** directories with a negation — but only for `-pp-cli`:

```gitignore
*-pp-cli
*-pp-mcp
*-pp-cli-[0-9]*
# But allow CLI source directories in the library
!library/**/*-pp-cli/      # ← exists
                           # ← no !library/**/*-pp-mcp/
```

Because there's no parallel negation for `-pp-mcp`, the pattern `*-pp-mcp` also matches the **source directory** `library/<cat>/<slug>/cmd/<slug>-pp-mcp/`. So `git add library/` silently drops the MCP command source, and the PR fails CI:

```
Verify manifest.json … cmd/<slug>-pp-mcp directory is missing
```

This is invisible on `main` because existing MCP CLIs had their `cmd/*-pp-mcp/` force-added historically (gitignore doesn't untrack already-tracked files).

## Impact

Hits **every new MCP-advertising CLI** published through the normal flow. It's bitten real PRs:
- function-health / others (see #2611, "gitignore sabotage")
- world-bank (#1254) — `Verify manifest.json: failure` on the first push; worked around with `git add -f`.

## Fix

One line, mirroring the existing `-pp-cli` negation:

```gitignore
!library/**/*-pp-cli/
!library/**/*-pp-mcp/
```

## Verification

```
$ git check-ignore -v library/other/example/cmd/example-pp-mcp/main.go
# (no output) → NOT ignored ✓   source dir is now tracked

$ git check-ignore -v library/other/example/example-pp-mcp
.gitignore:3:*-pp-mcp  library/other/example/example-pp-mcp
# → still ignored ✓   the built binary stays out of git
```

The negation has a trailing slash, so it only un-ignores **directories** — the compiled `*-pp-mcp` binary remains ignored as intended.

Refs #2611.
