### PR TITLE
fix(supabase): preserve auth token source

### DIFF
--- a/library/developer-tools/supabase/.printing-press-patches/preserve-auth-token-source.json
+++ b/library/developer-tools/supabase/.printing-press-patches/preserve-auth-token-source.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "preserve-auth-token-source",
+  "applied_at": "2026-06-17",
+  "base_run_id": "20260512-165514",
+  "base_printing_press_version": "4.5.1",
+  "summary": "Auth header construction must preserve whether a bearer token came from SUPABASE_ACCESS_TOKEN, persisted config, or an in-memory OAuth2 token.",
+  "reason": "Supabase doctor and agent reports use auth_source to explain credential provenance; rewriting every access_token to the env source misreports file-backed tokens and hides the real runtime state.",
+  "files": [
+    "internal/config/config.go",
+    "internal/config/config_test.go"
+  ],
+  "validated_outcome": "Focused config tests cover config-file token provenance, SUPABASE_ACCESS_TOKEN override provenance, and the fallback oauth2 label for an unlabeled in-memory access token."
+}

--- a/library/developer-tools/supabase/internal/config/config.go
+++ b/library/developer-tools/supabase/internal/config/config.go
@@ -79,13 +79,10 @@ func (c *Config) AuthHeader() string {
 	if c.AuthHeaderVal != "" {
 		return c.AuthHeaderVal
 	}
-	// Env-var token wins over file-stored AccessToken (env > config convention).
 	if c.AccessToken != "" {
-		c.AuthSource = "env:SUPABASE_ACCESS_TOKEN"
-		return "Bearer " + c.AccessToken
-	}
-	if c.AccessToken != "" {
-		c.AuthSource = "oauth2"
+		if c.AuthSource == "" {
+			c.AuthSource = "oauth2"
+		}
 		return "Bearer " + c.AccessToken
 	}
 	return ""

--- a/library/developer-tools/supabase/internal/config/config_test.go
+++ b/library/developer-tools/supabase/internal/config/config_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Giuliano Giacaglia and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigTokenSourceSurvivesAuthHeader(t *testing.T) {
+	t.Setenv("SUPABASE_ACCESS_TOKEN", "")
+	t.Setenv("SUPABASE_BASE_URL", "")
+	t.Setenv("SUPABASE_CONFIG", "")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("access_token = \"file-token\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AuthSource != "config" {
+		t.Fatalf("AuthSource after Load = %q, want config", cfg.AuthSource)
+	}
+	if got := cfg.AuthHeader(); got != "Bearer file-token" {
+		t.Fatalf("AuthHeader() = %q, want Bearer file-token", got)
+	}
+	if cfg.AuthSource != "config" {
+		t.Fatalf("AuthSource after AuthHeader = %q, want config", cfg.AuthSource)
+	}
+}
+
+func TestLoadEnvTokenOverridesConfigTokenSource(t *testing.T) {
+	t.Setenv("SUPABASE_ACCESS_TOKEN", "env-token")
+	t.Setenv("SUPABASE_BASE_URL", "")
+	t.Setenv("SUPABASE_CONFIG", "")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("access_token = \"file-token\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AccessToken != "env-token" {
+		t.Fatalf("AccessToken = %q, want env-token", cfg.AccessToken)
+	}
+	if cfg.AuthSource != "env:SUPABASE_ACCESS_TOKEN" {
+		t.Fatalf("AuthSource after Load = %q, want env:SUPABASE_ACCESS_TOKEN", cfg.AuthSource)
+	}
+	if got := cfg.AuthHeader(); got != "Bearer env-token" {
+		t.Fatalf("AuthHeader() = %q, want Bearer env-token", got)
+	}
+	if cfg.AuthSource != "env:SUPABASE_ACCESS_TOKEN" {
+		t.Fatalf("AuthSource after AuthHeader = %q, want env:SUPABASE_ACCESS_TOKEN", cfg.AuthSource)
+	}
+}
+
+func TestAuthHeaderLabelsUnloadedAccessTokenAsOAuth2(t *testing.T) {
+	cfg := &Config{AccessToken: "persisted-token"}
+	if got := cfg.AuthHeader(); got != "Bearer persisted-token" {
+		t.Fatalf("AuthHeader() = %q, want Bearer persisted-token", got)
+	}
+	if cfg.AuthSource != "oauth2" {
+		t.Fatalf("AuthSource = %q, want oauth2", cfg.AuthSource)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix Supabase auth header construction so it no longer rewrites every access token as `env:SUPABASE_ACCESS_TOKEN`.
- Preserve `env:SUPABASE_ACCESS_TOKEN` when the token came from the environment, preserve `config` for file-backed tokens loaded from config, and label unlabeled in-memory access tokens as `oauth2`.
- Add focused config tests and record the generated-output hand edit under `.printing-press-patches/`.

## Verification
- PASS: `go test ./internal/config` (from `library/developer-tools/supabase`)
- PASS: `go build ./...` (from `library/developer-tools/supabase`)
- PASS: `go vet ./...` (from `library/developer-tools/supabase`)
- PASS: `python3 .github/scripts/verify-skill/verify_skill.py --dir library/developer-tools/supabase/`
- PASS: `git diff --check`
- KNOWN BASELINE FAIL: `go test ./...` fails in `internal/store` with existing NOT NULL constraint failures for generated upsert tests; reproduced the same `go test ./internal/store` failure on a clean `origin/main` worktree.

## Scope
Supabase only. No WHOOP changes.
