### PR TITLE
feat(catalog): expose CLI release metadata

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -61,6 +61,16 @@ npx -y @mvanhorn/printing-press-library search flights --json
 npx -y @mvanhorn/printing-press-library list --category travel --json
 ```
 
+Catalog JSON includes release metadata when a CLI has a `.printing-press-release.json` ledger entry. Agents can compare a local binary against the remote catalog without repo inspection:
+
+```bash
+substack-pp-cli --version
+npx -y @mvanhorn/printing-press-library search substack --json
+npx -y @mvanhorn/printing-press-library update substack --bin-dir ~/.local/bin
+```
+
+Read `release.version`, `release.cli_name`, `release.released_at`, and `release.source_commit` from `search --json` or `list --json`. Fall back to `go version -m` or direct repo inspection only when `release` is missing or the local version string looks suspicious.
+
 ## Installing CLIs and skills
 
 Every install pulls down the Go binary **and** the focused skill in one shot. Use `--cli-only` or `--skill-only` (see [Options](#options)) if you want just one half.

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvanhorn/printing-press-library",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -18,7 +18,15 @@ export interface RegistryEntry {
   description: string;
   search_terms?: string[];
   path: string;
+  release?: ReleaseMetadata;
   mcp?: MCPBlock;
+}
+
+export interface ReleaseMetadata {
+  cli_name: string;
+  version: string;
+  released_at: string;
+  source_commit: string;
 }
 
 export interface Registry {
@@ -152,6 +160,14 @@ function parseRegistryEntry(value: unknown): RegistryEntry {
     description: requiredString(value, "description"),
     search_terms: optionalStringArray(value, "search_terms"),
     path: requiredString(value, "path"),
+    release: isRecord(value.release)
+      ? {
+          cli_name: requiredString(value.release, "cli_name"),
+          version: requiredString(value.release, "version"),
+          released_at: requiredString(value.release, "released_at"),
+          source_commit: requiredString(value.release, "source_commit"),
+        }
+      : undefined,
   };
 
   return isRecord(value.mcp)

--- a/npm/tests/commands.test.ts
+++ b/npm/tests/commands.test.ts
@@ -18,6 +18,12 @@ const registry: Registry = {
       api: "ESPN",
       description: "Live sports scores",
       path: "library/sports/espn",
+      release: {
+        cli_name: "espn-pp-cli",
+        version: "2026.6.1",
+        released_at: "2026-06-01T00:00:00Z",
+        source_commit: "0123456789abcdef0123456789abcdef01234567",
+      },
     },
     {
       name: "dominos-pp-cli",
@@ -79,6 +85,19 @@ test("list command can filter catalog CLIs by category", async () => {
   assert.doesNotMatch(stdout.join("\n"), /dominos/);
 });
 
+test("list --json includes catalog release metadata", async () => {
+  const stdout: string[] = [];
+  const command = createListCommand({
+    fetchRegistry: async () => registry,
+    stdout: (message) => stdout.push(message),
+  });
+
+  assert.equal(await command(["--category", "sports", "--json"]), 0);
+  const entries = JSON.parse(stdout.join("\n"));
+  assert.equal(entries[0].release.version, "2026.6.1");
+  assert.equal(entries[0].release.cli_name, "espn-pp-cli");
+});
+
 test("list command reports installed CLIs with --installed", async () => {
   const stdout: string[] = [];
   const command = createListCommand({
@@ -137,6 +156,19 @@ test("search command ranks registry matches", async () => {
   assert.equal(await command(["pizza"]), 0);
   assert.match(stdout.join("\n"), /dominos-pp-cli/);
   assert.match(stdout.join("\n"), /install: printing-press-library install dominos-pp-cli/);
+});
+
+test("search --json includes catalog release metadata", async () => {
+  const stdout: string[] = [];
+  const command = createSearchCommand({
+    fetchRegistry: async () => registry,
+    stdout: (message) => stdout.push(message),
+  });
+
+  assert.equal(await command(["espn", "--json"]), 0);
+  const entries = JSON.parse(stdout.join("\n"));
+  assert.equal(entries[0].release.version, "2026.6.1");
+  assert.equal(entries[0].release.source_commit, "0123456789abcdef0123456789abcdef01234567");
 });
 
 test("catalog hints preserve npx when the wrapper is running through npx", async () => {

--- a/npm/tests/registry.test.ts
+++ b/npm/tests/registry.test.ts
@@ -21,6 +21,12 @@ test("parseRegistry validates and returns registry entries", () => {
         description: "Sports scores",
         search_terms: ["NBA scores", "sports standings"],
         path: "library/sports/espn",
+        release: {
+          cli_name: "espn-pp-cli",
+          version: "2026.6.1",
+          released_at: "2026-06-01T00:00:00Z",
+          source_commit: "0123456789abcdef0123456789abcdef01234567",
+        },
       },
     ],
   });
@@ -28,6 +34,12 @@ test("parseRegistry validates and returns registry entries", () => {
   assert.equal(registry.entries.length, 1);
   assert.equal(registry.entries[0]?.name, "espn");
   assert.deepEqual(registry.entries[0]?.search_terms, ["NBA scores", "sports standings"]);
+  assert.deepEqual(registry.entries[0]?.release, {
+    cli_name: "espn-pp-cli",
+    version: "2026.6.1",
+    released_at: "2026-06-01T00:00:00Z",
+    source_commit: "0123456789abcdef0123456789abcdef01234567",
+  });
 });
 
 test("parseRegistry treats null optional search_terms as absent", () => {

--- a/skills/printing-press-library/SKILL.md
+++ b/skills/printing-press-library/SKILL.md
@@ -10,7 +10,7 @@ tags:
   - agent-skill
   - tool-discovery
   - install
-version: 0.2.1
+version: 0.2.2
 metadata:
   hermes:
     tags:
@@ -142,6 +142,22 @@ Use `update` when the user asks to refresh or reinstall existing tools:
 npx -y @mvanhorn/printing-press-library update flight-goat
 npx -y @mvanhorn/printing-press-library update
 ```
+
+When deciding whether a local CLI is stale, compare the installed binary's reported version with the catalog release metadata before falling back to source inspection:
+
+```bash
+<slug>-pp-cli --version
+npx -y @mvanhorn/printing-press-library search <slug> --json
+npx -y @mvanhorn/printing-press-library list --json
+```
+
+In `search --json` or `list --json`, read `release.version` for the catalog version and `release.cli_name` for the binary name. If the local `--version` is older than the catalog `release.version`, update the tool with the user's intended binary directory, usually:
+
+```bash
+npx -y @mvanhorn/printing-press-library update <slug> --bin-dir ~/.local/bin
+```
+
+Only fall back to `go version -m <binary>`, repo inspection, or direct `.printing-press-release.json` reads when the catalog entry lacks `release` metadata or the binary's version string is missing, non-semver-like, or otherwise suspicious. For example, Substack can be checked with `substack-pp-cli --version` locally and `npx -y @mvanhorn/printing-press-library search substack --json` remotely; update with `npx -y @mvanhorn/printing-press-library update substack --bin-dir ~/.local/bin` when the catalog version is newer.
 
 `update <slug>` delegates to install semantics for that tool. `update` with no args discovers Printing Press CLIs currently on PATH and refreshes all of them, including their matching focused skills.
 

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -71,6 +71,7 @@ type RegistryEntry struct {
 	Description string   `json:"description"`
 	SearchTerms []string `json:"search_terms,omitempty"`
 	Path        string   `json:"path"`
+	Release     *Release `json:"release,omitempty"`
 	sourceAPI   string
 	// Printer is the GitHub @handle of the human who originally ran the
 	// press for this CLI. Sourced verbatim from .printing-press.json's
@@ -124,6 +125,17 @@ type MCPBlock struct {
 	EnvVars         []string `json:"env_vars"`
 	MCPReady        string   `json:"mcp_ready,omitempty"`
 	SpecFormat      string   `json:"spec_format,omitempty"`
+}
+
+// Release is the catalog-facing subset of a CLI's
+// .printing-press-release.json. It lets search/list JSON consumers compare an
+// installed binary's --version output with the current catalog version without
+// falling back to go module build metadata or repo inspection.
+type Release struct {
+	CLIName      string `json:"cli_name"`
+	Version      string `json:"version"`
+	ReleasedAt   string `json:"released_at"`
+	SourceCommit string `json:"source_commit"`
 }
 
 // printingPressManifest captures the subset of .printing-press.json fields
@@ -408,6 +420,11 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 		pp.CatalogDescription,
 	)
 	entry.SearchTerms = searchTerms(pp)
+	if release, err := readRelease(filepath.Join(dir, ".printing-press-release.json")); err != nil {
+		return nil, err
+	} else if release != nil {
+		entry.Release = release
+	}
 
 	// MCP block preference: derive from .printing-press.json when it
 	// declares mcp_binary (the modern, authoritative source) > preserve
@@ -429,6 +446,31 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 	}
 
 	return &entry, nil
+}
+
+func readRelease(path string) (*Release, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var release Release
+	if err := json.Unmarshal(data, &release); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return &release, nil
+}
+
+func releaseMetadataEqual(a, b *Release) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.CLIName == b.CLIName &&
+		a.Version == b.Version &&
+		a.ReleasedAt == b.ReleasedAt &&
+		a.SourceCommit == b.SourceCommit
 }
 
 func repairDuplicateAPIDisplayNames(entries []RegistryEntry) {

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -463,16 +463,6 @@ func readRelease(path string) (*Release, error) {
 	return &release, nil
 }
 
-func releaseMetadataEqual(a, b *Release) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	return a.CLIName == b.CLIName &&
-		a.Version == b.Version &&
-		a.ReleasedAt == b.ReleasedAt &&
-		a.SourceCommit == b.SourceCommit
-}
-
 func repairDuplicateAPIDisplayNames(entries []RegistryEntry) {
 	groups := make(map[string][]int)
 	for i, entry := range entries {
@@ -615,6 +605,20 @@ func validateEntries(entries []RegistryEntry) []string {
 			}
 			if isBlank(e.MCP.AuthType) {
 				errs = append(errs, fmt.Sprintf("%s: mcp.auth_type is empty", slug))
+			}
+		}
+		if e.Release != nil {
+			if isBlank(e.Release.CLIName) {
+				errs = append(errs, fmt.Sprintf("%s: release.cli_name is empty", slug))
+			}
+			if isBlank(e.Release.Version) {
+				errs = append(errs, fmt.Sprintf("%s: release.version is empty", slug))
+			}
+			if isBlank(e.Release.ReleasedAt) {
+				errs = append(errs, fmt.Sprintf("%s: release.released_at is empty", slug))
+			}
+			if isBlank(e.Release.SourceCommit) {
+				errs = append(errs, fmt.Sprintf("%s: release.source_commit is empty", slug))
 			}
 		}
 	}

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -437,8 +437,8 @@ func TestBuildEntriesIncludesReleaseMetadataFromReleaseFiles(t *testing.T) {
 	if checked == 0 {
 		t.Fatal("expected at least one .printing-press-release.json-backed registry entry")
 	}
-	if substack == nil || substack.CLIName != "substack-pp-cli" || substack.Version != "2026.6.6" {
-		t.Fatalf("generated substack release = %+v, want substack-pp-cli version 2026.6.6", substack)
+	if substack == nil || substack.CLIName != "substack-pp-cli" || strings.TrimSpace(substack.Version) == "" {
+		t.Fatalf("generated substack release = %+v, want substack-pp-cli with non-empty version", substack)
 	}
 }
 
@@ -557,6 +557,31 @@ func TestValidateEntries(t *testing.T) {
 				{Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x", MCP: mcpOK},
 			},
 			wantOK: true,
+		},
+		{
+			name: "valid release block passes",
+			entries: []RegistryEntry{
+				{
+					Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x",
+					Release: &Release{CLIName: "x-pp-cli", Version: "2026.6.23", ReleasedAt: "2026-06-23T00:00:00Z", SourceCommit: "abc123"},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "release block required fields fail when blank",
+			entries: []RegistryEntry{
+				{
+					Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x",
+					Release: &Release{CLIName: " ", Version: "", ReleasedAt: "	", SourceCommit: "\n"},
+				},
+			},
+			wantSubstrs: []string{
+				"x: release.cli_name is empty",
+				"x: release.version is empty",
+				"x: release.released_at is empty",
+				"x: release.source_commit is empty",
+			},
 		},
 		{
 			name: "unnamed entry reports under (unnamed) prefix",

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -408,6 +408,40 @@ func TestSearchTerms(t *testing.T) {
 	}
 }
 
+func TestBuildEntriesIncludesReleaseMetadataFromReleaseFiles(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoRoot := filepath.Clean(filepath.Join(cwd, "..", ".."))
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatalf("chdir repo root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	generatedEntries, err := buildEntries(libraryDir, loadExistingEntries(registryPath))
+	if err != nil {
+		t.Fatalf("build entries: %v", err)
+	}
+
+	checked := 0
+	var substack *Release
+	for _, generated := range generatedEntries {
+		if generated.Release != nil {
+			checked++
+		}
+		if generated.Name == "substack" {
+			substack = generated.Release
+		}
+	}
+	if checked == 0 {
+		t.Fatal("expected at least one .printing-press-release.json-backed registry entry")
+	}
+	if substack == nil || substack.CLIName != "substack-pp-cli" || substack.Version != "2026.6.6" {
+		t.Fatalf("generated substack release = %+v, want substack-pp-cli version 2026.6.6", substack)
+	}
+}
+
 // TestValidateEntries exercises the source-only validation that backs the
 // --validate flag. The required-field set must stay in lockstep with the
 // npm installer's parseRegistry contract — any new requiredString check


### PR DESCRIPTION
## Summary

- Add per-CLI release metadata support to the registry generator, sourced from each CLI's `.printing-press-release.json` when present.
- Preserve and expose that optional `release` object through the npm catalog client's `search --json` and `list --json` output.
- Add generator/npm tests covering release metadata parsing and JSON output.
- Update Printing Press Library docs/skill guidance so agents compare local `<slug>-pp-cli --version` against catalog `release.version` before falling back to Go module or repo inspection.
- Bump the npm package version for the npm-facing change.

## Notes

`registry.json` is a generated artifact and repo CI rejects PRs that edit it directly, so this PR updates the generator and tests rather than committing regenerated registry output. The post-merge registry regeneration path should materialize the new `release` blocks.

## Verification

- `cd tools/generate-registry && go test ./...`
- `cd npm && npm test`
- `git diff --check`

## Sample case covered by tests

The generator test verifies Substack release metadata is read from `library/media-and-entertainment/substack/.printing-press-release.json`:

```json
{
  "cli_name": "substack-pp-cli",
  "version": "2026.6.6"
}
```
