### PR TITLE
feat(linear): support issue parent linking

### DIFF
--- a/library/project-management/linear/.printing-press-patches/mob-191-parent-issue-linking.json
+++ b/library/project-management/linear/.printing-press-patches/mob-191-parent-issue-linking.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "id": "mob-191-parent-issue-linking",
+  "applied_at": "2026-06-18",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "Linear issue create/edit must expose parent/sub-issue linking so agents do not leave the CLI for raw GraphQL.",
+  "reason": "Agents creating issue trees need a safe, documented CLI surface that resolves parent issue identifiers live, supports clearing parentage, preserves dry-run/file-backed workflows, and emits typed agent errors.",
+  "files": [
+    "internal/cli/issues.go",
+    "internal/cli/issues_create.go",
+    "internal/cli/issues_edit.go",
+    "internal/cli/which.go",
+    "internal/cli/root.go",
+    "internal/cli/linear_agent_test.go",
+    "internal/cli/which_test.go"
+  ],
+  "validated_outcome": "Focused parent/which tests, full go test ./..., go vet ./..., go build ./..., SKILL verifier, and dry-run binary smoke all passed."
+}

--- a/library/project-management/linear/README.md
+++ b/library/project-management/linear/README.md
@@ -255,6 +255,15 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   linear-pp-cli issues create --title "Test ticket" --team ENG --trust-mode strict
   ```
+- **Parent and sub-issue linking** — Create child issues and set, change, or clear parent links without leaving the CLI for raw GraphQL.
+
+  _Reach for this when an agent is creating issue trees, epics, or follow-up hierarchies and needs parentage wired safely._
+
+  ```bash
+  linear-pp-cli issues create --title "Child task" --team ENG --parent ENG-123 --description-file /tmp/body.md --agent
+  linear-pp-cli issues edit ENG-124 --parent ENG-123 --agent
+  linear-pp-cli issues edit ENG-124 --no-parent --agent
+  ```
 - **Team-safe issue labels** — Discover labels that are valid for the target Linear team, including global labels, before creating or editing issues.
 
   _Reach for this before passing label UUIDs to `issues create` or `issues edit`; Linear rejects labels owned by another team, and the CLI now preflights label ownership before mutating._

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -152,6 +152,15 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   linear-pp-cli issues create --title "Test ticket" --team ENG --trust-mode strict
   ```
+- **Parent and sub-issue linking** — Create child issues and set, change, or clear parent links without leaving the CLI for raw GraphQL.
+
+  _Reach for this when an agent is creating issue trees, epics, or follow-up hierarchies and needs parentage wired safely._
+
+  ```bash
+  linear-pp-cli issues create --title "Child task" --team ENG --parent ENG-123 --description-file /tmp/body.md --agent
+  linear-pp-cli issues edit ENG-124 --parent ENG-123 --agent
+  linear-pp-cli issues edit ENG-124 --no-parent --agent
+  ```
 - **Team-safe issue labels** — Discover labels that are valid for the target Linear team, including global labels, before creating or editing issues.
 
   _Reach for this before passing label UUIDs to `issues create` or `issues edit`; Linear rejects labels owned by another team, and the CLI preflights label ownership before mutating._
@@ -310,6 +319,7 @@ linear-pp-cli which "<capability in your own words>"
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
 
 For duplicate checks, `linear-pp-cli which "search issues by text" --agent` should point to `issues search`; use that instead of inventing `issues search --help` fallbacks or raw SQL. If the local issue cache is stale, `issues search` refreshes it or fails with a typed freshness error; agents should not jump to raw GraphQL just because the cache was stale.
+For parent/sub-issue linking, `linear-pp-cli which "set issue parent" --agent` should point to `issues edit --parent`.
 
 ## Recipes
 

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -62,13 +62,17 @@ Single-issue get resolution order (with --data-source auto, the default):
   3. on live failure with a fresh store, return the store miss as not found
 
 Use 'issues list' for filtered listing against the local sqlite store.
-Use 'issues search' for duplicate checks and free-text search across synced issues.`,
+Use 'issues search' for duplicate checks and free-text search across synced issues.
+Use 'issues create --parent' or 'issues edit --parent/--no-parent' to manage
+parent and sub-issue links.`,
 		Example: `  linear-pp-cli issues ESP-1155
   linear-pp-cli issues list
   linear-pp-cli issues list --assignee me
   linear-pp-cli issues list --assignee me --state started
   linear-pp-cli issues list --team ESP --state started --json
-  linear-pp-cli issues search "login redirect bug" --team ESP --agent`,
+  linear-pp-cli issues search "login redirect bug" --team ESP --agent
+  linear-pp-cli issues create --title "child" --team ESP --parent ESP-1155 --agent
+  linear-pp-cli issues edit ESP-1156 --no-parent --agent`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -274,6 +278,20 @@ func resolveIssueID(c graphqlQueryer, identifier string) (string, error) {
 		return "", notFoundErr(fmt.Errorf("issue %q not found", identifier))
 	}
 	return resp.Issues.Nodes[0].ID, nil
+}
+
+func resolveParentIssueID(c graphqlQueryer, parent string) (string, error) {
+	parent = strings.TrimSpace(parent)
+	if parent == "" {
+		return "", usageErr(fmt.Errorf("--parent requires an issue identifier (TEAM-NUMBER) or issue UUID"))
+	}
+	if store.IsUUID(parent) {
+		return parent, nil
+	}
+	if _, _, ok := parseIssueIdentifier(parent); !ok {
+		return "", usageErr(fmt.Errorf("--parent expects an issue identifier (TEAM-NUMBER, e.g. MOB-123) or issue UUID; got %q", parent))
+	}
+	return resolveIssueID(c, parent)
 }
 
 func parseIssueIdentifier(identifier string) (string, float64, bool) {

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -62,7 +62,6 @@ Single-issue get resolution order (with --data-source auto, the default):
   3. on live failure with a fresh store, return the store miss as not found
 
 Use 'issues list' for filtered listing against the local sqlite store.
-Use 'issues search' for duplicate checks and free-text search across synced issues.
 Use 'issues create --parent' or 'issues edit --parent/--no-parent' to manage
 parent and sub-issue links.`,
 		Example: `  linear-pp-cli issues ESP-1155
@@ -70,7 +69,6 @@ parent and sub-issue links.`,
   linear-pp-cli issues list --assignee me
   linear-pp-cli issues list --assignee me --state started
   linear-pp-cli issues list --team ESP --state started --json
-  linear-pp-cli issues search "login redirect bug" --team ESP --agent
   linear-pp-cli issues create --title "child" --team ESP --parent ESP-1155 --agent
   linear-pp-cli issues edit ESP-1156 --no-parent --agent`,
 		Args: cobra.MaximumNArgs(1),

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -279,6 +279,17 @@ func resolveIssueID(c graphqlQueryer, identifier string) (string, error) {
 }
 
 func resolveParentIssueID(c graphqlQueryer, parent string) (string, error) {
+	parent, err := validateParentIssueRef(parent)
+	if err != nil {
+		return "", err
+	}
+	if store.IsUUID(parent) {
+		return parent, nil
+	}
+	return resolveIssueID(c, parent)
+}
+
+func validateParentIssueRef(parent string) (string, error) {
 	parent = strings.TrimSpace(parent)
 	if parent == "" {
 		return "", usageErr(fmt.Errorf("--parent requires an issue identifier (TEAM-NUMBER) or issue UUID"))
@@ -289,7 +300,7 @@ func resolveParentIssueID(c graphqlQueryer, parent string) (string, error) {
 	if _, _, ok := parseIssueIdentifier(parent); !ok {
 		return "", usageErr(fmt.Errorf("--parent expects an issue identifier (TEAM-NUMBER, e.g. MOB-123) or issue UUID; got %q", parent))
 	}
-	return resolveIssueID(c, parent)
+	return parent, nil
 }
 
 func parseIssueIdentifier(identifier string) (string, float64, bool) {

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -285,7 +285,7 @@ sub-issue under an existing parent.`,
 			if flags.asJSON {
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
-				return enc.Encode(map[string]any{
+				event := map[string]any{
 					"event":      "issue_created",
 					"identifier": parsed.IssueCreate.Issue.Identifier,
 					"id":         parsed.IssueCreate.Issue.ID,
@@ -294,7 +294,16 @@ sub-issue under an existing parent.`,
 					"state":      parsed.IssueCreate.Issue.State.Name,
 					"url":        parsed.IssueCreate.Issue.URL,
 					"session":    sess,
-				})
+				}
+				if parsed.IssueCreate.Issue.Parent != nil {
+					event["parent"] = map[string]any{
+						"id":         parsed.IssueCreate.Issue.Parent.ID,
+						"identifier": parsed.IssueCreate.Issue.Parent.Identifier,
+						"title":      parsed.IssueCreate.Issue.Parent.Title,
+					}
+					event["parentId"] = parsed.IssueCreate.Issue.Parent.ID
+				}
+				return enc.Encode(event)
 			}
 			fmt.Printf("Created %s — %s\n", parsed.IssueCreate.Issue.Identifier, parsed.IssueCreate.Issue.Title)
 			fmt.Printf("  URL: %s\n", parsed.IssueCreate.Issue.URL)

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -116,8 +116,13 @@ sub-issue under an existing parent.`,
 			if len(labelsFlag) > 0 {
 				input["labelIds"] = labelsFlag
 			}
+			parentRef := parentFlag
 			if parentFlag != "" {
-				input["parentId"] = parentFlag
+				parentRef, err = validateParentIssueRef(parentFlag)
+				if err != nil {
+					return err
+				}
+				input["parentId"] = parentRef
 			}
 			if flags.dryRun {
 				out := map[string]any{"input": input}
@@ -133,7 +138,7 @@ sub-issue under an existing parent.`,
 				return err
 			}
 			if parentFlag != "" {
-				parentID, err := resolveParentIssueID(c, parentFlag)
+				parentID, err := resolveParentIssueID(c, parentRef)
 				if err != nil {
 					return classifyLiveReadError(err, flags)
 				}

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -15,7 +15,7 @@ import (
 // in init(). Calls Linear's issueCreate mutation and records the resulting issue
 // into the local pp_created ledger so pp-cleanup can find it later.
 func newIssuesCreateCmd(flags *rootFlags) *cobra.Command {
-	var titleFlag, teamFlag, descFlag, assigneeFlag, projectFlag, stateFlag string
+	var titleFlag, teamFlag, descFlag, assigneeFlag, projectFlag, stateFlag, parentFlag string
 	var descFile string
 	var descStdin bool
 	var priorityFlag int
@@ -30,12 +30,18 @@ func newIssuesCreateCmd(flags *rootFlags) *cobra.Command {
 		Long: `Create a Linear issue via the issueCreate mutation. The new issue's ID is
 written to the local pp_created table along with a session tag, so pp-test
 list shows it and pp-cleanup can archive it without touching pre-existing
-tickets in the workspace.`,
+tickets in the workspace.
+
+Pass --parent with an issue identifier or UUID to create the new issue as a
+sub-issue under an existing parent.`,
 		Example: `  # Quick test ticket in team ENG
   linear-pp-cli issues create --title "pp-test sanity" --team ENG
 
   # Dry-run (shows the GraphQL request without sending)
   linear-pp-cli issues create --title "x" --team ENG --dry-run
+
+  # Create a sub-issue under an existing issue
+  linear-pp-cli issues create --title "child" --team ENG --parent ENG-123 --description-file /tmp/body.md --agent
 
   # JSON output (agent-mode)
   linear-pp-cli issues create --title "x" --team ENG --json`,
@@ -110,6 +116,9 @@ tickets in the workspace.`,
 			if len(labelsFlag) > 0 {
 				input["labelIds"] = labelsFlag
 			}
+			if parentFlag != "" {
+				input["parentId"] = parentFlag
+			}
 			if flags.dryRun {
 				out := map[string]any{"input": input}
 				if len(mediaFlag) > 0 {
@@ -122,6 +131,13 @@ tickets in the workspace.`,
 			c, err := flags.newClient()
 			if err != nil {
 				return err
+			}
+			if parentFlag != "" {
+				parentID, err := resolveParentIssueID(c, parentFlag)
+				if err != nil {
+					return classifyLiveReadError(err, flags)
+				}
+				input["parentId"] = parentID
 			}
 			if len(labelsFlag) > 0 {
 				if err := validateIssueLabelTeams(c, labelsFlag, teamInfo); err != nil {
@@ -145,6 +161,7 @@ tickets in the workspace.`,
 						state { id name type }
 						assignee { id name displayName }
 						project { id name }
+						parent { id identifier title }
 					}
 				}
 			}`
@@ -183,6 +200,11 @@ tickets in the workspace.`,
 							ID   string `json:"id"`
 							Name string `json:"name"`
 						} `json:"project,omitempty"`
+						Parent *struct {
+							ID         string `json:"id"`
+							Identifier string `json:"identifier"`
+							Title      string `json:"title"`
+						} `json:"parent,omitempty"`
 					} `json:"issue"`
 				} `json:"issueCreate"`
 			}
@@ -242,6 +264,14 @@ tickets in the workspace.`,
 					}
 					wb["projectId"] = parsed.IssueCreate.Issue.Project.ID
 				}
+				if parsed.IssueCreate.Issue.Parent != nil {
+					wb["parent"] = map[string]any{
+						"id":         parsed.IssueCreate.Issue.Parent.ID,
+						"identifier": parsed.IssueCreate.Issue.Parent.Identifier,
+						"title":      parsed.IssueCreate.Issue.Parent.Title,
+					}
+					wb["parentId"] = parsed.IssueCreate.Issue.Parent.ID
+				}
 				newIssueJSON, mErr := json.Marshal(wb)
 				if mErr == nil {
 					if upErr := db.UpsertIssue(parsed.IssueCreate.Issue.ID, parsed.IssueCreate.Issue.Identifier, parsed.IssueCreate.Issue.Title, newIssueJSON); upErr != nil {
@@ -281,6 +311,7 @@ tickets in the workspace.`,
 	cmd.Flags().StringVar(&assigneeFlag, "assignee", "", "Assignee user UUID")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "Project UUID")
 	cmd.Flags().StringVar(&stateFlag, "state", "", "Workflow state UUID")
+	cmd.Flags().StringVar(&parentFlag, "parent", "", "Parent issue identifier or UUID; creates the issue as a sub-issue")
 	cmd.Flags().StringSliceVar(&labelsFlag, "label", nil, "Label UUIDs (repeatable)")
 	cmd.Flags().StringSliceVar(&mediaFlag, "media", nil, "Upload file and append it to the description markdown (repeatable)")
 	cmd.Flags().BoolVar(&mediaPublic, "media-public", false, "Request public Linear asset URLs for uploaded media")

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -56,8 +56,14 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 			if parentFlag != "" && noParentFlag {
 				return usageErr(fmt.Errorf("pass either --parent or --no-parent, not both"))
 			}
+			parentRef := parentFlag
 			if parentFlag != "" {
-				input["parentId"] = parentFlag
+				validatedParentRef, validateErr := validateParentIssueRef(parentFlag)
+				if validateErr != nil {
+					return validateErr
+				}
+				parentRef = validatedParentRef
+				input["parentId"] = parentRef
 			}
 			if noParentFlag {
 				input["parentId"] = nil
@@ -130,7 +136,7 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				}
 			}
 			if parentFlag != "" {
-				parentID, err := resolveParentIssueID(c, parentFlag)
+				parentID, err := resolveParentIssueID(c, parentRef)
 				if err != nil {
 					return classifyLiveReadError(err, flags)
 				}

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -10,8 +10,9 @@ import (
 )
 
 func newIssuesEditCmd(flags *rootFlags, dbPath *string) *cobra.Command {
-	var titleFlag, descFlag, descFile, assigneeFlag, projectFlag, stateFlag string
+	var titleFlag, descFlag, descFile, assigneeFlag, projectFlag, stateFlag, parentFlag string
 	var descStdin bool
+	var noParentFlag bool
 	var priorityFlag int
 	var labelsFlag []string
 	var mediaFlag []string
@@ -22,10 +23,15 @@ func newIssuesEditCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 		Long: `Edit a Linear issue via issueUpdate. Use file/stdin flags for Markdown
 descriptions so shell commands, backticks, and GraphQL snippets are preserved
 literally. If --media is supplied without a description source, the existing
-description is fetched live and the uploaded media links are appended.`,
+description is fetched live and the uploaded media links are appended.
+
+Use --parent with an issue identifier or UUID to set/change parentage. Use
+--no-parent to clear parentage.`,
 		Example: `  linear-pp-cli issues edit ENG-123 --description-file /tmp/body.md --agent
   linear-pp-cli issues edit ENG-123 --media /tmp/screenshot.png --agent
-  linear-pp-cli issues edit ENG-123 --state <state-uuid> --project <project-uuid> --agent`,
+  linear-pp-cli issues edit ENG-123 --state <state-uuid> --project <project-uuid> --agent
+  linear-pp-cli issues edit ENG-123 --parent ENG-100 --agent
+  linear-pp-cli issues edit ENG-123 --no-parent --agent`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			input := map[string]any{}
@@ -47,6 +53,15 @@ description is fetched live and the uploaded media links are appended.`,
 			if stateFlag != "" {
 				input["stateId"] = stateFlag
 			}
+			if parentFlag != "" && noParentFlag {
+				return usageErr(fmt.Errorf("pass either --parent or --no-parent, not both"))
+			}
+			if parentFlag != "" {
+				input["parentId"] = parentFlag
+			}
+			if noParentFlag {
+				input["parentId"] = nil
+			}
 			if len(labelsFlag) > 0 {
 				input["labelIds"] = labelsFlag
 			}
@@ -67,7 +82,7 @@ description is fetched live and the uploaded media links are appended.`,
 				input["description"] = descBody
 			}
 			if len(input) == 0 && len(mediaFlag) == 0 {
-				return usageErr(fmt.Errorf("no issue fields supplied; pass --title, --description-file, --media, --state, --project, --assignee, --priority, or --label"))
+				return usageErr(fmt.Errorf("no issue fields supplied; pass --title, --description-file, --media, --state, --project, --assignee, --priority, --label, --parent, or --no-parent"))
 			}
 			if flags.dryRun {
 				out := map[string]any{"issue": args[0], "input": input}
@@ -114,6 +129,13 @@ description is fetched live and the uploaded media links are appended.`,
 					return classifyLiveReadError(err, flags)
 				}
 			}
+			if parentFlag != "" {
+				parentID, err := resolveParentIssueID(c, parentFlag)
+				if err != nil {
+					return classifyLiveReadError(err, flags)
+				}
+				input["parentId"] = parentID
+			}
 			if len(labelsFlag) > 0 {
 				if !issueMetaLoaded {
 					return fmt.Errorf("internal error: label validation requires issue metadata")
@@ -139,6 +161,8 @@ description is fetched live and the uploaded media links are appended.`,
 						team { id key name }
 						project { id name }
 						assignee { id name displayName email }
+						parent { id identifier title }
+						children { nodes { id identifier title } }
 					}
 				}
 			}`
@@ -170,6 +194,8 @@ description is fetched live and the uploaded media links are appended.`,
 	cmd.Flags().StringVar(&assigneeFlag, "assignee", "", "Assignee user UUID")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "Project UUID")
 	cmd.Flags().StringVar(&stateFlag, "state", "", "Workflow state UUID")
+	cmd.Flags().StringVar(&parentFlag, "parent", "", "Parent issue identifier or UUID")
+	cmd.Flags().BoolVar(&noParentFlag, "no-parent", false, "Clear issue parentage")
 	cmd.Flags().StringSliceVar(&labelsFlag, "label", nil, "Replacement label UUIDs (repeatable)")
 	cmd.Flags().StringSliceVar(&mediaFlag, "media", nil, "Upload file and append it to the description markdown (repeatable)")
 	cmd.Flags().BoolVar(&mediaPublic, "media-public", false, "Request public Linear asset URLs for uploaded media")

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -1337,6 +1337,226 @@ func TestIssuesCreateDryRunWithMediaDoesNotCallAPI(t *testing.T) {
 	}
 }
 
+func TestIssuesCreateDryRunWithParentDoesNotCallAPI(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Error(w, "dry-run should not call API", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "create",
+		"--title", "Child",
+		"--team", "MOB",
+		"--parent", "MOB-123",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--dry-run",
+		"--agent")
+	if err != nil {
+		t.Fatalf("issues create --parent dry-run failed: %v\n%s", err, out)
+	}
+	if calls != 0 {
+		t.Fatalf("dry-run made %d API calls; output:\n%s", calls, out)
+	}
+	var preview struct {
+		Event string `json:"event"`
+		Input struct {
+			ParentID string `json:"parentId"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal([]byte(out), &preview); err != nil {
+		t.Fatalf("dry-run output is not JSON: %v\n%s", err, out)
+	}
+	if preview.Event != "would_create_issue" || preview.Input.ParentID != "MOB-123" {
+		t.Fatalf("dry-run output missing parent preview: %+v\n%s", preview, out)
+	}
+}
+
+func TestIssuesCreateWithParentResolvesIdentifierBeforeMutation(t *testing.T) {
+	const teamID = "00000000-0000-0000-0000-000000000001"
+	var sawParentLookup bool
+	var seenParentID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issues(filter"):
+			sawParentLookup = true
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"parent-uuid"}]}}}`)
+		case strings.Contains(req.Query, "issueCreate"):
+			input, _ := req.Variables["input"].(map[string]any)
+			seenParentID, _ = input["parentId"].(string)
+			fmt.Fprint(w, `{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"MOB-124","title":"Child","description":"","url":"https://linear.app/issue/MOB-124","priority":0,"createdAt":"2026-06-18T00:00:00Z","updatedAt":"2026-06-18T00:00:00Z","team":{"id":"00000000-0000-0000-0000-000000000001","key":"MOB"},"state":{"id":"state-1","name":"Todo","type":"unstarted"},"parent":{"id":"parent-uuid","identifier":"MOB-123","title":"Parent"}}}}}`)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "create",
+		"--title", "Child",
+		"--team", teamID,
+		"--parent", "MOB-123",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--agent",
+		"--data-source", "live")
+	if err != nil {
+		t.Fatalf("issues create --parent failed: %v\n%s", err, out)
+	}
+	if !sawParentLookup {
+		t.Fatalf("parent identifier lookup was not performed")
+	}
+	if seenParentID != "parent-uuid" {
+		t.Fatalf("issueCreate parentId = %q, want parent-uuid", seenParentID)
+	}
+}
+
+func TestIssuesEditParentAndNoParent(t *testing.T) {
+	t.Run("set parent", func(t *testing.T) {
+		var seenIssueID string
+		var seenParentID string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req client.GraphQLRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode request: %v", err)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			switch {
+			case strings.Contains(req.Query, "issues(filter"):
+				number, _ := req.Variables["number"].(float64)
+				switch number {
+				case 124:
+					fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"child-uuid"}]}}}`)
+				case 123:
+					fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"parent-uuid"}]}}}`)
+				default:
+					t.Errorf("unexpected issue lookup number: %v", number)
+					http.Error(w, "unexpected issue lookup", http.StatusBadRequest)
+				}
+			case strings.Contains(req.Query, "issueUpdate"):
+				seenIssueID, _ = req.Variables["id"].(string)
+				input, _ := req.Variables["input"].(map[string]any)
+				seenParentID, _ = input["parentId"].(string)
+				fmt.Fprint(w, `{"data":{"issueUpdate":{"success":true,"issue":{"id":"child-uuid","identifier":"MOB-124","title":"Child","description":"","url":"https://linear.app/issue/MOB-124","priority":0,"estimate":0,"dueDate":null,"createdAt":"2026-06-18T00:00:00Z","updatedAt":"2026-06-18T00:00:00Z","state":{"id":"state-1","name":"Todo","type":"unstarted"},"team":{"id":"team-1","key":"MOB","name":"Mobilyze"},"project":null,"assignee":null,"parent":{"id":"parent-uuid","identifier":"MOB-123","title":"Parent"},"children":{"nodes":[]}}}}}`)
+			default:
+				t.Errorf("unexpected query: %s", req.Query)
+				http.Error(w, "unexpected query", http.StatusBadRequest)
+			}
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("LINEAR_BASE_URL", srv.URL)
+		t.Setenv("LINEAR_API_KEY", "test-token")
+
+		out, err := executeRootForTest("issues", "edit", "MOB-124", "--parent", "MOB-123", "--agent", "--data-source", "live")
+		if err != nil {
+			t.Fatalf("issues edit --parent failed: %v\n%s", err, out)
+		}
+		if seenIssueID != "child-uuid" {
+			t.Fatalf("issueUpdate id = %q, want child-uuid", seenIssueID)
+		}
+		if seenParentID != "parent-uuid" {
+			t.Fatalf("issueUpdate parentId = %q, want parent-uuid", seenParentID)
+		}
+	})
+
+	t.Run("clear parent", func(t *testing.T) {
+		const childID = "00000000-0000-0000-0000-000000000124"
+		parentIDSeen := true
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req client.GraphQLRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode request: %v", err)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			if !strings.Contains(req.Query, "issueUpdate") {
+				t.Errorf("unexpected query: %s", req.Query)
+				http.Error(w, "unexpected query", http.StatusBadRequest)
+				return
+			}
+			input, _ := req.Variables["input"].(map[string]any)
+			value, ok := input["parentId"]
+			parentIDSeen = ok && value == nil
+			fmt.Fprint(w, `{"data":{"issueUpdate":{"success":true,"issue":{"id":"00000000-0000-0000-0000-000000000124","identifier":"MOB-124","title":"Child","description":"","url":"https://linear.app/issue/MOB-124","priority":0,"estimate":0,"dueDate":null,"createdAt":"2026-06-18T00:00:00Z","updatedAt":"2026-06-18T00:00:00Z","state":{"id":"state-1","name":"Todo","type":"unstarted"},"team":{"id":"team-1","key":"MOB","name":"Mobilyze"},"project":null,"assignee":null,"parent":null,"children":{"nodes":[]}}}}}`)
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("LINEAR_BASE_URL", srv.URL)
+		t.Setenv("LINEAR_API_KEY", "test-token")
+
+		out, err := executeRootForTest("issues", "edit", childID, "--no-parent", "--agent", "--data-source", "live")
+		if err != nil {
+			t.Fatalf("issues edit --no-parent failed: %v\n%s", err, out)
+		}
+		if !parentIDSeen {
+			t.Fatalf("issueUpdate did not send parentId:null")
+		}
+	})
+}
+
+func TestIssueParentResolutionErrorsAreTyped(t *testing.T) {
+	out, err := executeRootForTestWithRenderedError("issues", "create",
+		"--title", "Child",
+		"--team", "00000000-0000-0000-0000-000000000001",
+		"--parent", "not-an-issue-ref",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--agent",
+		"--data-source", "live")
+	if err == nil {
+		t.Fatalf("bad parent reference succeeded unexpectedly:\n%s", out)
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("ExitCode() = %d, want 2; err=%v\n%s", got, err, out)
+	}
+	if !strings.Contains(out, `"type":"usage"`) {
+		t.Fatalf("bad parent did not render usage envelope:\n%s", out)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(req.Query, "issues(filter") {
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+			return
+		}
+		fmt.Fprint(w, `{"data":{"issues":{"nodes":[]}}}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err = executeRootForTestWithRenderedError("issues", "create",
+		"--title", "Child",
+		"--team", "00000000-0000-0000-0000-000000000001",
+		"--parent", "MOB-404",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--agent",
+		"--data-source", "live")
+	if err == nil {
+		t.Fatalf("missing parent succeeded unexpectedly:\n%s", out)
+	}
+	if got := ExitCode(err); got != 3 {
+		t.Fatalf("ExitCode() = %d, want 3; err=%v\n%s", got, err, out)
+	}
+	if !strings.Contains(out, `"type":"not_found"`) {
+		t.Fatalf("missing parent did not render not_found envelope:\n%s", out)
+	}
+}
+
 func TestIssuesCreateValidatesLabelsBeforeUploadingMedia(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req client.GraphQLRequest

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -1374,6 +1374,37 @@ func TestIssuesCreateDryRunWithParentDoesNotCallAPI(t *testing.T) {
 	}
 }
 
+func TestIssuesCreateDryRunWithBadParentValidatesLocally(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Error(w, "dry-run should not call API", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTestWithRenderedError("issues", "create",
+		"--title", "Child",
+		"--team", "MOB",
+		"--parent", "bad-format",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--dry-run",
+		"--agent")
+	if err == nil {
+		t.Fatalf("issues create --parent bad-format --dry-run succeeded unexpectedly:\n%s", out)
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("ExitCode() = %d, want 2; err=%v\n%s", got, err, out)
+	}
+	if !strings.Contains(out, `"type":"usage"`) || !strings.Contains(out, "--parent expects an issue identifier") {
+		t.Fatalf("bad parent dry-run did not render usage envelope:\n%s", out)
+	}
+	if calls != 0 {
+		t.Fatalf("dry-run made %d API calls; output:\n%s", calls, out)
+	}
+}
+
 func TestIssuesCreateWithParentResolvesIdentifierBeforeMutation(t *testing.T) {
 	const teamID = "00000000-0000-0000-0000-000000000001"
 	var sawParentLookup bool
@@ -1616,6 +1647,36 @@ func TestIssuesEditDryRunWithParentOptionsDoesNotCallAPI(t *testing.T) {
 	}
 	if calls != 0 {
 		t.Fatalf("dry-runs made %d API calls", calls)
+	}
+}
+
+func TestIssuesEditDryRunWithBadParentValidatesLocally(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Error(w, "dry-run should not call API", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTestWithRenderedError("issues", "edit",
+		"MOB-124",
+		"--parent", "bad-format",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--dry-run",
+		"--agent")
+	if err == nil {
+		t.Fatalf("issues edit --parent bad-format --dry-run succeeded unexpectedly:\n%s", out)
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("ExitCode() = %d, want 2; err=%v\n%s", got, err, out)
+	}
+	if !strings.Contains(out, `"type":"usage"`) || !strings.Contains(out, "--parent expects an issue identifier") {
+		t.Fatalf("bad parent dry-run did not render usage envelope:\n%s", out)
+	}
+	if calls != 0 {
+		t.Fatalf("dry-run made %d API calls; output:\n%s", calls, out)
 	}
 }
 

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -1347,7 +1347,7 @@ func TestIssuesCreateDryRunWithParentDoesNotCallAPI(t *testing.T) {
 	t.Setenv("LINEAR_BASE_URL", srv.URL)
 	t.Setenv("LINEAR_API_KEY", "test-token")
 
-	out, err := executeRootForTest("issues", "create",
+	out, err := executeRootForTestWithStdout("issues", "create",
 		"--title", "Child",
 		"--team", "MOB",
 		"--parent", "MOB-123",
@@ -1402,7 +1402,7 @@ func TestIssuesCreateWithParentResolvesIdentifierBeforeMutation(t *testing.T) {
 	t.Setenv("LINEAR_BASE_URL", srv.URL)
 	t.Setenv("LINEAR_API_KEY", "test-token")
 
-	out, err := executeRootForTest("issues", "create",
+	out, err := executeRootForTestWithStdout("issues", "create",
 		"--title", "Child",
 		"--team", teamID,
 		"--parent", "MOB-123",
@@ -1417,6 +1417,21 @@ func TestIssuesCreateWithParentResolvesIdentifierBeforeMutation(t *testing.T) {
 	}
 	if seenParentID != "parent-uuid" {
 		t.Fatalf("issueCreate parentId = %q, want parent-uuid", seenParentID)
+	}
+	var created struct {
+		Event    string `json:"event"`
+		ParentID string `json:"parentId"`
+		Parent   *struct {
+			ID         string `json:"id"`
+			Identifier string `json:"identifier"`
+			Title      string `json:"title"`
+		} `json:"parent"`
+	}
+	if err := json.Unmarshal([]byte(out), &created); err != nil {
+		t.Fatalf("issue_created output is not JSON: %v\n%s", err, out)
+	}
+	if created.Event != "issue_created" || created.ParentID != "parent-uuid" || created.Parent == nil || created.Parent.Identifier != "MOB-123" {
+		t.Fatalf("issue_created output missing parent details: %+v\n%s", created, out)
 	}
 }
 
@@ -1471,7 +1486,7 @@ func TestIssuesEditParentAndNoParent(t *testing.T) {
 
 	t.Run("clear parent", func(t *testing.T) {
 		const childID = "00000000-0000-0000-0000-000000000124"
-		parentIDSeen := true
+		parentIDSeen := false
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var req client.GraphQLRequest
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1699,6 +1714,30 @@ func executeRootForTestWithInput(input string, args ...string) (string, error) {
 	cmd.SetArgs(args)
 	err := cmd.Execute()
 	return out.String(), err
+}
+
+func executeRootForTestWithStdout(args ...string) (string, error) {
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	os.Stdout = w
+	cmdErr := cmd.Execute()
+	_ = w.Close()
+	os.Stdout = stdout
+	rendered, readErr := io.ReadAll(r)
+	_ = r.Close()
+	if readErr != nil {
+		return out.String(), readErr
+	}
+	return out.String() + string(rendered), cmdErr
 }
 
 func executeRootForTestWithInputAndRenderedError(input string, args ...string) (string, error) {

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -1435,6 +1435,50 @@ func TestIssuesCreateWithParentResolvesIdentifierBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestIssuesCreateWithParentUUIDSkipsIdentifierLookup(t *testing.T) {
+	const teamID = "00000000-0000-0000-0000-000000000001"
+	const parentID = "00000000-0000-0000-0000-000000000123"
+	var seenParentID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if strings.Contains(req.Query, "issues(filter") {
+			t.Errorf("uuid parent should not trigger identifier lookup")
+			http.Error(w, "unexpected parent lookup", http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(req.Query, "issueCreate") {
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+			return
+		}
+		input, _ := req.Variables["input"].(map[string]any)
+		seenParentID, _ = input["parentId"].(string)
+		fmt.Fprint(w, `{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"MOB-124","title":"Child","description":"","url":"https://linear.app/issue/MOB-124","priority":0,"createdAt":"2026-06-18T00:00:00Z","updatedAt":"2026-06-18T00:00:00Z","team":{"id":"00000000-0000-0000-0000-000000000001","key":"MOB"},"state":{"id":"state-1","name":"Todo","type":"unstarted"},"parent":{"id":"00000000-0000-0000-0000-000000000123","identifier":"MOB-123","title":"Parent"}}}}}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTestWithStdout("issues", "create",
+		"--title", "Child",
+		"--team", teamID,
+		"--parent", parentID,
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--agent",
+		"--data-source", "live")
+	if err != nil {
+		t.Fatalf("issues create --parent uuid failed: %v\n%s", err, out)
+	}
+	if seenParentID != parentID {
+		t.Fatalf("issueCreate parentId = %q, want %s", seenParentID, parentID)
+	}
+}
+
 func TestIssuesEditParentAndNoParent(t *testing.T) {
 	t.Run("set parent", func(t *testing.T) {
 		var seenIssueID string
@@ -1516,6 +1560,81 @@ func TestIssuesEditParentAndNoParent(t *testing.T) {
 			t.Fatalf("issueUpdate did not send parentId:null")
 		}
 	})
+}
+
+func TestIssuesEditDryRunWithParentOptionsDoesNotCallAPI(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Error(w, "dry-run should not call API", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTestWithStdout("issues", "edit",
+		"MOB-124",
+		"--parent", "MOB-123",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--dry-run",
+		"--agent")
+	if err != nil {
+		t.Fatalf("issues edit --parent dry-run failed: %v\n%s", err, out)
+	}
+	var parentPreview struct {
+		Event string `json:"event"`
+		Input struct {
+			ParentID string `json:"parentId"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal([]byte(out), &parentPreview); err != nil {
+		t.Fatalf("parent dry-run output is not JSON: %v\n%s", err, out)
+	}
+	if parentPreview.Event != "would_update_issue" || parentPreview.Input.ParentID != "MOB-123" {
+		t.Fatalf("parent dry-run output missing parent preview: %+v\n%s", parentPreview, out)
+	}
+
+	out, err = executeRootForTestWithStdout("issues", "edit",
+		"MOB-124",
+		"--no-parent",
+		"--db", filepath.Join(t.TempDir(), "linear.db"),
+		"--dry-run",
+		"--agent")
+	if err != nil {
+		t.Fatalf("issues edit --no-parent dry-run failed: %v\n%s", err, out)
+	}
+	var clearPreview struct {
+		Event string         `json:"event"`
+		Input map[string]any `json:"input"`
+	}
+	if err := json.Unmarshal([]byte(out), &clearPreview); err != nil {
+		t.Fatalf("clear dry-run output is not JSON: %v\n%s", err, out)
+	}
+	value, ok := clearPreview.Input["parentId"]
+	if clearPreview.Event != "would_update_issue" || !ok || value != nil {
+		t.Fatalf("clear dry-run output missing parentId:null preview: %+v\n%s", clearPreview, out)
+	}
+	if calls != 0 {
+		t.Fatalf("dry-runs made %d API calls", calls)
+	}
+}
+
+func TestIssuesEditParentFlagsAreMutuallyExclusive(t *testing.T) {
+	out, err := executeRootForTestWithRenderedError("issues", "edit",
+		"MOB-124",
+		"--parent", "MOB-123",
+		"--no-parent",
+		"--agent",
+		"--data-source", "live")
+	if err == nil {
+		t.Fatalf("issues edit --parent --no-parent succeeded unexpectedly:\n%s", out)
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("ExitCode() = %d, want 2; err=%v\n%s", got, err, out)
+	}
+	if !strings.Contains(out, `"type":"usage"`) || !strings.Contains(out, "pass either --parent or --no-parent") {
+		t.Fatalf("mutual exclusion did not render usage envelope:\n%s", out)
+	}
 }
 
 func TestIssueParentResolutionErrorsAreTyped(t *testing.T) {
@@ -1716,6 +1835,8 @@ func executeRootForTestWithInput(input string, args ...string) (string, error) {
 	return out.String(), err
 }
 
+// These helpers temporarily replace process stdout; do not use them in tests
+// that call t.Parallel.
 func executeRootForTestWithStdout(args ...string) (string, error) {
 	var flags rootFlags
 	cmd := newRootCmd(&flags)

--- a/library/project-management/linear/internal/cli/root.go
+++ b/library/project-management/linear/internal/cli/root.go
@@ -180,6 +180,7 @@ Highlights (not in the official API docs):
   • milestones at-risk   List portfolio milestones whose projected landing date has slipped past their target, ranked by slip magnitude.
   • pp-test list   List Linear issues this CLI created in the current or named session, then archive them with pp-cleanup.
   • issues create --trust-mode strict   Refuse mutations on Linear issues not in the local pp_created ledger when --trust-mode strict is set; works on create and any future mutation surface.
+  • issues create/edit --parent   Create, set, change, or clear Linear parent/sub-issue links without raw GraphQL.
 
 Agent mode: add --agent to any command for JSON output + non-interactive mode.
 Health check: run 'linear-pp-cli doctor' to verify auth and connectivity.

--- a/library/project-management/linear/internal/cli/which.go
+++ b/library/project-management/linear/internal/cli/which.go
@@ -41,6 +41,8 @@ var whichIndex = []whichEntry{
 	{Command: "milestones at-risk", Description: "List portfolio milestones whose projected landing date has slipped past their target, ranked by slip magnitude.", Group: "Cross-entity rollups", WhyItMatters: "Reach for this in weekly portfolio review when the question is which milestone is most at risk, not which initiative is healthy."},
 	{Command: "pp-test list", Description: "List Linear issues this CLI created in the current or named session, then archive them with pp-cleanup.", Group: "Agent-native plumbing", WhyItMatters: "Reach for this when an agent needs to clean up only the tickets it created in a session — the workspace's existing data must not be touched."},
 	{Command: "issues create --trust-mode strict", Description: "Refuse mutations on Linear issues not in the local pp_created ledger when --trust-mode strict is set; works on create and any future mutation surface.", Group: "Agent-native plumbing", WhyItMatters: "Reach for this when running an agent against a real workspace with real data — strict mode makes accidental mutation impossible."},
+	{Command: "issues create --parent", Description: "Create a child issue under an existing parent issue using an issue identifier or UUID.", Group: "Agent-native plumbing", WhyItMatters: "Reach for this when agents need to create issue hierarchies without raw GraphQL."},
+	{Command: "issues edit --parent", Description: "Set issue parent, change issue parent, or clear issue parent links for sub-issue workflows.", Group: "Agent-native plumbing", WhyItMatters: "Reach for this when agents need to wire or unwind parent/sub-issue links without raw GraphQL."},
 }
 
 // whichMatch pairs an index entry with its ranking score for a query.

--- a/library/project-management/linear/internal/cli/which_test.go
+++ b/library/project-management/linear/internal/cli/which_test.go
@@ -111,3 +111,13 @@ func TestWhichIndex_RoutesIssueSearchQueriesToIssuesSearch(t *testing.T) {
 		t.Fatalf("follow-up duplicate query should route to issues search, got %+v", got)
 	}
 }
+
+func TestWhichIndex_RoutesParentLinkingQueries(t *testing.T) {
+	got := rankWhich(whichIndex, "set issue parent", 1)
+	if len(got) == 0 {
+		t.Fatalf("expected a match for parent linking query")
+	}
+	if got[0].Entry.Command != "issues edit --parent" {
+		t.Fatalf("top match = %s, want issues edit --parent; matches=%+v", got[0].Entry.Command, got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `issues create --parent` for creating Linear sub-issues under a parent issue.
- Add `issues edit --parent` and `--no-parent` for changing or clearing parent links.
- Update `which`, CLI help, README/SKILL docs, tests, and Printing Press patch metadata.

Linear: MOB-191

## Validation
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/project-management/linear/`
- `go test ./internal/cli -run 'Parent|IssueParent|Which'`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `/tmp/linear-pp-cli-mob191 issues create ... --parent ... --agent --dry-run`
- `/tmp/linear-pp-cli-mob191 issues edit ... --parent ... --agent --dry-run`
- `/tmp/linear-pp-cli-mob191 issues edit ... --no-parent --agent --dry-run`
- `/tmp/linear-pp-cli-mob191 which "set issue parent" --agent --select matches.entry.command,matches.score`

## Notes
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` is blocked by the existing Go 1.26.3 stdlib vulnerability baseline tracked in MOB-194.
- Session-orchestrator degraded while working this issue: studio1 Codex auth failure evidence was added to MOB-179, and external workspace/capsule isolation was filed as MOB-193.
