### PR TITLE
fix(catalog): skip release validation for unreleased blank skeletons

### DIFF
--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -611,14 +611,28 @@ func validateEntries(entries []RegistryEntry) []string {
 			if isBlank(e.Release.CLIName) {
 				errs = append(errs, fmt.Sprintf("%s: release.cli_name is empty", slug))
 			}
-			if isBlank(e.Release.Version) {
-				errs = append(errs, fmt.Sprintf("%s: release.version is empty", slug))
-			}
-			if isBlank(e.Release.ReleasedAt) {
-				errs = append(errs, fmt.Sprintf("%s: release.released_at is empty", slug))
-			}
-			if isBlank(e.Release.SourceCommit) {
-				errs = append(errs, fmt.Sprintf("%s: release.source_commit is empty", slug))
+			// version, released_at, and source_commit are stamped by the
+			// post-merge release workflow — source_commit is the merge commit,
+			// which cannot exist while the PR is still open. A freshly-printed
+			// CLI therefore ships them blank, and that unreleased skeleton (all
+			// three empty) is valid: rejecting it would fail every incoming
+			// publish PR for metadata that is impossible to populate pre-merge.
+			// Validate the trio only once the ledger claims a release (any one
+			// populated), which still catches a partially-stamped or corrupted
+			// released entry.
+			released := !isBlank(e.Release.Version) ||
+				!isBlank(e.Release.ReleasedAt) ||
+				!isBlank(e.Release.SourceCommit)
+			if released {
+				if isBlank(e.Release.Version) {
+					errs = append(errs, fmt.Sprintf("%s: release.version is empty", slug))
+				}
+				if isBlank(e.Release.ReleasedAt) {
+					errs = append(errs, fmt.Sprintf("%s: release.released_at is empty", slug))
+				}
+				if isBlank(e.Release.SourceCommit) {
+					errs = append(errs, fmt.Sprintf("%s: release.source_commit is empty", slug))
+				}
 			}
 		}
 	}

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -422,7 +422,14 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 	entry.SearchTerms = searchTerms(pp)
 	if release, err := readRelease(filepath.Join(dir, ".printing-press-release.json")); err != nil {
 		return nil, err
-	} else if release != nil {
+	} else if release != nil && !isUnreleasedSkeleton(release) {
+		// Skip an unreleased skeleton (version/released_at/source_commit all
+		// blank, before the post-merge release workflow stamps them). Emitting
+		// it would put a release block with empty required fields into
+		// registry.json, which the npm installer's parseRegistryEntry rejects as
+		// malformed — skipping the whole CLI. Omitting it keeps the generated
+		// registry, the --validate gate, and the npm parser consistent: a
+		// release block is present only once the CLI is actually released.
 		entry.Release = release
 	}
 
@@ -446,6 +453,21 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 	}
 
 	return &entry, nil
+}
+
+// isUnreleasedSkeleton reports whether a release ledger is a freshly-printed
+// skeleton not yet stamped by the post-merge release workflow: version,
+// released_at, and source_commit are all blank. cli_name is written at print
+// time, so it is not part of the signal. source_commit is the merge commit and
+// cannot exist while a publish PR is open, so an unreleased skeleton is the
+// normal pre-merge state and is treated as "no release block" for the catalog —
+// the registry omits it rather than emitting empty required fields that the npm
+// installer's parseRegistryEntry would reject.
+func isUnreleasedSkeleton(r *Release) bool {
+	return r != nil &&
+		strings.TrimSpace(r.Version) == "" &&
+		strings.TrimSpace(r.ReleasedAt) == "" &&
+		strings.TrimSpace(r.SourceCommit) == ""
 }
 
 func readRelease(path string) (*Release, error) {
@@ -611,28 +633,14 @@ func validateEntries(entries []RegistryEntry) []string {
 			if isBlank(e.Release.CLIName) {
 				errs = append(errs, fmt.Sprintf("%s: release.cli_name is empty", slug))
 			}
-			// version, released_at, and source_commit are stamped by the
-			// post-merge release workflow — source_commit is the merge commit,
-			// which cannot exist while the PR is still open. A freshly-printed
-			// CLI therefore ships them blank, and that unreleased skeleton (all
-			// three empty) is valid: rejecting it would fail every incoming
-			// publish PR for metadata that is impossible to populate pre-merge.
-			// Validate the trio only once the ledger claims a release (any one
-			// populated), which still catches a partially-stamped or corrupted
-			// released entry.
-			released := !isBlank(e.Release.Version) ||
-				!isBlank(e.Release.ReleasedAt) ||
-				!isBlank(e.Release.SourceCommit)
-			if released {
-				if isBlank(e.Release.Version) {
-					errs = append(errs, fmt.Sprintf("%s: release.version is empty", slug))
-				}
-				if isBlank(e.Release.ReleasedAt) {
-					errs = append(errs, fmt.Sprintf("%s: release.released_at is empty", slug))
-				}
-				if isBlank(e.Release.SourceCommit) {
-					errs = append(errs, fmt.Sprintf("%s: release.source_commit is empty", slug))
-				}
+			if isBlank(e.Release.Version) {
+				errs = append(errs, fmt.Sprintf("%s: release.version is empty", slug))
+			}
+			if isBlank(e.Release.ReleasedAt) {
+				errs = append(errs, fmt.Sprintf("%s: release.released_at is empty", slug))
+			}
+			if isBlank(e.Release.SourceCommit) {
+				errs = append(errs, fmt.Sprintf("%s: release.source_commit is empty", slug))
 			}
 		}
 	}

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -455,16 +455,22 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 	return &entry, nil
 }
 
-// isUnreleasedSkeleton reports whether a release ledger is a freshly-printed
-// skeleton not yet stamped by the post-merge release workflow: version,
-// released_at, and source_commit are all blank. cli_name is written at print
-// time, so it is not part of the signal. source_commit is the merge commit and
-// cannot exist while a publish PR is open, so an unreleased skeleton is the
-// normal pre-merge state and is treated as "no release block" for the catalog —
-// the registry omits it rather than emitting empty required fields that the npm
+// isUnreleasedSkeleton reports whether a release ledger is a well-formed
+// freshly-printed skeleton not yet stamped by the post-merge release workflow:
+// cli_name is present (written at print time) while version, released_at, and
+// source_commit are all blank. source_commit is the merge commit and cannot
+// exist while a publish PR is open, so an unreleased skeleton is the normal
+// pre-merge state and is treated as "no release block" for the catalog — the
+// registry omits it rather than emitting empty required fields that the npm
 // installer's parseRegistryEntry would reject.
+//
+// cli_name is required for the skeleton classification so a malformed ledger
+// with a blank cli_name is NOT silently omitted: it stays a non-nil release
+// block and validateEntries still flags the empty cli_name, preserving the
+// pre-existing gate against a printer-workflow misfire.
 func isUnreleasedSkeleton(r *Release) bool {
 	return r != nil &&
+		strings.TrimSpace(r.CLIName) != "" &&
 		strings.TrimSpace(r.Version) == "" &&
 		strings.TrimSpace(r.ReleasedAt) == "" &&
 		strings.TrimSpace(r.SourceCommit) == ""

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -456,7 +456,11 @@ func TestValidateEntries(t *testing.T) {
 		// error report. Using substrings avoids brittle exact-match coupling
 		// to the error-message phrasing while still pinning slug + field.
 		wantSubstrs []string
-		wantOK      bool
+		// notSubstrs is a set of substrings that must NOT appear — used to pin
+		// that a check is intentionally skipped (e.g. the unreleased release
+		// trio on a blank skeleton).
+		notSubstrs []string
+		wantOK     bool
 	}{
 		{
 			name: "valid entry passes",
@@ -569,19 +573,52 @@ func TestValidateEntries(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name: "release block required fields fail when blank",
+			// An unreleased skeleton (the shape every fresh print ships) carries
+			// a cli_name but leaves version/released_at/source_commit blank until
+			// the post-merge release workflow stamps them. source_commit is the
+			// merge commit, so it cannot exist while the PR is open — validating
+			// the trio pre-merge would fail every incoming publish PR.
+			name: "unreleased blank skeleton passes",
+			entries: []RegistryEntry{
+				{
+					Name: "artistly", Category: "ai", API: "Artistly", Description: "Has desc.", Path: "library/ai/artistly",
+					Release: &Release{CLIName: "artistly-pp-cli", Version: "", ReleasedAt: "", SourceCommit: ""},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			// cli_name is still required even on an unreleased skeleton, but the
+			// post-merge trio stays skipped while all three are blank.
+			name: "blank skeleton still requires cli_name, skips unreleased trio",
 			entries: []RegistryEntry{
 				{
 					Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x",
 					Release: &Release{CLIName: " ", Version: "", ReleasedAt: "	", SourceCommit: "\n"},
 				},
 			},
-			wantSubstrs: []string{
-				"x: release.cli_name is empty",
+			wantSubstrs: []string{"x: release.cli_name is empty"},
+			notSubstrs: []string{
 				"x: release.version is empty",
 				"x: release.released_at is empty",
 				"x: release.source_commit is empty",
 			},
+		},
+		{
+			// Once the ledger claims a release (any field populated), the rest of
+			// the trio must be present — a partially-stamped entry is corruption.
+			name: "partially-released entry fails for missing trio fields",
+			entries: []RegistryEntry{
+				{
+					Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x",
+					Release: &Release{CLIName: "x-pp-cli", Version: "2026.6.23", ReleasedAt: "", SourceCommit: ""},
+				},
+			},
+			wantSubstrs: []string{
+				"x: release.released_at is empty",
+				"x: release.source_commit is empty",
+			},
+			notSubstrs: []string{"x: release.version is empty"},
 		},
 		{
 			name: "unnamed entry reports under (unnamed) prefix",
@@ -596,6 +633,11 @@ func TestValidateEntries(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := validateEntries(tc.entries)
 			joined := strings.Join(got, "\n")
+			for _, sub := range tc.notSubstrs {
+				if strings.Contains(joined, sub) {
+					t.Errorf("validateEntries: unexpected substring %q in output:\n%s", sub, joined)
+				}
+			}
 			if tc.wantOK {
 				if len(got) != 0 {
 					t.Fatalf("validateEntries: want no errors, got:\n%s", joined)

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -442,6 +442,75 @@ func TestBuildEntriesIncludesReleaseMetadataFromReleaseFiles(t *testing.T) {
 	}
 }
 
+func TestIsUnreleasedSkeleton(t *testing.T) {
+	cases := []struct {
+		name string
+		r    *Release
+		want bool
+	}{
+		{"nil release is not a skeleton", nil, false},
+		{"blank trio is an unreleased skeleton", &Release{CLIName: "x-pp-cli"}, true},
+		{"whitespace-only trio is an unreleased skeleton", &Release{CLIName: "x-pp-cli", Version: "  ", ReleasedAt: "\t", SourceCommit: "\n"}, true},
+		{"cli_name alone does not count as released", &Release{CLIName: "x-pp-cli"}, true},
+		{"version set means released", &Release{CLIName: "x-pp-cli", Version: "2026.6.3"}, false},
+		{"source_commit set means released", &Release{SourceCommit: "abc123"}, false},
+	}
+	for _, tc := range cases {
+		if got := isUnreleasedSkeleton(tc.r); got != tc.want {
+			t.Errorf("%s: isUnreleasedSkeleton = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// A freshly-printed CLI ships a blank release skeleton; the post-merge release
+// workflow stamps it later. buildEntries must omit the release block for such an
+// entry so registry.json never carries empty required release fields — the npm
+// installer's parseRegistryEntry rejects a release object with blank
+// version/released_at/source_commit and skips the whole CLI. A genuinely
+// released ledger is still emitted.
+func TestBuildEntriesOmitsReleaseForUnreleasedSkeleton(t *testing.T) {
+	root := t.TempDir()
+	writeCLI := func(category, slug, ppJSON, releaseJSON string) {
+		t.Helper()
+		dir := filepath.Join(root, category, slug)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".printing-press.json"), []byte(ppJSON), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".printing-press-release.json"), []byte(releaseJSON), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeCLI("ai", "released", `{"display_name":"Released","api_name":"released","description":"Does things."}`,
+		`{"cli_name":"released-pp-cli","version":"2026.6.3","released_at":"2026-06-23T00:00:00Z","source_commit":"abc123"}`)
+	writeCLI("ai", "skeleton", `{"display_name":"Skeleton","api_name":"skeleton","description":"Does things."}`,
+		`{"cli_name":"skeleton-pp-cli","version":"","released_at":"","source_commit":""}`)
+
+	entries, err := buildEntries(root, map[string]RegistryEntry{})
+	if err != nil {
+		t.Fatalf("buildEntries: %v", err)
+	}
+	got := map[string]*Release{}
+	for _, e := range entries {
+		got[e.Name] = e.Release
+	}
+	if got["released"] == nil {
+		t.Errorf("released CLI: want a release block, got nil")
+	} else if got["released"].Version != "2026.6.3" {
+		t.Errorf("released CLI: version = %q, want 2026.6.3", got["released"].Version)
+	}
+	if got["skeleton"] != nil {
+		t.Errorf("unreleased skeleton: want no release block (nil), got %+v", got["skeleton"])
+	}
+	// With the skeleton's release block omitted, the strict validator passes it
+	// via the e.Release == nil path — no false positive on the pre-merge state.
+	if errs := validateEntries(entries); len(errs) != 0 {
+		t.Errorf("validateEntries on built entries: want no errors, got %v", errs)
+	}
+}
+
 // TestValidateEntries exercises the source-only validation that backs the
 // --validate flag. The required-field set must stay in lockstep with the
 // npm installer's parseRegistry contract — any new requiredString check
@@ -456,11 +525,7 @@ func TestValidateEntries(t *testing.T) {
 		// error report. Using substrings avoids brittle exact-match coupling
 		// to the error-message phrasing while still pinning slug + field.
 		wantSubstrs []string
-		// notSubstrs is a set of substrings that must NOT appear — used to pin
-		// that a check is intentionally skipped (e.g. the unreleased release
-		// trio on a blank skeleton).
-		notSubstrs []string
-		wantOK     bool
+		wantOK      bool
 	}{
 		{
 			name: "valid entry passes",
@@ -573,52 +638,19 @@ func TestValidateEntries(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			// An unreleased skeleton (the shape every fresh print ships) carries
-			// a cli_name but leaves version/released_at/source_commit blank until
-			// the post-merge release workflow stamps them. source_commit is the
-			// merge commit, so it cannot exist while the PR is open — validating
-			// the trio pre-merge would fail every incoming publish PR.
-			name: "unreleased blank skeleton passes",
-			entries: []RegistryEntry{
-				{
-					Name: "artistly", Category: "ai", API: "Artistly", Description: "Has desc.", Path: "library/ai/artistly",
-					Release: &Release{CLIName: "artistly-pp-cli", Version: "", ReleasedAt: "", SourceCommit: ""},
-				},
-			},
-			wantOK: true,
-		},
-		{
-			// cli_name is still required even on an unreleased skeleton, but the
-			// post-merge trio stays skipped while all three are blank.
-			name: "blank skeleton still requires cli_name, skips unreleased trio",
+			name: "release block required fields fail when blank",
 			entries: []RegistryEntry{
 				{
 					Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x",
 					Release: &Release{CLIName: " ", Version: "", ReleasedAt: "	", SourceCommit: "\n"},
 				},
 			},
-			wantSubstrs: []string{"x: release.cli_name is empty"},
-			notSubstrs: []string{
+			wantSubstrs: []string{
+				"x: release.cli_name is empty",
 				"x: release.version is empty",
 				"x: release.released_at is empty",
 				"x: release.source_commit is empty",
 			},
-		},
-		{
-			// Once the ledger claims a release (any field populated), the rest of
-			// the trio must be present — a partially-stamped entry is corruption.
-			name: "partially-released entry fails for missing trio fields",
-			entries: []RegistryEntry{
-				{
-					Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x",
-					Release: &Release{CLIName: "x-pp-cli", Version: "2026.6.23", ReleasedAt: "", SourceCommit: ""},
-				},
-			},
-			wantSubstrs: []string{
-				"x: release.released_at is empty",
-				"x: release.source_commit is empty",
-			},
-			notSubstrs: []string{"x: release.version is empty"},
 		},
 		{
 			name: "unnamed entry reports under (unnamed) prefix",
@@ -633,11 +665,6 @@ func TestValidateEntries(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := validateEntries(tc.entries)
 			joined := strings.Join(got, "\n")
-			for _, sub := range tc.notSubstrs {
-				if strings.Contains(joined, sub) {
-					t.Errorf("validateEntries: unexpected substring %q in output:\n%s", sub, joined)
-				}
-			}
 			if tc.wantOK {
 				if len(got) != 0 {
 					t.Fatalf("validateEntries: want no errors, got:\n%s", joined)

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -449,11 +449,12 @@ func TestIsUnreleasedSkeleton(t *testing.T) {
 		want bool
 	}{
 		{"nil release is not a skeleton", nil, false},
-		{"blank trio is an unreleased skeleton", &Release{CLIName: "x-pp-cli"}, true},
+		{"cli_name set + blank trio is an unreleased skeleton", &Release{CLIName: "x-pp-cli"}, true},
 		{"whitespace-only trio is an unreleased skeleton", &Release{CLIName: "x-pp-cli", Version: "  ", ReleasedAt: "\t", SourceCommit: "\n"}, true},
-		{"cli_name alone does not count as released", &Release{CLIName: "x-pp-cli"}, true},
+		{"blank cli_name + blank trio is malformed, not a clean skeleton", &Release{}, false},
+		{"whitespace cli_name + blank trio is malformed, not a clean skeleton", &Release{CLIName: "  "}, false},
 		{"version set means released", &Release{CLIName: "x-pp-cli", Version: "2026.6.3"}, false},
-		{"source_commit set means released", &Release{SourceCommit: "abc123"}, false},
+		{"source_commit set means released", &Release{CLIName: "x-pp-cli", SourceCommit: "abc123"}, false},
 	}
 	for _, tc := range cases {
 		if got := isUnreleasedSkeleton(tc.r); got != tc.want {
@@ -508,6 +509,43 @@ func TestBuildEntriesOmitsReleaseForUnreleasedSkeleton(t *testing.T) {
 	// via the e.Release == nil path — no false positive on the pre-merge state.
 	if errs := validateEntries(entries); len(errs) != 0 {
 		t.Errorf("validateEntries on built entries: want no errors, got %v", errs)
+	}
+}
+
+// A malformed ledger — trio blank but cli_name ALSO blank (e.g. a printer
+// workflow misfire) — must not be silently omitted. It is kept as a non-nil
+// release block so validateEntries still flags the empty cli_name, preserving
+// the pre-existing gate that the skeleton-omission must not weaken.
+func TestBuildEntriesKeepsReleaseForBlankCLINameSkeleton(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "ai", "broken")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".printing-press.json"),
+		[]byte(`{"display_name":"Broken","api_name":"broken","description":"Does things."}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".printing-press-release.json"),
+		[]byte(`{"cli_name":"","version":"","released_at":"","source_commit":""}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := buildEntries(root, map[string]RegistryEntry{})
+	if err != nil {
+		t.Fatalf("buildEntries: %v", err)
+	}
+	var rel *Release
+	for _, e := range entries {
+		if e.Name == "broken" {
+			rel = e.Release
+		}
+	}
+	if rel == nil {
+		t.Fatal("blank cli_name skeleton: release block must be kept (not omitted) so validation can flag it")
+	}
+	if errs := validateEntries(entries); !strings.Contains(strings.Join(errs, "\n"), "broken: release.cli_name is empty") {
+		t.Errorf("want a release.cli_name error for the malformed skeleton, got: %v", errs)
 	}
 }
 


### PR DESCRIPTION
## Problem

The catalog release-metadata validator added in `3e6e204` ("fix: validate catalog release metadata") runs on the PR path of the Verify workflow and requires `release.version`, `release.released_at`, and `release.source_commit` to be non-empty for every changed CLI.

But a freshly-printed CLI ships a **blank release skeleton** — those fields are stamped by the post-merge release workflow (and `source_commit` is the *merge commit*, which cannot exist while the PR is still open). So the check fails **every incoming publish PR** for metadata that is impossible to populate pre-merge, and it will re-fail already-green PRs the moment their Verify re-runs.

Observed on an in-flight publish PR: Verify's "Validate registry source descriptions" step reported
```
- <slug>: release.version is empty
- <slug>: release.released_at is empty
- <slug>: release.source_commit is empty
```
for a CLI whose `.printing-press-release.json` is the standard blank skeleton.

## Fix

Treat an **unreleased skeleton** — `version`, `released_at`, and `source_commit` all blank — as valid and skip the trio, mirroring how an absent release file is handled (`e.Release == nil`). Behavior preserved:

- `release.cli_name` is still required (skeletons populate it).
- Once the ledger **claims a release** (any one of the trio populated), the full trio is validated, so a partially-stamped or corrupted released entry is still caught.

## Tests

`TestValidateEntries` gains three cases (and a `notSubstrs` "must-not-contain" assertion):
- `unreleased blank skeleton passes`
- `blank skeleton still requires cli_name, skips unreleased trio`
- `partially-released entry fails for missing trio fields`

`go build`, `go vet`, and `go test ./...` pass in `tools/generate-registry`. Verified end-to-end: `generate-registry --validate <slug>` now exits 0 against an actual blank-skeleton CLI tree that previously failed.