### PR TITLE
fix(plane): derive child scope column from project on write-through cache

### DIFF
--- a/library/project-management/plane/.printing-press-patches/write-through-child-scope.json
+++ b/library/project-management/plane/.printing-press-patches/write-through-child-scope.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 2,
+  "id": "write-through-child-scope",
+  "applied_at": "2026-06-24",
+  "base_run_id": "20260602-073610",
+  "base_printing_press_version": "4.20.1",
+  "summary": "Backfill a typed child table's NOT NULL path-placeholder scope column (projects_id) from the item's own parent reference (project) inside UpsertBatch, so the write-through cache paths (live-read + mutation-response caching) stop stranding project-scoped child rows in the generic resources table with no typed projection.",
+  "reason": "Bug #2 — the 'typed-table upsert failed; generic resources rows preserved' warning (store.go ~2638). Project-scoped child tables (modules/cycles/states/labels/projects_issues/intake_issues/archived_*) declare a NOT NULL scope column 'projects_id' that ONLY the dependent-resource sync injects per item (obj[parentTable+\"_id\"]=parentID). The two write-through cache paths in internal/cli/data_source.go — writeThroughCache (auto/live reads) and writeMutationResponseToStore (create/update responses) — call db.UpsertBatch(resourceType, rawItems) with the RAW Plane API body, which carries the parent UUID under the singular 'project' key but NEVER 'projects_id'. So the per-item typed dispatch hit `NOT NULL constraint failed: modules.projects_id (1299)`, the per-item SAVEPOINT rolled back, and the row stranded in generic resources (data present, no typed row / no index). Non-data-loss but the typed table + typed queries (e.g. module-of, module enrichment which reads localModules from the typed table) silently miss those rows; incremental sync never re-fetches them, so the strand is permanent. Live evidence on the prod data.db: modules = 86 generic rows vs 25 typed; the 61 missing were all one bbm project, 0 carried a 'projects_id' key in their data blob (vs 21/25 present ones that did), dated 06-10..06-23 — i.e. rows the user live-read/mutated, not synced. cycles/states/labels/projects_issues matched 1:1 (only modules were actively live-read/mutated).",
+  "files": [
+    "internal/store/store.go"
+  ],
+  "change": [
+    "store.go: add childScopeColumnSources{\"projects_id\":\"project\"} (the typed child scope column -> the singular parent-reference field the API body carries natively) and deriveScopeColumns(obj) which backfills the scope column from that field when path injection is absent, never overwriting an already-present value.",
+    "store.go: UpsertBatch calls deriveScopeColumns(obj) after the generic insert and before the per-item typed SAVEPOINT dispatch, so both the sync path (no-op — projects_id already injected) and the write-through path (backfilled from project) populate the typed scope column. projects_id always equals the project UUID for these tables (the dependent sync sets projects_id = the iterated project's id, which is the same UUID the body's 'project' field holds)."
+  ],
+  "tests": [
+    "internal/store/upsert_batch_test.go: TestUpsertBatch_DerivesChildScopeFromProjectField (raw write-through shape {id,project,name} with NO projects_id lands in the typed modules table with projects_id derived from project). Existing TestUpsertBatch_TypedFailureDoesNotStrand*Generic still pass: their fixtures carry neither projects_id NOR project, so stranding (typed=0, generic preserved) remains the correct no-parent-info behavior."
+  ],
+  "validated_outcome": "Reproduced the exact production warning + concrete typedErr via the new failing test before fixing: `warning: 2/2 modules items: typed-table upsert failed; generic resources rows preserved` and `insert into modules: constraint failed: NOT NULL constraint failed: modules.projects_id (1299)`. After fix: go build ./... + go vet ./internal/store ./internal/cli + go test ./internal/store ./internal/cli all green; new test passes, no regressions.",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator-level: emit the child-scope backfill map from the spec so any printed CLI whose write-through caches project/parent-scoped sub-resources populates the typed scope column without a hand patch (drive scopeColumn->sourceField from the same parent-relationship metadata that produces parentFKKey in sync.go.tmpl).",
+      "reason": "Today only the dependent-sync template injects the path-placeholder scope column; the write-through cache (data_source.go) and the single-object Upsert<Child> methods have no equivalent, so the typed projection depends on the entry point. Modeling the parent reference once would make every entry point self-sufficient."
+    }
+  ]
+}

--- a/library/project-management/plane/internal/store/store.go
+++ b/library/project-management/plane/internal/store/store.go
@@ -2528,6 +2528,44 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 // rollback, so successful API fetches never strand in memory because one
 // downstream typed table is misconfigured. Failures are surfaced via a
 // trailing stderr warning rather than aborting the batch.
+// childScopeColumnSources maps a typed child table's NOT NULL path-placeholder
+// scope column (the FK the dependent sync injects into each item, e.g.
+// "projects_id") to the singular parent-reference field every Plane API body
+// carries natively (e.g. "project"). deriveScopeColumns consults this so the
+// write-through cache paths — live-read and mutation-response caching, which
+// pass RAW API items straight to UpsertBatch and so never carry the path-
+// injected "projects_id" — still satisfy the typed table's NOT NULL scope
+// column instead of stranding the row in the generic resources table with no
+// typed projection (the typed-table upsert warning below).
+var childScopeColumnSources = map[string]string{
+	"projects_id": "project",
+}
+
+// deriveScopeColumns backfills a typed child table's path-placeholder scope
+// column (e.g. "projects_id") from the item's own parent reference (e.g.
+// "project") when the path injection that normally supplies it is absent.
+// The dependent sync injects the scope column before upsert; the write-through
+// cache paths do not, so without this backfill the typed upsert violates the
+// NOT NULL scope constraint and the row strands in generic resources. A value
+// already present (valid injection) is never overwritten.
+func deriveScopeColumns(obj map[string]any) {
+	for scopeKey, sourceKey := range childScopeColumnSources {
+		if v := lookupFieldValue(obj, scopeKey); v != nil {
+			if s, ok := v.(string); !ok || s != "" {
+				continue // path injection already supplied a usable value
+			}
+		}
+		src := lookupFieldValue(obj, sourceKey)
+		if src == nil {
+			continue
+		}
+		if s, ok := src.(string); ok && s == "" {
+			continue
+		}
+		obj[scopeKey] = src
+	}
+}
+
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
@@ -2562,6 +2600,12 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, id, err)
 		}
 		stored++
+
+		// Backfill the typed child table's NOT NULL scope column from the
+		// item's own parent reference when the dependent-sync path injection
+		// is absent (write-through cache feeds RAW API items here). Without
+		// this the typed dispatch below violates NOT NULL and strands the row.
+		deriveScopeColumns(obj)
 
 		savepoint := fmt.Sprintf("pp_typed_%d", i)
 		if _, err := tx.Exec("SAVEPOINT " + savepoint); err != nil {

--- a/library/project-management/plane/internal/store/upsert_batch_test.go
+++ b/library/project-management/plane/internal/store/upsert_batch_test.go
@@ -1532,6 +1532,60 @@ func TestUpsertBatch_TypedFailureDoesNotStrandModulesGeneric(t *testing.T) {
 	}
 }
 
+// TestUpsertBatch_DerivesChildScopeFromProjectField pins the write-through
+// repair: live-read and mutation caching (data_source.go writeThroughCache /
+// writeMutationResponseToStore) pass RAW API items straight to UpsertBatch,
+// bypassing the dependent-sync injection that adds the NOT NULL scope column
+// "projects_id". The raw Plane body for a project-scoped child carries the
+// parent UUID under the singular "project" key (never "projects_id"), so the
+// typed upsert used to violate NOT NULL and strand the row in the generic
+// resources table with no typed projection (the store.go typed-table-upsert
+// warning). UpsertBatch must derive "projects_id" from "project" so the typed
+// row lands. Regression for the write-through stranding bug.
+func TestUpsertBatch_DerivesChildScopeFromProjectField(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	// Raw write-through shape: carries "project" (the parent UUID) but NOT the
+	// path-injected "projects_id" the dependent sync would have added.
+	items := []json.RawMessage{
+		json.RawMessage(`{"id": "wt-001", "project": "proj-X", "name": "Mod 1"}`),
+		json.RawMessage(`{"id": "wt-002", "project": "proj-X", "name": "Mod 2"}`),
+	}
+	stored, extractFailures, err := s.UpsertBatch("modules", items)
+	if err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+	if stored != len(items) {
+		t.Fatalf("stored = %d, want %d", stored, len(items))
+	}
+	if extractFailures != 0 {
+		t.Fatalf("extractFailures = %d, want 0", extractFailures)
+	}
+
+	db := s.DB()
+
+	var typed int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM "modules"`).Scan(&typed); err != nil {
+		t.Fatalf("count modules: %v", err)
+	}
+	if typed != len(items) {
+		t.Fatalf("typed modules = %d, want %d (projects_id not derived from project; rows stranded in generic)", typed, len(items))
+	}
+
+	var scoped int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM "modules" WHERE projects_id = ?`, "proj-X").Scan(&scoped); err != nil {
+		t.Fatalf("count by projects_id: %v", err)
+	}
+	if scoped != len(items) {
+		t.Fatalf("modules with projects_id=proj-X = %d, want %d (scope column not populated from project)", scoped, len(items))
+	}
+}
+
 // TestUpsertBatch_SetsModulesParentID verifies that dependent-resource
 // sync (which injects parent_id into each item's JSON) populates the typed
 // parent_id column when items go through UpsertBatch. Regression for issue #268.


### PR DESCRIPTION
## Problem

Project-scoped child tables (`modules`, `cycles`, `states`, `labels`, `projects_issues`, `intake_issues`, `archived_*`) declare a NOT NULL path-placeholder scope column `projects_id`. Only the dependent-resource sync injects it per item (`obj[parentTable+"_id"] = parentID`).

The two write-through cache paths in `internal/cli/data_source.go` — `writeThroughCache` (auto/live read results) and `writeMutationResponseToStore` (create/update responses) — pass the **raw** API body straight to `UpsertBatch`. The Plane body carries the parent UUID as the singular `project`, never `projects_id`. So the per-item typed dispatch hit:

```
insert into modules: constraint failed: NOT NULL constraint failed: modules.projects_id (1299)
```

the per-item `SAVEPOINT` rolled back, and the row stranded in the generic `resources` table with no typed projection — surfacing as the existing warning:

```
warning: N/M modules items: typed-table upsert failed; generic resources rows preserved
```

Non-data-loss (the generic blob survives), but the typed table and typed queries silently miss those rows, and incremental sync never re-fetches them, so the strand is permanent.

## Fix

`UpsertBatch` now backfills the typed scope column from the item's own parent reference (`project`) when the path injection is absent, via a small `deriveScopeColumns(obj)` helper + a `childScopeColumnSources{"projects_id":"project"}` map. An already-present (injected) value is never overwritten, so the dependent-sync path is a no-op. `projects_id` always equals the project UUID for these tables (the dependent sync sets `projects_id` = the iterated project's id, the same UUID the body's `project` field holds).

Every entry point — sync, live-read cache, mutation cache — now populates the typed table.

## Tests

- Adds `TestUpsertBatch_DerivesChildScopeFromProjectField`: a raw write-through item `{id, project, name}` with **no** `projects_id` now lands in the typed `modules` table with `projects_id` derived from `project`.
- Existing `TestUpsertBatch_TypedFailureDoesNotStrand*Generic` still pass: their fixtures carry neither `projects_id` nor `project`, so no-parent-info stranding (generic preserved, typed=0) remains the correct behavior.

`go build ./...` + `go vet` + `go test ./internal/store ./internal/cli` all green on the `main` base.

## Notes

Diff is plane-only (3 files, +124). Reproduced the exact warning + `typedErr` with a failing test before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)