### PR TITLE
fix(x-twitter): fall back to app-only bearer when OAuth2 user-context token is expired

### DIFF
--- a/library/social-and-messaging/x-twitter/.printing-press-patches/x-twitter-app-only-auth-fallback.json
+++ b/library/social-and-messaging/x-twitter/.printing-press-patches/x-twitter-app-only-auth-fallback.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "x-twitter-app-only-auth-fallback",
+  "applied_at": "2026-06-23",
+  "base_run_id": "20260603-230951",
+  "base_printing_press_version": "4.20.1",
+  "summary": "Public v2 reads fall back to app-only bearer token when OAuth2 user-context token is expired/stale and refresh unavailable.",
+  "reason": "When X_OAUTH2_USER_TOKEN is expired and refresh_token is missing or stale, `users get-by-username` and other public v2 reads fail with 401 even though a valid X_BEARER_TOKEN exists. Config.AuthHeader() prefers OAuth2 user-context over app-only bearer, so every request uses the dead token. The fix adds a fallback in the do() retry loop: after the existing refresh-on-401 attempt, if both credentials exist and the 401 persists, retry with the app-only bearer token. User-context-only endpoints like /2/users/me get a clearer 403 Unsupported Authentication instead of a generic 401.",
+  "files": [
+    "internal/client/client.go",
+    "internal/client/client_test.go"
+  ],
+  "validated_outcome": "go test ./internal/client/... -count=1; go test ./internal/cli/... -count=1; go build ./..."
+}

--- a/library/social-and-messaging/x-twitter/.printing-press-patches/x-twitter-oauth2-refresh-command.json
+++ b/library/social-and-messaging/x-twitter/.printing-press-patches/x-twitter-oauth2-refresh-command.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "x-twitter-oauth2-refresh-command",
+  "applied_at": "2026-06-23",
+  "base_run_id": "20260603-230951",
+  "base_printing_press_version": "4.20.1",
+  "summary": "Add an explicit OAuth2 user-context refresh command and report refresh failures in doctor output.",
+  "reason": "Public-read fallback alone does not fix stale or rejected OAuth2 user-context credentials. Operators need a direct `auth refresh` path that forces refresh-token exchange, persists rotated token tuples, and tells them when X rejects the refresh token so they can rerun OAuth2 login. Doctor previously attempted refresh after /2/users/me returned 401 but collapsed refresh-token failures into a generic invalid-token hint.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/cli/auth_test.go",
+    "internal/cli/doctor.go",
+    "internal/cli/doctor_test.go"
+  ],
+  "validated_outcome": "go test ./internal/cli/... -count=1 -run 'TestAuthRefresh|TestDoctorReportsOAuth2RefreshFailureReason|TestDoctorRefreshesOAuth2UserContextAfterUnauthorized'; go test ./internal/client/... ./internal/cli/... -count=1; go build ./..."
+}

--- a/library/social-and-messaging/x-twitter/internal/cli/auth.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/auth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/internal/config"
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newAuthSetTokenCmd(flags))
 	cmd.AddCommand(newAuthImportOAuth2Cmd(flags))
 	cmd.AddCommand(newAuthOAuth2LoginCmd(flags))
+	cmd.AddCommand(newAuthRefreshCmd(flags))
 	cmd.AddCommand(newAuthLogoutCmd(flags))
 
 	return cmd
@@ -115,6 +117,60 @@ func newAuthImportOAuth2Cmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&scopes, "scopes", "", "Comma-separated OAuth2 scopes granted to the token")
 	cmd.Flags().StringVar(&expiresAt, "expires-at", "", "Token expiry as RFC3339 timestamp")
 	cmd.Flags().StringVar(&expiresIn, "expires-in", "", "Token lifetime from now, such as 2h or 90m")
+	return cmd
+}
+
+func newAuthRefreshCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "refresh",
+		Short:   "Refresh the stored OAuth2 user-context token",
+		Example: "  x-twitter-pp-cli auth refresh --agent",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(flags.configPath)
+			if err != nil {
+				return configErr(err)
+			}
+			if strings.TrimSpace(cfg.RefreshToken) == "" {
+				return authErr(fmt.Errorf("OAuth2 user-context refresh token is missing; run `x-twitter-pp-cli auth oauth2-login --client-id <client-id>` or import a token with --refresh-token"))
+			}
+			if strings.TrimSpace(cfg.ClientID) == "" {
+				return authErr(fmt.Errorf("OAuth2 client ID is missing; run `x-twitter-pp-cli auth oauth2-login --client-id <client-id>` or import credentials with --client-id"))
+			}
+			oldRefresh := strings.TrimSpace(cfg.RefreshToken)
+			c := client.New(cfg, flags.timeout, flags.rateLimit)
+			refreshed, err := c.RefreshOAuth2UserContext(cmd.Context(), true)
+			if err != nil {
+				return authErr(fmt.Errorf("OAuth2 user-context refresh failed: %s\nhint: if X rejected the refresh token, it cannot be repaired locally; rerun `x-twitter-pp-cli auth oauth2-login --client-id <client-id>` to mint a new access+refresh token", cliutil.SanitizeErrorBody(err.Error())))
+			}
+			out := map[string]any{
+				"auth_lane":             "oauth2_user_context",
+				"refreshed":             refreshed,
+				"saved":                 refreshed,
+				"config_path":           cfg.Path,
+				"refresh_token_present": strings.TrimSpace(cfg.RefreshToken) != "",
+				"refresh_token_rotated": oldRefresh != "" && strings.TrimSpace(cfg.RefreshToken) != "" && oldRefresh != strings.TrimSpace(cfg.RefreshToken),
+				"client_id_present":     strings.TrimSpace(cfg.ClientID) != "",
+				"client_secret_present": strings.TrimSpace(cfg.ClientSecret) != "",
+			}
+			if !cfg.TokenExpiry.IsZero() {
+				out["expires_at"] = cfg.TokenExpiry.UTC().Format(time.RFC3339)
+			}
+			if len(cfg.Scopes) > 0 {
+				out["scopes"] = cfg.Scopes
+			}
+			if flags.asJSON {
+				return printJSONFiltered(cmd.OutOrStdout(), out, flags)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "OAuth2 user-context token refreshed and saved to %s\n", cfg.Path)
+			if !cfg.TokenExpiry.IsZero() {
+				fmt.Fprintf(cmd.OutOrStdout(), "Expires: %s\n", cfg.TokenExpiry.UTC().Format(time.RFC3339))
+			}
+			if out["refresh_token_rotated"] == true {
+				fmt.Fprintln(cmd.OutOrStdout(), "Refresh token rotated and persisted.")
+			}
+			return nil
+		},
+	}
 	return cmd
 }
 

--- a/library/social-and-messaging/x-twitter/internal/cli/auth_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/auth_test.go
@@ -5,11 +5,15 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/internal/config"
 )
 
@@ -372,5 +376,94 @@ func TestAuthImportOAuth2PreservesStoredClientID(t *testing.T) {
 	}
 	if cfg.ClientID != "existing-client" || cfg.ClientSecret != "existing-secret" {
 		t.Fatalf("client credentials not preserved: %+v", cfg)
+	}
+}
+
+func TestAuthRefreshPersistsRotatedOAuth2Token(t *testing.T) {
+	t.Setenv("X_BEARER_TOKEN", "")
+	t.Setenv("X_OAUTH2_USER_TOKEN", "")
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("oauth2_user_token = \"old-access\"\nrefresh_token = \"old-refresh\"\nclient_id = \"client-id\"\ntoken_expiry = 2026-06-08T12:00:00Z\n"), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/2/oauth2/token" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if r.Form.Get("grant_type") != "refresh_token" || r.Form.Get("refresh_token") != "old-refresh" || r.Form.Get("client_id") != "client-id" {
+			t.Fatalf("unexpected refresh form: %#v", r.Form)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600,"scope":"tweet.read users.read offline.access"}`))
+	}))
+	defer server.Close()
+	oldEndpoint := client.OAuth2TokenEndpoint
+	client.OAuth2TokenEndpoint = server.URL + "/2/oauth2/token"
+	defer func() { client.OAuth2TokenEndpoint = oldEndpoint }()
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", configPath, "auth", "refresh", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth refresh failed: %v\noutput: %s", err, out.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if payload["auth_lane"] != "oauth2_user_context" || payload["refreshed"] != true || payload["refresh_token_rotated"] != true {
+		t.Fatalf("payload = %#v", payload)
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.XOauth2UserToken != "new-access" || cfg.RefreshToken != "new-refresh" || cfg.AccessToken != "" {
+		t.Fatalf("refreshed token tuple not persisted: %+v", cfg)
+	}
+	if cfg.TokenExpiry.IsZero() || time.Until(cfg.TokenExpiry) < 30*time.Minute {
+		t.Fatalf("TokenExpiry = %s, want refreshed future expiry", cfg.TokenExpiry)
+	}
+}
+
+func TestAuthRefreshReportsRejectedRefreshToken(t *testing.T) {
+	t.Setenv("X_BEARER_TOKEN", "")
+	t.Setenv("X_OAUTH2_USER_TOKEN", "")
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("oauth2_user_token = \"old-access\"\nrefresh_token = \"dead-refresh\"\nclient_id = \"client-id\"\n"), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"refresh token expired"}`))
+	}))
+	defer server.Close()
+	oldEndpoint := client.OAuth2TokenEndpoint
+	client.OAuth2TokenEndpoint = server.URL + "/2/oauth2/token"
+	defer func() { client.OAuth2TokenEndpoint = oldEndpoint }()
+
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", configPath, "auth", "refresh", "--json"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected auth refresh to fail\noutput: %s", out.String())
+	}
+	if !strings.Contains(err.Error(), "OAuth2 user-context refresh failed") || !strings.Contains(err.Error(), "oauth2-login") {
+		t.Fatalf("refresh error should explain re-login path, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "dead-refresh") {
+		t.Fatalf("refresh error leaked refresh token: %v", err)
 	}
 }

--- a/library/social-and-messaging/x-twitter/internal/cli/doctor.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/doctor.go
@@ -100,8 +100,11 @@ func probeAuthLane(ctx context.Context, c *client.Client, header, source, path, 
 		body := apiErr.Body
 		switch {
 		case apiErr.StatusCode == 401:
+			var refreshErr error
 			if path == "/2/users/me" {
-				if refreshed, refreshErr := c.RefreshOAuth2UserContext(ctx, true); refreshErr == nil && refreshed {
+				var refreshed bool
+				refreshed, refreshErr = c.RefreshOAuth2UserContext(ctx, true)
+				if refreshErr == nil && refreshed {
 					refreshedHeader := c.Config.UserContextAuthHeader()
 					if refreshedHeader != "" && refreshedHeader != header {
 						refreshedHeaders := map[string]string{
@@ -122,11 +125,44 @@ func probeAuthLane(ctx context.Context, c *client.Client, header, source, path, 
 			}
 			lane := authLane("invalid", source, "token was rejected; refresh or replace this credential")
 			lane["http_status"] = apiErr.StatusCode
+			if refreshErr != nil {
+				lane["refresh_attempted"] = true
+				lane["refresh_error"] = cliutil.SanitizeErrorBody(refreshErr.Error())
+				lane["hint"] = "refresh token was rejected or could not be used; rerun `x-twitter-pp-cli auth oauth2-login --client-id <client-id>` to mint a new OAuth2 user-context token"
+			}
 			return lane
 		case apiErr.StatusCode == 403 && xAppOnlyUnsupportedAuth(body):
+			var refreshErr error
+			if path == "/2/users/me" && strings.TrimSpace(c.Config.RefreshToken) != "" && strings.TrimSpace(c.Config.ClientID) != "" {
+				var refreshed bool
+				refreshed, refreshErr = c.RefreshOAuth2UserContext(ctx, true)
+				if refreshErr == nil && refreshed {
+					refreshedHeader := c.Config.UserContextAuthHeader()
+					if refreshedHeader != "" && refreshedHeader != header {
+						refreshedHeaders := map[string]string{
+							"Authorization": refreshedHeader,
+							"User-Agent":    "x-twitter-pp-cli",
+						}
+						if refreshedBody, retryErr := c.GetWithHeaders(ctx, path, nil, refreshedHeaders); retryErr == nil {
+							lane := authLane("ok", source, "")
+							lane["refreshed"] = true
+							if user := userSummaryFromMeProbe(refreshedBody); len(user) > 0 {
+								lane["probe"] = "/2/users/me ok"
+								lane["user"] = user
+							}
+							return lane
+						}
+					}
+				}
+			}
 			lane := authLane("invalid", source, "this credential appears to be app-only; set/import a real OAuth2 user-context token in X_OAUTH2_USER_TOKEN")
 			lane["http_status"] = apiErr.StatusCode
 			lane["classification"] = "app_only_token_used_for_user_context"
+			if refreshErr != nil {
+				lane["refresh_attempted"] = true
+				lane["refresh_error"] = cliutil.SanitizeErrorBody(refreshErr.Error())
+				lane["hint"] = "stored user-context token is not usable and refresh failed; rerun `x-twitter-pp-cli auth oauth2-login --client-id <client-id>` to mint a new OAuth2 user-context token"
+			}
 			return lane
 		case apiErr.StatusCode == 403:
 			lane := authLane("invalid", source, "credential reached X but lacks permission for this probe")

--- a/library/social-and-messaging/x-twitter/internal/cli/doctor_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/doctor_test.go
@@ -266,6 +266,97 @@ token_expiry = 2026-06-08T12:00:00Z
 	}
 }
 
+func TestDoctorReportsOAuth2RefreshFailureReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"refresh token expired"}`))
+		case "/2/users/me":
+			http.Error(w, "expired", http.StatusUnauthorized)
+		case xAppOnlyProbePath:
+			http.Error(w, "missing app token", http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	oldEndpoint := client.OAuth2TokenEndpoint
+	client.OAuth2TokenEndpoint = server.URL + "/2/oauth2/token"
+	defer func() { client.OAuth2TokenEndpoint = oldEndpoint }()
+
+	home := t.TempDir()
+	configPath := writeDoctorConfig(t, t.TempDir(), server.URL, `oauth2_user_token = "doctor-stale"
+refresh_token = "doctor-refresh"
+client_id = "doctor-client"
+`)
+
+	report := runDoctorJSON(t, home, configPath)
+	userLane := laneFromReport(t, report, "oauth2_user_context")
+	if got, _ := userLane["status"].(string); got != "invalid" {
+		t.Fatalf("oauth2_user_context status = %q, want invalid (lane=%#v)", got, userLane)
+	}
+	if userLane["refresh_attempted"] != true {
+		t.Fatalf("refresh_attempted = %#v, want true (lane=%#v)", userLane["refresh_attempted"], userLane)
+	}
+	if refreshErr, _ := userLane["refresh_error"].(string); !strings.Contains(refreshErr, "invalid_grant") {
+		t.Fatalf("refresh_error should include sanitized upstream reason, got %q", refreshErr)
+	}
+	if hint, _ := userLane["hint"].(string); !strings.Contains(hint, "oauth2-login") {
+		t.Fatalf("hint should point to oauth2-login, got %q", hint)
+	}
+	out, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	for _, secret := range []string{"doctor-stale", "doctor-refresh"} {
+		if strings.Contains(string(out), secret) {
+			t.Fatalf("doctor report leaked secret %q: %s", secret, out)
+		}
+	}
+}
+
+func TestDoctorReportsOAuth2RefreshFailureWhenStoredTokenLooksAppOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_request","error_description":"Value passed for the token was invalid."}`))
+		case "/2/users/me":
+			http.Error(w, xUnsupportedAppOnlyBody, http.StatusForbidden)
+		case xAppOnlyProbePath:
+			http.Error(w, "missing app token", http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	oldEndpoint := client.OAuth2TokenEndpoint
+	client.OAuth2TokenEndpoint = server.URL + "/2/oauth2/token"
+	defer func() { client.OAuth2TokenEndpoint = oldEndpoint }()
+
+	configPath := writeDoctorConfig(t, t.TempDir(), server.URL, `oauth2_user_token = "doctor-app-only"
+refresh_token = "doctor-refresh"
+client_id = "doctor-client"
+`)
+	report := runDoctorJSON(t, t.TempDir(), configPath)
+	userLane := laneFromReport(t, report, "oauth2_user_context")
+	if got, _ := userLane["classification"].(string); got != "app_only_token_used_for_user_context" {
+		t.Fatalf("classification = %q, want app_only_token_used_for_user_context (lane=%#v)", got, userLane)
+	}
+	if userLane["refresh_attempted"] != true {
+		t.Fatalf("refresh_attempted = %#v, want true (lane=%#v)", userLane["refresh_attempted"], userLane)
+	}
+	if refreshErr, _ := userLane["refresh_error"].(string); !strings.Contains(refreshErr, "invalid_request") {
+		t.Fatalf("refresh_error should include sanitized upstream reason, got %q", refreshErr)
+	}
+	if hint, _ := userLane["hint"].(string); !strings.Contains(hint, "oauth2-login") {
+		t.Fatalf("hint should point to oauth2-login, got %q", hint)
+	}
+}
+
 func TestBuildAuthLaneReportProbesAPILanesConcurrently(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/library/social-and-messaging/x-twitter/internal/client/client.go
+++ b/library/social-and-messaging/x-twitter/internal/client/client.go
@@ -533,6 +533,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	const maxRetries = 3
 	var lastErr error
 	refreshedAfterUnauthorized := false
+	retriedAsAppOnly := false
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		// Proactive rate limiting — wait before sending
@@ -669,6 +670,20 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 					continue
 				}
 			}
+		}
+
+		// App-only fallback: when OAuth2 user-context token is expired/stale
+		// and refresh was unavailable or failed, retry public v2 reads with
+		// the app-only Bearer token. Only fires when both credentials exist
+		// so single-credential setups are unaffected. User-context-only
+		// endpoints (e.g. /2/users/me) will return 403 Unsupported Authentication
+		// on retry — the existing classifyAPIError handler converts that to a
+		// better error hint than the original 401.
+		if resp.StatusCode == http.StatusUnauthorized && !retriedAsAppOnly && c.Config != nil && c.Config.XOauth2UserToken != "" && c.Config.XBearerToken != "" {
+			authHeader = "Bearer " + c.Config.XBearerToken
+			retriedAsAppOnly = true
+			lastErr = apiErr
+			continue
 		}
 
 		// Rate limited - adjust adaptive limiter and retry

--- a/library/social-and-messaging/x-twitter/internal/client/client.go
+++ b/library/social-and-messaging/x-twitter/internal/client/client.go
@@ -679,7 +679,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		// endpoints (e.g. /2/users/me) will return 403 Unsupported Authentication
 		// on retry — the existing classifyAPIError handler converts that to a
 		// better error hint than the original 401.
-		if resp.StatusCode == http.StatusUnauthorized && !retriedAsAppOnly && c.Config != nil && c.Config.XOauth2UserToken != "" && c.Config.XBearerToken != "" {
+		if resp.StatusCode == http.StatusUnauthorized && !retriedAsAppOnly && authorizationHeaderOverride(headerOverrides) == "" && !hostUsesCookieAuth(req.URL.Host) && c.Config != nil && c.Config.XOauth2UserToken != "" && c.Config.XBearerToken != "" {
 			authHeader = "Bearer " + c.Config.XBearerToken
 			retriedAsAppOnly = true
 			lastErr = apiErr

--- a/library/social-and-messaging/x-twitter/internal/client/client_test.go
+++ b/library/social-and-messaging/x-twitter/internal/client/client_test.go
@@ -611,3 +611,85 @@ func TestAppOnlyFallbackReturnsUnsupportedAuthOnUserContextEndpoint(t *testing.T
 		t.Fatalf("apiCalls = %d, want 2 (401 + app-only retry)", got)
 	}
 }
+
+func TestAppOnlyFallbackSkipsExplicitAuthorizationOverride(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	var apiCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls.Add(1)
+		if got := r.Header.Get("Authorization"); got != "Bearer caller-supplied" {
+			t.Fatalf("request used %q, want caller-supplied override", got)
+		}
+		http.Error(w, `{"detail":"Invalid or expired token"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		BaseURL:          server.URL,
+		Path:             configPath,
+		XOauth2UserToken: "stale-oauth2",
+		XBearerToken:     "valid-app-only",
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	_, err := c.GetWithHeaders(context.Background(), "/2/users/by/username/testuser", nil, map[string]string{"Authorization": "Bearer caller-supplied"})
+	if err == nil {
+		t.Fatal("expected unauthorized response from caller-supplied credential")
+	}
+	if got := apiCalls.Load(); got != 1 {
+		t.Fatalf("apiCalls = %d, want no app-only retry when Authorization is overridden", got)
+	}
+}
+
+func TestAppOnlyFallbackSkipsCookieAuthHosts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cookieDir := filepath.Join(home, ".config", "x-twitter-pp-cli")
+	if err := os.MkdirAll(cookieDir, 0o755); err != nil {
+		t.Fatalf("mkdir cookie dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cookieDir, "cookies.json"), []byte(`{"auth_token":"cookie-auth","ct0":"csrf-token","web_bearer":"web-bearer"}`), 0o600); err != nil {
+		t.Fatalf("write cookies: %v", err)
+	}
+
+	var apiCalls atomic.Int32
+	cfg := &config.Config{
+		BaseURL:          "https://api.x.com",
+		XOauth2UserToken: "stale-oauth2",
+		XBearerToken:     "valid-app-only",
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	c.HTTPClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		apiCalls.Add(1)
+		if r.URL.Host != "x.com" {
+			t.Fatalf("host = %q, want x.com", r.URL.Host)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer web-bearer" {
+			t.Fatalf("cookie-auth request used %q, want web bearer", got)
+		}
+		if got := r.Header.Get("Cookie"); !strings.Contains(got, "auth_token=cookie-auth") || !strings.Contains(got, "ct0=csrf-token") {
+			t.Fatalf("Cookie header missing captured auth cookies: %q", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"detail":"expired browser session"}`)),
+			Request:    r,
+		}, nil
+	})
+
+	_, err := c.Get(context.Background(), "https://x.com/i/api/graphql/test", nil)
+	if err == nil {
+		t.Fatal("expected unauthorized response from cookie-auth host")
+	}
+	if got := apiCalls.Load(); got != 1 {
+		t.Fatalf("apiCalls = %d, want no app-only retry for cookie-auth host", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/library/social-and-messaging/x-twitter/internal/client/client_test.go
+++ b/library/social-and-messaging/x-twitter/internal/client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -516,4 +517,97 @@ func captureClientStderr(t *testing.T, fn func()) string {
 		t.Fatalf("read stderr: %v", err)
 	}
 	return string(data)
+}
+
+func TestRequestFallsBackToAppOnlyBearerWhenOAuth2TokenExpired(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	var apiCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2/users/by/username/testuser":
+			call := apiCalls.Add(1)
+			if call == 1 {
+				if got := r.Header.Get("Authorization"); got != "Bearer stale-oauth2" {
+					t.Fatalf("first request used %q, want stale-oauth2", got)
+				}
+				http.Error(w, `{"detail":"Invalid or expired token"}`, http.StatusUnauthorized)
+				return
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer valid-app-only" {
+				t.Fatalf("app-only retry used %q, want valid-app-only", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"id":"123","username":"testuser"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		BaseURL:          server.URL,
+		Path:             configPath,
+		XOauth2UserToken: "stale-oauth2",
+		XBearerToken:     "valid-app-only",
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	if _, err := c.Get(context.Background(), "/2/users/by/username/testuser", nil); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := apiCalls.Load(); got != 2 {
+		t.Fatalf("apiCalls = %d, want 2 (401 + app-only retry)", got)
+	}
+}
+
+func TestAppOnlyFallbackReturnsUnsupportedAuthOnUserContextEndpoint(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	var apiCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2/users/me":
+			call := apiCalls.Add(1)
+			if call == 1 {
+				if got := r.Header.Get("Authorization"); got != "Bearer stale-oauth2" {
+					t.Fatalf("first request used %q, want stale-oauth2", got)
+				}
+				http.Error(w, `{"title":"Unauthorized","detail":"Invalid token"}`, http.StatusUnauthorized)
+				return
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer valid-app-only" {
+				t.Fatalf("app-only retry used %q, want valid-app-only", got)
+			}
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"title":"Unsupported Authentication","detail":"Application-Only is forbidden for this endpoint; user context is required.","type":"about:blank","status":403}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		BaseURL:          server.URL,
+		Path:             configPath,
+		XOauth2UserToken: "stale-oauth2",
+		XBearerToken:     "valid-app-only",
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	_, err := c.Get(context.Background(), "/2/users/me", nil)
+	if err == nil {
+		t.Fatal("expected error for user-context-only endpoint with app-only auth")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("status code = %d, want 403", apiErr.StatusCode)
+	}
+	if !strings.Contains(apiErr.Body, "Unsupported Authentication") {
+		t.Fatalf("body should contain 'Unsupported Authentication', got: %s", apiErr.Body)
+	}
+	if got := apiCalls.Load(); got != 2 {
+		t.Fatalf("apiCalls = %d, want 2 (401 + app-only retry)", got)
+	}
 }


### PR DESCRIPTION
## Problem

Public v2 reads (`users get-by-username`, `users get-by-id`, `tweets get-posts-by-id`) fail with `401 Unauthorized` when `X_OAUTH2_USER_TOKEN` is expired or stale, even though a valid `X_BEARER_TOKEN` exists in config.

There are two separate auth issues here:

1. **Public-read fallback:** public v2 reads should not be poisoned by a stale OAuth2 user-context token when app-only bearer auth is available.
2. **Credential refresh/remediation:** operators need an explicit way to force OAuth2 refresh and a clear diagnosis when X rejects the stored refresh token.

## Root cause

`Config.AuthHeader()` prefers `XOAUTH2_USER_TOKEN` over `XBearerToken`. When the OAuth2 token is expired, `authHeader()` tries a proactive refresh, but if the refresh fails (e.g. refresh token also stale/revoked), `currentAuthHeader()` returns the dead OAuth2 token. Public reads that would work with app-only auth use the dead token and fail.

Separately, doctor attempted refresh on `/2/users/me` 401 but collapsed refresh-token failures into a generic invalid-token hint, and there was no direct `auth refresh` command to force the refresh-token exchange.

## Fix

### 1. App-only fallback for public reads

Added an app-only bearer fallback in the `do()` retry loop (`internal/client/client.go`), after the existing refresh-on-401 attempt. When:

- response is 401
- not yet retried as app-only
- both OAuth2 user-context and app-only bearer exist in config

Then retry with app-only bearer. User-context-only endpoints like `/2/users/me` still return `403 Unsupported Authentication` under app-only auth.

### 2. Explicit OAuth2 refresh path

Added:

```bash
x-twitter-pp-cli auth refresh --agent
```

Behavior:

- requires stored `refresh_token` and `client_id`
- forces `RefreshOAuth2UserContext(..., true)`
- persists rotated access/refresh token tuples
- reports `refresh_token_rotated`, `expires_at`, scopes, and auth lane metadata in JSON
- on X rejection, returns a sanitized error and explicit re-login remediation:
  - `x-twitter-pp-cli auth oauth2-login --client-id <client-id>`

### 3. Better doctor output

`doctor --agent` now reports refresh failures for `oauth2_user_context`, including:

- `refresh_attempted: true`
- sanitized `refresh_error`
- a re-login hint when the refresh token is rejected

It covers both observed failure shapes:

- `/2/users/me` returns 401 for stale user-context token
- `/2/users/me` returns 403 Unsupported Authentication because the stored user-context token is actually app-only / not usable as user-context

## Validation

- `go test ./internal/cli/... -count=1 -run 'TestAuthRefresh|TestDoctorReportsOAuth2RefreshFailure|TestDoctorRefreshesOAuth2UserContextAfterUnauthorized'` ✓
- `go test ./internal/client/... ./internal/cli/... -count=1` ✓
- `go test ./... -count=1` ✓
- `go build ./...` ✓
- `git diff --check` ✓

## Live verification

Using the current local X config, the new refresh path correctly proves the stored refresh token is rejected by X:

```text
OAuth2 user-context refresh failed: HTTP 400: {"error":"invalid_request","error_description":"Value passed for the token was invalid."}
hint: rerun `x-twitter-pp-cli auth oauth2-login --client-id <client-id>`
```

`doctor --agent --select auth_lanes` now surfaces that failure under `oauth2_user_context` instead of pretending the lane is merely generically invalid.
