### PR TITLE
chore: ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ Thumbs.db
 # Conductor workspace state
 .conductor/
 
+# Local Git worktrees
+.worktrees/
+
 # Local AI agent instructions (not for sharing)
 CLAUDE.local.md
 AGENTS.override.md


### PR DESCRIPTION
## Summary

Adds `.worktrees/` to the repository `.gitignore` so local Git worktree directories do not appear as untracked project files.

## Validation

- `git check-ignore -v .worktrees/example` -> `.gitignore:58:.worktrees/`
