### PR TITLE
fix(google-ads-mcp): remove double json.Marshal in MCP POST/PUT/PATCH handlers

### DIFF
--- a/library/marketing/google-ads/internal/mcp/code_orch.go
+++ b/library/marketing/google-ads/internal/mcp/code_orch.go
@@ -1504,17 +1504,13 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	case "DELETE":
 		data, _, err = c.Delete(path)
 	default:
-		body, mErr := json.Marshal(params)
-		if mErr != nil {
-			return mcplib.NewToolResultError(fmt.Sprintf("marshaling body: %v", mErr)), nil
-		}
 		switch ep.Method {
 		case "POST":
-			data, _, err = c.Post(path, body)
+			data, _, err = c.Post(path, params)
 		case "PUT":
-			data, _, err = c.Put(path, body)
+			data, _, err = c.Put(path, params)
 		case "PATCH":
-			data, _, err = c.Patch(path, body)
+			data, _, err = c.Patch(path, params)
 		default:
 			return mcplib.NewToolResultError(fmt.Sprintf("unsupported method %q", ep.Method)), nil
 		}

--- a/library/marketing/google-ads/internal/mcp/tools.go
+++ b/library/marketing/google-ads/internal/mcp/tools.go
@@ -107,14 +107,29 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 		case "GET":
 			data, err = c.Get(path, params)
 		case "POST":
-			body, _ := json.Marshal(args)
-			data, _, err = c.Post(path, body)
+			bodyMap := make(map[string]any, len(args))
+			for k, v := range args {
+				if !pathParams[k] {
+					bodyMap[k] = v
+				}
+			}
+			data, _, err = c.Post(path, bodyMap)
 		case "PUT":
-			body, _ := json.Marshal(args)
-			data, _, err = c.Put(path, body)
+			bodyMap := make(map[string]any, len(args))
+			for k, v := range args {
+				if !pathParams[k] {
+					bodyMap[k] = v
+				}
+			}
+			data, _, err = c.Put(path, bodyMap)
 		case "PATCH":
-			body, _ := json.Marshal(args)
-			data, _, err = c.Patch(path, body)
+			bodyMap := make(map[string]any, len(args))
+			for k, v := range args {
+				if !pathParams[k] {
+					bodyMap[k] = v
+				}
+			}
+			data, _, err = c.Patch(path, bodyMap)
 		case "DELETE":
 			data, _, err = c.Delete(path)
 		default:


### PR DESCRIPTION
## Bug

All MCP POST/PUT/PATCH endpoints (e.g. `customers_google_ads.search`) return a 400:
`Root element must be a message`

## Root cause

Both `internal/mcp/tools.go` and `internal/mcp/code_orch.go` pre-marshal the request body to `[]byte` before passing it to `c.Post()`. `client.do()` then calls `json.Marshal()` a second time.

`json.Marshal([]byte)` base64-encodes the bytes — so the HTTP body arrives as a JSON string instead of a JSON object. The protobuf decoder expects an object, hence the error.

## Fix

Remove the pre-marshal in both files and pass `map[string]any` directly so `client.do()` marshals exactly once. `tools.go` also now excludes URL path params from the POST body.