### PR TITLE
fix(substack): route draft APIs through global endpoint

### DIFF
--- a/library/media-and-entertainment/substack/.printing-press-patches.json
+++ b/library/media-and-entertainment/substack/.printing-press-patches.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "applied_at": "2026-06-23",
+  "base_run_id": "20260531-014452",
+  "base_printing_press_version": "4.19.0",
+  "patches": [
+    {
+      "id": "substack-global-draft-routes",
+      "summary": "Route Substack draft writer commands and sync paths through the global API with publication_id instead of publication-host draft URLs.",
+      "reason": "Custom-domain writer sessions receive HTTP 403 when draft endpoints are called through the publication host; the global Substack draft routes accept the writer cookie when publication_id is provided.",
+      "files": [
+        "internal/cli/drafts_delete.go",
+        "internal/cli/drafts_get.go",
+        "internal/cli/drafts_list.go",
+        "internal/cli/drafts_prepublish.go",
+        "internal/cli/drafts_publish.go",
+        "internal/cli/drafts_schedule.go",
+        "internal/cli/drafts_update.go",
+        "internal/cli/portfolio_sync.go",
+        "internal/cli/sync.go",
+        "internal/cli/auto_refresh.go",
+        "internal/cli/channel_workflow.go",
+        "internal/cli/publication_paths_test.go",
+        "internal/cli/portfolio_sync_routes_test.go"
+      ],
+      "validated_outcome": "go test ./internal/cli focused draft-route tests passed; dry-run smoke showed https://substack.com/api/v1/drafts?publication_id=... and no trevinsays.substack.com/api/v1/drafts route."
+    }
+  ]
+}

--- a/library/media-and-entertainment/substack/.printing-press-patches/draft-global-routing-complete.json
+++ b/library/media-and-entertainment/substack/.printing-press-patches/draft-global-routing-complete.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 2,
+  "id": "draft-global-routing-complete",
+  "applied_at": "2026-06-23",
+  "base_run_id": "20260531-014452",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Route all Substack draft authoring endpoints and portfolio draft sync through the global substack.com API with numeric publication_id.",
+  "reason": "Live custom-domain sessions still received 403s from publication-host draft list and portfolio draft sync even after draft create/image upload were moved to global routes. Dry-run sweep also showed draft get/update/delete/prepublish/publish/schedule still rendering publication-host writer URLs.",
+  "files": [
+    "internal/cli/drafts_list.go",
+    "internal/cli/drafts_get.go",
+    "internal/cli/drafts_update.go",
+    "internal/cli/drafts_delete.go",
+    "internal/cli/drafts_prepublish.go",
+    "internal/cli/drafts_publish.go",
+    "internal/cli/drafts_schedule.go",
+    "internal/cli/portfolio_sync.go",
+    "internal/cli/sync.go",
+    "internal/cli/auto_refresh.go",
+    "internal/cli/channel_workflow.go",
+    "internal/cli/publication_paths_test.go",
+    "internal/cli/portfolio_sync_routes_test.go"
+  ],
+  "upstream_pr": "https://github.com/mvanhorn/cli-printing-press/pull/3191"
+}

--- a/library/media-and-entertainment/substack/internal/cli/auto_refresh.go
+++ b/library/media-and-entertainment/substack/internal/cli/auto_refresh.go
@@ -228,7 +228,12 @@ func runAutoRefresh(ctx context.Context, flags *rootFlags, db *store.Store, reso
 			return ctx.Err()
 		default:
 		}
-		result := syncResource(ctx, c, db, resource, "", false, 1, true, nil, os.Stderr)
+		extraParams, err := syncResourceExtraParams(ctx, c, flags, resource)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", resource, err))
+			continue
+		}
+		result := syncResource(ctx, c, db, resource, "", false, 1, true, nil, os.Stderr, extraParams)
 		if result.Err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", resource, result.Err))
 		}

--- a/library/media-and-entertainment/substack/internal/cli/channel_workflow.go
+++ b/library/media-and-entertainment/substack/internal/cli/channel_workflow.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/store"
+	"github.com/spf13/cobra"
 )
 
 func newWorkflowCmd(flags *rootFlags) *cobra.Command {
@@ -72,7 +72,12 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			}
 
 			for _, resource := range resources {
-				res := syncResource(cmd.Context(), c, s, resource, "", full, 100, false, nil, syncEventWriter)
+				extraParams, err := syncResourceExtraParams(cmd.Context(), c, flags, resource)
+				if err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, err)
+					continue
+				}
+				res := syncResource(cmd.Context(), c, s, resource, "", full, 100, false, nil, syncEventWriter, extraParams)
 				if res.Err != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, res.Err)
 					continue

--- a/library/media-and-entertainment/substack/internal/cli/drafts_delete.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_delete.go
@@ -17,7 +17,7 @@ func newDraftsDeleteCmd(flags *rootFlags) *cobra.Command {
 		Use:         "delete <draft_id>",
 		Short:       "Delete a draft",
 		Example:     "  substack-pp-cli drafts delete 550e8400-e29b-41d4-a716-446655440000",
-		Annotations: map[string]string{"pp:endpoint": "drafts.delete", "pp:method": "DELETE", "pp:path": "https://{publication}.substack.com/api/v1/drafts/{draft_id}"},
+		Annotations: map[string]string{"pp:endpoint": "drafts.delete", "pp:method": "DELETE", "pp:path": "https://substack.com/api/v1/drafts/{draft_id}?publication_id={publication_id}"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return cmd.Help()
@@ -27,9 +27,13 @@ func newDraftsDeleteCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			path := "https://{publication}.substack.com/api/v1/drafts/{draft_id}"
+			path := globalAPIPath("/drafts/{draft_id}")
 			path = replacePathParam(path, "draft_id", args[0])
-			params := map[string]string{}
+			publicationID, err := writerPublicationID(cmd.Context(), c, flags)
+			if err != nil {
+				return err
+			}
+			params := map[string]string{"publication_id": publicationID}
 			data, statusCode, err := c.DeleteWithParams(cmd.Context(), path, params)
 			if err != nil {
 				return classifyDeleteError(err, flags)

--- a/library/media-and-entertainment/substack/internal/cli/drafts_get.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_get.go
@@ -17,7 +17,7 @@ func newDraftsGetCmd(flags *rootFlags) *cobra.Command {
 		Use:         "get <draft_id>",
 		Short:       "Get a draft by ID",
 		Example:     "  substack-pp-cli drafts get 550e8400-e29b-41d4-a716-446655440000",
-		Annotations: map[string]string{"pp:endpoint": "drafts.get", "pp:method": "GET", "pp:path": "https://{publication}.substack.com/api/v1/drafts/{draft_id}", "mcp:read-only": "true"},
+		Annotations: map[string]string{"pp:endpoint": "drafts.get", "pp:method": "GET", "pp:path": "https://substack.com/api/v1/drafts/{draft_id}?publication_id={publication_id}", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return cmd.Help()
@@ -27,9 +27,13 @@ func newDraftsGetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			path := "https://{publication}.substack.com/api/v1/drafts/{draft_id}"
+			path := globalAPIPath("/drafts/{draft_id}")
 			path = replacePathParam(path, "draft_id", args[0])
-			params := map[string]string{}
+			publicationID, err := writerPublicationID(cmd.Context(), c, flags)
+			if err != nil {
+				return err
+			}
+			params := map[string]string{"publication_id": publicationID}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "drafts", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)

--- a/library/media-and-entertainment/substack/internal/cli/drafts_list.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_list.go
@@ -20,15 +20,19 @@ func newDraftsListCmd(flags *rootFlags) *cobra.Command {
 		Use:         "list",
 		Short:       "List drafts",
 		Example:     "  substack-pp-cli drafts list",
-		Annotations: map[string]string{"pp:endpoint": "drafts.list", "pp:method": "GET", "pp:path": "https://{publication}.substack.com/api/v1/drafts", "mcp:read-only": "true"},
+		Annotations: map[string]string{"pp:endpoint": "drafts.list", "pp:method": "GET", "pp:path": "https://substack.com/api/v1/drafts?publication_id={publication_id}", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
 
-			path := "https://{publication}.substack.com/api/v1/drafts"
-			params := map[string]string{}
+			path := globalAPIPath("/drafts")
+			publicationID, err := writerPublicationID(cmd.Context(), c, flags)
+			if err != nil {
+				return err
+			}
+			params := map[string]string{"publication_id": publicationID}
 			if flagFilter != "" {
 				params["filter"] = fmt.Sprintf("%v", flagFilter)
 			}

--- a/library/media-and-entertainment/substack/internal/cli/drafts_prepublish.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_prepublish.go
@@ -19,7 +19,7 @@ func newDraftsPrepublishCmd(flags *rootFlags) *cobra.Command {
 		Use:         "prepublish <draft_id>",
 		Short:       "Validate a draft for publication; returns blockers",
 		Example:     "  substack-pp-cli drafts prepublish 550e8400-e29b-41d4-a716-446655440000",
-		Annotations: map[string]string{"pp:endpoint": "drafts.prepublish", "pp:method": "POST", "pp:path": "https://{publication}.substack.com/api/v1/drafts/{draft_id}/prepublish"},
+		Annotations: map[string]string{"pp:endpoint": "drafts.prepublish", "pp:method": "POST", "pp:path": "https://substack.com/api/v1/drafts/{draft_id}/prepublish?publication_id={publication_id}"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return cmd.Help()
@@ -31,9 +31,13 @@ func newDraftsPrepublishCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			path := "https://{publication}.substack.com/api/v1/drafts/{draft_id}/prepublish"
+			path := globalAPIPath("/drafts/{draft_id}/prepublish")
 			path = replacePathParam(path, "draft_id", args[0])
-			params := map[string]string{}
+			publicationID, err := writerPublicationID(cmd.Context(), c, flags)
+			if err != nil {
+				return err
+			}
+			params := map[string]string{"publication_id": publicationID}
 			var body map[string]any
 			if stdinBody {
 				stdinData, err := io.ReadAll(os.Stdin)

--- a/library/media-and-entertainment/substack/internal/cli/drafts_publish.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_publish.go
@@ -21,7 +21,7 @@ func newDraftsPublishCmd(flags *rootFlags) *cobra.Command {
 		Use:         "publish <draft_id>",
 		Short:       "Publish a draft now",
 		Example:     "  substack-pp-cli drafts publish 550e8400-e29b-41d4-a716-446655440000",
-		Annotations: map[string]string{"pp:endpoint": "drafts.publish", "pp:method": "POST", "pp:path": "https://{publication}.substack.com/api/v1/drafts/{draft_id}/publish"},
+		Annotations: map[string]string{"pp:endpoint": "drafts.publish", "pp:method": "POST", "pp:path": "https://substack.com/api/v1/drafts/{draft_id}/publish?publication_id={publication_id}"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return cmd.Help()
@@ -33,9 +33,13 @@ func newDraftsPublishCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			path := "https://{publication}.substack.com/api/v1/drafts/{draft_id}/publish"
+			path := globalAPIPath("/drafts/{draft_id}/publish")
 			path = replacePathParam(path, "draft_id", args[0])
-			params := map[string]string{}
+			publicationID, err := writerPublicationID(cmd.Context(), c, flags)
+			if err != nil {
+				return err
+			}
+			params := map[string]string{"publication_id": publicationID}
 			var body map[string]any
 			if stdinBody {
 				stdinData, err := io.ReadAll(os.Stdin)

--- a/library/media-and-entertainment/substack/internal/cli/drafts_schedule.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_schedule.go
@@ -55,7 +55,7 @@ Requires --subdomain <publication-subdomain>.`,
 		Annotations: map[string]string{
 			"pp:endpoint": "drafts.schedule",
 			"pp:method":   "POST",
-			"pp:path":     "https://{publication}.substack.com/api/v1/drafts/{id}/scheduled_release",
+			"pp:path":     "https://substack.com/api/v1/drafts/{id}/scheduled_release?publication_id={publication_id}",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -73,7 +73,16 @@ Requires --subdomain <publication-subdomain>.`,
 				return usageErr(err)
 			}
 
-			path := publicationAPIPath("/drafts/" + args[0] + "/scheduled_release")
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			path := globalAPIPath("/drafts/" + args[0] + "/scheduled_release")
+			publicationID, err := writerPublicationID(cmd.Context(), c, flags)
+			if err != nil {
+				return err
+			}
+			params := map[string]string{"publication_id": publicationID}
 			body := map[string]any{
 				"trigger_at":    triggerAt.UTC().Format(time.RFC3339),
 				"post_audience": postAudience,
@@ -107,12 +116,7 @@ Requires --subdomain <publication-subdomain>.`,
 				return nil
 			}
 
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
-			resp, status, err := c.Post(cmd.Context(), path, body)
+			resp, status, err := c.PostWithParams(cmd.Context(), path, params, body)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/library/media-and-entertainment/substack/internal/cli/drafts_update.go
+++ b/library/media-and-entertainment/substack/internal/cli/drafts_update.go
@@ -62,7 +62,7 @@ full field list.`,
 		Annotations: map[string]string{
 			"pp:endpoint":  "drafts.update",
 			"pp:method":    "PUT",
-			"pp:path":      "https://{publication}.substack.com/api/v1/drafts/{id}",
+			"pp:path":      "https://substack.com/api/v1/drafts/{id}?publication_id={publication_id}",
 			"pp:novel-ext": "full-field-coverage",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -74,8 +74,13 @@ full field list.`,
 				return err
 			}
 
-			path := publicationAPIPath("/drafts/{id}")
+			path := globalAPIPath("/drafts/{id}")
 			path = replacePathParam(path, "id", args[0])
+			publicationID, err := writerPublicationID(cmd.Context(), c, flags)
+			if err != nil {
+				return err
+			}
+			params := map[string]string{"publication_id": publicationID}
 			var body map[string]any
 
 			if stdinBody {
@@ -193,7 +198,7 @@ full field list.`,
 				}
 			}
 
-			data, statusCode, err := c.Put(cmd.Context(), path, body)
+			data, statusCode, err := c.PutWithParams(cmd.Context(), path, params, body)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/library/media-and-entertainment/substack/internal/cli/portfolio_sync.go
+++ b/library/media-and-entertainment/substack/internal/cli/portfolio_sync.go
@@ -258,9 +258,11 @@ func syncOnePublication(ctx context.Context, c *client.Client, s *store.Store, p
 		pr.Posts = n
 	}
 
-	// Drafts: /drafts on the pub host.
+	// Drafts: global /drafts with numeric publication_id avoids custom-domain
+	// Creator-host 403s for publications that serve authoring through a custom
+	// domain.
 	if includeDrafts {
-		drafts := fetchDrafts(ctx, c, warnW)
+		drafts := fetchDrafts(ctx, c, pub.ID, warnW)
 		if n, err := s.UpsertDraftsForPublication(pub.ID, drafts); err != nil {
 			pr.Warning = appendWarning(pr.Warning, fmt.Sprintf("drafts upsert: %v", err))
 		} else {
@@ -392,8 +394,8 @@ func normalizePost(p map[string]any) map[string]any {
 }
 
 // fetchDrafts pulls the publication's drafts.
-func fetchDrafts(ctx context.Context, c *client.Client, warnW interface{ Write([]byte) (int, error) }) []map[string]any {
-	data, err := c.Get(ctx, "https://{publication}.substack.com/api/v1/drafts", nil)
+func fetchDrafts(ctx context.Context, c *client.Client, publicationID string, warnW interface{ Write([]byte) (int, error) }) []map[string]any {
+	data, err := c.Get(ctx, globalAPIPath("/drafts"), map[string]string{"publication_id": publicationID})
 	if err != nil {
 		warnf(warnW, "fetch drafts: %v", err)
 		return nil

--- a/library/media-and-entertainment/substack/internal/cli/portfolio_sync_routes_test.go
+++ b/library/media-and-entertainment/substack/internal/cli/portfolio_sync_routes_test.go
@@ -12,17 +12,26 @@ import (
 )
 
 type captureTransport struct {
-	url string
+	urls []string
 }
 
 func (t *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	t.url = req.URL.String()
+	t.urls = append(t.urls, req.URL.String())
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     make(http.Header),
-		Body:       io.NopCloser(strings.NewReader(`{"posts":[]}`)),
+		Body:       io.NopCloser(strings.NewReader(`[]`)),
 		Request:    req,
 	}, nil
+}
+
+func (t *captureTransport) firstDraftURL() string {
+	for _, u := range t.urls {
+		if strings.Contains(u, "/api/v1/drafts") {
+			return u
+		}
+	}
+	return ""
 }
 
 func TestPortfolioFetchDraftsUsesGlobalPublicationIDRoute(t *testing.T) {
@@ -33,7 +42,7 @@ func TestPortfolioFetchDraftsUsesGlobalPublicationIDRoute(t *testing.T) {
 
 	fetchDrafts(context.Background(), c, "7019888", io.Discard)
 
-	if got, want := transport.url, "https://substack.com/api/v1/drafts?publication_id=7019888"; got != want {
+	if got, want := transport.firstDraftURL(), "https://substack.com/api/v1/drafts?publication_id=7019888"; got != want {
 		t.Fatalf("fetchDrafts URL = %q, want %q", got, want)
 	}
 }

--- a/library/media-and-entertainment/substack/internal/cli/portfolio_sync_routes_test.go
+++ b/library/media-and-entertainment/substack/internal/cli/portfolio_sync_routes_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/config"
+)
+
+type captureTransport struct {
+	url string
+}
+
+func (t *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.url = req.URL.String()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"posts":[]}`)),
+		Request:    req,
+	}, nil
+}
+
+func TestPortfolioFetchDraftsUsesGlobalPublicationIDRoute(t *testing.T) {
+	transport := &captureTransport{}
+	c := client.New(&config.Config{BaseURL: "https://trevinsays.substack.com/api/v1"}, 0, 0)
+	c.NoCache = true
+	c.HTTPClient.Transport = transport
+
+	fetchDrafts(context.Background(), c, "7019888", io.Discard)
+
+	if got, want := transport.url, "https://substack.com/api/v1/drafts?publication_id=7019888"; got != want {
+		t.Fatalf("fetchDrafts URL = %q, want %q", got, want)
+	}
+}
+
+func TestSyncDraftsUsesGlobalPublicationIDRoute(t *testing.T) {
+	path, err := syncResourcePath("drafts")
+	if err != nil {
+		t.Fatalf("syncResourcePath: %v", err)
+	}
+	if got, want := path, "https://substack.com/api/v1/drafts"; got != want {
+		t.Fatalf("sync drafts path = %q, want %q", got, want)
+	}
+
+	flags := &rootFlags{publicationID: "7019888"}
+	params, err := syncResourceExtraParams(context.Background(), nil, flags, "drafts")
+	if err != nil {
+		t.Fatalf("syncResourceExtraParams: %v", err)
+	}
+	if got, want := params["publication_id"], "7019888"; got != want {
+		t.Fatalf("sync drafts publication_id = %q, want %q", got, want)
+	}
+}

--- a/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
+++ b/library/media-and-entertainment/substack/internal/cli/publication_paths_test.go
@@ -71,6 +71,37 @@ func TestDraftCreateDryRunJSONReportsGlobalWriterURL(t *testing.T) {
 	}
 }
 
+func TestDraftListDryRunJSONReportsGlobalWriterURL(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+
+	restoreStderr := captureProcessStderr(t)
+
+	root := RootCmd()
+	var stdout, cmdStderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&cmdStderr)
+	root.SetArgs([]string{
+		"--subdomain", "trevinsays",
+		"--publication-id", "7019888",
+		"drafts", "list",
+		"--data-source", "live",
+		"--dry-run",
+		"--agent",
+	})
+
+	if err := root.Execute(); err != nil {
+		got := restoreStderr()
+		t.Fatalf("execute dry-run: %v; cmd stderr=%s; process stderr=%s", err, cmdStderr.String(), got)
+	}
+	got := restoreStderr()
+	if !strings.Contains(got, "GET https://substack.com/api/v1/drafts") || !strings.Contains(got, "?publication_id=7019888") {
+		t.Fatalf("stderr = %q, want global drafts endpoint with publication_id", got)
+	}
+	if strings.Contains(got, "trevinsays.substack.com") || strings.Contains(got, "{publication}") {
+		t.Fatalf("stderr = %q, should not use publication-host drafts endpoint", got)
+	}
+}
+
 func TestImagesDryRunUsesGlobalUploadEndpoint(t *testing.T) {
 	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
 
@@ -186,7 +217,7 @@ func captureProcessStderr(t *testing.T) func() string {
 func TestSyncResourcePathPublicationScopedResourcesUsePublicationHost(t *testing.T) {
 	t.Parallel()
 
-	for _, resource := range []string{"drafts", "posts", "posts-published", "posts-ranked", "sections", "subs", "tags"} {
+	for _, resource := range []string{"posts", "posts-published", "posts-ranked", "sections", "subs", "tags"} {
 		resource := resource
 		t.Run(resource, func(t *testing.T) {
 			t.Parallel()

--- a/library/media-and-entertainment/substack/internal/cli/sync.go
+++ b/library/media-and-entertainment/substack/internal/cli/sync.go
@@ -252,6 +252,18 @@ Resource scoping:
 				concurrency = 1
 			}
 
+			var draftExtraParams map[string]string
+			for _, resource := range resources {
+				if resource == "drafts" {
+					var err error
+					draftExtraParams, err = syncResourceExtraParams(cmd.Context(), c, flags, resource)
+					if err != nil {
+						return err
+					}
+					break
+				}
+			}
+
 			started := time.Now()
 			work := make(chan string, len(resources))
 			results := make(chan syncResult, len(resources))
@@ -262,10 +274,9 @@ Resource scoping:
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						extraParams, err := syncResourceExtraParams(cmd.Context(), c, flags, resource)
-						if err != nil {
-							results <- syncResult{Resource: resource, Err: err}
-							continue
+						var extraParams map[string]string
+						if resource == "drafts" {
+							extraParams = draftExtraParams
 						}
 						res := syncResource(cmd.Context(), c, db, resource, sinceTS, full, maxPages, effectiveLatestOnly, userParams, syncEventWriter, extraParams)
 						results <- res
@@ -513,6 +524,7 @@ func syncResource(ctx context.Context, c interface {
 	var extractFailureTotal int
 	var consumedTotal int
 	anomalyEmitted := false
+	publicationParamWarningEmitted := false
 
 	for {
 		params := map[string]string{}
@@ -521,6 +533,7 @@ func syncResource(ctx context.Context, c interface {
 				params[k] = v
 			}
 		}
+		basePublicationID := params["publication_id"]
 
 		if resourceSupportsPagination(resource) {
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
@@ -538,6 +551,16 @@ func syncResource(ctx context.Context, c interface {
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
+		if resource == "drafts" && basePublicationID != "" && params["publication_id"] != basePublicationID && !publicationParamWarningEmitted {
+			msg := fmt.Sprintf("user-supplied publication_id %q overrides auto-resolved drafts publication_id %q", params["publication_id"], basePublicationID)
+			if !humanFriendly {
+				fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"publication_id_override","message":"%s"}`+"\n",
+					resource, strings.ReplaceAll(msg, `"`, `\"`))
+			} else {
+				fmt.Fprintf(os.Stderr, "  %s: warning: %s\n", resource, msg)
+			}
+			publicationParamWarningEmitted = true
+		}
 
 		data, err := c.Get(ctx, path, params)
 		if err != nil {

--- a/library/media-and-entertainment/substack/internal/cli/sync.go
+++ b/library/media-and-entertainment/substack/internal/cli/sync.go
@@ -262,7 +262,12 @@ Resource scoping:
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(cmd.Context(), c, db, resource, sinceTS, full, maxPages, effectiveLatestOnly, userParams, syncEventWriter)
+						extraParams, err := syncResourceExtraParams(cmd.Context(), c, flags, resource)
+						if err != nil {
+							results <- syncResult{Resource: resource, Err: err}
+							continue
+						}
+						res := syncResource(cmd.Context(), c, db, resource, sinceTS, full, maxPages, effectiveLatestOnly, userParams, syncEventWriter, extraParams)
 						results <- res
 					}
 				}()
@@ -386,6 +391,17 @@ Resource scoping:
 	return cmd
 }
 
+func syncResourceExtraParams(ctx context.Context, c *client.Client, flags *rootFlags, resource string) (map[string]string, error) {
+	if resource != "drafts" {
+		return nil, nil
+	}
+	publicationID, err := writerPublicationID(ctx, c, flags)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"publication_id": publicationID}, nil
+}
+
 // syncResource handles the full paginated sync of a single resource.
 // It resumes from the last cursor unless sinceTS or full mode overrides it.
 // channel_workflow.go.tmpl mirrors the trailing dates arg conditional;
@@ -393,7 +409,7 @@ Resource scoping:
 func syncResource(ctx context.Context, c interface {
 	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, resource, sinceTS string, full bool, maxPages int, latestOnly bool, userParams *syncUserParams, syncEvents io.Writer) syncResult {
+}, db *store.Store, resource, sinceTS string, full bool, maxPages int, latestOnly bool, userParams *syncUserParams, syncEvents io.Writer, baseParams map[string]string) syncResult {
 	started := time.Now()
 	if syncEvents == nil {
 		syncEvents = io.Discard
@@ -500,6 +516,11 @@ func syncResource(ctx context.Context, c interface {
 
 	for {
 		params := map[string]string{}
+		for k, v := range baseParams {
+			if v != "" {
+				params[k] = v
+			}
+		}
 
 		if resourceSupportsPagination(resource) {
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
@@ -1277,7 +1298,7 @@ func knownSyncResourceNames() []string {
 func syncResourcePath(resource string) (string, error) {
 	paths := map[string]string{
 		"categories":      "/categories",
-		"drafts":          publicationAPIPath("/drafts"),
+		"drafts":          globalAPIPath("/drafts"),
 		"inbox":           "/reader/feed",
 		"inbox-posts":     "/reader/posts",
 		"posts":           publicationAPIPath("/archive"),


### PR DESCRIPTION
## Summary
- routes all Substack draft commands (`list/get/update/delete/prepublish/publish/schedule`) through the global `https://substack.com/api/v1/drafts` API with numeric `publication_id`
- routes portfolio draft sync and generic/local-store draft sync through the same global draft endpoint
- adds regression coverage for draft list dry-run JSON, portfolio draft fetch routing, and sync draft routing
- records the printed-CLI patch manifest and cross-links the durable generator fix in mvanhorn/cli-printing-press#3191

## Why
Live custom-domain auth for `trevinsays` is valid, but the installed CLI still routed draft reads through `https://trevinsays.substack.com/api/v1/drafts`, which returns `HTTP 403: Not authorized`. `drafts create` and image upload were already fixed to use global routes; the sweep showed the remaining draft surface was broader than just `drafts list` / portfolio sync.

## Broader sweep
Verified with the installed CLI before patching:
- `drafts create --dry-run --publication-id 7019888` already used `POST https://substack.com/api/v1/drafts?publication_id=7019888`
- image upload dry-run already used `https://substack.com/api/v1/image`
- `drafts list --data-source live --publication-id 7019888 --subdomain trevinsays` still hit `https://trevinsays.substack.com/api/v1/drafts` and 403'd
- dry-run sweep showed `drafts get/update/delete/prepublish/publish/schedule` and draft freshness/sync paths still used publication-host draft routes
- portfolio sync also surfaced custom-domain 403s for non-draft endpoints (`/publication`, `/post_management/published`, `/publication_launch_checklist`), but this PR intentionally only changes the documented working draft/image global contract

## Tests
- `cd library/media-and-entertainment/substack && go test ./...`
- `git diff --check`
- dry-run smoke: `go run ./cmd/substack-pp-cli --subdomain trevinsays --publication-id 7019888 drafts get 123 --dry-run --agent`
  - verified freshness pre-read and actual draft fetch both render `https://substack.com/api/v1/drafts...publication_id=7019888`
  - verified no `trevinsays.substack.com/api/v1/drafts` remains in the dry-run output

No live writes, publishes, deletes, scheduling, or image uploads were performed.
