### PR TITLE
feat(update): --stale-only skips current CLIs (uses printing_press_version)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,8 @@ Adding or updating a CLI does not require an npm publish. The package is a thin 
 
 The repo is public, the package is published, and `npx -y @mvanhorn/printing-press install <name>` works end-to-end for unauthenticated users.
 
+`update` (no name) is **smart by default**: it stamps each installed CLI's `printing_press_version` into `~/.agents/.pp-cli-versions.json` at install time, then on the next run compares that stamp against the registry to skip current CLIs and re-install only stale/unknown ones. `--all` forces the old unconditional sweep; `--stale-only` is the default. CLIs whose registry entry lacks `printing_press_version` are treated as unknown and always re-installed, so smart-update degrades gracefully to the old sweep until the field propagates across the catalog.
+
 ## Releasing the npm installer
 
 Single rule: **bump `npm/package.json`'s `version` field in your release PR.** Everything else is automated.

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.19
+
+- Make `update` smart by default: skip CLIs whose installed generator version (`printing_press_version`) matches the registry, re-installing only stale or unknown ones. Adds `--stale-only` (default) and `--all` flags; `--all` restores the old unconditional sweep.
+- Record the installed `printing_press_version` per CLI in `~/.agents/.pp-cli-versions.json` on every successful `install`, so `update --stale-only` can compare against the live registry.
+
+## 0.1.18
+
+- Surface an additive `printing_press_version` field on `RegistryEntry` (TS) and the Go registry generator, sourced verbatim from each CLI's `.printing-press.json`.
+
 ## 0.1.17
 
 - Raise the documented direct `go install` floor to Go 1.26.4 so npm installer guidance matches the catalog-wide module enforcement floor.

--- a/npm/README.md
+++ b/npm/README.md
@@ -99,6 +99,18 @@ npx -y @mvanhorn/printing-press-library uninstall espn --yes
 
 `reinstall` is an alias for `update`: `reinstall <name>` rebuilds one CLI from the latest catalog code and re-adds its skill, while `reinstall` with no name refreshes every Printing Press CLI already on your `PATH`. Reach for it when a binary or skill needs a clean refresh — `install <name>` overwrites in place too, so either works.
 
+`update` (with no name) is smart by default: it skips CLIs whose installed generator version matches the registry and only re-installs the stale ones. Pass `--all` to force the old unconditional sweep:
+
+```bash
+# Smart: skip current CLIs, re-install only stale ones (default)
+npx -y @mvanhorn/printing-press-library update
+
+# Force: re-install every detected CLI regardless of version
+npx -y @mvanhorn/printing-press-library update --all
+```
+
+The version comparison uses the `printing_press_version` field in the catalog. CLIs whose registry entry does not carry that field (older prints) are treated as unknown and always re-installed, so smart-update degrades to the old sweep until the field propagates across the catalog.
+
 ## Options
 
 ```bash

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvanhorn/printing-press-library",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvanhorn/printing-press-library",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/src/cli.ts
+++ b/npm/src/cli.ts
@@ -84,6 +84,10 @@ Install options:
   --bin-dir <dir>        Install the Go binary into this directory via GOBIN
   --json                 Emit machine-readable output
 
+Update options:
+  --stale-only           Skip CLIs whose installed version matches the registry (default)
+  --all                  Re-install all detected CLIs regardless of version
+
 Top-level options:
   -h, --help             Show help
   -v, --version          Show version`);

--- a/npm/src/commands/install.ts
+++ b/npm/src/commands/install.ts
@@ -14,6 +14,11 @@ import {
   type Registry,
 } from "../registry.js";
 import { installSkill } from "../skill.js";
+import {
+  defaultStampDeps,
+  readInstalledVersions,
+  writeInstalledVersion,
+} from "../versions.js";
 
 interface InstallOptions {
   agents: string[];
@@ -43,6 +48,13 @@ interface InstallDeps {
   home?: string;
   /** Environment inherited by subprocesses; injectable for targeted install tests. */
   env: NodeJS.ProcessEnv;
+  /**
+   * Installed-version stamp IO (defaults to `~/.agents/.pp-cli-versions.json`).
+   * Injectable so install tests can capture the stamped version without touching
+   * the real filesystem. See `../versions.ts`.
+   */
+  readInstalledVersions: () => Promise<Record<string, string>>;
+  writeInstalledVersion: (name: string, version: string | undefined) => Promise<void>;
 }
 
 interface InstallSummary {
@@ -97,6 +109,8 @@ export function createInstallCommand(overrides: Partial<InstallDeps> = {}) {
     shell: process.env.SHELL,
     home: process.env.HOME ?? process.env.USERPROFILE,
     env: process.env,
+    readInstalledVersions: () => readInstalledVersions(defaultStampDeps),
+    writeInstalledVersion: (name, version) => writeInstalledVersion(name, version, defaultStampDeps),
     ...overrides,
   };
 
@@ -253,6 +267,14 @@ async function installOne(
     if (summary.skill) {
       deps.stdout(`  skill: ${summary.skill}`);
     }
+  }
+
+  // Stamp the installed generator version so `update --stale-only` can skip this
+  // CLI on the next run. Only stamped when the registry carries a version; entries
+  // without `printing_press_version` are left unstamped so `update` treats them as
+  // unknown (→ re-install) rather than silently current.
+  if (entry.printing_press_version) {
+    await deps.writeInstalledVersion(entry.name, entry.printing_press_version);
   }
 
   return { ok: true, name: entry.name, data: summary };

--- a/npm/src/commands/update.ts
+++ b/npm/src/commands/update.ts
@@ -2,6 +2,7 @@ import { createInstallCommand } from "./install.js";
 import { mapWithConcurrency } from "../concurrency.js";
 import { commandOnPath } from "../process.js";
 import { cliBinaryName, DEFAULT_REGISTRY_URL, fetchRegistry, type Registry } from "../registry.js";
+import { defaultStampDeps, readInstalledVersions } from "../versions.js";
 
 /** Output sinks handed to a single buffered install run. */
 interface InstallIO {
@@ -18,6 +19,12 @@ interface BufferedLine {
 interface UpdateDeps {
   fetchRegistry: (url: string) => Promise<Registry>;
   commandOnPath: (binary: string) => Promise<string | null>;
+  /**
+   * Read the installed-version stamp (`~/.agents/.pp-cli-versions.json`).
+   * Injectable so update tests can simulate installed-at-version-X scenarios
+   * without touching the real filesystem.
+   */
+  readInstalledVersions: () => Promise<Record<string, string>>;
   /**
    * Build an install command bound to the given output sinks. A factory (rather
    * than a single shared install fn) lets the bulk path give each concurrent run
@@ -40,6 +47,7 @@ export function createUpdateCommand(overrides: Partial<UpdateDeps> = {}) {
   const deps: UpdateDeps = {
     fetchRegistry: (url) => fetchRegistry(url),
     commandOnPath: (binary) => commandOnPath(binary),
+    readInstalledVersions: () => readInstalledVersions(defaultStampDeps),
     createInstall: (io) => createInstallCommand({ stdout: io.stdout, stderr: io.stderr }),
     stdout: (message) => console.log(message),
     stderr: (message) => console.error(message),
@@ -55,6 +63,8 @@ export function createUpdateCommand(overrides: Partial<UpdateDeps> = {}) {
 
     if (parsed.name) {
       // Single target: stream output straight through, no buffering needed.
+      // The stale-only flag is intentionally ignored here — naming a CLI
+      // explicitly is a force-refresh of that one CLI.
       const install = deps.createInstall({ stdout: deps.stdout, stderr: deps.stderr });
       return install([parsed.name, ...parsed.installArgs]);
     }
@@ -76,10 +86,54 @@ export function createUpdateCommand(overrides: Partial<UpdateDeps> = {}) {
       return 0;
     }
 
+    // Partition into "current" (skip) and "stale/unknown" (re-install) when
+    // running in stale-only mode (the default). A CLI is current only when both
+    // the stamp and the registry carry a `printing_press_version` and they match;
+    // any uncertainty (missing stamp, missing field, mismatch) → re-install.
+    const entryByName = new Map(registry.entries.map((e) => [e.name, e]));
+    const json = parsed.installArgs.includes("--json");
+
+    let skipped: Array<{ name: string; version: string }> = [];
+    let toUpdate: string[];
+
+    if (parsed.staleOnly) {
+      const stamp = await deps.readInstalledVersions();
+      skipped = [];
+      toUpdate = [];
+      for (const name of installed) {
+        const registryVersion = entryByName.get(name)?.printing_press_version;
+        const installedVersion = stamp[name];
+        if (registryVersion && installedVersion && registryVersion === installedVersion) {
+          skipped.push({ name, version: registryVersion });
+        } else {
+          toUpdate.push(name);
+        }
+      }
+    } else {
+      toUpdate = installed;
+    }
+
+    // Emit skip notices first (immediate, before the buffered install output).
+    for (const { name, version } of skipped) {
+      if (json) {
+        deps.stdout(JSON.stringify({ ok: true, name, skipped: true, printing_press_version: version }));
+      } else {
+        deps.stdout(`${name} is current (printing_press_version ${version}), skipping.`);
+      }
+    }
+
+    if (toUpdate.length === 0) {
+      if (!json) {
+        const word = skipped.length === 1 ? "CLI is" : "CLIs are";
+        deps.stdout(`All ${skipped.length} detected ${word} current. Re-run with --all to force re-install.`);
+      }
+      return 0;
+    }
+
     // Refresh concurrently, but record each run's output in emission order and
     // replay it per CLI in catalog order — so parallel runs don't interleave into
     // scrambled lines, while stdout/stderr ordering within a CLI is preserved.
-    const results = await mapWithConcurrency(installed, INSTALL_CONCURRENCY, async (name) => {
+    const results = await mapWithConcurrency(toUpdate, INSTALL_CONCURRENCY, async (name) => {
       const lines: BufferedLine[] = [];
       const install = deps.createInstall({
         stdout: (message) => lines.push({ stream: "out", message }),
@@ -103,6 +157,21 @@ export function createUpdateCommand(overrides: Partial<UpdateDeps> = {}) {
       }
     }
 
+    if (!json && skipped.length > 0) {
+      const updated = results.filter((r) => r.code === 0).length;
+      const failed = toUpdate.length - updated;
+      deps.stdout("");
+      if (failed === 0) {
+        deps.stdout(
+          `Updated ${updated} of ${toUpdate.length}; ${skipped.length} current. Re-run with --all to force re-install.`,
+        );
+      } else {
+        deps.stdout(
+          `Updated ${updated} of ${toUpdate.length}; ${skipped.length} current, ${failed} failed. Re-run with --all to force re-install.`,
+        );
+      }
+    }
+
     const failures = results.filter((result) => result.code !== 0).length;
     return failures === 0 ? 0 : 1;
   };
@@ -111,15 +180,23 @@ export function createUpdateCommand(overrides: Partial<UpdateDeps> = {}) {
 export const updateCommand = createUpdateCommand();
 
 function parseUpdateArgs(args: string[]):
-  | { name?: string; registryUrl: string; installArgs: string[] }
+  | { name?: string; registryUrl: string; installArgs: string[]; staleOnly: boolean }
   | { error: string } {
   let name: string | undefined;
   let registryUrl = DEFAULT_REGISTRY_URL;
+  // `--stale-only` is the default: only re-install CLIs whose stamped
+  // `printing_press_version` is missing or behind the registry. `--all` opts
+  // back into the unconditional sweep (the pre-smart-update behavior).
+  let staleOnly = true;
   const installArgs: string[] = [];
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]!;
-    if (arg === "--registry-url") {
+    if (arg === "--stale-only") {
+      staleOnly = true;
+    } else if (arg === "--all") {
+      staleOnly = false;
+    } else if (arg === "--registry-url") {
       const value = args[++i];
       if (!value) {
         return { error: "Missing value for --registry-url" };
@@ -144,5 +221,5 @@ function parseUpdateArgs(args: string[]):
     }
   }
 
-  return { name, registryUrl, installArgs };
+  return { name, registryUrl, installArgs, staleOnly };
 }

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -18,6 +18,8 @@ export interface RegistryEntry {
   description: string;
   search_terms?: string[];
   path: string;
+  /** Version of the Printing Press generator that printed this CLI (semver). Optional for backward compatibility. */
+  printing_press_version?: string;
   mcp?: MCPBlock;
 }
 
@@ -152,6 +154,10 @@ function parseRegistryEntry(value: unknown): RegistryEntry {
     description: requiredString(value, "description"),
     search_terms: optionalStringArray(value, "search_terms"),
     path: requiredString(value, "path"),
+    printing_press_version:
+      typeof value.printing_press_version === "string" && value.printing_press_version.trim() !== ""
+        ? value.printing_press_version
+        : undefined,
   };
 
   return isRecord(value.mcp)

--- a/npm/src/versions.ts
+++ b/npm/src/versions.ts
@@ -1,0 +1,103 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/**
+ * Filename of the installed-version stamp, parked alongside the `skills`
+ * package's lockfile under `~/.agents/`. Keyed by CLI catalog name →
+ * `printing_press_version` (the generator version that printed the installed
+ * binary, sourced from the registry entry at install time).
+ *
+ * A parallel stamp (rather than reusing `~/.agents/.skill-lock.json`) keeps the
+ * version tracking decoupled from the `skills` package's content-hash contract —
+ * that file is owned by another tool whose format can change independently.
+ */
+export const STAMP_FILENAME = ".pp-cli-versions.json";
+
+export interface VersionStampDeps {
+  /** Home directory; when absent the stamp is skipped (read returns empty, write is a no-op). */
+  home?: string;
+  readFile: (path: string, encoding: BufferEncoding) => Promise<string>;
+  writeFile: (path: string, data: string) => Promise<void>;
+  mkdir: (path: string, options: { recursive: boolean }) => Promise<unknown>;
+}
+
+export const defaultStampDeps: VersionStampDeps = {
+  home: process.env.HOME ?? process.env.USERPROFILE,
+  readFile: (path, encoding) => readFile(path, encoding),
+  writeFile: (path, data) => writeFile(path, data, "utf8"),
+  mkdir: (path, options) => mkdir(path, options),
+};
+
+export function ppVersionsPath(home: string): string {
+  return join(home, ".agents", STAMP_FILENAME);
+}
+
+/**
+ * Read the installed-version stamp. Returns an empty map when the stamp is
+ * missing, corrupt, or `home` is unknown — callers treat "no stamp" as
+ * "version unknown → update" so the smart-update path degrades to the old
+ * unconditional sweep for first-time runs and malformed stamps.
+ */
+export async function readInstalledVersions(
+  deps: VersionStampDeps = defaultStampDeps,
+): Promise<Record<string, string>> {
+  if (!deps.home) {
+    return {};
+  }
+  let raw: string;
+  try {
+    raw = await deps.readFile(ppVersionsPath(deps.home), "utf8");
+  } catch {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  return isStringRecord(parsed) ? { ...parsed } : {};
+}
+
+/**
+ * Record (or clear) the installed `printing_press_version` for a single CLI.
+ * A read-modify-write preserves sibling entries; concurrent installs in a
+ * bundle run serially inside `installOne`, so there is no write-write race.
+ * Failures are swallowed: a missing stamp must not fail an otherwise-successful
+ * install, and the next install will retry the write.
+ */
+export async function writeInstalledVersion(
+  name: string,
+  version: string | undefined,
+  deps: VersionStampDeps = defaultStampDeps,
+): Promise<void> {
+  if (!deps.home) {
+    return;
+  }
+  const current = await readInstalledVersions(deps);
+  if (version === undefined || version === "") {
+    delete current[name];
+  } else {
+    current[name] = version;
+  }
+  const path = ppVersionsPath(deps.home);
+  try {
+    await deps.mkdir(dirname(path), { recursive: true });
+    await deps.writeFile(path, JSON.stringify(current, null, 2) + "\n");
+  } catch {
+    // Stamp write is best-effort; a failed write just means the next
+    // `update --stale-only` treats this CLI as unknown → re-installs.
+  }
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  for (const v of Object.values(value as Record<string, unknown>)) {
+    if (typeof v !== "string") {
+      return false;
+    }
+  }
+  return true;
+}

--- a/npm/tests/commands.test.ts
+++ b/npm/tests/commands.test.ts
@@ -334,6 +334,201 @@ test("update skips a CLI whose PATH probe throws instead of aborting the run", a
   assert.deepEqual(installed.sort(), ["cal-com", "espn"]);
 });
 
+// --- update --stale-only (smart skip) -------------------------------------
+
+const versionedRegistry: Registry = {
+  schema_version: 2,
+  entries: [
+    {
+      name: "espn",
+      category: "sports",
+      api: "ESPN",
+      description: "Live sports scores",
+      path: "library/sports/espn",
+      printing_press_version: "4.24.0",
+    },
+    {
+      name: "cal-com",
+      category: "productivity",
+      api: "Cal.com",
+      description: "Scheduling and booking links",
+      path: "library/productivity/cal-com",
+      printing_press_version: "4.25.0",
+    },
+  ],
+};
+
+test("update --stale-only skips current CLIs and re-installs stale ones", async () => {
+  const installs: string[] = [];
+  const stdout: string[] = [];
+  const command = createUpdateCommand({
+    fetchRegistry: async () => versionedRegistry,
+    commandOnPath: async (binary) =>
+      binary === "espn-pp-cli" || binary === "cal-com-pp-cli" ? `/bin/${binary}` : null,
+    readInstalledVersions: async () => ({
+      // espn was installed at 4.24.0 → matches registry → current (skip).
+      espn: "4.24.0",
+      // cal-com was installed at 4.24.0 → registry says 4.25.0 → stale (update).
+      "cal-com": "4.24.0",
+    }),
+    createInstall: () => async (args) => {
+      installs.push(args[0]!);
+      return 0;
+    },
+    stdout: (message) => stdout.push(message),
+  });
+
+  assert.equal(await command([]), 0);
+  // Only the stale CLI re-installs.
+  assert.deepEqual(installs, ["cal-com"]);
+  // The current CLI gets a skip notice.
+  assert.match(stdout.join("\n"), /espn is current.*skipping/);
+});
+
+test("update defaults to stale-only without an explicit flag", async () => {
+  const installs: string[] = [];
+  const command = createUpdateCommand({
+    fetchRegistry: async () => versionedRegistry,
+    commandOnPath: async (binary) => `/bin/${binary}`,
+    readInstalledVersions: async () => ({
+      espn: "4.24.0",
+      "cal-com": "4.25.0",
+    }),
+    createInstall: () => async (args) => {
+      installs.push(args[0]!);
+      return 0;
+    },
+  });
+
+  // No flag → stale-only is the default. Both CLIs are current → no installs.
+  assert.equal(await command([]), 0);
+  assert.deepEqual(installs, []);
+});
+
+test("update --all forces re-install of current CLIs", async () => {
+  const installs: string[] = [];
+  const command = createUpdateCommand({
+    fetchRegistry: async () => versionedRegistry,
+    commandOnPath: async (binary) =>
+      binary === "espn-pp-cli" || binary === "cal-com-pp-cli" ? `/bin/${binary}` : null,
+    readInstalledVersions: async () => ({
+      espn: "4.24.0",
+      "cal-com": "4.25.0",
+    }),
+    createInstall: () => async (args) => {
+      installs.push(args[0]!);
+      return 0;
+    },
+  });
+
+  assert.equal(await command(["--all"]), 0);
+  // --all ignores the stamp and re-installs everything detected.
+  assert.deepEqual(installs.sort(), ["cal-com", "espn"]);
+});
+
+test("update --stale-only treats a missing stamp entry as unknown and updates", async () => {
+  const installs: string[] = [];
+  const command = createUpdateCommand({
+    fetchRegistry: async () => versionedRegistry,
+    commandOnPath: async (binary) => `/bin/${binary}`,
+    readInstalledVersions: async () => ({
+      // espn stamped, cal-com missing from stamp entirely.
+      espn: "4.24.0",
+    }),
+    createInstall: () => async (args) => {
+      installs.push(args[0]!);
+      return 0;
+    },
+  });
+
+  assert.equal(await command([]), 0);
+  // espn is current (skip); cal-com is unknown → re-install.
+  assert.deepEqual(installs, ["cal-com"]);
+});
+
+test("update --stale-only treats a registry entry without printing_press_version as unknown and updates", async () => {
+  const unstampedRegistry: Registry = {
+    schema_version: 2,
+    entries: [
+      {
+        name: "espn",
+        category: "sports",
+        api: "ESPN",
+        description: "Live sports scores",
+        path: "library/sports/espn",
+        // no printing_press_version — can't determine currency → update.
+      },
+    ],
+  };
+  const installs: string[] = [];
+  const command = createUpdateCommand({
+    fetchRegistry: async () => unstampedRegistry,
+    commandOnPath: async () => "/bin/espn-pp-cli",
+    readInstalledVersions: async () => ({ espn: "4.24.0" }),
+    createInstall: () => async (args) => {
+      installs.push(args[0]!);
+      return 0;
+    },
+  });
+
+  assert.equal(await command([]), 0);
+  // No registry version → unknown → re-install rather than silently skip.
+  assert.deepEqual(installs, ["espn"]);
+});
+
+test("update --stale-only reports all-current and installs nothing", async () => {
+  const installs: string[] = [];
+  const stdout: string[] = [];
+  const command = createUpdateCommand({
+    fetchRegistry: async () => versionedRegistry,
+    commandOnPath: async (binary) => `/bin/${binary}`,
+    readInstalledVersions: async () => ({
+      espn: "4.24.0",
+      "cal-com": "4.25.0",
+    }),
+    createInstall: () => async (args) => {
+      installs.push(args[0]!);
+      return 0;
+    },
+    stdout: (message) => stdout.push(message),
+  });
+
+  assert.equal(await command([]), 0);
+  assert.deepEqual(installs, []);
+  assert.match(stdout.join("\n"), /2 detected CLIs are current/);
+  assert.match(stdout.join("\n"), /--all/);
+});
+
+test("update --stale-only then --all lets the last flag win (force all)", async () => {
+  const installs: string[] = [];
+  const command = createUpdateCommand({
+    fetchRegistry: async () => versionedRegistry,
+    commandOnPath: async (binary) => (binary === "espn-pp-cli" ? "/bin/espn-pp-cli" : null),
+    readInstalledVersions: async () => ({ espn: "4.24.0" }),
+    createInstall: () => async (args) => {
+      installs.push(args[0]!);
+      return 0;
+    },
+  });
+
+  // --all appears after --stale-only → last flag wins → force re-install.
+  assert.equal(await command(["--stale-only", "--all"]), 0);
+  assert.deepEqual(installs, ["espn"]);
+});
+
+test("help documents the --stale-only and --all update flags", async () => {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (message) => lines.push(String(message));
+  try {
+    await run(["--help"]);
+  } finally {
+    console.log = originalLog;
+  }
+  assert.match(lines.join("\n"), /--stale-only/);
+  assert.match(lines.join("\n"), /--all/);
+});
+
 test("uninstall command requires --yes", async () => {
   const stderr: string[] = [];
   const command = createUninstallCommand({

--- a/npm/tests/install.test.ts
+++ b/npm/tests/install.test.ts
@@ -801,3 +801,66 @@ test("install command points at the install dir when nothing is on PATH", async 
   // The error message names the specific path the user needs to add to PATH.
   assert.match(stderr.join("\n"), /\/Users\/example\/\.local\/bin\/espn-pp-cli/);
 });
+
+test("install stamps printing_press_version after a successful install", async () => {
+  const stampedRegistry: Registry = {
+    schema_version: 2,
+    entries: [
+      {
+        name: "espn",
+        category: "sports",
+        api: "ESPN",
+        description: "Sports scores",
+        path: "library/sports/espn",
+        printing_press_version: "4.24.0",
+      },
+    ],
+  };
+  const stamped: Array<{ name: string; version: string | undefined }> = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => stampedRegistry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
+    commandOnPath: async () => "/Users/example/go/bin/espn-pp-cli",
+    mkdir: async () => {},
+    installSkill: async () => ok(),
+    stdout: () => {},
+    stderr: () => {},
+    home: "/Users/example",
+    env: {},
+    readInstalledVersions: async () => ({}),
+    writeInstalledVersion: async (name, version) => {
+      stamped.push({ name, version });
+    },
+  });
+
+  assert.equal(await command(["espn"]), 0);
+  assert.deepEqual(stamped, [{ name: "espn", version: "4.24.0" }]);
+});
+
+test("install does not stamp when registry entry has no printing_press_version", async () => {
+  const stamped: Array<{ name: string; version: string | undefined }> = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
+    commandOnPath: async () => "/Users/example/go/bin/espn-pp-cli",
+    mkdir: async () => {},
+    installSkill: async () => ok(),
+    stdout: () => {},
+    stderr: () => {},
+    home: "/Users/example",
+    env: {},
+    readInstalledVersions: async () => ({}),
+    writeInstalledVersion: async (name, version) => {
+      stamped.push({ name, version });
+    },
+  });
+
+  assert.equal(await command(["espn"]), 0);
+  assert.deepEqual(stamped, []);
+});

--- a/npm/tests/registry.test.ts
+++ b/npm/tests/registry.test.ts
@@ -316,3 +316,56 @@ test("fetchGoModulePath reads go.mod next to a registry entry", async () => {
 test("parseGoModulePath returns null when no module declaration exists", () => {
   assert.equal(parseGoModulePath("go 1.23\n"), null);
 });
+
+test("parseRegistry preserves optional printing_press_version", () => {
+  const registry = parseRegistry({
+    schema_version: 2,
+    entries: [
+      {
+        name: "espn",
+        category: "sports",
+        api: "ESPN",
+        description: "Sports scores",
+        path: "library/sports/espn",
+        printing_press_version: "4.24.0",
+      },
+    ],
+  });
+
+  assert.equal(registry.entries[0]?.printing_press_version, "4.24.0");
+});
+
+test("parseRegistry leaves printing_press_version undefined when absent", () => {
+  const registry = parseRegistry({
+    schema_version: 2,
+    entries: [
+      {
+        name: "espn",
+        category: "sports",
+        api: "ESPN",
+        description: "Sports scores",
+        path: "library/sports/espn",
+      },
+    ],
+  });
+
+  assert.equal(registry.entries[0]?.printing_press_version, undefined);
+});
+
+test("parseRegistry treats blank printing_press_version as absent", () => {
+  const registry = parseRegistry({
+    schema_version: 2,
+    entries: [
+      {
+        name: "espn",
+        category: "sports",
+        api: "ESPN",
+        description: "Sports scores",
+        path: "library/sports/espn",
+        printing_press_version: "   ",
+      },
+    ],
+  });
+
+  assert.equal(registry.entries[0]?.printing_press_version, undefined);
+});

--- a/npm/tests/versions.test.ts
+++ b/npm/tests/versions.test.ts
@@ -1,0 +1,140 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ppVersionsPath,
+  readInstalledVersions,
+  STAMP_FILENAME,
+  writeInstalledVersion,
+  type VersionStampDeps,
+} from "../src/versions.js";
+
+function inMemoryDeps(home: string): {
+  deps: VersionStampDeps;
+  files: Map<string, string>;
+} {
+  const files = new Map<string, string>();
+  const deps: VersionStampDeps = {
+    home,
+    readFile: async (path) => files.get(path) ?? assert.fail(`read of unwritten file: ${path}`),
+    writeFile: async (path, data) => {
+      files.set(path, data);
+    },
+    mkdir: async () => {},
+  };
+  return { deps, files };
+}
+
+function lenientDeps(home: string): {
+  deps: VersionStampDeps;
+  files: Map<string, string>;
+} {
+  const files = new Map<string, string>();
+  const deps: VersionStampDeps = {
+    home,
+    readFile: async (path) => {
+      if (!files.has(path)) throw new Error("ENOENT");
+      return files.get(path)!;
+    },
+    writeFile: async (path, data) => {
+      files.set(path, data);
+    },
+    mkdir: async () => {},
+  };
+  return { deps, files };
+}
+
+test("ppVersionsPath lives under .agents next to the skills lockfile", () => {
+  assert.equal(ppVersionsPath("/Users/example"), `/Users/example/.agents/${STAMP_FILENAME}`);
+  assert.equal(STAMP_FILENAME, ".pp-cli-versions.json");
+});
+
+test("readInstalledVersions returns empty when the stamp is missing", async () => {
+  const { deps } = lenientDeps("/Users/example");
+  assert.deepEqual(await readInstalledVersions(deps), {});
+});
+
+test("readInstalledVersions returns empty when home is unset", async () => {
+  const deps: VersionStampDeps = {
+    home: undefined,
+    readFile: async () => assert.fail("should not read"),
+    writeFile: async () => assert.fail("should not write"),
+    mkdir: async () => {},
+  };
+  assert.deepEqual(await readInstalledVersions(deps), {});
+});
+
+test("readInstalledVersions parses a valid stamp", async () => {
+  const { deps, files } = lenientDeps("/Users/example");
+  files.set(
+    ppVersionsPath("/Users/example"),
+    JSON.stringify({ espn: "4.24.0", "weather-goat": "4.23.0" }) + "\n",
+  );
+  assert.deepEqual(await readInstalledVersions(deps), {
+    espn: "4.24.0",
+    "weather-goat": "4.23.0",
+  });
+});
+
+test("readInstalledVersions treats a corrupt stamp as empty", async () => {
+  const { deps, files } = lenientDeps("/Users/example");
+  files.set(ppVersionsPath("/Users/example"), "{not json");
+  assert.deepEqual(await readInstalledVersions(deps), {});
+});
+
+test("readInstalledVersions rejects non-string values", async () => {
+  const { deps, files } = lenientDeps("/Users/example");
+  files.set(
+    ppVersionsPath("/Users/example"),
+    JSON.stringify({ espn: "4.24.0", bad: 123 }),
+  );
+  assert.deepEqual(await readInstalledVersions(deps), {});
+});
+
+test("writeInstalledVersion records the version for a single CLI", async () => {
+  const { deps, files } = inMemoryDeps("/Users/example");
+  await writeInstalledVersion("espn", "4.24.0", deps);
+  const raw = files.get(ppVersionsPath("/Users/example"));
+  assert.ok(raw);
+  assert.deepEqual(JSON.parse(raw!), { espn: "4.24.0" });
+});
+
+test("writeInstalledVersion preserves sibling entries (read-modify-write)", async () => {
+  const { deps, files } = inMemoryDeps("/Users/example");
+  files.set(ppVersionsPath("/Users/example"), JSON.stringify({ espn: "4.24.0" }) + "\n");
+  await writeInstalledVersion("linear", "4.25.0", deps);
+  const raw = files.get(ppVersionsPath("/Users/example"));
+  assert.deepEqual(JSON.parse(raw!), { espn: "4.24.0", linear: "4.25.0" });
+});
+
+test("writeInstalledVersion overwrites an existing entry in place", async () => {
+  const { deps, files } = inMemoryDeps("/Users/example");
+  files.set(ppVersionsPath("/Users/example"), JSON.stringify({ espn: "4.24.0" }) + "\n");
+  await writeInstalledVersion("espn", "4.25.0", deps);
+  const raw = files.get(ppVersionsPath("/Users/example"));
+  assert.deepEqual(JSON.parse(raw!), { espn: "4.25.0" });
+});
+
+test("writeInstalledVersion with undefined clears the entry", async () => {
+  const { deps, files } = inMemoryDeps("/Users/example");
+  files.set(
+    ppVersionsPath("/Users/example"),
+    JSON.stringify({ espn: "4.24.0", linear: "4.25.0" }) + "\n",
+  );
+  await writeInstalledVersion("espn", undefined, deps);
+  const raw = files.get(ppVersionsPath("/Users/example"));
+  assert.deepEqual(JSON.parse(raw!), { linear: "4.25.0" });
+});
+
+test("writeInstalledVersion is a no-op when home is unset", async () => {
+  let wrote = false;
+  const deps: VersionStampDeps = {
+    home: undefined,
+    readFile: async () => "",
+    writeFile: async () => {
+      wrote = true;
+    },
+    mkdir: async () => {},
+  };
+  await writeInstalledVersion("espn", "4.24.0", deps);
+  assert.equal(wrote, false);
+});

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -91,8 +91,16 @@ type RegistryEntry struct {
 	Creator *Person `json:"creator,omitempty"`
 	// Contributors accrue as others improve a CLI (reprinter first), sourced
 	// from .printing-press.json's `contributors` array.
-	Contributors []Person  `json:"contributors,omitempty"`
-	MCP          *MCPBlock `json:"mcp,omitempty"`
+	Contributors []Person `json:"contributors,omitempty"`
+	// PrintingPressVersion is the version of the Printing Press generator
+	// that produced this CLI, sourced verbatim from .printing-press.json's
+	// `printing_press_version` field (a semver string like "4.24.0"). It
+	// answers "which generator binary printed this CLI?", distinct from the
+	// per-CLI release version in .printing-press-release.json. Emitted with
+	// omitempty so entries whose manifest predates the field (and any
+	// hand-authored registry.json without it) keep loading unchanged.
+	PrintingPressVersion string `json:"printing_press_version,omitempty"`
+	MCP                  *MCPBlock `json:"mcp,omitempty"`
 }
 
 // Person is one credited human (creator or contributor): a slug-safe GitHub
@@ -131,15 +139,16 @@ type MCPBlock struct {
 // (scorecard_total, run_id, etc.); we ignore them so a future generator
 // version that adds fields doesn't break this consumer.
 type printingPressManifest struct {
-	APIName            string   `json:"api_name"`
-	DisplayName        string   `json:"display_name"`
-	CatalogDescription string   `json:"catalog_description"`
-	Description        string   `json:"description"`
-	Creator            *Person  `json:"creator"`
-	Contributors       []Person `json:"contributors"`
-	Printer            string   `json:"printer"`
-	PrinterName        string   `json:"printer_name"`
-	CLIName            string   `json:"cli_name"`
+	APIName              string   `json:"api_name"`
+	DisplayName          string   `json:"display_name"`
+	CatalogDescription   string   `json:"catalog_description"`
+	Description          string   `json:"description"`
+	Creator              *Person  `json:"creator"`
+	Contributors         []Person `json:"contributors"`
+	Printer              string   `json:"printer"`
+	PrinterName          string   `json:"printer_name"`
+	PrintingPressVersion string   `json:"printing_press_version"`
+	CLIName              string   `json:"cli_name"`
 	AuthDescription    string   `json:"auth_description"`
 	MCPBinary          string   `json:"mcp_binary"`
 	MCPToolCount       int      `json:"mcp_tool_count"`
@@ -394,6 +403,11 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 		// transition; both come straight from .printing-press.json.
 		Creator:      pp.Creator,
 		Contributors: pp.Contributors,
+		// PrintingPressVersion is manifest-sourced like the other
+		// provenance fields. Entries whose manifest predates the field
+		// emit no key (omitempty), so the registry stays backward-
+		// compatible with hand-authored entries that lack it.
+		PrintingPressVersion: pp.PrintingPressVersion,
 	}
 
 	// Description preference: explicit .printing-press.json catalog_description

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -840,4 +841,112 @@ No sentinels here.
 	if !strings.Contains(err.Error(), "missing begin sentinel") {
 		t.Errorf("expected missing-sentinel error, got: %v", err)
 	}
+}
+
+// TestRegistryEntry_PrintingPressVersionRoundTrip pins the JSON
+// serialization contract for printing_press_version: a set value
+// round-trips through marshal/unmarshal, and an empty value is omitted
+// (omitempty) so existing registry.json entries without the field keep
+// loading unchanged. This is the backward-compatibility guarantee the
+// additive field rests on.
+func TestRegistryEntry_PrintingPressVersionRoundTrip(t *testing.T) {
+	t.Run("set value round-trips", func(t *testing.T) {
+		entry := RegistryEntry{
+			Name:                 "espn",
+			Category:             "media",
+			API:                  "ESPN",
+			Description:          "Scores.",
+			Path:                 "library/media/espn",
+			PrintingPressVersion: "4.24.0",
+		}
+		data, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !strings.Contains(string(data), `"printing_press_version":"4.24.0"`) {
+			t.Fatalf("marshaled JSON missing printing_press_version, got: %s", data)
+		}
+		var back RegistryEntry
+		if err := json.Unmarshal(data, &back); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if back.PrintingPressVersion != "4.24.0" {
+			t.Errorf("round-trip PrintingPressVersion = %q, want %q", back.PrintingPressVersion, "4.24.0")
+		}
+	})
+
+	t.Run("empty value is omitted", func(t *testing.T) {
+		entry := RegistryEntry{
+			Name:        "legacy",
+			Category:    "tools",
+			API:         "Legacy",
+			Description: "Old entry.",
+			Path:        "library/tools/legacy",
+		}
+		data, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(data), "printing_press_version") {
+			t.Fatalf("empty PrintingPressVersion should be omitted, got: %s", data)
+		}
+	})
+
+	t.Run("missing field loads as empty", func(t *testing.T) {
+		raw := `{"name":"x","category":"c","api":"X","description":"d","path":"p"}`
+		var entry RegistryEntry
+		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if entry.PrintingPressVersion != "" {
+			t.Errorf("PrintingPressVersion = %q, want empty for entry without the field", entry.PrintingPressVersion)
+		}
+	})
+}
+
+// TestBuildEntry_PropagatesPrintingPressVersion verifies the manifest's
+// printing_press_version reaches the registry entry. Uses a temp CLI
+// directory with a minimal .printing-press.json so the buildEntry path
+// (the real source-of-truth wiring) is exercised end-to-end.
+func TestBuildEntry_PropagatesPrintingPressVersion(t *testing.T) {
+	cliDir := t.TempDir()
+	manifest := `{
+		"api_name": "demo",
+		"cli_name": "demo-pp-cli",
+		"printing_press_version": "4.19.0",
+		"display_name": "Demo",
+		"description": "A demo CLI."
+	}`
+	if err := os.WriteFile(filepath.Join(cliDir, ".printing-press.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	entry, err := buildEntry(cliDir, "tools", "demo", map[string]RegistryEntry{})
+	if err != nil {
+		t.Fatalf("buildEntry: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("buildEntry returned nil entry")
+	}
+	if entry.PrintingPressVersion != "4.19.0" {
+		t.Errorf("entry.PrintingPressVersion = %q, want %q", entry.PrintingPressVersion, "4.19.0")
+	}
+
+	t.Run("manifest without field yields empty entry value", func(t *testing.T) {
+		emptyDir := t.TempDir()
+		noVersion := `{"api_name":"nov","cli_name":"nov-pp-cli","display_name":"Nov","description":"No version."}`
+		if err := os.WriteFile(filepath.Join(emptyDir, ".printing-press.json"), []byte(noVersion), 0o644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+		entry, err := buildEntry(emptyDir, "tools", "nov", map[string]RegistryEntry{})
+		if err != nil {
+			t.Fatalf("buildEntry: %v", err)
+		}
+		if entry == nil {
+			t.Fatal("buildEntry returned nil entry")
+		}
+		if entry.PrintingPressVersion != "" {
+			t.Errorf("entry.PrintingPressVersion = %q, want empty when manifest lacks the field", entry.PrintingPressVersion)
+		}
+	})
 }


### PR DESCRIPTION
## Intent

Make `printing-press-library update` smart: skip CLIs whose installed generator version matches the registry, re-installing only the stale or unknown ones. Today `update` re-installs every detected CLI unconditionally — no staleness check. This is the strategic move from the pp-update-explore-k2 scout and the visibility/staleness gap [#1299](https://github.com/mvanhorn/printing-press-library/issues/1299) targets.

Builds on [#1311](https://github.com/mvanhorn/printing-press-library/pull/1311) (`printing_press_version` field in `RegistryEntry`); branched off `feat/registryentry-printing-press-version`.

## Approach

Three additive pieces, all behind injectable deps for testing:

**1. Installed-version stamp** (`npm/src/versions.ts`, new): read/write a parallel stamp at `~/.agents/.pp-cli-versions.json` keyed by CLI catalog name → `printing_press_version`. A parallel stamp (not the `skills` package's `.skill-lock.json`) keeps the version tracking decoupled from that file's content-hash contract — the two tools evolve independently. Missing/corrupt stamps read as `{}` so `update` degrades to the old sweep on first run and after any filesystem mishap.

**2. Stamping on install** (`install.ts`): after a successful install, record `entry.printing_press_version` in the stamp. Only stamped when the registry carries the field; entries without it stay unstamped so `update` treats them as unknown (→ re-install) rather than silently current. `writeInstalledVersion` is best-effort — a failed write is swallowed so it can't fail an otherwise-successful install.

**3. Smart update** (`update.ts`): after detecting installed CLIs, partition into "current" (skip) and "stale/unknown" (re-install). A CLI is current only when both the stamp and the registry carry a `printing_press_version` and they match; any uncertainty (missing stamp, missing field, mismatch) → re-install. Skip notices are emitted before the buffered install output; a summary line reports the skip count and points at `--all`.

**Flags:**
- `--stale-only` is the **default** (smart skip).
- `--all` forces the old unconditional sweep.
- Both together: last flag wins (conventional CLI toggle behavior).
- Single-target `update <name>` ignores stale-only — naming a CLI explicitly is a force-refresh of that one CLI.

**Graceful degradation:** CLIs whose registry entry lacks `printing_press_version` (older prints, pre-#1311 catalog entries) are treated as unknown and always re-installed. Smart-update behaves identically to the old sweep until the field propagates across the catalog.

## Scope

| File | Change |
|---|---|
| `npm/src/versions.ts` (new) | Stamp read/write module with injectable IO |
| `npm/src/commands/install.ts` | Stamp after successful install; add stamp deps |
| `npm/src/commands/update.ts` | `--stale-only` (default) / `--all` flags; skip logic |
| `npm/src/cli.ts` | Help text for new flags |
| `npm/tests/versions.test.ts` (new) | 12 unit tests for stamp read/write |
| `npm/tests/install.test.ts` | 2 tests: stamps when version present, skips when absent |
| `npm/tests/commands.test.ts` | 7 tests: stale-only skip/current, --all, unknown, default, help |
| `npm/README.md` | Document smart update + flags |
| `npm/CHANGELOG.md` | 0.1.18 + 0.1.19 entries |
| `npm/package.json` / `package-lock.json` | 0.1.18 → 0.1.19 (verify-npm-version-bump gate) |
| `AGENTS.md` | Document smart-update behavior in NPM installer surface section |

## Risk

- **Behavior change:** `update` (no name) now skips current CLIs by default. Users who relied on the unconditional sweep get it back with `--all`. The skip is safe: it only fires when stamp and registry versions are both present and match; any uncertainty → re-install.
- **First run after this ships:** stamps are empty, so every detected CLI is "unknown → re-install" — identical to the old sweep. The second run starts benefiting from skips.
- **No change to single-target** `update <name>` — still always installs.
- **Stamp file location** (`~/.agents/.pp-cli-versions.json`) sits alongside the skills lockfile but is a separate file; the skills package never reads or writes it.

## Verification

```
npm test  → 113 tests, 113 pass, 0 fail
npm run build → clean (tsc strict)
```

Key test scenarios covered:
- Install at version X → bump registry to Y → `update --stale-only` → only stale CLI re-installs, current one skipped
- Missing stamp entry → unknown → re-install
- Missing registry `printing_press_version` → unknown → re-install
- `--all` forces re-install of current CLIs
- Default (no flag) is stale-only
- Help documents both flags

## AI disclosure

Human-reviewed.
