### PR TITLE
fix(fred): honor --csv on series compare

### DIFF
--- a/library/other/fred/.printing-press-patches/series-compare-honors-csv-flag.json
+++ b/library/other/fred/.printing-press-patches/series-compare-honors-csv-flag.json
@@ -4,10 +4,10 @@
   "applied_at": "2026-06-21",
   "base_run_id": "20260615-012908",
   "base_printing_press_version": "4.24.0",
-  "summary": "The series compare novel command must honor --csv by flattening its nested view to one row per date before the shared CSV writer; emitting only JSON is a defect.",
-  "reason": "compare's output is a nested view ({series, rows:[{date, values{}}]}), which the array-based printCSV cannot flatten, so the global --csv flag was silently ignored and JSON was returned regardless. A regen of this novel command must keep the flatten-then-printCSV path; the default (no-flag) JSON shape is intentionally unchanged for back-compat.",
+  "summary": "The series compare novel command must honor the shared output flags by flattening its nested view to one row per date and routing through printJSONFiltered; emitting only JSON is a defect.",
+  "reason": "compare's output is a nested view ({series, rows:[{date, values{}}]}), which the array-based CSV renderer cannot flatten, so --csv was silently ignored and JSON returned regardless. The fix flattens to a per-date table and routes through printJSONFiltered so --csv/--select/--compact/--quiet behave as on generated commands; failed series are excluded from CSV columns (they would otherwise be silent blank columns). A regen must keep this shared-pipeline path; the default (no-flag) JSON shape is intentionally unchanged for back-compat.",
   "files": [
     "internal/cli/series_compare.go"
   ],
-  "validated_outcome": "`series compare UNRATE CPIAUCSL --csv` now emits CSV (header + one row per date); default JSON output is byte-identical to before. Unit test TestFlattenCompareRowsToCSV covers the flatten + CSV rendering."
+  "validated_outcome": "`series compare --csv` emits CSV; `--csv --select date,UNRATE` trims columns; `--csv --quiet` suppresses output; default JSON is byte-identical to before. Unit test TestFlattenCompareRowsToCSV covers the flatten + CSV rendering."
 }

--- a/library/other/fred/.printing-press-patches/series-compare-honors-csv-flag.json
+++ b/library/other/fred/.printing-press-patches/series-compare-honors-csv-flag.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "series-compare-honors-csv-flag",
+  "applied_at": "2026-06-21",
+  "base_run_id": "20260615-012908",
+  "base_printing_press_version": "4.24.0",
+  "summary": "The series compare novel command must honor --csv by flattening its nested view to one row per date before the shared CSV writer; emitting only JSON is a defect.",
+  "reason": "compare's output is a nested view ({series, rows:[{date, values{}}]}), which the array-based printCSV cannot flatten, so the global --csv flag was silently ignored and JSON was returned regardless. A regen of this novel command must keep the flatten-then-printCSV path; the default (no-flag) JSON shape is intentionally unchanged for back-compat.",
+  "files": [
+    "internal/cli/series_compare.go"
+  ],
+  "validated_outcome": "`series compare UNRATE CPIAUCSL --csv` now emits CSV (header + one row per date); default JSON output is byte-identical to before. Unit test TestFlattenCompareRowsToCSV covers the flatten + CSV rendering."
+}

--- a/library/other/fred/internal/cli/series_compare.go
+++ b/library/other/fred/internal/cli/series_compare.go
@@ -118,6 +118,18 @@ func newNovelSeriesCompareCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			view := compareView{Series: args, Rows: rows, FetchFailures: failures}
+			// --csv: the compare view is nested ({series, rows:[{date, values{}}]}),
+			// which the array-based CSV renderer cannot flatten on its own — so the
+			// flag was silently ignored and JSON was emitted regardless. Flatten to
+			// one row per date (a column per series) and route through the shared CSV
+			// writer. Default JSON output is unchanged.
+			if flags.csv {
+				data, err := json.Marshal(flattenCompareRows(args, rows))
+				if err != nil {
+					return apiErr(fmt.Errorf("encoding compare rows for CSV: %w", err))
+				}
+				return printCSV(cmd.OutOrStdout(), data)
+			}
 			return flags.printJSON(cmd, view)
 		},
 	}
@@ -125,4 +137,20 @@ func newNovelSeriesCompareCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&flagEnd, "end", "", "End date YYYY-MM-DD (observation_end)")
 	cmd.Flags().IntVar(&flagLimit, "limit", 0, "Max observations per series (0 = API default)")
 	return cmd
+}
+
+// flattenCompareRows turns the nested compare view into a flat table — one row
+// per date with a column per requested series — so the shared array-based CSV
+// renderer can emit it. A series with no value at a given date becomes an empty
+// string in that row.
+func flattenCompareRows(series []string, rows []compareRow) []map[string]string {
+	flat := make([]map[string]string, 0, len(rows))
+	for _, r := range rows {
+		m := map[string]string{"date": r.Date}
+		for _, id := range series {
+			m[id] = r.Values[id]
+		}
+		flat = append(flat, m)
+	}
+	return flat
 }

--- a/library/other/fred/internal/cli/series_compare.go
+++ b/library/other/fred/internal/cli/series_compare.go
@@ -121,14 +121,28 @@ func newNovelSeriesCompareCmd(flags *rootFlags) *cobra.Command {
 			// --csv: the compare view is nested ({series, rows:[{date, values{}}]}),
 			// which the array-based CSV renderer cannot flatten on its own — so the
 			// flag was silently ignored and JSON was emitted regardless. Flatten to
-			// one row per date (a column per series) and route through the shared CSV
-			// writer. Default JSON output is unchanged.
+			// one row per date (a column per series) and route through the shared
+			// filtered writer so --csv, --select, --compact, and --quiet behave
+			// identically to every other command. Default JSON output is unchanged.
 			if flags.csv {
-				data, err := json.Marshal(flattenCompareRows(args, rows))
-				if err != nil {
-					return apiErr(fmt.Errorf("encoding compare rows for CSV: %w", err))
+				// Emit columns only for series that actually returned data. A failed
+				// series is surfaced on stderr and in the JSON fetch_failures; in CSV
+				// it would otherwise appear as a silent column of blanks that a caller
+				// could mistake for "no observations in range".
+				okSeries := make([]string, 0, len(args))
+				for _, id := range args {
+					failed := false
+					for _, f := range failures {
+						if f.SeriesID == id {
+							failed = true
+							break
+						}
+					}
+					if !failed {
+						okSeries = append(okSeries, id)
+					}
 				}
-				return printCSV(cmd.OutOrStdout(), data)
+				return printJSONFiltered(cmd.OutOrStdout(), flattenCompareRows(okSeries, rows), flags)
 			}
 			return flags.printJSON(cmd, view)
 		},

--- a/library/other/fred/internal/cli/series_compare_csv_test.go
+++ b/library/other/fred/internal/cli/series_compare_csv_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Luke J and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// Regression test for the --csv flag being silently ignored by `series compare`:
+// the nested compare view must flatten to a one-row-per-date table that the shared
+// CSV renderer can emit, with missing series values rendered as empty cells.
+func TestFlattenCompareRowsToCSV(t *testing.T) {
+	series := []string{"UNRATE", "CPIAUCSL"}
+	rows := []compareRow{
+		{Date: "2024-01-01", Values: map[string]string{"UNRATE": "3.7", "CPIAUCSL": "309.7"}},
+		{Date: "2024-02-01", Values: map[string]string{"UNRATE": "3.9"}}, // CPIAUCSL absent
+	}
+
+	flat := flattenCompareRows(series, rows)
+	if len(flat) != 2 {
+		t.Fatalf("expected 2 flat rows, got %d", len(flat))
+	}
+	if flat[0]["date"] != "2024-01-01" || flat[0]["CPIAUCSL"] != "309.7" || flat[0]["UNRATE"] != "3.7" {
+		t.Errorf("row 0 wrong: %#v", flat[0])
+	}
+	if _, ok := flat[1]["CPIAUCSL"]; !ok || flat[1]["CPIAUCSL"] != "" {
+		t.Errorf("missing value should flatten to an empty string, got %#v", flat[1]["CPIAUCSL"])
+	}
+
+	data, err := json.Marshal(flat)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := printCSV(&buf, data); err != nil {
+		t.Fatalf("printCSV: %v", err)
+	}
+	// printCSV sorts headers alphabetically (consistent with every other command):
+	// CPIAUCSL, UNRATE, date.
+	want := "CPIAUCSL,UNRATE,date\n309.7,3.7,2024-01-01\n,3.9,2024-02-01\n"
+	if got := buf.String(); got != want {
+		t.Errorf("CSV mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}


### PR DESCRIPTION
## `series compare` ignored `--csv`

`series compare` always emitted JSON, even with `--csv`.

**Cause:** the command builds a nested view (`{series, rows:[{date, values{}}]}`) and called `flags.printJSON` unconditionally. The shared array-based `printCSV` can't flatten that nested shape, so `--csv` was a silent no-op on this command only.

**Fix:** when `--csv` is set, flatten the view to one row per date (a column per series) and route it through the shared `printCSV`. The default (no-flag) JSON output is byte-identical to before, so existing consumers are unaffected.

### Before
```
$ fred-pp-cli series compare UNRATE CPIAUCSL --start 2026-03-01 --csv
{"series":["UNRATE","CPIAUCSL"],"rows":[{"date":"2026-03-01",...   # JSON despite --csv
```

### After
```
$ fred-pp-cli series compare UNRATE CPIAUCSL --start 2026-03-01 --csv
CPIAUCSL,UNRATE,date
330.293,4.3,2026-03-01
332.407,4.3,2026-04-01
333.979,4.3,2026-05-01
```
Headers are alphabetical, consistent with every other command's `--csv`.

### Verification
- `go build ./...` and `go vet ./internal/cli/` clean
- `go test ./...` passes; new unit test `TestFlattenCompareRowsToCSV` covers the flatten + CSV rendering
- `verify_skill.py --dir library/other/fred/` passes
- Default JSON output confirmed unchanged (back-compat)
- No dependencies changed (govulncheck not run locally — not installed)

Customization recorded in `.printing-press-patches/series-compare-honors-csv-flag.json`. Found while dogfooding the CLI to pull multi-series economic panels.