### PR TITLE
docs(flight-goat): clarify primary value prop

### DIFF
--- a/library/travel/flight-goat/README.md
+++ b/library/travel/flight-goat/README.md
@@ -1,49 +1,51 @@
 # Flight Goat CLI
 
 # Introduction
-AeroAPI is a simple, query-based API that gives software developers access
-to a variety of FlightAware's flight data. Users can obtain current or
-historical data. AeroAPI is a RESTful API delivering accurate and
-actionable aviation data. With the introduction of Foresight™, customers
-have access to the data that powers over half of the predictive airline
-ETAs in the US.
 
-## Categories
-AeroAPI is divided into several categories to make things easier to
-discover.
-- Flights: Summary information, planned routes, positions and more
-- Foresight: Flight positions enhanced with FlightAware Foresight™
-- Airports: Airport information and FIDS style resources
-- Operators: Operator information and fleet activity resources
-- Alerts: Configure flight alerts and delivery destinations
-- History: Historical flight access for various endpoints
-- Miscellaneous: Flight disruption, future schedule information, and aircraft owner information
+Flight Goat is a consumer-flight decision CLI first, and a FlightAware/AeroAPI wrapper second.
 
-## Development Tools
-AeroAPI is defined using the OpenAPI Spec 3.0, which means it can be easily
-imported into tools like Postman. To get started try importing the API
-specification using
-[Postman's instructions](https://learning.postman.com/docs/integrations/available-integrations/working-with-openAPI/).
-Once imported as a collection only the "Value" field under the collection's
-Authorization tab needs to be populated and saved before making calls.
+Its primary job is to answer practical flight questions from the terminal:
 
-The AeroAPI OpenAPI specification is located at:\
-https://flightaware.com/commercial/aeroapi/resources/aeroapi-openapi.yml
+- **Find real fares** with Google Flights for one-way, round-trip, and multi-city trips.
+- **Scan date ranges** to find cheaper travel dates between airports.
+- **Explore nonstop and long-haul routes** from an airport using Kayak's route data.
+- **Compare price against operational risk** by joining fare results with reliability, delay, weather, and tracking context when you have a FlightAware AeroAPI key.
+- **Produce agent-friendly JSON** for travel planning, monitoring, rebooking, and briefing workflows.
 
-Our [open source AeroApps project](/aeroapi/portal/resources)
-provides a small collection of services and sample applications to help
-you get started.
+Most fare-discovery commands are free and require no account. AeroAPI is optional: add it when you need live flight status, historical reliability, airport delays, alerts, tail/aircraft lookups, or Foresight-backed predictions.
 
-The Flight Information Display System (FIDS) AeroApp is an example of a
-multi-tier application using multiple languages and Docker containers.
-It demonstrates connectivity, data caching, flight presentation, and leveraging flight maps.
+## Headline commands
 
-The Alerts AeroApp demonstrates the use of AeroAPI to set, edit, and
-receive alerts in a sample application with a Dockerized Python backend
-and a React frontend.
+These are the commands to try first:
 
-Our AeroAPI push notification [testing interface](/commercial/aeroapi/send.rvt)
-provides a quick and easy way to test the delivery of customized alerts via AeroAPI push.
+```bash
+# Search Google Flights for a specific itinerary. Free; no API key required.
+flight-goat-pp-cli flights SEA LHR 2026-06-15 --sort cheapest
+
+# Find the cheapest dates across a window. Free; no API key required.
+flight-goat-pp-cli dates JFK CDG --from 2026-07-01 --to 2026-07-31 --sort
+
+# Explore nonstop destinations from an airport via Kayak route data. Free; no API key required.
+flight-goat-pp-cli explore SEA --agent
+
+# Filter nonstop destinations by long-haul duration. Free; no API key required.
+flight-goat-pp-cli longhaul SEA --min-hours 8 --agent
+
+# Join fares with reliability and delay context. Uses AeroAPI when configured.
+flight-goat-pp-cli compare SEA LHR 2026-06-15 --agent
+
+# Decide whether a delayed flight is route-wide, airport-wide, or flight-specific.
+flight-goat-pp-cli assess --origin SFO --destination DCA --delayed-flight UA123 --agent
+```
+
+## Data sources and credentials
+
+| Capability | Source | Credential |
+|---|---|---|
+| Fare search, cheapest dates, Google Flights links | Google Flights native backend | None |
+| Nonstop destination and long-haul route discovery | Kayak route data | None |
+| Live status, airport delays, disruption counts, aircraft/tail lookups, route reliability, alerts, history, Foresight | FlightAware AeroAPI | Optional `FLIGHT_GOAT_API_KEY_AUTH` |
+| Compound decisions like `compare`, `assess`, `digest`, `monitor`, and `ontime-now` | Google Flights/Kayak plus AeroAPI/FAA/weather where relevant | Partial results without every source; AeroAPI improves operational depth |
 
 Created by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 Contributors: [@lloydarmbrust](https://github.com/lloydarmbrust) (Lloyd Armbrust).
@@ -168,9 +170,19 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 See [Install](#install) above.
 
-### 2. Set Up Credentials
+### 2. Try the free fare commands
 
-Get your API key from your API provider's developer portal. The key typically looks like a long alphanumeric string.
+Most headline fare and route-discovery commands do not need credentials:
+
+```bash
+flight-goat-pp-cli flights SEA LHR 2026-06-15 --sort cheapest
+flight-goat-pp-cli dates JFK CDG --from 2026-07-01 --to 2026-07-31 --sort
+flight-goat-pp-cli explore SEA --agent
+```
+
+### 3. Add AeroAPI only for operational data
+
+Set `FLIGHT_GOAT_API_KEY_AUTH` when you need FlightAware-backed status, reliability, alerts, history, aircraft/tail, disruption, or Foresight commands.
 
 ```bash
 export FLIGHT_GOAT_API_KEY_AUTH="<paste-your-key>"
@@ -178,19 +190,13 @@ export FLIGHT_GOAT_API_KEY_AUTH="<paste-your-key>"
 
 You can also persist this in your config file at `~/.config/flight-goat-pp-cli/config.toml`.
 
-### 3. Verify Setup
+### 4. Verify Setup
 
 ```bash
 flight-goat-pp-cli doctor
 ```
 
-This checks your configuration and credentials.
-
-### 4. Try Your First Command
-
-```bash
-flight-goat-pp-cli airports get mock-value
-```
+This checks your CLI configuration and reports whether optional AeroAPI credentials are available.
 
 ## Usage
 
@@ -558,19 +564,19 @@ one year into the future.
 
 ```bash
 # Human-readable table (default in terminal, JSON when piped)
-flight-goat-pp-cli airports get mock-value
+flight-goat-pp-cli flights SEA LHR 2026-06-15
 
 # JSON for scripting and agents
-flight-goat-pp-cli airports get mock-value --json
+flight-goat-pp-cli flights SEA LHR 2026-06-15 --json
 
-# Filter to specific fields
-flight-goat-pp-cli airports get mock-value --json --select id,name,status
+# Filter generated AeroAPI responses to specific fields
+flight-goat-pp-cli airports get KSEA --json --select id,name,status
 
 # Dry run — show the request without sending
-flight-goat-pp-cli airports get mock-value --dry-run
+flight-goat-pp-cli flights SEA LHR 2026-06-15 --dry-run
 
 # Agent mode — JSON + compact + no prompts in one flag
-flight-goat-pp-cli airports get mock-value --agent
+flight-goat-pp-cli flights SEA LHR 2026-06-15 --agent
 ```
 
 ## Agent Usage
@@ -595,7 +601,7 @@ Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API
 flight-goat-pp-cli doctor
 ```
 
-Verifies configuration, credentials, and connectivity to the API.
+Verifies CLI configuration, optional credentials, and connectivity to configured upstreams.
 
 ## Configuration
 
@@ -606,8 +612,8 @@ Environment variables:
 
 ## Troubleshooting
 **Authentication errors (exit code 4)**
-- Run `flight-goat-pp-cli doctor` to check credentials
-- Verify the environment variable is set: `echo $FLIGHT_GOAT_API_KEY_AUTH`
+- Run `flight-goat-pp-cli doctor` to check whether AeroAPI credentials are configured
+- Verify the environment variable is present without printing it, e.g. `test -n "$FLIGHT_GOAT_API_KEY_AUTH" && echo set || echo missing`
 **Not found errors (exit code 3)**
 - Check the resource ID is correct
 - Run the `list` command to see available items

--- a/library/travel/flight-goat/SKILL.md
+++ b/library/travel/flight-goat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-flight-goat
-description: "Search Google Flights, scan Kayak long-haul routes, and join FlightAware AeroAPI reliability, alerts, and tracking from one CLI."
+description: "Find real fares with Google Flights, scan Kayak nonstop/long-haul routes, and add FlightAware reliability/tracking only when operational context matters."
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"
@@ -17,6 +17,21 @@ metadata:
 ---
 
 # Flight Goat — Printing Press CLI
+
+## What this skill is for
+
+Use Flight Goat when the user is making a flight decision, not merely looking up an aviation API endpoint.
+
+Default to the free fare and route-discovery commands first:
+
+- `flights` — Google Flights fare search for a specific itinerary.
+- `dates` — cheapest-date scan across a travel window.
+- `explore` — nonstop destinations from an airport using Kayak route data.
+- `longhaul` and `cheapest-longhaul` — long-haul route discovery and cheap-date scans.
+- `compare` — fares plus route reliability when operational risk matters.
+- `assess` — delayed-flight/rebooking assessment using airport, route, weather, and optional price context.
+
+FlightAware AeroAPI is secondary and optional. Use AeroAPI-backed commands when the user needs live status, airport delays, disruption counts, aircraft/tail history, alerts, route reliability, or Foresight predictions. Do not present the whole CLI as credential-gated: Google Flights and Kayak-backed commands work without `FLIGHT_GOAT_API_KEY_AUTH`.
 
 ## Prerequisites: Install the CLI
 
@@ -37,16 +52,18 @@ go install github.com/mvanhorn/printing-press-library/library/travel/flight-goat
 
 If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
-## Categories
-AeroAPI is divided into several categories to make things easier to
-discover.
-- Flights: Summary information, planned routes, positions and more
-- Foresight: Flight positions enhanced with FlightAware Foresight™
-- Airports: Airport information and FIDS style resources
-- Operators: Operator information and fleet activity resources
-- Alerts: Configure flight alerts and delivery destinations
-- History: Historical flight access for various endpoints
-- Miscellaneous: Flight disruption, future schedule information, and aircraft owner information
+## Data sources and credential posture
+
+| Job | Primary commands | Credential |
+|---|---|---|
+| Find fares for known dates | `flights`, `gf-search` | None |
+| Find cheaper travel dates | `dates`, `cheapest-longhaul` | None |
+| Discover nonstop or long-haul destinations | `explore`, `longhaul` | None |
+| Weigh price against reliability | `compare`, `reliability`, `assess` | AeroAPI improves reliability/status evidence |
+| Monitor or investigate live operations | `monitor`, `ontime-now`, `digest`, `heatmap`, `aircraft-bio`, `eta`, `resolve` | Usually needs AeroAPI |
+| Manage FlightAware alerting/history/airport/operator APIs | `alerts`, `history`, `airports`, `operators`, `schedules`, `foresight` | AeroAPI required |
+
+If the user asks a normal travel-planning question, start with Google Flights/Kayak commands. Reach for AeroAPI only when operational evidence changes the decision.
 
 ## Google Flights Currency
 
@@ -83,31 +100,9 @@ complete all-clear. Use `--include-raw` only when the original AeroAPI JSON is
 needed for audit or custom scoring. FAA NOTAM data is not part of this command
 yet.
 
-## Development Tools
-AeroAPI is defined using the OpenAPI Spec 3.0, which means it can be easily
-imported into tools like Postman. To get started try importing the API
-specification using
-[Postman's instructions](https://learning.postman.com/docs/integrations/available-integrations/working-with-openAPI/).
-Once imported as a collection only the "Value" field under the collection's
-Authorization tab needs to be populated and saved before making calls.
+## AeroAPI endpoint families
 
-The AeroAPI OpenAPI specification is located at:\
-https://flightaware.com/commercial/aeroapi/resources/aeroapi-openapi.yml
-
-Our [open source AeroApps project](/aeroapi/portal/resources)
-provides a small collection of services and sample applications to help
-you get started.
-
-The Flight Information Display System (FIDS) AeroApp is an example of a
-multi-tier application using multiple languages and Docker containers.
-It demonstrates connectivity, data caching, flight presentation, and leveraging flight maps.
-
-The Alerts AeroApp demonstrates the use of AeroAPI to set, edit, and
-receive alerts in a sample application with a Dockerized Python backend
-and a React frontend.
-
-Our AeroAPI push notification [testing interface](/commercial/aeroapi/send.rvt)
-provides a quick and easy way to test the delivery of customized alerts via AeroAPI push.
+AeroAPI still matters when the task is operational rather than fare-shopping. The generated command reference below exposes FlightAware endpoint families for current and historical flights, Foresight predictions, airports, operators, alerts, schedules, and disruption counts. Treat those as the operational layer behind the higher-level decision commands, not as the CLI's core value proposition.
 
 ## Command Reference
 
@@ -246,7 +241,9 @@ flight-goat-pp-cli which "<capability in your own words>"
 
 ## Auth Setup
 
-Set your API key via environment variable:
+Do **not** require AeroAPI auth for normal fare discovery. `flights`, `dates`, `explore`, `longhaul`, `gf-search`, and `cheapest-longhaul` can run without `FLIGHT_GOAT_API_KEY_AUTH`.
+
+Set the optional AeroAPI key only when the user needs FlightAware-backed status, reliability, alerts, history, aircraft/tail, disruption, or Foresight commands:
 
 ```bash
 export FLIGHT_GOAT_API_KEY_AUTH="<your-key>"
@@ -254,7 +251,7 @@ export FLIGHT_GOAT_API_KEY_AUTH="<your-key>"
 
 Or persist it in `~/.config/flight-goat-pp-cli/config.toml`.
 
-Run `flight-goat-pp-cli doctor` to verify setup.
+Run `flight-goat-pp-cli doctor` to verify which upstreams are configured.
 
 ## Agent Mode
 
@@ -264,7 +261,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
-  flight-goat-pp-cli airports get mock-value --agent --select id,name,status
+  flight-goat-pp-cli airports get KSEA --agent --select id,name,status
   ```
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available
@@ -340,11 +337,11 @@ Unknown schemes are refused with a structured error naming the supported set. We
 A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
 
 ```
-flight-goat-pp-cli profile save briefing --json
-flight-goat-pp-cli --profile briefing airports get mock-value
+flight-goat-pp-cli profile save agent-json --json --compact --no-input --no-color --yes
+flight-goat-pp-cli --profile agent-json dates SEA LHR --from 2026-06-01 --to 2026-08-31 --sort
 flight-goat-pp-cli profile list --json
-flight-goat-pp-cli profile show briefing
-flight-goat-pp-cli profile delete briefing --yes
+flight-goat-pp-cli profile show agent-json
+flight-goat-pp-cli profile delete agent-json --yes
 ```
 
 Explicit flags always win over profile values; profile values win over defaults. `agent-context` lists all available profiles under `available_profiles` so introspecting agents discover them at runtime.


### PR DESCRIPTION
## Summary
- Reframe Flight Goat as a consumer-flight decision CLI first: Google Flights fares, cheapest-date scans, and Kayak nonstop/long-haul discovery
- Move FlightAware AeroAPI into the optional operational context layer instead of leading the README/skill with copied AeroAPI prose
- Update quick-start and agent examples away from mock AeroAPI calls toward the actual headline commands

## Verification
- git diff --check
- flight-goat-pp-cli flights SEA LHR 2026-06-15 --dry-run
- flight-goat-pp-cli dates SEA LHR --from 2026-06-01 --to 2026-08-31 --sort --dry-run
- flight-goat-pp-cli airports get KSEA --dry-run --json --select id,name,status
