### PR TITLE
fix(linear): refresh issues search before duplicate checks

### DIFF
--- a/library/project-management/linear/.printing-press-patches/mob-123-issues-search-discoverability.json
+++ b/library/project-management/linear/.printing-press-patches/mob-123-issues-search-discoverability.json
@@ -4,8 +4,8 @@
   "applied_at": "2026-06-17",
   "base_run_id": "20260518-232543",
   "base_printing_press_version": "4.9.0",
-  "summary": "Expose issue duplicate search through the intuitive `issues search` command path, route natural-language command discovery to it, and treat empty search text as a usage error.",
-  "reason": "Agents repeatedly guessed unsupported `issues search` or search flags before falling back to `similar`, wasting tool calls during duplicate checks and ticket creation.",
+  "summary": "Expose issue duplicate search through the intuitive `issues search` command path and make that path coordinate local-cache freshness before mutation-sensitive duplicate checks.",
+  "reason": "Agents repeatedly guessed unsupported search flags, then either trusted stale local FTS data or escaped to raw API workarounds during search-before-create. The supported path must refresh stale issue search data or fail visibly.",
   "files": [
     "internal/cli/similar.go",
     "internal/cli/issues.go",
@@ -16,5 +16,5 @@
     "SKILL.md",
     "README.md"
   ],
-  "validated_outcome": "Regression coverage confirms `issues search` uses the same team-scoped FTS search engine as `similar`, accepts unquoted multi-word queries, returns agent JSON with `--select`, emits a JSON usage envelope for missing queries, ranks `issues search` first for issue-search discovery queries, and preserves the corrected usage-code contract for empty `similar` queries."
+  "validated_outcome": "Regression coverage confirms `issues search` uses the same team-scoped FTS search engine as `similar`, accepts unquoted multi-word queries, returns agent JSON with `--select`, emits a JSON usage envelope for missing queries, ranks `issues search` first for issue-search discovery queries, preserves the corrected usage-code contract for empty `similar` queries, skips network refresh for fresh local issue data, refreshes stale/empty issue search data behind a cross-process lock, reclaims stale refresh locks, refreshes all issue/label pages for duplicate-search freshness, refuses stale results when refresh fails, distinguishes explicit stale-local mode from `--max-age 0`, marks empty local stores as unsynced, attributes self/peer/external refreshes, and documents the `issues search` provenance envelope versus the legacy `similar` raw array."
 }

--- a/library/project-management/linear/README.md
+++ b/library/project-management/linear/README.md
@@ -37,7 +37,7 @@ npx -y @mvanhorn/printing-press-library install linear --agent claude-code --age
 
 ### Without Node (Go fallback)
 
-If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.4 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli@latest
@@ -174,7 +174,7 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   linear-pp-cli stale --days 30 --team ENG --json
   ```
-- **`issues search` / `similar`** — Find issues that look like duplicates of a query string using offline FTS5 fuzzy matching.
+- **`issues search` / `similar`** — Find issues that look like duplicates of a query string using local FTS5 search.
 
   _Reach for this during triage when you suspect an incoming bug duplicates an existing issue._
 
@@ -185,7 +185,7 @@ These capabilities aren't available in any other tool for this API.
   linear-pp-cli similar "pipeline follow-up" --team SYMPH --limit 10 --agent
   ```
 
-  Prefer `issues search` when checking for existing tickets before creating or updating follow-up work. Add `--team <key-name-or-uuid>` when a common project name or label appears across teams and the duplicate check must stay inside the target team's queue.
+  Prefer `issues search` when checking for existing tickets before creating or updating follow-up work. It coordinates freshness for duplicate checks: fresh local data is searched immediately, stale or empty issue data refreshes behind a cross-process lock before search, and refresh failures return a typed error instead of silently serving stale results. Add `--team <key-name-or-uuid>` when a common project name or label appears across teams and the duplicate check must stay inside the target team's queue. Under `--agent` / `--json`, `issues search` returns a provenance envelope with freshness metadata; `similar` keeps the legacy raw result array. Use `--data-source local` only when stale/offline local results are intentional.
 
 ### Cross-entity rollups
 - **`projects burndown`** — Project a project's landing date by linear-regressing remaining estimate against the team's measured velocity.
@@ -530,7 +530,8 @@ Read commands fall into three categories with different data-source semantics. T
 | Category | Commands | Default | Override |
 | --- | --- | --- | --- |
 | **Live-first with local fallback** | `attachments`, `projects get`, `teams`, `initiatives get`, `issues`, `issues list` (the v4 refactor) | `--data-source auto`: live API → write-through → fall back to local on network error | `--data-source live` (no fallback), `--data-source local` (no API) |
-| **Snapshot-computational** | `today`, `bottleneck`, `blocking`, `issues search`, `similar`, `velocity`, `slipped`, `cycles compare`, `projects burndown`, `initiatives health`, `milestones at-risk` | Local store only — no live equivalent exists. **Must `sync` first.** | None (flag ignored) |
+| **Freshness-coordinated local search** | `issues search` | Local FTS over synced issues. If issue data is stale or empty, the command refreshes teams, workflow states, labels, and issues behind a cross-process lock before searching; if refresh fails, it returns a typed error. Agent/JSON output is a provenance envelope with freshness metadata; `refreshed` means local issue data changed during the invocation, and `refreshed_by` identifies whether this process, a peer, or an external sync did it. | `--data-source local` explicitly allows stale/offline local results; `--max-age 0` disables the freshness gate and marks `freshness_gate_disabled`. Empty local stores are marked with `unsynced`. |
+| **Snapshot-computational** | `today`, `bottleneck`, `blocking`, `similar`, `velocity`, `slipped`, `cycles compare`, `projects burndown`, `initiatives health`, `milestones at-risk` | Local store only — no live equivalent exists. **Must `sync` first.** | None (flag ignored) |
 | **Label discovery** | `labels list --team ENG` | `--data-source auto`: reads live by default; `--data-source local` reads the synced `issue_labels` table | `--data-source live`, `--data-source local` |
 | **Live collaboration reads** | `comments list`, `documents`, `documents list` | Always live; comments and working-session docs are collaboration surfaces where stale local state is misleading | n/a |
 | **Mutations** | `issues create`, `issues edit`, `comments add`, `comments edit`, `documents create`, `documents edit`, `pp-cleanup` | Always live; on success, the HTTP cache is invalidated AND issue mutations are written back to the local store | n/a |

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -25,7 +25,7 @@ This skill drives the `linear-pp-cli` binary. **Do not invoke a command named `l
 2. Verify: `linear-pp-cli --version`
 3. Ensure the reported install directory is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.4 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli@latest
@@ -36,7 +36,7 @@ If `--version` reports "command not found" after install, the runtime cannot see
 ## Agent Contract
 
 - Add `--agent` to commands unless a human-readable table is explicitly needed. It implies JSON, compact output, non-interactive mode, no color, and confirmation-safe scripting.
-- Use `--data-source live` for closeout/state/description checks where current truth matters. Use `--data-source local` or `similar` for duplicate search and analytics after `sync`.
+- Use `--data-source live` for closeout/state/description checks where current truth matters. Use `issues search` for duplicate checks; it refreshes stale issue search data or fails visibly. Use `--data-source local` or `similar` only when stale/offline local duplicate search is intentional.
 - A missing `description` in compact output does not mean an empty issue body. Request it explicitly: `linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.name,url`.
 - Before passing label UUIDs to `issues create` or `issues edit`, run `linear-pp-cli labels list --team ENG --agent --select id,name,global,team.key`. Use only global labels or labels owned by the target issue team; the CLI preflights label ownership and refuses cross-team labels before mutating.
 - Never pass multiline Markdown, shell snippets, GraphQL, logs, backticks, `$()` expansions, or media-rich content as inline shell arguments. Write the body to a file or stdin and use the `*-file` / `*-stdin` flags below.
@@ -71,7 +71,7 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   linear-pp-cli stale --days 30 --team ENG --json
   ```
-- **`issues search` / `similar`** — Find issues that look like duplicates of a query string using offline FTS5 fuzzy matching.
+- **`issues search` / `similar`** — Find issues that look like duplicates of a query string using local FTS5 search.
 
   _Reach for this during triage when you suspect an incoming bug duplicates an existing issue._
 
@@ -82,7 +82,7 @@ These capabilities aren't available in any other tool for this API.
   linear-pp-cli similar "pipeline follow-up" --team SYMPH --limit 10 --agent
   ```
 
-  Prefer `issues search` when checking for existing tickets before creating or updating follow-up work; it is the supported issue-search spelling agents tend to reach for. Add `--team <key-name-or-uuid>` when a common project name or label appears across teams and the duplicate check must stay inside the target team's queue. Multi-word `issues search` queries may be quoted or passed as separate words; both forms are joined into one FTS query.
+  Prefer `issues search` when checking for existing tickets before creating or updating follow-up work; it is the supported issue-search spelling agents tend to reach for. It coordinates freshness for duplicate checks: fresh local data is searched immediately, stale or empty issue data refreshes behind a cross-process lock before search, and refresh failures return a typed error instead of silently serving stale results. Add `--team <key-name-or-uuid>` when a common project name or label appears across teams and the duplicate check must stay inside the target team's queue. Multi-word `issues search` queries may be quoted or passed as separate words; both forms are joined into one FTS query. Under `--agent` / `--json`, `issues search` returns a provenance envelope with freshness metadata; `similar` keeps the legacy raw result array. Use `--data-source local` only when stale/offline local results are intentional.
 
 ### Cross-entity rollups
 - **`projects burndown`** — Project a project's landing date by linear-regressing remaining estimate against the team's measured velocity.
@@ -309,7 +309,7 @@ linear-pp-cli which "<capability in your own words>"
 
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
 
-For duplicate checks, `linear-pp-cli which "search issues by text" --agent` should point to `issues search`; use that instead of inventing `issues search --help` fallbacks or raw SQL.
+For duplicate checks, `linear-pp-cli which "search issues by text" --agent` should point to `issues search`; use that instead of inventing `issues search --help` fallbacks or raw SQL. If the local issue cache is stale, `issues search` refreshes it or fails with a typed freshness error; agents should not jump to raw GraphQL just because the cache was stale.
 
 ## Recipes
 
@@ -378,6 +378,12 @@ Commands fall into three categories with different data-source semantics. Use `-
 - These compute joins/aggregations/FTS5 matches over your synced corpus — there is no single live Linear API call that returns these shapes. The `--data-source` flag is ignored; they always read from the local store.
 - **You must `sync` before using these.** Cold-start hint: an empty result prints `(no <resource> in local store — run 'linear-pp-cli sync' to populate)` to stderr.
 - Stale-data hint: if the local store hasn't been synced within `--max-age` (default 30 minutes), reads print `(<resource> data is Xm old, exceeds --max-age=30m — run 'linear-pp-cli sync' to refresh)` to stderr. `--json` output stays clean (the hint is stderr-only).
+
+**Freshness-coordinated local search**
+
+- `issues search`
+- Uses the local FTS issue index, but coordinates freshness for duplicate checks. If issues data is fresh enough, it searches immediately. If issues data is stale or empty, it takes a cross-process lock, refreshes teams, workflow states, labels, and issues, then searches.
+- If refresh fails, it emits a typed JSON error under `--agent` instead of returning stale duplicate-search results. Agent/JSON output is a provenance envelope with freshness metadata; `refreshed` means local issue data changed during the invocation, and `refreshed_by` identifies whether this process, a peer, or an external sync did it. Use `--data-source local` only for explicit offline/stale mode; the JSON metadata marks that stale-local policy. Use `--max-age 0` only when disabling the freshness gate is intentional; the metadata marks `freshness_gate_disabled`. Empty local stores are marked with `unsynced`.
 
 **Category 3: Mutations**
 

--- a/library/project-management/linear/go.mod
+++ b/library/project-management/linear/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/printing-press-library/library/project-management/linear
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,7 +11,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
@@ -245,16 +249,26 @@ func TestIssuesSearchAliasUsesSimilarSearchEngine(t *testing.T) {
 		t.Fatalf("close store: %v", err)
 	}
 
-	out, err := executeRootForTest("issues", "search", "Kimi", "replay", "temp", "directories", "cleanup", "--team", "SYMPH", "--limit", "10", "--db", dbPath, "--agent", "--select", "identifier,title")
+	out, err := executeRootForTest("issues", "search", "Kimi", "replay", "temp", "directories", "cleanup", "--team", "SYMPH", "--limit", "10", "--db", dbPath, "--agent", "--data-source", "local", "--select", "identifier,title")
 	if err != nil {
 		t.Fatalf("issues search failed: %v\n%s", err, out)
 	}
-	var results []map[string]any
-	if err := json.Unmarshal([]byte(out), &results); err != nil {
+	var got struct {
+		Results []map[string]any `json:"results"`
+		Meta    struct {
+			Freshness struct {
+				StalePolicy string `json:"stale_policy"`
+			} `json:"freshness"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
 		t.Fatalf("issues search output is not JSON: %v\n%s", err, out)
 	}
-	if len(results) != 1 || results[0]["identifier"] != "SYMPH-689" || results[0]["title"] != "Kimi replay temp directories cleanup" {
+	if len(got.Results) != 1 || got.Results[0]["identifier"] != "SYMPH-689" || got.Results[0]["title"] != "Kimi replay temp directories cleanup" {
 		t.Fatalf("unexpected issues search results: %s", out)
+	}
+	if got.Meta.Freshness.StalePolicy != "allow" {
+		t.Fatalf("issues search test DB should use stale-local policy via --data-source local, got %+v", got.Meta.Freshness)
 	}
 }
 
@@ -277,6 +291,460 @@ func TestIssuesSearchMissingQueryReturnsAgentUsageEnvelope(t *testing.T) {
 	if envelope.Code != 2 || envelope.Type != "usage" || !strings.Contains(envelope.Error, "linear-pp-cli similar") {
 		t.Fatalf("usage error envelope = %+v, want code=2 type=usage with similar hint; output=%s", envelope, out)
 	}
+}
+
+func TestIssuesSearchRefreshesStaleCacheBeforeSearch(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	seedStaleIssueSearchStore(t, dbPath)
+	var issuesQueries int32
+	srv := newIssueSearchRefreshServer(t, &issuesQueries, http.StatusOK, 0)
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "search", "Fresh", "duplicate", "--team", "SYMPH", "--db", dbPath, "--agent", "--select", "identifier,title")
+	if err != nil {
+		t.Fatalf("issues search refresh failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Results []map[string]any `json:"results"`
+		Meta    struct {
+			Source    string `json:"source"`
+			Freshness struct {
+				StalePolicy   string `json:"stale_policy"`
+				Refreshed     bool   `json:"refreshed"`
+				RefreshReason string `json:"refresh_reason"`
+			} `json:"freshness"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("issues search output is not provenance JSON: %v\n%s", err, out)
+	}
+	if len(got.Results) != 1 || got.Results[0]["identifier"] != "SYMPH-999" {
+		t.Fatalf("unexpected refreshed search results: %+v\n%s", got.Results, out)
+	}
+	if got.Meta.Source != "local" || got.Meta.Freshness.StalePolicy != "refresh" || !got.Meta.Freshness.Refreshed || got.Meta.Freshness.RefreshReason != "stale" {
+		t.Fatalf("unexpected freshness metadata: %+v\n%s", got.Meta, out)
+	}
+	if atomic.LoadInt32(&issuesQueries) != 1 {
+		t.Fatalf("issues refresh queries = %d, want 1", issuesQueries)
+	}
+}
+
+func TestIssuesSearchFreshCacheSkipsRefresh(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	seedFreshIssueSearchStore(t, dbPath)
+	var apiCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&apiCalls, 1)
+		http.Error(w, "fresh cache should not call API", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "search", "Fresh", "local", "--team", "SYMPH", "--db", dbPath, "--agent", "--select", "identifier,title")
+	if err != nil {
+		t.Fatalf("issues search fresh cache failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Results []map[string]any `json:"results"`
+		Meta    struct {
+			Freshness struct {
+				Refreshed       bool   `json:"refreshed"`
+				RefreshReason   string `json:"refresh_reason"`
+				LocalIssueCount int    `json:"local_issue_count"`
+				Unsynced        bool   `json:"unsynced"`
+			} `json:"freshness"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("fresh cache output is not provenance JSON: %v\n%s", err, out)
+	}
+	if len(got.Results) != 1 || got.Results[0]["identifier"] != "SYMPH-FRESH" {
+		t.Fatalf("unexpected fresh-cache results: %+v\n%s", got.Results, out)
+	}
+	if atomic.LoadInt32(&apiCalls) != 0 {
+		t.Fatalf("fresh cache API calls = %d, want 0", apiCalls)
+	}
+	if got.Meta.Freshness.Refreshed || got.Meta.Freshness.RefreshReason != "" || got.Meta.Freshness.LocalIssueCount != 1 || got.Meta.Freshness.Unsynced {
+		t.Fatalf("unexpected fresh-cache metadata: %+v\n%s", got.Meta.Freshness, out)
+	}
+}
+
+func TestIssuesSearchRefreshesAllIssueAndLabelPages(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	seedStaleIssueSearchStore(t, dbPath)
+	var issuesQueries int32
+	var labelQueries int32
+	srv := newIssueSearchMultiPageRefreshServer(t, &issuesQueries, &labelQueries)
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "search", "Fresh", "duplicate", "--team", "SYMPH", "--db", dbPath, "--agent", "--select", "identifier,title")
+	if err != nil {
+		t.Fatalf("issues search multi-page refresh failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Results []map[string]any `json:"results"`
+		Meta    struct {
+			Freshness struct {
+				Refreshed       bool   `json:"refreshed"`
+				RefreshedBy     string `json:"refreshed_by"`
+				LocalIssueCount int    `json:"local_issue_count"`
+			} `json:"freshness"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("multi-page output is not provenance JSON: %v\n%s", err, out)
+	}
+	if len(got.Results) != 1 || got.Results[0]["identifier"] != "SYMPH-999" {
+		t.Fatalf("unexpected multi-page results: %+v\n%s", got.Results, out)
+	}
+	if atomic.LoadInt32(&issuesQueries) != 2 || atomic.LoadInt32(&labelQueries) != 2 {
+		t.Fatalf("page counts issues=%d labels=%d, want 2/2", issuesQueries, labelQueries)
+	}
+	if !got.Meta.Freshness.Refreshed || got.Meta.Freshness.RefreshedBy != "self" || got.Meta.Freshness.LocalIssueCount != 2 {
+		t.Fatalf("unexpected multi-page freshness metadata: %+v\n%s", got.Meta.Freshness, out)
+	}
+}
+
+func TestIssuesSearchReclaimsStaleRefreshLock(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	seedStaleIssueSearchStore(t, dbPath)
+	lockPath := dbPath + ".issues-search-sync.lock"
+	staleCreatedAt := time.Now().UTC().Add(-(issueSearchRefreshLockTimeout + time.Second)).Format(time.RFC3339)
+	if err := os.WriteFile(lockPath, []byte(fmt.Sprintf("pid=%d\ncreated_at=%s\n", os.Getpid(), staleCreatedAt)), 0o600); err != nil {
+		t.Fatalf("write stale lock: %v", err)
+	}
+	var issuesQueries int32
+	srv := newIssueSearchRefreshServer(t, &issuesQueries, http.StatusOK, 0)
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "search", "Fresh", "duplicate", "--team", "SYMPH", "--db", dbPath, "--agent", "--select", "identifier,title")
+	if err != nil {
+		t.Fatalf("issues search with stale lock failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Results []map[string]any `json:"results"`
+		Meta    struct {
+			Freshness struct {
+				LockContended bool `json:"lock_contended"`
+				LockReclaimed bool `json:"lock_reclaimed"`
+				Refreshed     bool `json:"refreshed"`
+			} `json:"freshness"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("issues search output is not provenance JSON: %v\n%s", err, out)
+	}
+	if len(got.Results) != 1 || got.Results[0]["identifier"] != "SYMPH-999" {
+		t.Fatalf("unexpected refreshed search results after lock reclaim: %+v\n%s", got.Results, out)
+	}
+	if !got.Meta.Freshness.LockContended || !got.Meta.Freshness.LockReclaimed || !got.Meta.Freshness.Refreshed {
+		t.Fatalf("unexpected lock freshness metadata: %+v\n%s", got.Meta.Freshness, out)
+	}
+	if _, err := os.Stat(lockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("refresh lock after command: err=%v, want not exist", err)
+	}
+}
+
+func TestIssuesSearchRefreshFailureReturnsTypedError(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	seedStaleIssueSearchStore(t, dbPath)
+	var issuesQueries int32
+	srv := newIssueSearchRefreshServer(t, &issuesQueries, http.StatusInternalServerError, 0)
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTestWithRenderedError("issues", "search", "Old", "duplicate", "--team", "SYMPH", "--db", dbPath, "--agent")
+	if err == nil {
+		t.Fatalf("issues search with failed refresh succeeded unexpectedly:\n%s", out)
+	}
+	if got := ExitCode(err); got != 5 {
+		t.Fatalf("ExitCode() = %d, want 5; err=%v\n%s", got, err, out)
+	}
+	var envelope struct {
+		Code  int    `json:"code"`
+		Type  string `json:"type"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("refresh failure output is not JSON: %v\n%s", err, out)
+	}
+	if envelope.Code != 5 || envelope.Type != "api" || !strings.Contains(envelope.Error, "--data-source local") {
+		t.Fatalf("unexpected refresh failure envelope: %+v\n%s", envelope, out)
+	}
+}
+
+func TestIssuesSearchDataSourceLocalAllowsStaleCache(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	seedStaleIssueSearchStore(t, dbPath)
+
+	out, err := executeRootForTest("issues", "search", "Old", "duplicate", "--team", "SYMPH", "--db", dbPath, "--agent", "--data-source", "local", "--select", "identifier,title")
+	if err != nil {
+		t.Fatalf("issues search --data-source local failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Results []map[string]any `json:"results"`
+		Meta    struct {
+			Freshness struct {
+				StalePolicy   string `json:"stale_policy"`
+				Refreshed     bool   `json:"refreshed"`
+				RefreshReason string `json:"refresh_reason"`
+			} `json:"freshness"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("local stale output is not provenance JSON: %v\n%s", err, out)
+	}
+	if len(got.Results) != 1 || got.Results[0]["identifier"] != "SYMPH-OLD" {
+		t.Fatalf("unexpected stale-local results: %+v\n%s", got.Results, out)
+	}
+	if got.Meta.Freshness.StalePolicy != "allow" || got.Meta.Freshness.Refreshed || got.Meta.Freshness.RefreshReason != "user_requested_local" {
+		t.Fatalf("unexpected stale-local metadata: %+v\n%s", got.Meta.Freshness, out)
+	}
+}
+
+func TestIssuesSearchMaxAgeZeroDisablesFreshnessGate(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	seedStaleIssueSearchStore(t, dbPath)
+
+	out, err := executeRootForTest("issues", "search", "Old", "duplicate", "--team", "SYMPH", "--db", dbPath, "--agent", "--max-age", "0", "--select", "identifier,title")
+	if err != nil {
+		t.Fatalf("issues search --max-age 0 failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Results []map[string]any `json:"results"`
+		Meta    struct {
+			Freshness struct {
+				StalePolicy   string `json:"stale_policy"`
+				Refreshed     bool   `json:"refreshed"`
+				RefreshReason string `json:"refresh_reason"`
+			} `json:"freshness"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("max-age zero output is not provenance JSON: %v\n%s", err, out)
+	}
+	if len(got.Results) != 1 || got.Results[0]["identifier"] != "SYMPH-OLD" {
+		t.Fatalf("unexpected max-age zero results: %+v\n%s", got.Results, out)
+	}
+	if got.Meta.Freshness.StalePolicy != "allow" || got.Meta.Freshness.Refreshed || got.Meta.Freshness.RefreshReason != "freshness_gate_disabled" {
+		t.Fatalf("unexpected max-age zero metadata: %+v\n%s", got.Meta.Freshness, out)
+	}
+}
+
+func TestIssuesSearchMaxAgeZeroMarksUnsyncedStore(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	out, err := executeRootForTest("issues", "search", "missing", "duplicate", "--db", dbPath, "--agent", "--max-age", "0")
+	if err != nil {
+		t.Fatalf("issues search --max-age 0 empty store failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Results []map[string]any `json:"results"`
+		Meta    struct {
+			Freshness struct {
+				RefreshReason   string `json:"refresh_reason"`
+				LocalIssueCount int    `json:"local_issue_count"`
+				Unsynced        bool   `json:"unsynced"`
+			} `json:"freshness"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("max-age zero empty-store output is not provenance JSON: %v\n%s", err, out)
+	}
+	if len(got.Results) != 0 {
+		t.Fatalf("empty store returned results: %+v\n%s", got.Results, out)
+	}
+	if got.Meta.Freshness.RefreshReason != "freshness_gate_disabled" || got.Meta.Freshness.LocalIssueCount != 0 || !got.Meta.Freshness.Unsynced {
+		t.Fatalf("unexpected max-age zero empty-store metadata: %+v\n%s", got.Meta.Freshness, out)
+	}
+}
+
+func TestIssuesSearchConcurrentRefreshCoalesces(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	seedStaleIssueSearchStore(t, dbPath)
+	var issuesQueries int32
+	srv := newIssueSearchRefreshServer(t, &issuesQueries, http.StatusOK, 150*time.Millisecond)
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	var wg sync.WaitGroup
+	errs := make(chan string, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := executeRootForTest("issues", "search", "Fresh", "duplicate", "--team", "SYMPH", "--db", dbPath, "--agent")
+			if err != nil {
+				errs <- fmt.Sprintf("%v\n%s", err, out)
+				return
+			}
+			var got struct {
+				Results []map[string]any `json:"results"`
+			}
+			if err := json.Unmarshal([]byte(out), &got); err != nil || len(got.Results) != 1 || got.Results[0]["identifier"] != "SYMPH-999" {
+				errs <- fmt.Sprintf("bad output: %v\n%s", err, out)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for msg := range errs {
+		t.Fatal(msg)
+	}
+	if got := atomic.LoadInt32(&issuesQueries); got != 1 {
+		t.Fatalf("issues refresh queries = %d, want 1", got)
+	}
+}
+
+func TestIssueSearchRefreshMetadataMarksExternalSync(t *testing.T) {
+	freshness := issueSearchFreshness{
+		PreviousSyncedAt: "2026-06-19T14:00:00Z",
+		SyncedAt:         "2026-06-19T14:01:00Z",
+	}
+
+	applyIssueSearchRefreshMetadata(&freshness, false, false)
+
+	if !freshness.Refreshed || freshness.RefreshedBy != "external" {
+		t.Fatalf("unexpected external refresh metadata: %+v", freshness)
+	}
+	if len(freshness.RefreshResources) != 0 {
+		t.Fatalf("external refresh should not claim resources refreshed by this process: %+v", freshness.RefreshResources)
+	}
+}
+
+func seedStaleIssueSearchStore(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.UpsertTeam("team-symph", json.RawMessage(`{"id":"team-symph","key":"SYMPH","name":"Symphony"}`)); err != nil {
+		t.Fatalf("UpsertTeam: %v", err)
+	}
+	if err := db.UpsertIssue("issue-old", "SYMPH-OLD", "Old duplicate", json.RawMessage(`{"id":"issue-old","identifier":"SYMPH-OLD","title":"Old duplicate","description":"stale local row","team":{"id":"team-symph","key":"SYMPH"},"teamId":"team-symph"}`)); err != nil {
+		t.Fatalf("UpsertIssue: %v", err)
+	}
+	if err := db.UpdateSyncCursor("issues", "", 1); err != nil {
+		t.Fatalf("UpdateSyncCursor: %v", err)
+	}
+	if _, err := db.DB().Exec(`UPDATE sync_state SET last_synced_at = datetime('now', '-2 hours') WHERE resource_type = 'issues'`); err != nil {
+		t.Fatalf("age sync_state: %v", err)
+	}
+}
+
+func seedFreshIssueSearchStore(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.UpsertTeam("team-symph", json.RawMessage(`{"id":"team-symph","key":"SYMPH","name":"Symphony"}`)); err != nil {
+		t.Fatalf("UpsertTeam: %v", err)
+	}
+	if err := db.UpsertIssue("issue-fresh", "SYMPH-FRESH", "Fresh local duplicate", json.RawMessage(`{"id":"issue-fresh","identifier":"SYMPH-FRESH","title":"Fresh local duplicate","description":"fresh local row","team":{"id":"team-symph","key":"SYMPH"},"teamId":"team-symph"}`)); err != nil {
+		t.Fatalf("UpsertIssue: %v", err)
+	}
+	if err := db.UpdateSyncCursor("issues", "", 1); err != nil {
+		t.Fatalf("UpdateSyncCursor: %v", err)
+	}
+}
+
+func newIssueSearchRefreshServer(t *testing.T, issuesQueries *int32, status int, issueDelay time.Duration) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if status != http.StatusOK {
+			http.Error(w, "upstream unavailable", status)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "workflowStates"):
+			fmt.Fprint(w, `{"data":{"workflowStates":{"nodes":[]}}}`)
+		case strings.Contains(req.Query, "issueLabels"):
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "issues("):
+			atomic.AddInt32(issuesQueries, 1)
+			if issueDelay > 0 {
+				time.Sleep(issueDelay)
+			}
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-fresh","identifier":"SYMPH-999","title":"Fresh duplicate","description":"fresh remote row","team":{"id":"team-symph","key":"SYMPH"},"teamId":"team-symph","state":{"name":"Backlog","type":"backlog"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "teams"):
+			fmt.Fprint(w, `{"data":{"teams":{"nodes":[{"id":"team-symph","key":"SYMPH","name":"Symphony"}]}}}`)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+		}
+	}))
+}
+
+func newIssueSearchMultiPageRefreshServer(t *testing.T, issuesQueries *int32, labelQueries *int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "workflowStates"):
+			fmt.Fprint(w, `{"data":{"workflowStates":{"nodes":[]}}}`)
+		case strings.Contains(req.Query, "issueLabels"):
+			atomic.AddInt32(labelQueries, 1)
+			after, _ := req.Variables["after"].(string)
+			if after == "" {
+				fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-1","name":"bug","color":"#111","team":{"id":"team-symph","key":"SYMPH","name":"Symphony"}}],"pageInfo":{"hasNextPage":true,"endCursor":"label-page-2"}}}}`)
+				return
+			}
+			if after != "label-page-2" {
+				t.Errorf("issueLabels after cursor = %q, want label-page-2", after)
+				http.Error(w, "unexpected label cursor", http.StatusBadRequest)
+				return
+			}
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-2","name":"duplicate","color":"#222","team":{"id":"team-symph","key":"SYMPH","name":"Symphony"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "issues("):
+			atomic.AddInt32(issuesQueries, 1)
+			after, _ := req.Variables["after"].(string)
+			if after == "" {
+				fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-page-1","identifier":"SYMPH-998","title":"Fresh page one","description":"first remote page","team":{"id":"team-symph","key":"SYMPH"},"teamId":"team-symph","state":{"name":"Backlog","type":"backlog"}}],"pageInfo":{"hasNextPage":true,"endCursor":"issue-page-2"}}}}`)
+				return
+			}
+			if after != "issue-page-2" {
+				t.Errorf("issues after cursor = %q, want issue-page-2", after)
+				http.Error(w, "unexpected issue cursor", http.StatusBadRequest)
+				return
+			}
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-fresh","identifier":"SYMPH-999","title":"Fresh duplicate","description":"fresh remote row","team":{"id":"team-symph","key":"SYMPH"},"teamId":"team-symph","state":{"name":"Backlog","type":"backlog"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "teams"):
+			fmt.Fprint(w, `{"data":{"teams":{"nodes":[{"id":"team-symph","key":"SYMPH","name":"Symphony"}]}}}`)
+		default:
+			t.Errorf("unexpected query: %s", req.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+		}
+	}))
 }
 
 func TestDocumentsCreateRequiresExactlyOneParentBeforeMutation(t *testing.T) {

--- a/library/project-management/linear/internal/cli/similar.go
+++ b/library/project-management/linear/internal/cli/similar.go
@@ -4,8 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
 
@@ -32,11 +38,12 @@ func newSimilarCmd(flags *rootFlags) *cobra.Command {
 				return cmd.Help()
 			}
 			return runIssueSearch(cmd, flags, issueSearchOptions{
-				DBPath:  resolveDBPath(dbPath),
-				JSONOut: jsonOut,
-				Limit:   limit,
-				Team:    team,
-				Query:   args[0],
+				DBPath:      resolveDBPath(dbPath),
+				JSONOut:     jsonOut,
+				Limit:       limit,
+				Team:        team,
+				Query:       args[0],
+				AutoRefresh: false,
 			})
 		},
 	}
@@ -59,7 +66,9 @@ func newIssuesSearchCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 
 This subcommand exists because agents naturally look for 'issues search' when
 checking for existing tickets before creating a follow-up. Multi-word queries
-may be quoted or passed as separate words; both forms are joined into one query.`,
+may be quoted or passed as separate words; both forms are joined into one query.
+Under --agent/--json it returns a provenance envelope with freshness metadata;
+use 'similar' for the legacy local-only raw-array shape.`,
 		Example: `  linear-pp-cli issues search "login bug" --agent
   linear-pp-cli issues search "pipeline follow-up" --team SYMPH --limit 10 --agent
   linear-pp-cli issues search Kimi replay temp directories cleanup --team SYMPH --agent`,
@@ -68,11 +77,12 @@ may be quoted or passed as separate words; both forms are joined into one query.
 				return usageErr(fmt.Errorf("issues search requires a query; use: linear-pp-cli issues search \"login bug\" --team ENG --agent (equivalent: linear-pp-cli similar \"login bug\" --team ENG --agent)"))
 			}
 			return runIssueSearch(cmd, flags, issueSearchOptions{
-				DBPath:  resolveDBPath(*dbPath),
-				JSONOut: jsonOut,
-				Limit:   limit,
-				Team:    team,
-				Query:   strings.Join(args, " "),
+				DBPath:      resolveDBPath(*dbPath),
+				JSONOut:     jsonOut,
+				Limit:       limit,
+				Team:        team,
+				Query:       strings.Join(args, " "),
+				AutoRefresh: true,
 			})
 		},
 	}
@@ -83,11 +93,35 @@ may be quoted or passed as separate words; both forms are joined into one query.
 }
 
 type issueSearchOptions struct {
-	DBPath  string
-	JSONOut bool
-	Limit   int
-	Team    string
-	Query   string
+	DBPath      string
+	JSONOut     bool
+	Limit       int
+	Team        string
+	Query       string
+	AutoRefresh bool
+}
+
+type issueSearchFreshness struct {
+	StalePolicy        string   `json:"stale_policy"`
+	Refreshed          bool     `json:"refreshed"`
+	RefreshedBy        string   `json:"refreshed_by,omitempty"`
+	RefreshReason      string   `json:"refresh_reason,omitempty"`
+	PreviousSyncedAt   string   `json:"previous_synced_at,omitempty"`
+	PreviousAgeSeconds float64  `json:"previous_age_seconds,omitempty"`
+	SyncedAt           string   `json:"synced_at,omitempty"`
+	AgeSeconds         float64  `json:"age_seconds,omitempty"`
+	LocalIssueCount    int      `json:"local_issue_count"`
+	Unsynced           bool     `json:"unsynced,omitempty"`
+	RefreshWaitMillis  int64    `json:"refresh_wait_ms,omitempty"`
+	RefreshResources   []string `json:"refresh_resources,omitempty"`
+	LockReclaimed      bool     `json:"lock_reclaimed,omitempty"`
+	LockContended      bool     `json:"lock_contended,omitempty"`
+}
+
+type issueSearchRefreshLockResult struct {
+	wait      time.Duration
+	contended bool
+	reclaimed bool
 }
 
 func runIssueSearch(cmd *cobra.Command, flags *rootFlags, opts issueSearchOptions) error {
@@ -105,6 +139,15 @@ func runIssueSearch(cmd *cobra.Command, flags *rootFlags, opts issueSearchOption
 		return fmt.Errorf("opening database: %w\nRun 'linear-pp-cli sync' first.", err)
 	}
 	defer db.Close()
+
+	freshness := issueSearchFreshness{StalePolicy: "manual"}
+	if opts.AutoRefresh {
+		var err error
+		freshness, err = ensureIssueSearchFresh(cmd, flags, opts.DBPath, db)
+		if err != nil {
+			return err
+		}
+	}
 
 	teamID := ""
 	if opts.Team != "" {
@@ -126,10 +169,12 @@ func runIssueSearch(cmd *cobra.Command, flags *rootFlags, opts issueSearchOption
 		results = results[:opts.Limit]
 	}
 
-	if len(results) == 0 {
-		hintIfUnsynced(cmd, db, "issues")
-	} else {
-		hintIfStale(cmd, db, "issues", flags.maxAge)
+	if !opts.AutoRefresh {
+		if len(results) == 0 {
+			hintIfUnsynced(cmd, db, "issues")
+		} else {
+			hintIfStale(cmd, db, "issues", flags.maxAge)
+		}
 	}
 
 	if opts.JSONOut || flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
@@ -141,6 +186,18 @@ func runIssueSearch(cmd *cobra.Command, flags *rootFlags, opts issueSearchOption
 			data = filterFields(data, flags.selectFields)
 		} else if flags.compact {
 			data = compactFields(data)
+		}
+		if opts.AutoRefresh {
+			wrapped, err := wrapWithProvenance(data, DataProvenance{
+				Source:       "local",
+				ResourceType: "issues",
+				Reason:       "fts_search",
+				Freshness:    freshness,
+			})
+			if err != nil {
+				return err
+			}
+			return printOutput(cmd.OutOrStdout(), wrapped, true)
 		}
 		return printOutput(cmd.OutOrStdout(), data, true)
 	}
@@ -170,4 +227,252 @@ func runIssueSearch(cmd *cobra.Command, flags *rootFlags, opts issueSearchOption
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "\n%d results for %q\n", len(results), query)
 	return nil
+}
+
+func ensureIssueSearchFresh(cmd *cobra.Command, flags *rootFlags, dbPath string, db *store.Store) (issueSearchFreshness, error) {
+	freshness := issueSearchFreshness{StalePolicy: "refresh"}
+	if flags.dataSource == "local" {
+		freshness.StalePolicy = "allow"
+		freshness.Refreshed = false
+		freshness.RefreshReason = "user_requested_local"
+		attachIssueSyncState(db, &freshness, false)
+		return freshness, nil
+	}
+	if flags.maxAge == 0 {
+		freshness.StalePolicy = "allow"
+		freshness.Refreshed = false
+		freshness.RefreshReason = "freshness_gate_disabled"
+		attachIssueSyncState(db, &freshness, false)
+		return freshness, nil
+	}
+
+	needsRefresh, reason, err := issueSearchNeedsRefresh(db, flags.maxAge)
+	if err != nil {
+		return freshness, fmt.Errorf("checking issues search freshness: %w", err)
+	}
+	if !needsRefresh {
+		attachIssueSyncState(db, &freshness, false)
+		return freshness, nil
+	}
+
+	attachIssueSyncState(db, &freshness, true)
+	freshness.RefreshReason = reason
+	selfRefreshed := false
+	lockResult, err := withIssueSearchRefreshLock(dbPath, func() error {
+		innerNeedsRefresh, _, err := issueSearchNeedsRefresh(db, flags.maxAge)
+		if err != nil {
+			return err
+		}
+		if !innerNeedsRefresh {
+			return nil
+		}
+		c, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		if err := refreshIssueSearchResources(c, db); err != nil {
+			return err
+		}
+		selfRefreshed = true
+		return nil
+	})
+	freshness.RefreshWaitMillis = lockResult.wait.Milliseconds()
+	freshness.LockReclaimed = lockResult.reclaimed
+	freshness.LockContended = lockResult.contended
+	if err != nil {
+		return freshness, apiErr(fmt.Errorf("issues search cache is %s and refresh failed; retry or pass --data-source local to explicitly allow stale local results: %w", reason, err))
+	}
+
+	afterNeedsRefresh, _, err := issueSearchNeedsRefresh(db, flags.maxAge)
+	if err != nil {
+		return freshness, fmt.Errorf("checking refreshed issues search freshness: %w", err)
+	}
+	attachIssueSyncState(db, &freshness, false)
+	if afterNeedsRefresh {
+		return freshness, apiErr(fmt.Errorf("issues search cache remained stale after refresh; pass --data-source local only if stale local results are acceptable"))
+	}
+	applyIssueSearchRefreshMetadata(&freshness, selfRefreshed, lockResult.contended)
+	if freshness.RefreshReason == "" {
+		freshness.RefreshReason = reason
+	}
+	return freshness, nil
+}
+
+func issueSearchNeedsRefresh(db *store.Store, maxAge time.Duration) (bool, string, error) {
+	_, lastSynced, count, err := db.GetSyncState("issues")
+	if err != nil {
+		return false, "", err
+	}
+	if count == 0 || lastSynced.IsZero() {
+		return true, "unsynced", nil
+	}
+	if maxAge > 0 && time.Since(lastSynced) > maxAge {
+		return true, "stale", nil
+	}
+	return false, "", nil
+}
+
+func attachIssueSyncState(db *store.Store, freshness *issueSearchFreshness, previous bool) {
+	_, lastSynced, count, _ := db.GetSyncState("issues")
+	freshness.LocalIssueCount = count
+	freshness.Unsynced = count == 0 || lastSynced.IsZero()
+	if lastSynced.IsZero() {
+		return
+	}
+	ts := lastSynced.UTC().Format(time.RFC3339)
+	age := time.Since(lastSynced).Seconds()
+	if previous {
+		freshness.PreviousSyncedAt = ts
+		freshness.PreviousAgeSeconds = age
+		return
+	}
+	freshness.SyncedAt = ts
+	freshness.AgeSeconds = age
+}
+
+func applyIssueSearchRefreshMetadata(freshness *issueSearchFreshness, selfRefreshed bool, lockContended bool) {
+	freshness.Refreshed = freshness.PreviousSyncedAt != freshness.SyncedAt
+	if !freshness.Refreshed {
+		return
+	}
+	if selfRefreshed {
+		freshness.RefreshedBy = "self"
+		freshness.RefreshResources = []string{"teams", "workflow_states", "issue_labels", "issues"}
+		return
+	}
+	if lockContended {
+		freshness.RefreshedBy = "peer"
+		freshness.RefreshResources = []string{"teams", "workflow_states", "issue_labels", "issues"}
+		return
+	}
+	freshness.RefreshedBy = "external"
+}
+
+func refreshIssueSearchResources(c *client.Client, db *store.Store) error {
+	const syncAllPages = 0
+	if _, err := syncTeams(c, db, syncAllPages); err != nil {
+		return fmt.Errorf("sync teams: %w", err)
+	}
+	if _, err := syncWorkflowStates(c, db, syncAllPages); err != nil {
+		return fmt.Errorf("sync workflow states: %w", err)
+	}
+	if _, err := syncLabels(c, db, syncAllPages); err != nil {
+		return fmt.Errorf("sync labels: %w", err)
+	}
+	if _, err := syncIssues(c, db, syncAllPages); err != nil {
+		return fmt.Errorf("sync issues: %w", err)
+	}
+	return nil
+}
+
+func withIssueSearchRefreshLock(dbPath string, fn func() error) (issueSearchRefreshLockResult, error) {
+	lockPath := dbPath + ".issues-search-sync.lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return issueSearchRefreshLockResult{}, err
+	}
+	start := time.Now()
+	deadline := start.Add(issueSearchRefreshLockTimeout)
+	contended := false
+	reclaimed := false
+	for {
+		f, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			fmt.Fprintf(f, "pid=%d\ncreated_at=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339))
+			_ = f.Close()
+			defer os.Remove(lockPath)
+			return issueSearchRefreshLockResult{wait: time.Since(start), contended: contended, reclaimed: reclaimed}, fn()
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return issueSearchRefreshLockResult{wait: time.Since(start), contended: contended, reclaimed: reclaimed}, err
+		}
+		contended = true
+		didReclaim, reclaimErr := reclaimStaleIssueSearchRefreshLock(lockPath)
+		if reclaimErr != nil {
+			return issueSearchRefreshLockResult{wait: time.Since(start), contended: contended, reclaimed: reclaimed}, reclaimErr
+		}
+		if didReclaim {
+			reclaimed = true
+			continue
+		}
+		if time.Now().After(deadline) {
+			return issueSearchRefreshLockResult{wait: time.Since(start), contended: contended, reclaimed: reclaimed}, fmt.Errorf("timed out waiting for issues search refresh lock %s", lockPath)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+const issueSearchRefreshLockTimeout = 2 * time.Minute
+
+func reclaimStaleIssueSearchRefreshLock(lockPath string) (bool, error) {
+	info, err := os.Stat(lockPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	contents, _ := os.ReadFile(lockPath)
+	pid, createdAt := parseIssueSearchRefreshLock(contents)
+	if pid > 0 && issueSearchLockHolderDead(pid) {
+		return removeIssueSearchRefreshLock(lockPath)
+	}
+	if !createdAt.IsZero() && time.Since(createdAt) > issueSearchRefreshLockTimeout {
+		return removeIssueSearchRefreshLock(lockPath)
+	}
+	if createdAt.IsZero() && time.Since(info.ModTime()) > issueSearchRefreshLockTimeout {
+		return removeIssueSearchRefreshLock(lockPath)
+	}
+	return false, nil
+}
+
+func parseIssueSearchRefreshLock(contents []byte) (int, time.Time) {
+	var pid int
+	var createdAt time.Time
+	for _, line := range strings.Split(string(contents), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "pid":
+			if parsed, err := strconv.Atoi(strings.TrimSpace(value)); err == nil {
+				pid = parsed
+			}
+		case "created_at":
+			if parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(value)); err == nil {
+				createdAt = parsed
+			}
+		}
+	}
+	return pid, createdAt
+}
+
+func issueSearchLockHolderDead(pid int) bool {
+	if pid == os.Getpid() {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+		return true
+	}
+	// Liveness probing is best-effort; age-based reclamation covers platforms
+	// or permissions where signal(0) cannot prove a dead lock holder.
+	return false
+}
+
+func removeIssueSearchRefreshLock(lockPath string) (bool, error) {
+	if err := os.Remove(lockPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }


### PR DESCRIPTION
## Summary

- make `linear-pp-cli issues search` coordinate stale/empty local issue search data before duplicate checks
- refresh teams, workflow states, labels, and issues behind a cross-process lock, then search the local FTS index
- return freshness provenance for `issues search --agent`, including `local_issue_count`, `unsynced`, and `refreshed_by` metadata
- keep `similar` as the legacy local-only raw-array duplicate-search command
- bump the Linear CLI module to Go 1.26.4 so the reachable standard-library vulnerability gate is clean

Linear: MOB-123

## Validation

- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/project-management/linear/`
- `cd library/project-management/linear && go test ./internal/cli -run 'TestSimilar|TestIssuesSearch|TestWhichIndex_Routes'`
- `cd library/project-management/linear && go test ./...`
- `cd library/project-management/linear && go vet ./...`
- `cd library/project-management/linear && govulncheck ./...` with Go 1.26.4
- `cd library/project-management/linear && GOOS=windows GOARCH=amd64 go test -c ./internal/cli -o /tmp/linear-cli-windows.test.exe`
- `git diff --check`
- installed local smoke: `linear-pp-cli issues search "session orchestrator crabbox council council-flow" --team MOB --limit 3 --agent --select identifier,title,state.name,url`
- installed local smoke: `linear-pp-cli which "search issues by text" --agent`

## Review Evidence

- crabbox-council initial run: `/tmp/crabbox-council-pr1293-20260619T143610Z/council-report.md`
- usable crabbox-council recheck: `/tmp/crabbox-council-pr1293-recheck-20260619T144815Z/council-report.md`
- addressed reviewer findings with stale-lock reclamation, full-page issue/label refresh, fresh-cache no-refresh coverage, unsynced escape-hatch metadata, and explicit `refreshed_by` semantics
- tracked broader sync-pruning follow-up as MOB-220
- recorded the static-lease admission recurrence from the failed second recheck on MOB-176

## Notes

The previous alias-only MOB-123 PR is already merged upstream. This PR covers the 2026-06-19 refinement on stale-cache behavior.

The session-orchestrator worker path was attempted first and failed before investigation with `spawn bin/crabrunner ENOENT` from an external workspace run. I updated existing Linear substrate issue MOB-193 with the run evidence and continued locally.
