### PR TITLE
fix(clickup): load + orphans read assignees[] array instead of scalar assignee

### DIFF
--- a/library/project-management/clickup/.printing-press-patches/assignees-array-aggregation.json
+++ b/library/project-management/clickup/.printing-press-patches/assignees-array-aggregation.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "assignees-array-aggregation",
+  "applied_at": "2026-06-16",
+  "base_run_id": "20260510-202319",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Make `load` (workload distribution) and `orphans` read ClickUp's `assignees[]` array of {id, username, ...} instead of a non-existent scalar `assignee`/`owner` field. `load` now counts a task once per assignee (resolving username -> name -> displayName -> id) and only falls back to the legacy scalar keys for non-task resources, preserving an \"(unassigned)\" bucket. `orphans` adds `$.assignees` as the first assignee path so a task with a populated assignees array is no longer flagged missing-assignee.",
+  "reason": "Live-data audit (2026-06-16): `clickup-pp-cli load` reported all 1121 resources as \"(unassigned)\" and `orphans` flagged every task as missing an assignee, even though the mirror correctly stores assignees. ClickUp task records have NO singular `assignee`/`owner` field; the real data is the `assignees[]` array, which neither command inspected. Generic gap worth backporting upstream (any ClickUp-shaped API with array-valued assignees).",
+  "files": [
+    "internal/cli/pm_load.go",
+    "internal/cli/pm_orphans.go"
+  ],
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/TBD-assignees-array-aggregation"
+}

--- a/library/project-management/clickup/internal/cli/pm_load.go
+++ b/library/project-management/clickup/internal/cli/pm_load.go
@@ -98,42 +98,69 @@ person. Helps identify overloaded team members and unbalanced workload.`,
 					continue
 				}
 
-				assignee := ""
-				for _, key := range []string{"assigneeId", "assignee_id", "assignee", "ownerId", "owner_id", "owner"} {
-					v, ok := obj[key]
-					if !ok || v == nil {
-						continue
+				// PATCH(assignees-array-aggregation): ClickUp tasks expose assignees as an
+				// `assignees[]` array of {id, username, ...}, not a scalar assignee/owner.
+				// Resolve a display name from an assignee object ({id, username, name, ...}).
+				resolveName := func(m map[string]any) string {
+					for _, nameKey := range []string{"username", "name", "displayName", "display_name"} {
+						if n, ok := m[nameKey]; ok && n != nil {
+							return fmt.Sprintf("%v", n)
+						}
 					}
-					// Handle nested object: {id: "...", name: "Sheldon"}
-					if m, ok := v.(map[string]any); ok {
-						for _, nameKey := range []string{"name", "displayName", "display_name"} {
-							if n, ok := m[nameKey]; ok && n != nil {
-								assignee = fmt.Sprintf("%v", n)
-								break
-							}
-						}
-						if assignee == "" {
-							if aid, ok := m["id"]; ok {
-								assignee = fmt.Sprintf("%v", aid)
-							}
-						}
-					} else {
-						// Flat string — try to resolve from user lookup
-						raw := fmt.Sprintf("%v", v)
+					if aid, ok := m["id"]; ok {
+						raw := fmt.Sprintf("%v", aid)
 						if name, ok := userNames[raw]; ok {
-							assignee = name
-						} else {
-							assignee = raw
+							return name
 						}
+						return raw
 					}
-					break
-				}
-				if assignee == "" || assignee == "<nil>" {
-					assignee = "(unassigned)"
+					return ""
 				}
 
-				counts[assignee]++
-				total++
+				// ClickUp tasks carry an `assignees[]` array of {id, username, ...};
+				// count a task once per assignee (a workload distribution). Other
+				// resources may use a scalar assignee/owner field.
+				var names []string
+				if arr, ok := obj["assignees"].([]any); ok {
+					for _, el := range arr {
+						if m, ok := el.(map[string]any); ok {
+							if n := resolveName(m); n != "" && n != "<nil>" {
+								names = append(names, n)
+							}
+						}
+					}
+				}
+				if len(names) == 0 {
+					assignee := ""
+					for _, key := range []string{"assigneeId", "assignee_id", "assignee", "ownerId", "owner_id", "owner"} {
+						v, ok := obj[key]
+						if !ok || v == nil {
+							continue
+						}
+						// Handle nested object: {id: "...", name: "Sheldon"}
+						if m, ok := v.(map[string]any); ok {
+							assignee = resolveName(m)
+						} else {
+							// Flat string — try to resolve from user lookup
+							raw := fmt.Sprintf("%v", v)
+							if name, ok := userNames[raw]; ok {
+								assignee = name
+							} else {
+								assignee = raw
+							}
+						}
+						break
+					}
+					if assignee == "" || assignee == "<nil>" {
+						assignee = "(unassigned)"
+					}
+					names = append(names, assignee)
+				}
+
+				for _, n := range names {
+					counts[n]++
+					total++
+				}
 			}
 
 			var entries []loadEntry

--- a/library/project-management/clickup/internal/cli/pm_load.go
+++ b/library/project-management/clickup/internal/cli/pm_load.go
@@ -82,6 +82,27 @@ person. Helps identify overloaded team members and unbalanced workload.`,
 				Count    int    `json:"count"`
 			}
 
+			// PATCH(assignees-array-aggregation): ClickUp tasks expose assignees as an
+			// `assignees[]` array of {id, username, ...}, not a scalar assignee/owner.
+			// Resolve a display name from an assignee object ({id, username, name, ...}).
+			// Hoisted above the row loop — it captures only the immutable userNames map,
+			// so one closure is reused for every row instead of allocating per iteration.
+			resolveName := func(m map[string]any) string {
+				for _, nameKey := range []string{"username", "name", "displayName", "display_name"} {
+					if n, ok := m[nameKey]; ok && n != nil {
+						return fmt.Sprintf("%v", n)
+					}
+				}
+				if aid, ok := m["id"]; ok {
+					raw := fmt.Sprintf("%v", aid)
+					if name, ok := userNames[raw]; ok {
+						return name
+					}
+					return raw
+				}
+				return ""
+			}
+
 			counts := make(map[string]int)
 			total := 0
 			for rows.Next() {
@@ -96,25 +117,6 @@ person. Helps identify overloaded team members and unbalanced workload.`,
 				var obj map[string]any
 				if err := json.Unmarshal(data, &obj); err != nil {
 					continue
-				}
-
-				// PATCH(assignees-array-aggregation): ClickUp tasks expose assignees as an
-				// `assignees[]` array of {id, username, ...}, not a scalar assignee/owner.
-				// Resolve a display name from an assignee object ({id, username, name, ...}).
-				resolveName := func(m map[string]any) string {
-					for _, nameKey := range []string{"username", "name", "displayName", "display_name"} {
-						if n, ok := m[nameKey]; ok && n != nil {
-							return fmt.Sprintf("%v", n)
-						}
-					}
-					if aid, ok := m["id"]; ok {
-						raw := fmt.Sprintf("%v", aid)
-						if name, ok := userNames[raw]; ok {
-							return name
-						}
-						return raw
-					}
-					return ""
 				}
 
 				// ClickUp tasks carry an `assignees[]` array of {id, username, ...};
@@ -157,9 +159,12 @@ person. Helps identify overloaded team members and unbalanced workload.`,
 					names = append(names, assignee)
 				}
 
+				// Count one item per task record; tally assignees separately so a
+				// multi-assignee task doesn't inflate the item total (a 3-assignee
+				// task is still one item).
+				total++
 				for _, n := range names {
 					counts[n]++
-					total++
 				}
 			}
 

--- a/library/project-management/clickup/internal/cli/pm_orphans.go
+++ b/library/project-management/clickup/internal/cli/pm_orphans.go
@@ -43,7 +43,8 @@ such as assignee, project, priority, or labels. Useful for triaging unowned work
 				jsonPaths []string
 				label     string
 			}{
-				{[]string{"$.assigneeId", "$.assignee_id", "$.assignee", "$.ownerId", "$.owner_id"}, "assignee"},
+				// PATCH(assignees-array-aggregation): check the `assignees[]` array first; a task with a populated assignees array is no longer flagged missing-assignee.
+				{[]string{"$.assignees", "$.assigneeId", "$.assignee_id", "$.assignee", "$.ownerId", "$.owner_id"}, "assignee"},
 				{[]string{"$.projectId", "$.project_id", "$.project"}, "project"},
 				{[]string{"$.priority", "$.priorityId", "$.priority_id"}, "priority"},
 				{[]string{"$.labels", "$.labelIds", "$.label_ids", "$.tags"}, "labels"},


### PR DESCRIPTION
## Summary

ClickUp task records carry assignees as an `assignees[]` array of `{id, username, ...}` and have **no** singular `assignee`/`owner` field. The `load` (workload distribution) and `orphans` (missing-field triage) commands read only the scalar keys, so `load` bucketed every task as `(unassigned)` and `orphans` flagged every assigned task as missing an assignee.

This reads the array: `load` counts a task once per assignee (resolving `username -> name -> displayName -> id`, falling back to the legacy scalar keys for non-task resources and preserving an `(unassigned)` bucket); `orphans` adds `$.assignees` as the first assignee path so a task with a populated assignees array is no longer flagged missing-assignee.

## Findings

| ID | Category | Type | Rationale |
|---|---|---|---|
| F1 | pm-aggregation-field-shape | bug | `load` reported all synced resources as `(unassigned)` and `orphans` flagged every task missing-assignee; the real data lives in `assignees[]`, which neither command inspected. Generic gap for any ClickUp-shaped API with array-valued assignees. |

## Changes

```
 .../assignees-array-aggregation.json               | 14 ++++
 .../clickup/internal/cli/pm_load.go                | 81 ++++++++++++++--------
 .../clickup/internal/cli/pm_orphans.go             |  3 +-
 3 files changed, 70 insertions(+), 28 deletions(-)
```

## Verification

- `go build ./...`: PASS
- `go vet ./internal/cli/`: PASS
- `gofmt`: clean
- `--help` / `--version`: PASS
- `cli-printing-press publish validate`: the remaining non-passing checks (`go mod tidy`, `govulncheck`, `verify-skill`) are **pre-existing on upstream `main`** — a baseline validate of the unpatched tree returns byte-identical check results, so this patch introduces none of them. (`govulncheck` flags Go stdlib CVEs GO-2026-5039 / GO-2026-5037 fixed in go1.26.4; `verify-skill` flags prior hand-edit drift in the generator-owned SKILL.md install section; `go mod tidy` is the published go.mod/go.sum state.)
- Verified live against a real ClickUp mirror: `load --json` now shows real per-person counts; `orphans` no longer flags assigned tasks.

## Patch contract

Tracked as `.printing-press-patches/assignees-array-aggregation.json` (`schema_version: 2`); `// PATCH(assignees-array-aggregation)` markers at both changed sites. The patch carries a `deferred_to_upstream`-style note in its `reason` — this is a generic ClickUp-shaped gap (array-valued assignees) worth backporting to the generator.

## Evidence

- Patch record: https://github.com/jgrubka92/printing-press-library/blob/9cb541f8456fa1b7f4a5be9569f702569395900e/library/project-management/clickup/.printing-press-patches/assignees-array-aggregation.json
