### PR TITLE
fix(x-twitter): refresh oauth2 user-context tokens

### DIFF
--- a/library/social-and-messaging/x-twitter/.printing-press-patches/oauth2-user-context-refresh.json
+++ b/library/social-and-messaging/x-twitter/.printing-press-patches/oauth2-user-context-refresh.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "oauth2-user-context-refresh",
+  "applied_at": "2026-06-17",
+  "base_run_id": "20260603-230951",
+  "base_printing_press_version": "4.20.1",
+  "summary": "OAuth2 user-context requests and doctor probes refresh stale access tokens with the stored refresh token before declaring credentials invalid.",
+  "reason": "The runtime request path and doctor probe could keep using a stale oauth2_user_token even when refresh_token and client_id were present. Refreshing must update oauth2_user_token, the same field UserContextAuthHeader prefers, and persist rotated refresh tokens/expiry.",
+  "files": [
+    "internal/client/client.go",
+    "internal/client/client_test.go",
+    "internal/cli/doctor.go",
+    "internal/cli/doctor_test.go"
+  ],
+  "validated_outcome": "go test ./internal/config ./internal/client ./internal/cli -run 'OAuth2UserContext|DoctorRefreshes|RequestRefreshes' -count=1; go test ./...; go build ./cmd/x-twitter-pp-cli"
+}

--- a/library/social-and-messaging/x-twitter/internal/cli/doctor.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/doctor.go
@@ -100,6 +100,26 @@ func probeAuthLane(ctx context.Context, c *client.Client, header, source, path, 
 		body := apiErr.Body
 		switch {
 		case apiErr.StatusCode == 401:
+			if path == "/2/users/me" {
+				if refreshed, refreshErr := c.RefreshOAuth2UserContext(ctx, true); refreshErr == nil && refreshed {
+					refreshedHeader := c.Config.UserContextAuthHeader()
+					if refreshedHeader != "" && refreshedHeader != header {
+						refreshedHeaders := map[string]string{
+							"Authorization": refreshedHeader,
+							"User-Agent":    "x-twitter-pp-cli",
+						}
+						if refreshedBody, retryErr := c.GetWithHeaders(ctx, path, nil, refreshedHeaders); retryErr == nil {
+							lane := authLane("ok", source, "")
+							lane["refreshed"] = true
+							if user := userSummaryFromMeProbe(refreshedBody); len(user) > 0 {
+								lane["probe"] = "/2/users/me ok"
+								lane["user"] = user
+							}
+							return lane
+						}
+					}
+				}
+			}
 			lane := authLane("invalid", source, "token was rejected; refresh or replace this credential")
 			lane["http_status"] = apiErr.StatusCode
 			return lane

--- a/library/social-and-messaging/x-twitter/internal/cli/doctor_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/doctor_test.go
@@ -196,6 +196,76 @@ func TestDoctorClassifiesAppOnlyTokenInUserContextLane(t *testing.T) {
 	}
 }
 
+func TestDoctorRefreshesOAuth2UserContextAfterUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2/oauth2/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if got := r.Form.Get("refresh_token"); got != "doctor-refresh" && got != "doctor-rotated" {
+				t.Fatalf("unexpected refresh token: %#v", r.Form)
+			}
+			if r.Form.Get("client_id") != "doctor-client" {
+				t.Fatalf("unexpected refresh client_id: %#v", r.Form)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"doctor-fresh","refresh_token":"doctor-rotated","expires_in":3600}`))
+		case "/2/users/me":
+			switch r.Header.Get("Authorization") {
+			case "Bearer doctor-stale":
+				http.Error(w, "expired", http.StatusUnauthorized)
+			case "Bearer doctor-fresh":
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":{"id":"123","username":"tester"}}`))
+			default:
+				http.Error(w, "invalid", http.StatusUnauthorized)
+			}
+		case xAppOnlyProbePath:
+			http.Error(w, "missing app token", http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	oldEndpoint := client.OAuth2TokenEndpoint
+	client.OAuth2TokenEndpoint = server.URL + "/2/oauth2/token"
+	defer func() { client.OAuth2TokenEndpoint = oldEndpoint }()
+
+	home := t.TempDir()
+	configPath := writeDoctorConfig(t, t.TempDir(), server.URL, `oauth2_user_token = "doctor-stale"
+refresh_token = "doctor-refresh"
+client_id = "doctor-client"
+token_expiry = 2026-06-08T12:00:00Z
+`)
+
+	report := runDoctorJSON(t, home, configPath)
+	userLane := laneFromReport(t, report, "oauth2_user_context")
+	if got, _ := userLane["status"].(string); got != "ok" {
+		t.Fatalf("oauth2_user_context status = %q, want ok after refresh (lane=%#v)", got, userLane)
+	}
+	if userLane["refreshed"] != true {
+		t.Fatalf("refreshed marker = %#v, want true (lane=%#v)", userLane["refreshed"], userLane)
+	}
+	encoded, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(encoded)
+	if strings.Contains(text, "doctor-stale") || !strings.Contains(text, "doctor-fresh") || !strings.Contains(text, "doctor-rotated") {
+		t.Fatalf("config did not persist refreshed user-context tuple: %s", text)
+	}
+	out, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	for _, secret := range []string{"doctor-stale", "doctor-refresh", "doctor-fresh", "doctor-rotated"} {
+		if strings.Contains(string(out), secret) {
+			t.Fatalf("doctor report leaked secret %q: %s", secret, out)
+		}
+	}
+}
+
 func TestBuildAuthLaneReportProbesAPILanesConcurrently(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/library/social-and-messaging/x-twitter/internal/client/client.go
+++ b/library/social-and-messaging/x-twitter/internal/client/client.go
@@ -27,6 +27,8 @@ import (
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
 
+var OAuth2TokenEndpoint = "https://api.twitter.com/2/oauth2/token"
+
 var ErrPlaceholderCredential = errors.New("auth placeholder credential")
 
 type Client struct {
@@ -196,6 +198,15 @@ func binaryResponseHeaderValue(headers map[string]string) (bool, bool) {
 		}
 	}
 	return false, found
+}
+
+func authorizationHeaderOverride(headers map[string]string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, "Authorization") {
+			return v
+		}
+	}
+	return ""
 }
 
 func (c *Client) validateCachedRequestAuth(ctx context.Context) error {
@@ -502,7 +513,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	// media-upload calls; their auth is injected per-request below via
 	// cookies.apply().
 	var authHeader string
-	if !hostUsesCookieAuth(hostFromURL(targetURL)) {
+	if overrideAuth := authorizationHeaderOverride(headerOverrides); overrideAuth != "" {
+		authHeader = overrideAuth
+	} else if !hostUsesCookieAuth(hostFromURL(targetURL)) {
 		h, err := c.authHeader(ctx)
 		if err != nil {
 			return nil, 0, err
@@ -517,6 +530,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 
 	const maxRetries = 3
 	var lastErr error
+	refreshedAfterUnauthorized := false
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		// Proactive rate limiting — wait before sending
@@ -563,6 +577,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 		// Per-endpoint header overrides (e.g., different API version per resource)
 		for k, v := range headerOverrides {
+			if strings.EqualFold(k, "Authorization") && authHeader != "" && v != authHeader {
+				continue
+			}
 			req.Header.Set(k, v)
 		}
 		binaryResponse := strings.EqualFold(req.Header.Get(BinaryResponseHeader), "true")
@@ -635,6 +652,18 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			Path:       c.displayURL(path, authHeader),
 			StatusCode: resp.StatusCode,
 			Body:       c.maskCredentialText(truncateBody(respBody), authHeader),
+		}
+
+		if resp.StatusCode == http.StatusUnauthorized && !refreshedAfterUnauthorized && authorizationHeaderOverride(headerOverrides) == "" && !hostUsesCookieAuth(req.URL.Host) {
+			refreshed, refreshErr := c.RefreshOAuth2UserContext(ctx, true)
+			if refreshErr == nil && refreshed {
+				if h, err := c.authHeader(ctx); err == nil && h != "" {
+					authHeader = h
+					refreshedAfterUnauthorized = true
+					lastErr = apiErr
+					continue
+				}
+			}
 		}
 
 		// Rate limited - adjust adaptive limiter and retry
@@ -848,11 +877,82 @@ func (c *Client) authHeader(ctx context.Context) (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}
+	if _, err := c.RefreshOAuth2UserContext(ctx, false); err != nil {
+		return "", err
+	}
 	authHeader := c.Config.AuthHeader()
 	if authHeaderLooksLikePlaceholderCredential(authHeader) {
 		return "", authPlaceholderCredentialError(c.Config)
 	}
 	return authHeader, nil
+}
+
+func (c *Client) RefreshOAuth2UserContext(ctx context.Context, force bool) (bool, error) {
+	if c == nil || c.Config == nil {
+		return false, nil
+	}
+	cfg := c.Config
+	if strings.TrimSpace(cfg.RefreshToken) == "" || strings.TrimSpace(cfg.ClientID) == "" {
+		return false, nil
+	}
+	if !force && (cfg.TokenExpiry.IsZero() || time.Until(cfg.TokenExpiry) > time.Minute) {
+		return false, nil
+	}
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", strings.TrimSpace(cfg.RefreshToken))
+	form.Set("client_id", strings.TrimSpace(cfg.ClientID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, OAuth2TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if strings.TrimSpace(cfg.ClientSecret) != "" {
+		req.SetBasicAuth(strings.TrimSpace(cfg.ClientID), strings.TrimSpace(cfg.ClientSecret))
+	}
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("refreshing OAuth2 user-context token: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false, fmt.Errorf("refreshing OAuth2 user-context token failed: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var token struct {
+		TokenType    string `json:"token_type"`
+		ExpiresIn    int    `json:"expires_in"`
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		Scope        string `json:"scope"`
+	}
+	if err := json.Unmarshal(body, &token); err != nil {
+		return false, fmt.Errorf("parsing OAuth2 refresh response: %w", err)
+	}
+	accessToken := strings.TrimSpace(token.AccessToken)
+	if accessToken == "" {
+		return false, fmt.Errorf("OAuth2 refresh response did not include access_token")
+	}
+	refreshToken := strings.TrimSpace(token.RefreshToken)
+	if refreshToken == "" {
+		refreshToken = strings.TrimSpace(cfg.RefreshToken)
+	}
+	expiry := time.Time{}
+	if token.ExpiresIn > 0 {
+		expiry = time.Now().UTC().Add(time.Duration(token.ExpiresIn) * time.Second)
+	}
+	scopes := cfg.Scopes
+	if strings.TrimSpace(token.Scope) != "" {
+		scopes = strings.Fields(strings.ReplaceAll(token.Scope, ",", " "))
+	}
+	if err := cfg.SaveOAuth2UserContext(cfg.ClientID, cfg.ClientSecret, accessToken, refreshToken, expiry, scopes); err != nil {
+		return false, fmt.Errorf("saving refreshed OAuth2 user-context token: %w", err)
+	}
+	return true, nil
 }
 
 func authHeaderLooksLikePlaceholderCredential(header string) bool {

--- a/library/social-and-messaging/x-twitter/internal/client/client.go
+++ b/library/social-and-messaging/x-twitter/internal/client/client.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -39,6 +40,7 @@ type Client struct {
 	NoCache    bool
 	cacheDir   string
 	limiter    *cliutil.AdaptiveLimiter
+	refreshMu  sync.Mutex
 }
 
 // RequestBaseURL returns the base URL used for requests.
@@ -657,7 +659,10 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		if resp.StatusCode == http.StatusUnauthorized && !refreshedAfterUnauthorized && authorizationHeaderOverride(headerOverrides) == "" && !hostUsesCookieAuth(req.URL.Host) {
 			refreshed, refreshErr := c.RefreshOAuth2UserContext(ctx, true)
 			if refreshErr == nil && refreshed {
-				if h, err := c.authHeader(ctx); err == nil && h != "" {
+				// The forced refresh above already exchanged and persisted the token.
+				// Read the current header directly so the retry does not perform a
+				// second proactive refresh before sending the recovered request.
+				if h, err := c.currentAuthHeader(); err == nil && h != "" {
 					authHeader = h
 					refreshedAfterUnauthorized = true
 					lastErr = apiErr
@@ -878,7 +883,19 @@ func (c *Client) authHeader(ctx context.Context) (string, error) {
 		return "", nil
 	}
 	if _, err := c.RefreshOAuth2UserContext(ctx, false); err != nil {
-		return "", err
+		// Proactive refresh is best-effort. If the token endpoint is briefly
+		// unavailable, keep the current access token on the wire and let the
+		// normal 401 path decide whether a forced refresh is actually required.
+		// This avoids turning a likely-successful near-expiry request into an
+		// immediate local failure.
+		return c.currentAuthHeader()
+	}
+	return c.currentAuthHeader()
+}
+
+func (c *Client) currentAuthHeader() (string, error) {
+	if c == nil || c.Config == nil {
+		return "", nil
 	}
 	authHeader := c.Config.AuthHeader()
 	if authHeaderLooksLikePlaceholderCredential(authHeader) {
@@ -891,6 +908,9 @@ func (c *Client) RefreshOAuth2UserContext(ctx context.Context, force bool) (bool
 	if c == nil || c.Config == nil {
 		return false, nil
 	}
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+
 	cfg := c.Config
 	if strings.TrimSpace(cfg.RefreshToken) == "" || strings.TrimSpace(cfg.ClientID) == "" {
 		return false, nil

--- a/library/social-and-messaging/x-twitter/internal/client/client_test.go
+++ b/library/social-and-messaging/x-twitter/internal/client/client_test.go
@@ -9,8 +9,10 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -155,6 +157,124 @@ func TestRequestRejectsEmptyMethod(t *testing.T) {
 	c := New(&config.Config{BaseURL: "https://api.x.com"}, time.Second, 0)
 	if _, _, err := c.Request(context.Background(), "  ", "/2/users/me", nil, nil, nil); err == nil {
 		t.Fatal("expected empty method error")
+	}
+}
+
+func TestRequestRefreshesExpiredOAuth2UserContextToken(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	var sawAPIWithFresh bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2/oauth2/token":
+			if got := r.Header.Get("Authorization"); strings.Contains(got, "old-access") || strings.Contains(got, "old-refresh") {
+				t.Fatalf("refresh request leaked token in Authorization header: %q", got)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if r.Form.Get("grant_type") != "refresh_token" || r.Form.Get("refresh_token") != "old-refresh" || r.Form.Get("client_id") != "client-id" {
+				t.Fatalf("unexpected refresh form: %#v", r.Form)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"fresh-access","refresh_token":"rotated-refresh","expires_in":3600,"scope":"tweet.read users.read offline.access"}`))
+		case "/2/users/me":
+			if got := r.Header.Get("Authorization"); got != "Bearer fresh-access" {
+				http.Error(w, "wrong token", http.StatusUnauthorized)
+				return
+			}
+			sawAPIWithFresh = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"id":"123"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	oldEndpoint := OAuth2TokenEndpoint
+	OAuth2TokenEndpoint = server.URL + "/2/oauth2/token"
+	defer func() { OAuth2TokenEndpoint = oldEndpoint }()
+
+	cfg := &config.Config{
+		BaseURL:          server.URL,
+		Path:             configPath,
+		XOauth2UserToken: "old-access",
+		RefreshToken:     "old-refresh",
+		ClientID:         "client-id",
+		TokenExpiry:      time.Now().Add(-time.Minute),
+		Scopes:           []string{"tweet.read"},
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	if _, err := c.Get(context.Background(), "/2/users/me", nil); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !sawAPIWithFresh {
+		t.Fatal("API was not called with refreshed token")
+	}
+	if cfg.XOauth2UserToken != "fresh-access" || cfg.AccessToken != "" || cfg.RefreshToken != "rotated-refresh" {
+		t.Fatalf("tokens were not persisted into user-context fields: %#v", cfg)
+	}
+	if cfg.TokenExpiry.IsZero() || time.Until(cfg.TokenExpiry) < 30*time.Minute {
+		t.Fatalf("TokenExpiry was not updated: %s", cfg.TokenExpiry)
+	}
+	onDisk, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if onDisk.XOauth2UserToken != "fresh-access" || onDisk.AccessToken != "" || onDisk.RefreshToken != "rotated-refresh" {
+		t.Fatalf("disk config did not persist rotated tokens: %#v", onDisk)
+	}
+}
+
+func TestRequestRefreshesOAuth2UserContextTokenAfterUnauthorized(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	apiCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"fresh-after-401","refresh_token":"rotated-after-401","expires_in":3600}`))
+		case "/2/users/me":
+			apiCalls++
+			if apiCalls == 1 {
+				if got := r.Header.Get("Authorization"); got != "Bearer stale-access" {
+					t.Fatalf("first request used %q, want stale token", got)
+				}
+				http.Error(w, "expired", http.StatusUnauthorized)
+				return
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer fresh-after-401" {
+				t.Fatalf("retry request used %q, want refreshed token", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"id":"123"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	oldEndpoint := OAuth2TokenEndpoint
+	OAuth2TokenEndpoint = server.URL + "/2/oauth2/token"
+	defer func() { OAuth2TokenEndpoint = oldEndpoint }()
+
+	cfg := &config.Config{
+		BaseURL:          server.URL,
+		Path:             configPath,
+		XOauth2UserToken: "stale-access",
+		RefreshToken:     "stale-refresh",
+		ClientID:         "client-id",
+		TokenExpiry:      time.Now().Add(time.Hour),
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	if _, err := c.Get(context.Background(), "/2/users/me", nil); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if apiCalls != 2 {
+		t.Fatalf("apiCalls = %d, want initial 401 plus retry", apiCalls)
+	}
+	if cfg.XOauth2UserToken != "fresh-after-401" || cfg.RefreshToken != "rotated-after-401" {
+		t.Fatalf("refreshed tokens not stored: %#v", cfg)
 	}
 }
 

--- a/library/social-and-messaging/x-twitter/internal/client/client_test.go
+++ b/library/social-and-messaging/x-twitter/internal/client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -275,6 +278,110 @@ func TestRequestRefreshesOAuth2UserContextTokenAfterUnauthorized(t *testing.T) {
 	}
 	if cfg.XOauth2UserToken != "fresh-after-401" || cfg.RefreshToken != "rotated-after-401" {
 		t.Fatalf("refreshed tokens not stored: %#v", cfg)
+	}
+}
+
+func TestRequestFallsBackToCurrentTokenWhenProactiveRefreshFails(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	var apiCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2/oauth2/token":
+			http.Error(w, "temporary token endpoint outage", http.StatusBadGateway)
+		case "/2/users/me":
+			apiCalls.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer still-valid-access" {
+				t.Fatalf("request used %q, want fallback to current token", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"id":"123"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	oldEndpoint := OAuth2TokenEndpoint
+	OAuth2TokenEndpoint = server.URL + "/2/oauth2/token"
+	defer func() { OAuth2TokenEndpoint = oldEndpoint }()
+
+	cfg := &config.Config{
+		BaseURL:          server.URL,
+		Path:             configPath,
+		XOauth2UserToken: "still-valid-access",
+		RefreshToken:     "refresh-token",
+		ClientID:         "client-id",
+		TokenExpiry:      time.Now().Add(30 * time.Second),
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	if _, err := c.Get(context.Background(), "/2/users/me", nil); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := apiCalls.Load(); got != 1 {
+		t.Fatalf("apiCalls = %d, want request attempted after proactive refresh failure", got)
+	}
+}
+
+func TestConcurrentOAuth2UserContextRefreshUsesRotatedTokenSerially(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	var refreshCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2/oauth2/token":
+			call := refreshCalls.Add(1)
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			wantRefresh := "old-refresh"
+			if call == 2 {
+				wantRefresh = "rotated-refresh-1"
+			}
+			if got := r.Form.Get("refresh_token"); got != wantRefresh {
+				t.Fatalf("refresh call %d used %q, want %q", call, got, wantRefresh)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"access_token":"fresh-access-%d","refresh_token":"rotated-refresh-%d","expires_in":3600}`, call, call)))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	oldEndpoint := OAuth2TokenEndpoint
+	OAuth2TokenEndpoint = server.URL + "/2/oauth2/token"
+	defer func() { OAuth2TokenEndpoint = oldEndpoint }()
+
+	cfg := &config.Config{
+		BaseURL:          server.URL,
+		Path:             configPath,
+		XOauth2UserToken: "old-access",
+		RefreshToken:     "old-refresh",
+		ClientID:         "client-id",
+		TokenExpiry:      time.Now().Add(-time.Minute),
+	}
+	c := New(cfg, time.Second, 0)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := c.RefreshOAuth2UserContext(context.Background(), true)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("RefreshOAuth2UserContext: %v", err)
+		}
+	}
+	if got := refreshCalls.Load(); got != 2 {
+		t.Fatalf("refreshCalls = %d, want two serialized forced refreshes", got)
+	}
+	if cfg.XOauth2UserToken != "fresh-access-2" || cfg.RefreshToken != "rotated-refresh-2" {
+		t.Fatalf("final tokens not persisted from serialized refreshes: %#v", cfg)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the recurring `x-twitter-pp-cli` OAuth2 user-context refresh failure where `doctor --json` could report `oauth2_user_context` as invalid after a 401 even though `refresh_token` and `client_id` were present.

## What changed

- Added a refresh-capable OAuth2 user-context path in the x-twitter client.
- Refresh now persists the new access token into `oauth2_user_token` / `XOauth2UserToken`, matching the field preferred by `UserContextAuthHeader()`.
- Persists rotated refresh tokens and expiry from the token endpoint.
- Retries normal runtime requests once after a 401 when refresh succeeds.
- Makes `doctor` refresh/retry the `/2/users/me` user-context probe before reporting the credential invalid.
- Added a `.printing-press-patches/` manifest for the generated CLI hand edit.

## Validation

- `gofmt -w internal/client/client.go internal/client/client_test.go internal/cli/doctor.go internal/cli/doctor_test.go`
- `go test ./internal/config ./internal/client ./internal/cli -run 'OAuth2UserContext|DoctorRefreshes|RequestRefreshes' -count=1`
- `go test ./...`
- `go build ./cmd/x-twitter-pp-cli`
- `git diff --check`

## Notes

This is a narrow published-library fix for the shipped x-twitter CLI. If the same stale OAuth2 user-context refresh pattern exists in Printing Press generator templates, it should be upstreamed separately so future reprints retain this behavior.
