### PR TITLE
fix(suno): re-seed captcha cookies + repair interactive recovery + wire --exclude (supersedes #1159)

### DIFF
--- a/library/media-and-entertainment/suno/.printing-press-patches/captcha-always-reseed-and-interactive-recovery.json
+++ b/library/media-and-entertainment/suno/.printing-press-patches/captcha-always-reseed-and-interactive-recovery.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "captcha-always-reseed-and-interactive-recovery",
+  "applied_at": "2026-06-21",
+  "base_run_id": "20260528-222057",
+  "base_printing_press_version": "4.14.0",
+  "summary": "Harden the piloted-Chrome hCaptcha solver: re-seed the full Suno cookie jar on every solve (avoids paperfoot/suno-cli#3's per-generation OAuth popup), remove the vestigial Seeded flag that tempted a regression back into that bug, and repair the broken interactive recovery so the solver window actually comes on-screen (CDP setWindowBounds) with a rendered-challenge probe and three distinct, actionable timeout/error messages.",
+  "reason": "Follow-up correctness fixes to the piloted-Chrome captcha subsystem shipped in PR #1076. Three findings, all live-verified (captcha-gated `generate describe --wait` produced 2 complete clips, exit 0, no orphaned Chrome): (1) ALWAYS-RESEED — the solver and ReadSunoCookies doc comments claimed the dedicated profile was seeded once and persisted thereafter, but a persisted profile session can outlive the actual Clerk/Google-SSO login; that stale session is exactly what triggers paperfoot/suno-cli#3's per-generation \"Continue as <user>\" OAuth popup. Solve() already re-seeds the full cookie jar (incl. Clerk __client/__session) every call and never calls clearBrowserCookies; the two stale doc comments were corrected and a regression test (TestSolve_AlwaysSeeds) locks the always-reseed invariant in. (2) REMOVE SEEDED FLAG — Options.Seeded, config CaptchaProfile.Seeded (toml `seeded`), the persistSeeded callback, and the `seeded=%v` status output were written, persisted, and displayed but gated nothing — a latent trap inviting a regression back into #3. Removed; go-toml/v2 ignores the now-unknown key so existing configs still load. (3) INTERACTIVE RECOVERY — showOnScreen used window.moveTo(), a no-op on a top-level browser window, so on the rare interactive captcha the challenge stayed parked offscreen (x=-32000) and the user had to kill Chrome by hand. It now repositions via CDP Browser.setWindowBounds; the re-render-every-2s loop (which spawned a new widget each tick) was replaced with a single non-blocking execute + token poll; a challenge-visibility probe (challengeVisibleJS) verifies the captcha is genuinely presented and fails fast if it never renders; and three distinct messages distinguish window-couldn't-show / challenge-never-rendered / shown-but-not-solved. Interactive timing knobs were made vars so tests can shrink them, with tests added for all three paths. Verified: go build ./..., go vet ./... clean, gofmt clean, full test suite passes (captcha/auth/config/cli green; new tests TestSolve_AlwaysSeeds, TestSolve_InteractiveFallback_ShowsVerifiesAndSolves, TestSolve_InteractiveChallengeNeverRenders_Errors, TestSolve_InteractiveShownButUnsolved_TimesOut all pass).",
+  "files": [
+    "internal/captcha/solver.go",
+    "internal/captcha/execute.go",
+    "internal/captcha/chrome.go",
+    "internal/captcha/cookies.go",
+    "internal/captcha/config.go",
+    "internal/captcha/solver_test.go",
+    "internal/auth/chrome.go",
+    "internal/cli/suno_auth_captcha.go",
+    "internal/cli/suno_captcha_solver.go",
+    "internal/config/suno_captcha.go"
+  ],
+  "validated_outcome": "go build ./... && go vet ./... && gofmt -l (clean) && go test ./internal/captcha/ ./internal/auth/ ./internal/config/ ./internal/cli/ (all pass, incl. 4 new captcha interactive/always-seeds tests)",
+  "findings_addressed": [
+    "F1-always-reseed-avoids-oauth-popup",
+    "F2-remove-vestigial-seeded-flag",
+    "F3-interactive-window-show-and-render-probe"
+  ]
+}

--- a/library/media-and-entertainment/suno/internal/auth/chrome.go
+++ b/library/media-and-entertainment/suno/internal/auth/chrome.go
@@ -80,9 +80,11 @@ type SunoCookie struct {
 }
 
 // ReadSunoCookies returns every cookie on suno.com / auth.suno.com / .suno.com
-// from the user's Chrome store. Used once per profile to seed a dedicated
-// solver profile; the session then persists in that profile and this is not
-// called again. Returns an empty slice (not an error) when none are found.
+// from the user's Chrome store — the full jar, including the Clerk __client and
+// __session cookies. The captcha solver re-seeds from this on every solve so the
+// dedicated profile's session can never go stale (this is what keeps us clear of
+// paperfoot/suno-cli#3's popup); SunoStudioCookieHeader also reads it. Returns
+// an empty slice (not an error) when none are found.
 func ReadSunoCookies(ctx context.Context) ([]SunoCookie, error) {
 	raw := kooky.TraverseCookies(ctx, kooky.DomainHasSuffix("suno.com")).Collect(ctx)
 	out := make([]SunoCookie, 0, len(raw))

--- a/library/media-and-entertainment/suno/internal/captcha/chrome.go
+++ b/library/media-and-entertainment/suno/internal/captcha/chrome.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"time"
 
+	cdpbrowser "github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
@@ -118,8 +119,25 @@ func (b *chromedpBrowser) evaluate(_ context.Context, js string) (string, error)
 	return out, err
 }
 
+// showOnScreen repositions the offscreen solver window back onto the visible
+// desktop via CDP Browser.setWindowBounds. The window is launched parked at
+// x=-32000; window.moveTo() does NOT move a top-level browser window (it only
+// works on script-opened popups), which is why the interactive fallback used to
+// leave the challenge invisible and the user had to kill Chrome by hand. Left/
+// Top are positive on purpose: cdproto's Bounds tags Left/Top omitzero, so 0
+// would be dropped from the JSON and the window would stay parked offscreen.
 func (b *chromedpBrowser) showOnScreen(_ context.Context) error {
-	return chromedp.Run(b.runCtx, chromedp.Evaluate(`window.moveTo(0,0); window.focus();`, nil))
+	return chromedp.Run(b.runCtx, chromedp.ActionFunc(func(ctx context.Context) error {
+		winID, _, err := cdpbrowser.GetWindowForTarget().Do(ctx)
+		if err != nil {
+			return err
+		}
+		bounds := &cdpbrowser.Bounds{
+			Left: 60, Top: 60, Width: 1280, Height: 900,
+			WindowState: cdpbrowser.WindowStateNormal,
+		}
+		return cdpbrowser.SetWindowBounds(winID, bounds).Do(ctx)
+	}))
 }
 
 func (b *chromedpBrowser) close() {

--- a/library/media-and-entertainment/suno/internal/captcha/config.go
+++ b/library/media-and-entertainment/suno/internal/captcha/config.go
@@ -36,7 +36,6 @@ type Options struct {
 	Profile     string        // resolved profile name (e.g. "default", "work")
 	UserDataDir string        // dedicated profile dir; never the user's real Chrome
 	CDPPort     int           // this profile's CDP port
-	Seeded      bool          // whether the profile already has a persisted session
 	Interactive bool          // false under --no-input/--agent — suppress the visible fallback
 	Timeout     time.Duration // overall solve budget (0 => DefaultTimeout)
 }

--- a/library/media-and-entertainment/suno/internal/captcha/cookies.go
+++ b/library/media-and-entertainment/suno/internal/captcha/cookies.go
@@ -1,8 +1,11 @@
 // Copyright 2026 horknfbr. Licensed under Apache-2.0. See LICENSE.
 //
-// First-use seeding: map the user's Suno cookies (read once from their main
-// browser) into CDP Network.setCookies params. After seeding, the session
-// persists in the dedicated profile and this path is not exercised again.
+// Per-solve seeding: map the user's full Suno cookie jar (read live from their
+// main browser on every solve) into CDP Network.setCookies params. Re-seeding
+// each call — rather than trusting the dedicated profile to persist the session
+// — keeps the Clerk/Google-SSO session fresh and avoids paperfoot/suno-cli#3's
+// per-generation "Continue as <user>" OAuth popup (a stale dedicated-profile
+// session that can no longer re-auth silently).
 
 package captcha
 

--- a/library/media-and-entertainment/suno/internal/captcha/execute.go
+++ b/library/media-and-entertainment/suno/internal/captcha/execute.go
@@ -92,7 +92,7 @@ func challengeVisibleJS() string {
     const s = (f.src || '').toLowerCase();
     if (t.indexOf('hcaptcha') < 0 && s.indexOf('hcaptcha') < 0) continue;
     const r = f.getBoundingClientRect();
-    if (r.width > 40 && r.height > 40 && f.offsetParent !== null) return 'visible';
+    if (r.width > 40 && r.height > 40) return 'visible';
   }
   return 'hidden';
 })()`

--- a/library/media-and-entertainment/suno/internal/captcha/execute.go
+++ b/library/media-and-entertainment/suno/internal/captcha/execute.go
@@ -12,9 +12,11 @@ import (
 )
 
 // solveJS returns the page script that renders an invisible hCaptcha widget and
-// resolves to the token string (or "ERR:<reason>").
+// resolves to the token string (or "ERR:<reason>"). This is the headless,
+// no-interaction attempt: it awaits execute() inline and is used before any
+// window is shown.
 func solveJS() string {
-	return fmt.Sprintf(`
+	return fmt.Sprintf(`/*pp:invisible*/
 (async () => {
   try {
     const div = document.createElement('div');
@@ -35,6 +37,65 @@ func solveJS() string {
     return 'ERR:' + String(e);
   }
 })()`, SunoHCaptchaSitekey, hcaptchaEndpoint, hcaptchaAssetHost, hcaptchaImgHost, hcaptchaReportAPI)
+}
+
+// interactiveKickJS renders a fresh invisible widget and fires execute()
+// WITHOUT awaiting it inline, stashing the eventual token on window.__ppTok (or
+// the error on window.__ppErr). Once the solver window is on-screen, execute()
+// surfaces the visible hCaptcha challenge overlay; the user solves it and the
+// promise resolves. Because it doesn't block, the Go side can poll both for the
+// token (interactiveTokenJS) and for the challenge actually rendering
+// (challengeVisibleJS) instead of re-rendering a new widget every tick.
+func interactiveKickJS() string {
+	return fmt.Sprintf(`/*pp:kick*/
+(() => {
+  try {
+    window.__ppTok = ''; window.__ppErr = '';
+    const div = document.createElement('div');
+    div.style.cssText = 'position:fixed;top:-9999px;left:-9999px;';
+    document.body.appendChild(div);
+    const id = hcaptcha.render(div, {
+      sitekey: '%s', size:'invisible', sentry: false,
+      endpoint: '%s', assethost: '%s', imghost: '%s', reportapi: '%s',
+    });
+    hcaptcha.execute(id, { async: true })
+      .then(r => { window.__ppTok = (r && r.response) ? r.response : ''; })
+      .catch(e => { window.__ppErr = String(e); });
+    return 'ok';
+  } catch (e) { return 'ERR:' + String(e); }
+})()`, SunoHCaptchaSitekey, hcaptchaEndpoint, hcaptchaAssetHost, hcaptchaImgHost, hcaptchaReportAPI)
+}
+
+// interactiveTokenJS reports the result of the in-flight interactive execute():
+// the token once solved, "ERR:<reason>" if it rejected, or "" while still
+// waiting on the user.
+func interactiveTokenJS() string {
+	return `/*pp:token*/
+(() => {
+  if (window.__ppTok) return window.__ppTok;
+  if (window.__ppErr) return 'ERR:' + window.__ppErr;
+  return '';
+})()`
+}
+
+// challengeVisibleJS returns "visible" once an hCaptcha challenge iframe is
+// actually rendered with a non-trivial on-screen box, else "hidden". This is how
+// the solver verifies the captcha was genuinely presented to the user, so it can
+// fail fast with a clear message instead of waiting out the whole budget on a
+// window showing nothing solvable.
+func challengeVisibleJS() string {
+	return `/*pp:visible*/
+(() => {
+  const fs = Array.from(document.querySelectorAll('iframe'));
+  for (const f of fs) {
+    const t = (f.title || '').toLowerCase();
+    const s = (f.src || '').toLowerCase();
+    if (t.indexOf('hcaptcha') < 0 && s.indexOf('hcaptcha') < 0) continue;
+    const r = f.getBoundingClientRect();
+    if (r.width > 40 && r.height > 40 && f.offsetParent !== null) return 'visible';
+  }
+  return 'hidden';
+})()`
 }
 
 // classifyToken interprets the raw JS result:

--- a/library/media-and-entertainment/suno/internal/captcha/solver.go
+++ b/library/media-and-entertainment/suno/internal/captcha/solver.go
@@ -127,6 +127,23 @@ func (s *solver) Solve(ctx context.Context, opts Options) (string, error) {
 	return solveInteractively(ctx, b, timeout)
 }
 
+// kickInteractive renders+executes a fresh invisible hCaptcha challenge. The
+// kick script's outer try/catch returns "ERR:..." synchronously when
+// hcaptcha.render/execute throws (e.g. hcaptcha not loaded, widget limit hit)
+// — a path that never sets window.__ppErr, so the token poll would otherwise
+// stay empty and the caller would wait out the render-grace before reporting a
+// misleading "never rendered". Surface that JS failure immediately instead.
+func kickInteractive(ctx context.Context, b browser) error {
+	raw, err := b.evaluate(ctx, interactiveKickJS())
+	if err != nil {
+		return err
+	}
+	if r := strings.TrimSpace(raw); strings.HasPrefix(r, "ERR:") {
+		return fmt.Errorf("captcha: could not start the interactive challenge: %s", strings.TrimPrefix(r, "ERR:"))
+	}
+	return nil
+}
+
 // solveInteractively brings the offscreen solver window onto the desktop,
 // presents a fresh hCaptcha challenge, verifies it actually rendered, then polls
 // for the user-submitted token until the deadline. It distinguishes three
@@ -136,7 +153,7 @@ func solveInteractively(ctx context.Context, b browser, budget time.Duration) (s
 	if err := b.showOnScreen(ctx); err != nil {
 		return "", fmt.Errorf("captcha: could not bring the solver window on-screen: %w", err)
 	}
-	if _, err := b.evaluate(ctx, interactiveKickJS()); err != nil {
+	if err := kickInteractive(ctx, b); err != nil {
 		return "", err
 	}
 
@@ -165,7 +182,7 @@ func solveInteractively(ctx context.Context, b browser, budget time.Duration) (s
 			if strings.Contains(reason, "expired") {
 				// The challenge timed out before the user finished. Present a
 				// fresh one and restart the render-grace window.
-				if _, err := b.evaluate(ctx, interactiveKickJS()); err != nil {
+				if err := kickInteractive(ctx, b); err != nil {
 					return "", err
 				}
 				sawChallenge = false

--- a/library/media-and-entertainment/suno/internal/captcha/solver.go
+++ b/library/media-and-entertainment/suno/internal/captcha/solver.go
@@ -31,8 +31,14 @@ func New() Solver {
 }
 
 // interactivePollInterval is how often the visible-fallback re-checks for a
-// solved token.
-const interactivePollInterval = 2 * time.Second
+// solved token and for the challenge having rendered. Var, not const, so tests
+// can shrink it.
+var interactivePollInterval = 2 * time.Second
+
+// challengeRenderGrace bounds how long we wait, after foregrounding the window,
+// for the hCaptcha challenge to actually appear. If it never renders we fail
+// with a clear error instead of blocking on a window the user can't act on.
+var challengeRenderGrace = 15 * time.Second
 
 // hcaptchaLoadPollInterval is how often we re-check whether the hCaptcha API
 // has finished loading on the page.
@@ -78,8 +84,10 @@ func (s *solver) Solve(ctx context.Context, opts Options) (string, error) {
 	// Always seed the session from the user's logged-in Chrome cookies before
 	// navigating: suno.com/create only loads the hCaptcha API for an
 	// authenticated session, and the dedicated solver profile is not a reliable
-	// persistence store — the Seeded flag can outlive the actual session, which
-	// left the page logged out and hCaptcha unloaded.
+	// persistence store — a persisted profile session can outlive the actual
+	// login, which left the page logged out and hCaptcha unloaded. Re-seeding the
+	// full cookie jar every solve is also what keeps us clear of
+	// paperfoot/suno-cli#3's per-generation OAuth popup.
 	cookies, serr := s.seed(ctx)
 	if serr != nil {
 		return "", serr
@@ -116,26 +124,67 @@ func (s *solver) Solve(ctx context.Context, opts Options) (string, error) {
 	if !opts.Interactive {
 		return "", ErrInteractiveRequired
 	}
+	return solveInteractively(ctx, b, timeout)
+}
 
+// solveInteractively brings the offscreen solver window onto the desktop,
+// presents a fresh hCaptcha challenge, verifies it actually rendered, then polls
+// for the user-submitted token until the deadline. It distinguishes three
+// failure modes so the user knows what went wrong: the window couldn't be shown,
+// the challenge never rendered, or it rendered but wasn't solved in time.
+func solveInteractively(ctx context.Context, b browser, budget time.Duration) (string, error) {
 	if err := b.showOnScreen(ctx); err != nil {
+		return "", fmt.Errorf("captcha: could not bring the solver window on-screen: %w", err)
+	}
+	if _, err := b.evaluate(ctx, interactiveKickJS()); err != nil {
 		return "", err
 	}
+
+	graceDeadline := time.Now().Add(challengeRenderGrace)
+	sawChallenge := false
 	for {
 		select {
 		case <-ctx.Done():
-			return "", ctx.Err()
+			if !sawChallenge {
+				return "", fmt.Errorf("captcha: the challenge never appeared in the Chrome window within %s — re-run, or check you're logged into suno.com in Chrome: %w", budget, ctx.Err())
+			}
+			return "", fmt.Errorf("captcha: challenge was shown but not solved within %s — solve it sooner or re-run: %w", budget, ctx.Err())
 		case <-time.After(interactivePollInterval):
 		}
-		raw, err := b.evaluate(ctx, solveJS())
+
+		raw, err := b.evaluate(ctx, interactiveTokenJS())
 		if err != nil {
 			return "", err
 		}
-		tok, _, cerr := classifyToken(raw)
-		if cerr != nil {
-			return "", cerr
+		raw = strings.TrimSpace(raw)
+		switch {
+		case raw == "":
+			// still waiting on the user
+		case strings.HasPrefix(raw, "ERR:"):
+			reason := strings.ToLower(strings.TrimPrefix(raw, "ERR:"))
+			if strings.Contains(reason, "expired") {
+				// The challenge timed out before the user finished. Present a
+				// fresh one and restart the render-grace window.
+				if _, err := b.evaluate(ctx, interactiveKickJS()); err != nil {
+					return "", err
+				}
+				sawChallenge = false
+				graceDeadline = time.Now().Add(challengeRenderGrace)
+				continue
+			}
+			return "", fmt.Errorf("captcha solver: %s", strings.TrimPrefix(raw, "ERR:"))
+		default:
+			return raw, nil // solved
 		}
-		if tok != "" {
-			return tok, nil
+
+		// Verify the challenge is genuinely on-screen; fail fast if it never is.
+		if !sawChallenge {
+			vis, _ := b.evaluate(ctx, challengeVisibleJS())
+			if strings.TrimSpace(vis) == "visible" {
+				sawChallenge = true
+			} else if time.Now().After(graceDeadline) {
+				return "", fmt.Errorf("captcha: the hCaptcha challenge did not render in the Chrome window within %s — the page presented no solvable challenge; re-run or verify your suno.com login", challengeRenderGrace)
+			}
 		}
 	}
 }

--- a/library/media-and-entertainment/suno/internal/captcha/solver_test.go
+++ b/library/media-and-entertainment/suno/internal/captcha/solver_test.go
@@ -71,6 +71,7 @@ type fakeBrowser struct {
 	tokenResults []string // /*pp:token*/ results, in sequence
 	tokenCalls   int
 	visible      string // /*pp:visible*/ result; "" defaults to "visible"
+	kickResult   string // /*pp:kick*/ result; "" defaults to "ok"
 	shown        bool
 	cookiesSet   bool
 	kicks        int
@@ -91,6 +92,9 @@ func (f *fakeBrowser) evaluate(_ context.Context, js string) (string, error) {
 		return f.firstResult, nil
 	case strings.Contains(js, "/*pp:kick*/"):
 		f.kicks++
+		if f.kickResult != "" {
+			return f.kickResult, nil
+		}
 		return "ok", nil
 	case strings.Contains(js, "/*pp:token*/"):
 		r := ""
@@ -200,6 +204,23 @@ func TestSolve_InteractiveChallengeNeverRenders_Errors(t *testing.T) {
 	_, err := s.Solve(context.Background(), Options{Profile: "default", Interactive: true})
 	if err == nil || !strings.Contains(err.Error(), "did not render") {
 		t.Fatalf("want 'did not render' error, got %v", err)
+	}
+}
+
+// TestSolve_InteractiveKickError_SurfacesImmediately: when the kick script throws
+// synchronously (hcaptcha.render/execute), it returns "ERR:..." without ever
+// setting window.__ppErr. The solver must report that JS failure right away
+// rather than waiting out the render-grace and blaming a non-rendered challenge.
+func TestSolve_InteractiveKickError_SurfacesImmediately(t *testing.T) {
+	defer swapTiming(1*time.Millisecond, time.Hour)() // huge grace: a render-grace fallthrough would hang, not fail fast
+	fb := &fakeBrowser{firstResult: "", kickResult: "ERR:hcaptcha is not defined"}
+	s := newTestSolver(fb, func(context.Context) ([]CDPCookie, error) { return nil, nil })
+	_, err := s.Solve(context.Background(), Options{Profile: "default", Interactive: true})
+	if err == nil || !strings.Contains(err.Error(), "hcaptcha is not defined") {
+		t.Fatalf("want kick failure surfaced, got %v", err)
+	}
+	if strings.Contains(err.Error(), "did not render") {
+		t.Fatalf("must not mask the real JS error as a render timeout: %v", err)
 	}
 }
 

--- a/library/media-and-entertainment/suno/internal/captcha/solver_test.go
+++ b/library/media-and-entertainment/suno/internal/captcha/solver_test.go
@@ -41,7 +41,7 @@ func newReadinessSolver(fb *readinessFake) *solver {
 
 func TestSolve_WaitsForHCaptchaThenSolves(t *testing.T) {
 	fb := &readinessFake{notReadyLeft: 2, token: "P1_after_load"}
-	tok, err := newReadinessSolver(fb).Solve(context.Background(), Options{Profile: "default", Seeded: true})
+	tok, err := newReadinessSolver(fb).Solve(context.Background(), Options{Profile: "default"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,37 +56,57 @@ func TestSolve_WaitsForHCaptchaThenSolves(t *testing.T) {
 func TestSolve_HCaptchaNeverLoads_Errors(t *testing.T) {
 	fb := &readinessFake{notReadyLeft: 1 << 30, token: "x"}
 	_, err := newReadinessSolver(fb).Solve(context.Background(),
-		Options{Profile: "default", Seeded: true, Timeout: 300 * time.Millisecond})
+		Options{Profile: "default", Timeout: 300 * time.Millisecond})
 	if err == nil || !strings.Contains(err.Error(), "never finished loading") {
 		t.Fatalf("want 'never finished loading' error, got %v", err)
 	}
 }
 
-// fakeBrowser drives solver branch tests without real Chrome.
+// fakeBrowser drives solver branch tests without real Chrome. It dispatches on
+// the JS markers emitted by execute.go, so each phase (the invisible attempt,
+// the interactive kick, the token poll, the visibility probe) is steered
+// independently rather than via a brittle call-sequence.
 type fakeBrowser struct {
-	evalResults []string // returned in sequence per evaluate call
-	calls       int
-	shown       bool
-	cookiesSet  bool
+	firstResult  string   // /*pp:invisible*/ result (headless attempt)
+	tokenResults []string // /*pp:token*/ results, in sequence
+	tokenCalls   int
+	visible      string // /*pp:visible*/ result; "" defaults to "visible"
+	shown        bool
+	cookiesSet   bool
+	kicks        int
 }
 
 func (f *fakeBrowser) setCookies(_ context.Context, _ []CDPCookie) error {
 	f.cookiesSet = true
 	return nil
 }
-func (f *fakeBrowser) navigate(_ context.Context) error { return nil }
-func (f *fakeBrowser) evaluate(_ context.Context, js string) (string, error) {
-	// The readiness poll runs before the solve JS; report ready immediately so
-	// these branch tests exercise the solve path, not the load wait.
-	if strings.Contains(js, "hcaptcha.render === 'function'") {
-		return "ready", nil
-	}
-	r := f.evalResults[f.calls]
-	f.calls++
-	return r, nil
-}
+func (f *fakeBrowser) navigate(_ context.Context) error     { return nil }
 func (f *fakeBrowser) showOnScreen(_ context.Context) error { f.shown = true; return nil }
 func (f *fakeBrowser) close()                               {}
+func (f *fakeBrowser) evaluate(_ context.Context, js string) (string, error) {
+	switch {
+	case strings.Contains(js, "render === 'function'"): // readiness poll
+		return "ready", nil
+	case strings.Contains(js, "/*pp:invisible*/"):
+		return f.firstResult, nil
+	case strings.Contains(js, "/*pp:kick*/"):
+		f.kicks++
+		return "ok", nil
+	case strings.Contains(js, "/*pp:token*/"):
+		r := ""
+		if f.tokenCalls < len(f.tokenResults) {
+			r = f.tokenResults[f.tokenCalls]
+		}
+		f.tokenCalls++
+		return r, nil
+	case strings.Contains(js, "/*pp:visible*/"):
+		if f.visible == "" {
+			return "visible", nil
+		}
+		return f.visible, nil
+	}
+	return "", nil
+}
 
 func newTestSolver(fb *fakeBrowser, seed SeedFunc) *solver {
 	return &solver{
@@ -95,10 +115,18 @@ func newTestSolver(fb *fakeBrowser, seed SeedFunc) *solver {
 	}
 }
 
+// swapTiming shrinks the interactive timing knobs for tests, returning a restore
+// func to defer.
+func swapTiming(poll, grace time.Duration) func() {
+	op, og := interactivePollInterval, challengeRenderGrace
+	interactivePollInterval, challengeRenderGrace = poll, grace
+	return func() { interactivePollInterval, challengeRenderGrace = op, og }
+}
+
 func TestSolve_InvisibleSuccess(t *testing.T) {
-	fb := &fakeBrowser{evalResults: []string{"P1_goodtoken"}}
+	fb := &fakeBrowser{firstResult: "P1_goodtoken"}
 	s := newTestSolver(fb, func(context.Context) ([]CDPCookie, error) { return nil, nil })
-	tok, err := s.Solve(context.Background(), Options{Profile: "default", Seeded: true, Interactive: true})
+	tok, err := s.Solve(context.Background(), Options{Profile: "default", Interactive: true})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -110,26 +138,31 @@ func TestSolve_InvisibleSuccess(t *testing.T) {
 	}
 }
 
-func TestSolve_SeedsWhenUnseeded(t *testing.T) {
-	fb := &fakeBrowser{evalResults: []string{"P1_tok"}}
+// TestSolve_AlwaysSeeds locks in the issue #3 invariant: every solve re-seeds
+// the full cookie jar from the user's browser (there is no "already seeded"
+// shortcut to gate on). Skipping the re-seed lets the dedicated profile's
+// Clerk/Google-SSO session go stale and resurfaces the per-generation
+// "Continue as <user>" OAuth popup.
+func TestSolve_AlwaysSeeds(t *testing.T) {
+	fb := &fakeBrowser{firstResult: "P1_tok"}
 	seeded := false
 	s := newTestSolver(fb, func(context.Context) ([]CDPCookie, error) {
 		seeded = true
 		return []CDPCookie{{Name: "__client", Value: "x", Domain: ".suno.com", Path: "/"}}, nil
 	})
-	_, err := s.Solve(context.Background(), Options{Profile: "default", Seeded: false, Interactive: true})
+	_, err := s.Solve(context.Background(), Options{Profile: "default", Interactive: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !seeded || !fb.cookiesSet {
-		t.Fatal("unseeded profile must seed cookies from browser")
+		t.Fatal("every solve must re-seed cookies from the browser (keeps us clear of issue #3)")
 	}
 }
 
 func TestSolve_InteractiveNeeded_NoInput_ReturnsErr(t *testing.T) {
-	fb := &fakeBrowser{evalResults: []string{""}}
+	fb := &fakeBrowser{firstResult: ""}
 	s := newTestSolver(fb, func(context.Context) ([]CDPCookie, error) { return nil, nil })
-	_, err := s.Solve(context.Background(), Options{Profile: "default", Seeded: true, Interactive: false})
+	_, err := s.Solve(context.Background(), Options{Profile: "default", Interactive: false})
 	if !errors.Is(err, ErrInteractiveRequired) {
 		t.Fatalf("want ErrInteractiveRequired, got %v", err)
 	}
@@ -138,10 +171,11 @@ func TestSolve_InteractiveNeeded_NoInput_ReturnsErr(t *testing.T) {
 	}
 }
 
-func TestSolve_InteractiveFallback_ShowsAndRetries(t *testing.T) {
-	fb := &fakeBrowser{evalResults: []string{"", "P1_after_manual"}}
+func TestSolve_InteractiveFallback_ShowsVerifiesAndSolves(t *testing.T) {
+	defer swapTiming(1*time.Millisecond, 50*time.Millisecond)()
+	fb := &fakeBrowser{firstResult: "", visible: "visible", tokenResults: []string{"", "P1_after_manual"}}
 	s := newTestSolver(fb, func(context.Context) ([]CDPCookie, error) { return nil, nil })
-	tok, err := s.Solve(context.Background(), Options{Profile: "default", Seeded: true, Interactive: true})
+	tok, err := s.Solve(context.Background(), Options{Profile: "default", Interactive: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,5 +184,33 @@ func TestSolve_InteractiveFallback_ShowsAndRetries(t *testing.T) {
 	}
 	if !fb.shown {
 		t.Fatal("interactive fallback must show the window")
+	}
+	if fb.kicks < 1 {
+		t.Fatal("interactive fallback must present a challenge")
+	}
+}
+
+// TestSolve_InteractiveChallengeNeverRenders_Errors covers the exact failure the
+// user hit: the window comes forward but no solvable challenge appears. We must
+// fail fast with a clear message instead of blocking the whole budget.
+func TestSolve_InteractiveChallengeNeverRenders_Errors(t *testing.T) {
+	defer swapTiming(1*time.Millisecond, 20*time.Millisecond)()
+	fb := &fakeBrowser{firstResult: "", visible: "hidden"}
+	s := newTestSolver(fb, func(context.Context) ([]CDPCookie, error) { return nil, nil })
+	_, err := s.Solve(context.Background(), Options{Profile: "default", Interactive: true})
+	if err == nil || !strings.Contains(err.Error(), "did not render") {
+		t.Fatalf("want 'did not render' error, got %v", err)
+	}
+}
+
+// TestSolve_InteractiveShownButUnsolved_TimesOut: challenge rendered, user never
+// solved it before the budget elapsed.
+func TestSolve_InteractiveShownButUnsolved_TimesOut(t *testing.T) {
+	defer swapTiming(1*time.Millisecond, time.Hour)() // huge grace so we hit the budget, not the render check
+	fb := &fakeBrowser{firstResult: "", visible: "visible"}
+	s := newTestSolver(fb, func(context.Context) ([]CDPCookie, error) { return nil, nil })
+	_, err := s.Solve(context.Background(), Options{Profile: "default", Interactive: true, Timeout: 30 * time.Millisecond})
+	if err == nil || !strings.Contains(err.Error(), "not solved within") {
+		t.Fatalf("want 'not solved within' error, got %v", err)
 	}
 }

--- a/library/media-and-entertainment/suno/internal/cli/suno_auth_captcha.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_auth_captcha.go
@@ -31,7 +31,7 @@ func newAuthCaptchaLoginCmd(flags *rootFlags) *cobra.Command {
 		Short: "Open a visible Chrome to sign a profile into Suno (then persists)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			captchaProfileFlag = profile
-			opts, _, err := resolveCaptchaOptions(flags.configPath, true)
+			opts, err := resolveCaptchaOptions(flags.configPath, true)
 			if err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func newAuthCaptchaStatusCmd(flags *rootFlags) *cobra.Command {
 				if st.Running {
 					state = "running"
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "%s  port=%d  %s  seeded=%v\n", name, p.CDPPort, state, p.Seeded)
+				fmt.Fprintf(cmd.OutOrStdout(), "%s  port=%d  %s\n", name, p.CDPPort, state)
 			}
 			return nil
 		},

--- a/library/media-and-entertainment/suno/internal/cli/suno_captcha_solver.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_captcha_solver.go
@@ -1,9 +1,8 @@
 // Copyright 2026 horknfbr. Licensed under Apache-2.0. See LICENSE.
 //
 // Bridges the cobra/flags world to internal/captcha: resolves the active
-// profile from --captcha-profile / SUNO_CAPTCHA_PROFILE / config, builds
-// captcha.Options (dedicated user-data-dir + CDP port), and persists the
-// `seeded` flag after a successful solve.
+// profile from --captcha-profile / SUNO_CAPTCHA_PROFILE / config and builds
+// captcha.Options (dedicated user-data-dir + CDP port).
 
 package cli
 
@@ -33,12 +32,12 @@ func captchaProfilesDir() string {
 }
 
 // resolveCaptchaOptions loads config, resolves the profile (env > flag handled
-// by passing env-or-flag), ensures it exists (assigning a port), and returns
-// the Options plus a persist callback to mark the profile seeded.
-func resolveCaptchaOptions(configPath string, interactive bool) (captcha.Options, func() error, error) {
+// by passing env-or-flag), ensures it exists (assigning a port, persisted so the
+// port survives), and returns the Options.
+func resolveCaptchaOptions(configPath string, interactive bool) (captcha.Options, error) {
 	cfg, err := config.Load(configPath)
 	if err != nil {
-		return captcha.Options{}, nil, err
+		return captcha.Options{}, err
 	}
 	sel := captchaProfileFlag
 	if sel == "" {
@@ -51,30 +50,24 @@ func resolveCaptchaOptions(configPath string, interactive bool) (captcha.Options
 	if dir == "" {
 		dir = filepath.Join(captchaProfilesDir(), name)
 	}
-	opts := captcha.Options{
+	if err := cfg.SaveCaptcha(); err != nil {
+		return captcha.Options{}, err
+	}
+	return captcha.Options{
 		Profile:     name,
 		UserDataDir: dir,
 		CDPPort:     prof.CDPPort,
-		Seeded:      prof.Seeded,
 		Interactive: interactive,
-	}
-	persistSeeded := func() error {
-		prof.Seeded = true
-		return cfg.SaveCaptcha()
-	}
-	if err := cfg.SaveCaptcha(); err != nil {
-		return captcha.Options{}, nil, err
-	}
-	return opts, persistSeeded, nil
+	}, nil
 }
 
 // defaultSolver is the production Solver, overridable in tests.
 var defaultSolver captcha.Solver = captcha.New()
 
 // solveCaptchaToken runs the solver for the active profile and returns a fresh
-// token, persisting the seeded flag on success.
+// token.
 func solveCaptchaToken(ctx context.Context, configPath string, interactive bool) (string, error) {
-	opts, persistSeeded, err := resolveCaptchaOptions(configPath, interactive)
+	opts, err := resolveCaptchaOptions(configPath, interactive)
 	if err != nil {
 		return "", err
 	}
@@ -86,6 +79,5 @@ func solveCaptchaToken(ctx context.Context, configPath string, interactive bool)
 		}
 		return "", err
 	}
-	_ = persistSeeded()
 	return tok, nil
 }

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate.go
@@ -99,7 +99,6 @@ description-driven (non-custom) generation, use the 'generate describe' command 
 			if v := vocalTag(vocal); v != "" {
 				finalTags = appendTag(finalTags, v)
 			}
-			_ = exclude // negative_tags is always "" per upstream contract; --exclude is accepted but folded out.
 
 			variationVal, verr := variationPtr(variation)
 			if verr != nil {
@@ -111,6 +110,7 @@ description-driven (non-custom) generation, use the 'generate describe' command 
 				mv:             mv,
 				title:          title,
 				tags:           finalTags,
+				negativeTags:   strings.TrimSpace(exclude),
 				prompt:         resolvedLyrics,
 				instrumental:   instrumental,
 				personaID:      persona,
@@ -125,7 +125,7 @@ description-driven (non-custom) generation, use the 'generate describe' command 
 
 	cmd.Flags().StringVar(&title, "title", "", "Song title")
 	cmd.Flags().StringVar(&tags, "tags", "", "Style tags (comma-separated, e.g. \"synthwave, melodic\")")
-	cmd.Flags().StringVar(&exclude, "exclude", "", "Styles to exclude (accepted for compatibility; negative_tags is sent empty)")
+	cmd.Flags().StringVar(&exclude, "exclude", "", "Styles to exclude from the generation (comma-separated; sent as negative_tags)")
 	cmd.Flags().StringVar(&lyrics, "lyrics", "", "Lyrics for the song")
 	cmd.Flags().StringVar(&lyricsFile, "lyrics-file", "", "Read lyrics from this file")
 	cmd.Flags().StringVar(&model, "model", defaultGenerateModel, "Model: v5.5, v5, v4.5+, v4.5, v4, v3.5, v3, v2")

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_types.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_types.go
@@ -130,6 +130,7 @@ type generateInput struct {
 	mv           string // wire model key
 	title        string
 	tags         string
+	negativeTags string // styles to exclude; empty -> sent as ""
 	prompt       string // lyrics for custom, description for inspiration
 	instrumental bool
 	personaID    string
@@ -195,7 +196,7 @@ func buildGenerateBody(in generateInput) sunoGenerateBody {
 		GenerationType:        "TEXT",
 		Title:                 alwaysStrPtr(in.title),
 		Tags:                  alwaysStrPtr(in.tags),
-		NegativeTags:          "",
+		NegativeTags:          in.negativeTags,
 		Mv:                    in.mv,
 		Prompt:                in.prompt,
 		MakeInstrumental:      in.instrumental,

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_types_test.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_types_test.go
@@ -47,6 +47,19 @@ func TestBuildGenerateBody_Custom(t *testing.T) {
 	}
 }
 
+func TestBuildGenerateBody_NegativeTags(t *testing.T) {
+	body := buildGenerateBody(generateInput{
+		createMode:   "custom",
+		mv:           "chirp-fenix",
+		tags:         "synthwave",
+		negativeTags: "country, banjo",
+		prompt:       "la la la",
+	})
+	if body.NegativeTags != "country, banjo" {
+		t.Errorf("negative_tags = %q, want %q", body.NegativeTags, "country, banjo")
+	}
+}
+
 func TestBuildGenerateBody_WebSchemaPlaceholders(t *testing.T) {
 	body := buildGenerateBody(generateInput{
 		createMode: "custom",

--- a/library/media-and-entertainment/suno/internal/config/suno_captcha.go
+++ b/library/media-and-entertainment/suno/internal/config/suno_captcha.go
@@ -26,7 +26,6 @@ type CaptchaConfig struct {
 type CaptchaProfile struct {
 	UserDataDir  string `toml:"user_data_dir,omitempty"` // empty => derived path
 	CDPPort      int    `toml:"cdp_port"`
-	Seeded       bool   `toml:"seeded"`                  // true after first-use cookie bootstrap
 	AccountLabel string `toml:"account_label,omitempty"` // optional human note
 }
 


### PR DESCRIPTION
## Summary

Consolidates two sets of live-verified suno fixes into one PR.

**(1) Captcha piloted-Chrome solver hardening** (builds on #1076). Three correctness fixes, all live-verified end-to-end (captcha-gated `generate describe --wait` produced 2 complete clips, exit 0, no orphaned Chrome): the solver now re-seeds the full Suno cookie jar on every solve so the dedicated profile's Clerk/Google-SSO session can't go stale and trigger paperfoot/suno-cli#3's per-generation "Continue as &lt;user&gt;" OAuth popup; the vestigial `Seeded` flag that tempted a regression back into that bug is removed; and the broken interactive-captcha recovery now actually brings the solver window on-screen with a rendered-challenge probe and three distinct, actionable error messages.

**(2) `--exclude` -> `negative_tags` wiring** (supersedes #1159). `--exclude` was accepted on `generate create` but silently discarded ("folded out"); it now flows through `generateInput.negativeTags` into the request body's `negative_tags`. The related `alwaysStrPtr` empty-serialization fix and `negativeTags` field-ordering tidy from the same dev branch were already present in the published copy, so only the `--exclude` wiring needed to carry over.

> **Once this PR is open, close #1159 as superseded** — its sole behavioral change is folded in here.

## Findings

| ID | Category | Type | Rationale |
|---|---|---|---|
| F1 | stale-session / oauth-popup-avoidance | bug | Doc comments claimed the dedicated solver profile is seeded once and persists, but a persisted session can outlive the actual login — the stale state that triggers paperfoot/suno-cli#3's per-generation OAuth popup. Solver now re-seeds the full jar (incl. Clerk `__client`/`__session`) every solve and never calls `clearBrowserCookies`; `TestSolve_AlwaysSeeds` locks the invariant. |
| F2 | dead-code / latent-trap | bug | `Options.Seeded`, config `CaptchaProfile.Seeded` (toml `seeded`), the `persistSeeded` callback, and the `seeded=%v` status output were written, persisted, and displayed but gated nothing. Removed; go-toml/v2 ignores the unknown key so existing configs still load. |
| F3 | interactive-fallback-broken | bug | `showOnScreen` used `window.moveTo()`, a no-op on a top-level browser window, so the challenge stayed parked offscreen (x=-32000) and the user had to kill Chrome by hand. Now repositions via CDP `Browser.setWindowBounds`, replaces the re-render-every-2s loop with a single non-blocking `execute` + token poll, adds a challenge-visibility probe that fails fast, and emits three distinct messages (window-couldn't-show / challenge-never-rendered / shown-but-not-solved). Tests added for all three paths. |
| F4 | dropped-input | bug | `--exclude` on `generate create` was parsed then discarded; the request always sent `negative_tags: ""`. Now wired through `generateInput.negativeTags`. `TestBuildGenerateBody_NegativeTags` locks the wiring. (Supersedes #1159.) |

## Verification

- Build: PASS (`go build ./...` in the library module)
- Vet: PASS (`go vet ./...`); gofmt clean
- Tests: PASS incl. new captcha tests (`TestSolve_AlwaysSeeds`, `TestSolve_InteractiveFallback_ShowsVerifiesAndSolves`, `TestSolve_InteractiveChallengeNeverRenders_Errors`, `TestSolve_InteractiveShownButUnsolved_TimesOut`) and `TestBuildGenerateBody_NegativeTags`
- Dogfood: PASS (live captcha-gated `generate describe --wait` -> 2 clips complete, exit 0, no orphaned Chrome on :9233)
- `cli-printing-press publish validate`: PASS (all 11 checks green)
- Patch contract: `.printing-press-patches/captcha-always-reseed-and-interactive-recovery.json` added

https://claude.ai/code/session_01UHpAeF1kMQ2dqcKqWFwtyX