### PR TITLE
feat(forgejo): add fj repo command group (create, list, view, delete)

### DIFF
--- a/library/developer-tools/forgejo/.printing-press-patches/forgejo-repo-command-group.json
+++ b/library/developer-tools/forgejo/.printing-press-patches/forgejo-repo-command-group.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "forgejo-repo-command-group",
+  "applied_at": "2026-06-23",
+  "base_run_id": "20260524-172642",
+  "base_printing_press_version": "4.14.0",
+  "summary": "Add top-level 'fj repo' command group (create, list, view, delete).",
+  "reason": "Agent dogfood: creating a repo required knowing 'fj user create-current-repo --name X', buried 2 levels deep and undiscoverable from root help. Agents fell back to raw curl. 'fj repo create' mirrors 'gh repo create' ergonomics.",
+  "files": [
+    "internal/cli/novel_repo.go",
+    "internal/cli/root.go"
+  ],
+  "validated_outcome": "fj repo list, fj repo view jrimmer/tau, and fj repo create --dry-run all pass against code.lacy.casa."
+}

--- a/library/developer-tools/forgejo/.printing-press-pii-polish.json
+++ b/library/developer-tools/forgejo/.printing-press-pii-polish.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-05-25T07:12:57.321667Z",
+  "timestamp": "2026-06-22T20:07:13.157989Z",
   "cli_dir": "\u003ccli-dir\u003e/forgejo",
   "findings": null,
   "findings_count_before": 0

--- a/library/developer-tools/forgejo/.printing-press-tools-polish.json
+++ b/library/developer-tools/forgejo/.printing-press-tools-polish.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-05-25T06:08:57.660261Z",
-  "cli_dir": "\u003ccli-dir\u003e/forgejo-pp-cli",
+  "timestamp": "2026-06-22T20:07:13.001029Z",
+  "cli_dir": "\u003ccli-dir\u003e/forgejo",
   "findings": [
     {
       "kind": "thin-short",

--- a/library/developer-tools/forgejo/dogfood-results.json
+++ b/library/developer-tools/forgejo/dogfood-results.json
@@ -1,5 +1,5 @@
 {
-  "dir": "\u003ccli-dir\u003e/forgejo-pp-cli",
+  "dir": "\u003ccli-dir\u003e/forgejo",
   "spec_path": "\u003ccli-dir\u003e/spec.json",
   "spec_source": "bundled",
   "verdict": "PASS",

--- a/library/developer-tools/forgejo/internal/cli/novel_repo.go
+++ b/library/developer-tools/forgejo/internal/cli/novel_repo.go
@@ -65,10 +65,6 @@ func newNovelRepoCreateCmd(flags *rootFlags) *cobra.Command {
 			if !stdinBody && name == "" && !flags.dryRun {
 				return fmt.Errorf("--name is required\nUsage: fj repo create --name <name>")
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
 
 			path := "/user/repos"
 			var body map[string]any
@@ -118,6 +114,11 @@ func newNovelRepoCreateCmd(flags *rootFlags) *cobra.Command {
 				bodyJSON, _ := json.MarshalIndent(body, "", "  ")
 				fmt.Fprintf(cmd.OutOrStdout(), "dry-run: POST %s\n%s\n", path, string(bodyJSON))
 				return nil
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
 			}
 
 			data, statusCode, err := c.PostWithParams(cmd.Context(), path, map[string]string{}, body)
@@ -261,7 +262,7 @@ func newNovelRepoListCmd(flags *rootFlags) *cobra.Command {
 					if err := printAutoTable(cmd.OutOrStdout(), items); err != nil {
 						return err
 					}
-					if len(items) >= limit {
+					if len(items) >= limit && !all {
 						fmt.Fprintf(os.Stderr, "\nShowing %d results. To see more: add --limit N or --all.\n", len(items))
 					}
 					return nil

--- a/library/developer-tools/forgejo/internal/cli/novel_repo.go
+++ b/library/developer-tools/forgejo/internal/cli/novel_repo.go
@@ -259,7 +259,7 @@ func newNovelRepoListCmd(flags *rootFlags) *cobra.Command {
 					if err := printAutoTable(cmd.OutOrStdout(), items); err != nil {
 						return err
 					}
-					if len(items) >= 25 {
+					if len(items) >= limit {
 						fmt.Fprintf(os.Stderr, "\nShowing %d results. To see more: add --limit N or --all.\n", len(items))
 					}
 					return nil
@@ -397,7 +397,7 @@ func newNovelRepoDeleteCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Confirm unless --yes
-			if !flags.yes && !flags.noInput && isTerminal(cmd.OutOrStdout()) {
+			if !flags.yes && !flags.noInput && isTerminal(os.Stdin) {
 				fmt.Fprintf(os.Stderr, "Delete repository %s/%s? This cannot be undone. [y/N]: ", owner, repo)
 				var confirm string
 				fmt.Fscan(os.Stdin, &confirm)
@@ -445,10 +445,17 @@ func newNovelRepoDeleteCmd(flags *rootFlags) *cobra.Command {
 }
 
 // splitOwnerRepo splits "owner/repo" into ["owner", "repo"].
+// Returns a single-element slice if the input has zero or more than one slash.
 func splitOwnerRepo(s string) []string {
 	for i, c := range s {
 		if c == '/' {
-			return []string{s[:i], s[i+1:]}
+			rest := s[i+1:]
+			for _, rc := range rest {
+				if rc == '/' {
+					return []string{s}
+				}
+			}
+			return []string{s[:i], rest}
 		}
 	}
 	return []string{s}

--- a/library/developer-tools/forgejo/internal/cli/novel_repo.go
+++ b/library/developer-tools/forgejo/internal/cli/novel_repo.go
@@ -3,10 +3,12 @@
 package cli
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -399,8 +401,9 @@ func newNovelRepoDeleteCmd(flags *rootFlags) *cobra.Command {
 			// Confirm unless --yes
 			if !flags.yes && !flags.noInput && isTerminal(os.Stdin) {
 				fmt.Fprintf(os.Stderr, "Delete repository %s/%s? This cannot be undone. [y/N]: ", owner, repo)
-				var confirm string
-				fmt.Fscan(os.Stdin, &confirm)
+				reader := bufio.NewReader(os.Stdin)
+				line, _ := reader.ReadString('\n')
+				confirm := strings.TrimSpace(line)
 				if confirm != "y" && confirm != "Y" {
 					fmt.Fprintln(os.Stderr, "Aborted.")
 					return nil

--- a/library/developer-tools/forgejo/internal/cli/novel_repo.go
+++ b/library/developer-tools/forgejo/internal/cli/novel_repo.go
@@ -1,0 +1,455 @@
+// Copyright 2026 jrimmer. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// newRepoCmd creates the top-level 'repo' command group, mirroring gh's UX.
+// This is the primary entry point for repository operations — create, list,
+// view, and delete. For the full generated API surface see 'fj user', 'fj repos'.
+func newRepoCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repo",
+		Short: "Create, list, view, and delete repositories",
+		Long: `Manage Forgejo repositories. Common operations at your fingertips.
+
+  fj repo create --name myproject
+  fj repo list
+  fj repo view owner/repo
+  fj repo delete owner/repo
+
+For the full generated API surface see 'fj user' and 'fj repos'.`,
+		RunE: parentNoSubcommandRunE(flags),
+	}
+	cmd.AddCommand(newNovelRepoCreateCmd(flags))
+	cmd.AddCommand(newNovelRepoListCmd(flags))
+	cmd.AddCommand(newNovelRepoViewCmd(flags))
+	cmd.AddCommand(newNovelRepoDeleteCmd(flags))
+	return cmd
+}
+
+// newNovelRepoCreateCmd creates a repository for the authenticated user.
+// Proxies POST /user/repos (fj user create-current-repo).
+func newNovelRepoCreateCmd(flags *rootFlags) *cobra.Command {
+	var name, description, defaultBranch, gitignores, license, readme, trustModel string
+	var private, autoInit, template bool
+	var stdinBody bool
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new repository",
+		Long:  "Create a new repository for the authenticated user.",
+		Example: `  # Create a public repository
+  fj repo create --name myproject --description "My new project"
+
+  # Create a private repository with a README and MIT license
+  fj repo create --name myproject --private --auto-init --readme Default --license mit
+
+  # Create from JSON on stdin
+  echo '{"name":"myproject","private":true}' | fj repo create --stdin`,
+		Annotations: map[string]string{
+			"pp:endpoint": "user.create-current-repo",
+			"pp:method":   "POST",
+			"pp:path":     "/user/repos",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !stdinBody && name == "" && !flags.dryRun {
+				return fmt.Errorf("--name is required\nUsage: fj repo create --name <name>")
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			path := "/user/repos"
+			var body map[string]any
+			if stdinBody {
+				stdinData, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return fmt.Errorf("reading stdin: %w", err)
+				}
+				if err := json.Unmarshal(stdinData, &body); err != nil {
+					return fmt.Errorf("parsing stdin JSON: %w", err)
+				}
+			} else {
+				body = map[string]any{}
+				if name != "" {
+					body["name"] = name
+				}
+				if description != "" {
+					body["description"] = description
+				}
+				if cmd.Flags().Changed("private") {
+					body["private"] = private
+				}
+				if cmd.Flags().Changed("auto-init") {
+					body["auto_init"] = autoInit
+				}
+				if defaultBranch != "" {
+					body["default_branch"] = defaultBranch
+				}
+				if gitignores != "" {
+					body["gitignores"] = gitignores
+				}
+				if license != "" {
+					body["license"] = license
+				}
+				if readme != "" {
+					body["readme"] = readme
+				}
+				if trustModel != "" {
+					body["trust_model"] = trustModel
+				}
+				if cmd.Flags().Changed("template") {
+					body["template"] = template
+				}
+			}
+
+			if flags.dryRun {
+				bodyJSON, _ := json.MarshalIndent(body, "", "  ")
+				fmt.Fprintf(cmd.OutOrStdout(), "dry-run: POST %s\n%s\n", path, string(bodyJSON))
+				return nil
+			}
+
+			data, statusCode, err := c.PostWithParams(cmd.Context(), path, map[string]string{}, body)
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+
+			var partialFailure *partialFailureReport
+			if statusCode >= 200 && statusCode < 300 {
+				partialFailure = detectPartialFailure(data)
+				if partialFailure != nil {
+					fmt.Fprintf(os.Stderr, "warning: partial failure detected: %s\n", partialFailure.Message)
+				}
+			}
+
+			if statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure) {
+				writeMutationResponseToStore(cmd.Context(), "user", data, "")
+			}
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
+				filtered := data
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				} else if flags.compact {
+					filtered = compactFields(filtered)
+				}
+				envelope := map[string]any{
+					"action":   "post",
+					"resource": "user",
+					"path":     path,
+					"status":   statusCode,
+					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
+				}
+				if len(filtered) > 0 {
+					var parsed any
+					if err := json.Unmarshal(filtered, &parsed); err == nil {
+						envelope["data"] = parsed
+					}
+				}
+				envelopeJSON, _ := json.Marshal(envelope)
+				return printOutput(cmd.OutOrStdout(), json.RawMessage(envelopeJSON), true)
+			}
+
+			if perr := printOutputWithFlags(cmd.OutOrStdout(), data, flags); perr != nil {
+				return perr
+			}
+			if partialFailure != nil && !flags.allowPartialFailure {
+				return partialFailureErr(fmt.Errorf("partial failure: %s", partialFailure.Message))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Repository name (required)")
+	cmd.Flags().StringVar(&description, "description", "", "Repository description")
+	cmd.Flags().BoolVar(&private, "private", false, "Make the repository private")
+	cmd.Flags().BoolVar(&autoInit, "auto-init", false, "Initialize the repository with a README commit")
+	cmd.Flags().StringVar(&defaultBranch, "default-branch", "", "Default branch name (default: main or server default)")
+	cmd.Flags().StringVar(&gitignores, "gitignore", "", ".gitignore template name (e.g. Go, Python, Node)")
+	cmd.Flags().StringVar(&license, "license", "", "License template name (e.g. mit, apache-2.0)")
+	cmd.Flags().StringVar(&readme, "readme", "", "README template (Default, or a custom template name)")
+	cmd.Flags().StringVar(&trustModel, "trust-model", "", "Signature trust model (collaborator, committer, collaboratorcommitter)")
+	cmd.Flags().BoolVar(&template, "template", false, "Make this repository a template")
+	cmd.Flags().BoolVar(&stdinBody, "stdin", false, "Read request body as JSON from stdin")
+
+	return cmd
+}
+
+// newNovelRepoListCmd lists repositories owned by the authenticated user.
+// Proxies GET /user/repos (fj user current-list-repos).
+func newNovelRepoListCmd(flags *rootFlags) *cobra.Command {
+	var limit int
+	var orderBy string
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List your repositories",
+		Long:  "List repositories owned by the authenticated user.",
+		Example: `  # List your repositories
+  fj repo list
+
+  # List all (paginate through everything)
+  fj repo list --all
+
+  # Output as JSON
+  fj repo list --json
+
+  # Sort by most recently updated
+  fj repo list --order-by recentupdate --limit 10`,
+		Annotations: map[string]string{
+			"pp:endpoint":   "user.current-list-repos",
+			"pp:method":     "GET",
+			"pp:path":       "/user/repos",
+			"mcp:read-only": "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return writeNoop(flags, "dry-run", "dry-run: would list your repositories")
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			params := map[string]string{
+				"limit": fmt.Sprintf("%d", limit),
+			}
+			if orderBy != "" {
+				params["order_by"] = orderBy
+			}
+
+			data, prov, err := resolvePaginatedRead(cmd.Context(), c, flags, "user", "/user/repos", params, nil, all, "page", "", "", cmd.ErrOrStderr())
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				var countItems []json.RawMessage
+				_ = json.Unmarshal(data, &countItems)
+				printProvenance(cmd, len(countItems), prov)
+			}
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
+				filtered := data
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				} else if flags.compact {
+					filtered = compactFields(filtered)
+				}
+				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
+				if wrapErr != nil {
+					return wrapErr
+				}
+				return printOutput(cmd.OutOrStdout(), wrapped, true)
+			}
+
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				var items []map[string]any
+				if json.Unmarshal(data, &items) == nil && len(items) > 0 {
+					if err := printAutoTable(cmd.OutOrStdout(), items); err != nil {
+						return err
+					}
+					if len(items) >= 25 {
+						fmt.Fprintf(os.Stderr, "\nShowing %d results. To see more: add --limit N or --all.\n", len(items))
+					}
+					return nil
+				}
+			}
+			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 30, "Maximum number of results to return")
+	cmd.Flags().StringVar(&orderBy, "order-by", "", "Sort order: newest, oldest, recentupdate, leastupdate, alphabetically, reversealphabetically, moststars, feweststars")
+	cmd.Flags().BoolVar(&all, "all", false, "Paginate through all results")
+
+	return cmd
+}
+
+// newNovelRepoViewCmd shows details about a repository.
+// Proxies GET /repos/{owner}/{repo} (fj repos get).
+func newNovelRepoViewCmd(flags *rootFlags) *cobra.Command {
+	var owner, repo string
+
+	cmd := &cobra.Command{
+		Use:   "view [owner/repo]",
+		Short: "View repository details",
+		Long:  "Show details about a repository. Accepts owner/repo as a positional argument or --owner/--repo flags.",
+		Example: `  fj repo view jrimmer/myproject
+  fj repo view --owner jrimmer --repo myproject`,
+		Annotations: map[string]string{
+			"pp:endpoint":   "repos.get",
+			"pp:method":     "GET",
+			"pp:path":       "/repos/{owner}/{repo}",
+			"mcp:read-only": "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return writeNoop(flags, "dry-run", "dry-run: would fetch repository details")
+			}
+
+			// Accept owner/repo as a single positional arg
+			if len(args) == 1 {
+				parts := splitOwnerRepo(args[0])
+				if len(parts) == 2 {
+					owner, repo = parts[0], parts[1]
+				} else {
+					return fmt.Errorf("expected owner/repo, got %q\nUsage: fj repo view <owner>/<repo>", args[0])
+				}
+			}
+			if owner == "" || repo == "" {
+				return fmt.Errorf("owner and repo are required\nUsage: fj repo view <owner>/<repo>")
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			path := fmt.Sprintf("/repos/%s/%s", owner, repo)
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "repos", false, path, map[string]string{}, nil, cmd.ErrOrStderr())
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+			data = extractResponseData(data)
+
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				var countItems []json.RawMessage
+				if json.Unmarshal(data, &countItems) != nil {
+					countItems = []json.RawMessage{data}
+				}
+				printProvenance(cmd, len(countItems), prov)
+			}
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
+				filtered := data
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				} else if flags.compact {
+					filtered = compactFields(filtered)
+				}
+				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
+				if wrapErr != nil {
+					return wrapErr
+				}
+				return printOutput(cmd.OutOrStdout(), wrapped, true)
+			}
+
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				var items []map[string]any
+				if json.Unmarshal(data, &items) == nil && len(items) > 0 {
+					return printAutoTable(cmd.OutOrStdout(), items)
+				}
+			}
+			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&owner, "owner", "", "Repository owner (user or org)")
+	cmd.Flags().StringVar(&repo, "repo", "", "Repository name")
+
+	return cmd
+}
+
+// newNovelRepoDeleteCmd deletes a repository.
+// Proxies DELETE /repos/{owner}/{repo} (fj repos delete).
+func newNovelRepoDeleteCmd(flags *rootFlags) *cobra.Command {
+	var owner, repo string
+
+	cmd := &cobra.Command{
+		Use:   "delete [owner/repo]",
+		Short: "Delete a repository",
+		Long:  "Permanently delete a repository. This cannot be undone. Requires confirmation unless --yes is set.",
+		Example: `  fj repo delete jrimmer/myproject
+  fj repo delete --owner jrimmer --repo myproject --yes`,
+		Annotations: map[string]string{
+			"pp:endpoint": "repos.delete",
+			"pp:method":   "DELETE",
+			"pp:path":     "/repos/{owner}/{repo}",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Accept owner/repo as a single positional arg
+			if len(args) == 1 {
+				parts := splitOwnerRepo(args[0])
+				if len(parts) == 2 {
+					owner, repo = parts[0], parts[1]
+				} else {
+					return fmt.Errorf("expected owner/repo, got %q\nUsage: fj repo delete <owner>/<repo>", args[0])
+				}
+			}
+			if owner == "" || repo == "" {
+				return fmt.Errorf("owner and repo are required\nUsage: fj repo delete <owner>/<repo>")
+			}
+
+			if flags.dryRun {
+				fmt.Fprintf(cmd.OutOrStdout(), "dry-run: DELETE /repos/%s/%s\n", owner, repo)
+				return nil
+			}
+
+			// Confirm unless --yes
+			if !flags.yes && !flags.noInput && isTerminal(cmd.OutOrStdout()) {
+				fmt.Fprintf(os.Stderr, "Delete repository %s/%s? This cannot be undone. [y/N]: ", owner, repo)
+				var confirm string
+				fmt.Fscan(os.Stdin, &confirm)
+				if confirm != "y" && confirm != "Y" {
+					fmt.Fprintln(os.Stderr, "Aborted.")
+					return nil
+				}
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			path := fmt.Sprintf("/repos/%s/%s", owner, repo)
+			data, statusCode, err := c.DeleteWithParams(cmd.Context(), path, map[string]string{})
+			if err != nil {
+				return classifyDeleteError(err, flags)
+			}
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
+				envelope := map[string]any{
+					"action":   "delete",
+					"resource": "repos",
+					"path":     path,
+					"status":   statusCode,
+					"success":  statusCode >= 200 && statusCode < 300,
+				}
+				envelopeJSON, _ := json.Marshal(envelope)
+				return printOutput(cmd.OutOrStdout(), json.RawMessage(envelopeJSON), true)
+			}
+
+			if statusCode == 204 || (statusCode >= 200 && statusCode < 300 && len(data) == 0) {
+				fmt.Fprintf(cmd.OutOrStdout(), "Repository %s/%s deleted.\n", owner, repo)
+				return nil
+			}
+			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&owner, "owner", "", "Repository owner (user or org)")
+	cmd.Flags().StringVar(&repo, "repo", "", "Repository name")
+
+	return cmd
+}
+
+// splitOwnerRepo splits "owner/repo" into ["owner", "repo"].
+func splitOwnerRepo(s string) []string {
+	for i, c := range s {
+		if c == '/' {
+			return []string{s[:i], s[i+1:]}
+		}
+	}
+	return []string{s}
+}

--- a/library/developer-tools/forgejo/internal/cli/root.go
+++ b/library/developer-tools/forgejo/internal/cli/root.go
@@ -274,6 +274,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newIssueCmd(flags))
 	rootCmd.AddCommand(newPRCmd(flags))
+	rootCmd.AddCommand(newRepoCmd(flags))
 	rootCmd.AddCommand(newReleaseCmd(flags))
 	rootCmd.AddCommand(newRunnerCmd(flags))
 	rootCmd.AddCommand(newNotificationCmd(flags))

--- a/library/developer-tools/forgejo/workflow-verify-report.json
+++ b/library/developer-tools/forgejo/workflow-verify-report.json
@@ -1,5 +1,5 @@
 {
-  "dir": "\u003ccli-dir\u003e/forgejo-pp-cli",
+  "dir": "\u003ccli-dir\u003e/forgejo",
   "workflows": null,
   "verdict": "workflow-pass",
   "issues": [


### PR DESCRIPTION
## forgejo

The `gh` for Forgejo — works with any instance, stores your data locally, and speaks Forgejo natively.

**API:** forgejo | **Category:** developer-tools | **Press version:** 4.14.0
**Spec:** Not specified

### Publication Path

Reprint/replace — `library/developer-tools/forgejo` already exists from PR #842. This update adds the `fj repo` top-level command group discovered missing during agent dogfood.

### CLI Shape

```bash
$ fj --help
Forgejo CLI — The 'gh' for Forgejo — works with any instance, stores your data locally, and speaks Forgejo natively.

Highlights (not in the official API docs):
  • issue dashboard   See all your open issues across every repo (and every Forgejo host) in one sorted table — no browser, no tab-switching.
  • notification inbox   One inbox for all your Forgejo instances — Codeberg, company Forgejo, university instance — sorted by recency with a host column.
  • runner sweep   See the status of every Actions runner across all your orgs in one pass — flag offline runners, watch live with --watch.
  • release changelog   Auto-generate a grouped changelog between two tags from closed issues and merged PRs — label-grouped, markdown or JSON output.
  • release upload   Upload release assets with a real progress bar, automatic retry on failure, and post-upload size verification — not silent curl.
  • issue sweep   Find issues with no activity past a threshold, label them, post a comment, and optionally close — with --dry-run and confirmation before acting.
  • pr queue   Your pending reviews across all repos in one view — PRs where you are a requested reviewer, with CI check status and approval counts.
  • ci status   Pass/fail status of the latest CI run per repo (or per branch) across all watched repos, with --watch for live tailing.

Agent mode: add --agent to any command for JSON output + non-interactive mode.
Health check: run 'fj doctor' to verify auth and connectivity.

Usage:
  fj [command]

Available Commands:
  agent-context   Emit structured JSON describing this CLI for agents
  analytics       Run analytics queries on locally synced data
  api             Browse all API endpoints by interface name
  auth            Manage authentication for Forgejo
  ci              CI/Actions check status
  completion      Generate the autocompletion script for the specified shell
  doctor          Check CLI health
  export          Export data to JSONL or JSON for backup, migration, or analysis
  feedback        Record feedback about this CLI (local by default; upstream opt-in)
  forgejo-version Returns the version of the running application
  help            Help about any command
  import          Import data from JSONL file via API create/upsert calls
  issue           Work with issues across repos
  markup          Render a markup document as HTML
  nodeinfo        Returns the nodeinfo of the Forgejo application
  notification    View and manage notifications
  pr              Work with pull requests
  profile         Named sets of flags saved for reuse
  release         Manage releases and release assets
  repo            Create, list, view, and delete repositories
  repositories    Get a repository by id
  runner          Manage and monitor Actions runners
  search          Full-text search across synced data or live API
  signing-key-gpg Get default signing-key.gpg
  signing-key-ssh Get default signing-key.ssh
  sync            Sync API data to local SQLite for offline search and analysis
  tail            Stream live changes by polling the API at regular intervals
  topics          Search for topics by keyword
  version         Print version
  which           Find the command that implements a capability
  workflow        Compound workflows that combine multiple API operations
```

### Novel Commands (from manifest)

| Command | Name | Description |
|---------|------|-------------|
| `issue dashboard` | Multi-repo triage dashboard | See all your open issues across every repo (and every Forgejo host) in one sorted table — no browser, no tab-switching. |
| `notification inbox` | Unified notification inbox (cross-host) | One inbox for all your Forgejo instances — Codeberg, company Forgejo, university instance — sorted by recency with a host column. |
| `runner sweep` | Runner health sweep (cross-org) | See the status of every Actions runner across all your orgs in one pass — flag offline runners, watch live with --watch. |
| `release changelog` | Release changelog generation | Auto-generate a grouped changelog between two tags from closed issues and merged PRs — label-grouped, markdown or JSON output. |
| `release upload` | Release upload with progress and retry | Upload release assets with a real progress bar, automatic retry on failure, and post-upload size verification — not silent curl. |
| `issue sweep` | Stale issue sweeper | Find issues with no activity past a threshold, label them, post a comment, and optionally close — with --dry-run and confirmation before acting. |
| `pr queue` | PR review queue | Your pending reviews across all repos in one view — PRs where you are a requested reviewer, with CI check status and approval counts. |
| `ci status` | CI check status summary | Pass/fail status of the latest CI run per repo (or per branch) across all watched repos, with --watch for live tailing. |

### What Changed in This Update

Added `fj repo` top-level command group with four subcommands, discovered as a gap during agent dogfood:

- `fj repo create --name <name>` — create a new repository (proxies `POST /user/repos`)
- `fj repo list` — list your repositories (proxies `GET /user/repos`)
- `fj repo view <owner>/<repo>` — show repository details
- `fj repo delete <owner>/<repo>` — delete a repository with confirmation

**Why:** During a dogfood session, an agent needed to create a new Forgejo repo. It tried `fj create repository`, `fj repositories list`, and `fj api repos create` — all failed or were unergonomic. It fell back to raw `curl`. The fix mirrors `gh repo create` conventions, placing repo CRUD at the top level where agents and humans expect to find it.

### Manuscripts

- [Research Brief](https://github.com/mvanhorn/printing-press-library/blob/b728299a08be1768fb752c3915728060337963e8/library/developer-tools/forgejo/.manuscripts/20260524-172642/research/2026-05-24-172642-feat-forgejo-pp-cli-brief.md)
- [Absorb Manifest](https://github.com/mvanhorn/printing-press-library/blob/b728299a08be1768fb752c3915728060337963e8/library/developer-tools/forgejo/.manuscripts/20260524-172642/research/2026-05-24-172642-feat-forgejo-pp-cli-absorb-manifest.md)
- [Novel Features Brainstorm](https://github.com/mvanhorn/printing-press-library/blob/b728299a08be1768fb752c3915728060337963e8/library/developer-tools/forgejo/.manuscripts/20260524-172642/research/2026-05-24-172642-novel-features-brainstorm.md)
- [Phase 5 Acceptance](https://github.com/mvanhorn/printing-press-library/blob/b728299a08be1768fb752c3915728060337963e8/library/developer-tools/forgejo/.manuscripts/20260524-172642/proofs/phase5-acceptance.json)
- [Phase 5 Skip](https://github.com/mvanhorn/printing-press-library/blob/b728299a08be1768fb752c3915728060337963e8/library/developer-tools/forgejo/.manuscripts/20260524-172642/proofs/phase5-skip.json)

### Validation Results

| Check | Result |
|-------|--------|
| Manifest | PASS |
| Phase 5 | PASS |
| go mod tidy | PASS |
| govulncheck (this CLI only, reachable findings) | PASS |
| go vet | PASS |
| go build | PASS |
| --help | PASS |
| --version | PASS |
| Manuscripts | PRESENT |
