### PR TITLE
fix(flight-goat): harden google flights fallback

### DIFF
--- a/library/travel/flight-goat/.printing-press-patches/google-flights-rpc-retry-and-ds1-fallback.json
+++ b/library/travel/flight-goat/.printing-press-patches/google-flights-rpc-retry-and-ds1-fallback.json
@@ -4,8 +4,8 @@
   "applied_at": "2026-06-26",
   "base_run_id": "2026-05-02T22:09:06.820184Z",
   "base_printing_press_version": "3.6.0",
-  "summary": "Retry transient Google Flights RPC code-13 envelopes before falling back, and harden the HTML fallback against ds:1 script and page-error variants.",
-  "reason": "Google's FlightsFrontendService can alternate between a valid response and HTTP 200 wrb.fr code-13 errors for the same request, so one blocked envelope should not immediately force the lower-fidelity HTML path. When fallback is needed, Google page data can appear as a direct script.ds:1 data payload or an embedded errorHasStatus page; both must be handled explicitly so usable page data is parsed and page-level errors are not reported as legitimate empty results.",
+  "summary": "Retry transient Google Flights RPC code-13 envelopes before falling back, and harden the HTML fallback against ds:1 script, malformed-script, and page-error variants.",
+  "reason": "Google's FlightsFrontendService can alternate between a valid response and HTTP 200 wrb.fr code-13 errors for the same request, so one blocked envelope should not immediately force the lower-fidelity HTML path. When fallback is needed, Google page data can appear as a direct script.ds:1 data payload, after unrelated malformed script blocks, or as an embedded errorHasStatus page; these cases must be handled explicitly so usable page data is parsed and page-level errors are not reported as legitimate empty results.",
   "files": [
     "internal/gflights/flights_native.go",
     "internal/gflights/dates_native.go",

--- a/library/travel/flight-goat/.printing-press-patches/google-flights-rpc-retry-and-ds1-fallback.json
+++ b/library/travel/flight-goat/.printing-press-patches/google-flights-rpc-retry-and-ds1-fallback.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "id": "google-flights-rpc-retry-and-ds1-fallback",
+  "applied_at": "2026-06-26",
+  "base_run_id": "2026-05-02T22:09:06.820184Z",
+  "base_printing_press_version": "3.6.0",
+  "summary": "Retry transient Google Flights RPC code-13 envelopes before falling back, and harden the HTML fallback against ds:1 script and page-error variants.",
+  "reason": "Google's FlightsFrontendService can alternate between a valid response and HTTP 200 wrb.fr code-13 errors for the same request, so one blocked envelope should not immediately force the lower-fidelity HTML path. When fallback is needed, Google page data can appear as a direct script.ds:1 data payload or an embedded errorHasStatus page; both must be handled explicitly so usable page data is parsed and page-level errors are not reported as legitimate empty results.",
+  "files": [
+    "internal/gflights/flights_native.go",
+    "internal/gflights/dates_native.go",
+    "internal/gflights/rpc_http.go",
+    "internal/gflights/rpc_retry.go",
+    "internal/gflights/rpc_retry_test.go",
+    "internal/gflights/html_fallback.go",
+    "internal/gflights/html_fallback_test.go"
+  ],
+  "validated_outcome": "`go test ./internal/gflights/...` and `go test ./...` pass; live `go run ./cmd/flight-goat-pp-cli flights SEA NRT 2026-12-18 --return 2027-01-01 --passengers 4 --agent` returns success with 9 itineraries via the HTML fallback after RPC retry attempts."
+}

--- a/library/travel/flight-goat/internal/gflights/dates_native.go
+++ b/library/travel/flight-goat/internal/gflights/dates_native.go
@@ -25,8 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -100,11 +98,9 @@ func datesNative(ctx context.Context, opts DatesOptions) (*DatesResult, error) {
 		// the equivalent inside its loop.
 		chunk, err := datesChunk(ctx, opts, cur, chunkEnd)
 		if err != nil {
-			// PATCH(amend-2026-06-11): when Google's calendar RPC rejects the
-			// request with the gated-client ErrorResponse, serve the whole
-			// requested range from per-day server-rendered pages instead.
-			// One blocked chunk means every chunk is blocked — no point
-			// retrying the rest over the RPC.
+			// PATCH(amend-2026-06-26): datesChunk retries transient code-13
+			// envelopes internally. If the BotGuard gate persists, serve the
+			// whole requested range from per-day server-rendered pages instead.
 			if errors.Is(err, errShoppingBlocked) {
 				all, note, err = datesViaHTML(ctx, opts, from, to, currencyCode)
 				if err != nil {
@@ -143,36 +139,17 @@ func datesChunk(ctx context.Context, opts DatesOptions, from, to time.Time) ([]D
 	}
 	body := "f.req=" + payload
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, calendarEndpoint, strings.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("building request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
-	req.Header.Set("User-Agent", chromeUserAgent)
-	req.Header.Set("Accept", "*/*")
-	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 	_, currencyCode, _ := normalizeCurrency(opts.Currency)
-	req.Header.Set("x-goog-ext-259736195-jspb", googleFlightsCurrencyHeader(currencyCode))
-
-	resp, err := utlsClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("calling calendar endpoint: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		snippet := string(respBody)
-		if len(snippet) > 200 {
-			snippet = snippet[:200] + "..."
+	var rows []DatePrice
+	err = retryBlockedRPC(ctx, func() error {
+		respBody, err := postFlightsFrontendRPC(ctx, calendarEndpoint, "calendar", body, currencyCode)
+		if err != nil {
+			return err
 		}
-		return nil, fmt.Errorf("calendar endpoint returned HTTP %d: %s", resp.StatusCode, snippet)
-	}
-
-	return parseDatesResponse(respBody, currencyCode)
+		rows, err = parseDatesResponse(respBody, currencyCode)
+		return err
+	})
+	return rows, err
 }
 
 // buildDatesPayload constructs the URL-encoded `f.req` value for a single

--- a/library/travel/flight-goat/internal/gflights/flights_native.go
+++ b/library/travel/flight-goat/internal/gflights/flights_native.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -146,43 +144,23 @@ func searchNativeDirect(ctx context.Context, opts SearchOptions) (*SearchResult,
 	}
 	body := "f.req=" + payload
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, offersEndpoint, strings.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("building request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
-	req.Header.Set("User-Agent", chromeUserAgent)
-	req.Header.Set("Accept", "*/*")
-	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
-	req.Header.Set("x-goog-ext-259736195-jspb", googleFlightsCurrencyHeader(currencyCode))
-
-	resp, err := utlsClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("calling shopping endpoint: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		snippet := string(respBody)
-		if len(snippet) > 200 {
-			snippet = snippet[:200] + "..."
-		}
-		return nil, fmt.Errorf("shopping endpoint returned HTTP %d: %s", resp.StatusCode, snippet)
-	}
-
 	note := ""
-	flights, err := parseOffersResponse(respBody, currencyCode)
+	var flights []Flight
+	err = retryBlockedRPC(ctx, func() error {
+		respBody, err := postFlightsFrontendRPC(ctx, offersEndpoint, "shopping", body, currencyCode)
+		if err != nil {
+			return err
+		}
+		flights, err = parseOffersResponse(respBody, currencyCode)
+		return err
+	})
 	switch {
 	case errors.Is(err, errShoppingBlocked):
-		// PATCH(amend-2026-06-11): Google gates the RPC for non-interactive
-		// clients (ErrorResponse code 13). Serve the search from the
-		// server-rendered HTML page instead — same inner schema, parsed by
-		// the same row parser. Page prices are per-person already, so the
-		// group-total divide below is intentionally skipped on this path.
+		// PATCH(amend-2026-06-26): Google can intermittently return HTTP 200
+		// with a wrb.fr gRPC code-13 envelope. retryBlockedRPC gives the native
+		// RPC a few chances first; if the BotGuard gate persists, serve the
+		// search from the server-rendered HTML page. Page prices are per-person
+		// already, so the group-total divide below is skipped on this path.
 		flights, note, err = searchViaHTML(ctx, opts, currencyCode)
 		if err != nil {
 			return nil, fmt.Errorf("google flights RPC is blocked and the HTML fallback failed: %w", err)

--- a/library/travel/flight-goat/internal/gflights/html_fallback.go
+++ b/library/travel/flight-goat/internal/gflights/html_fallback.go
@@ -249,15 +249,19 @@ func extractDS1ScriptBlobs(html string) []string {
 		rest = rest[si+len(scriptMark):]
 		closeTag := strings.Index(rest, ">")
 		if closeTag < 0 {
-			break
+			continue
 		}
 		attrs := rest[:closeTag]
 		afterOpen := rest[closeTag+1:]
 		endTag := strings.Index(afterOpen, "</script>")
 		if endTag < 0 {
-			break
+			continue
 		}
 		body := afterOpen[:endTag]
+		if nested := strings.Index(body, scriptMark); nested >= 0 {
+			rest = afterOpen[nested:]
+			continue
+		}
 		rest = afterOpen[endTag+len("</script>"):]
 		if !strings.Contains(attrs, "ds:1") {
 			continue

--- a/library/travel/flight-goat/internal/gflights/html_fallback.go
+++ b/library/travel/flight-goat/internal/gflights/html_fallback.go
@@ -236,6 +236,53 @@ func extractInitDataBlobs(html string) []string {
 	return blobs
 }
 
+func extractDS1ScriptBlobs(html string) []string {
+	const scriptMark = "<script"
+	const dataMark = "data:"
+	var blobs []string
+	rest := html
+	for {
+		si := strings.Index(rest, scriptMark)
+		if si < 0 {
+			break
+		}
+		rest = rest[si+len(scriptMark):]
+		closeTag := strings.Index(rest, ">")
+		if closeTag < 0 {
+			break
+		}
+		attrs := rest[:closeTag]
+		afterOpen := rest[closeTag+1:]
+		endTag := strings.Index(afterOpen, "</script>")
+		if endTag < 0 {
+			break
+		}
+		body := afterOpen[:endTag]
+		rest = afterOpen[endTag+len("</script>"):]
+		if !strings.Contains(attrs, "ds:1") {
+			continue
+		}
+		di := strings.Index(body, dataMark)
+		if di < 0 {
+			continue
+		}
+		seg := body[di+len(dataMark):]
+		j := 0
+		for j < len(seg) && (seg[j] == ' ' || seg[j] == '\n' || seg[j] == '\t' || seg[j] == '\r') {
+			j++
+		}
+		if j >= len(seg) || seg[j] != '[' {
+			continue
+		}
+		end, ok := scanBalancedArray(seg[j:])
+		if !ok {
+			continue
+		}
+		blobs = append(blobs, seg[j:j+end])
+	}
+	return blobs
+}
+
 // scanBalancedArray returns the exclusive end offset of the JSON array that
 // starts at s[0] == '['. String literals and backslash escapes are honored.
 func scanBalancedArray(s string) (int, bool) {
@@ -303,7 +350,8 @@ func flightsFromEmbeddedPayload(inner []any, currency string) []Flight {
 // several unrelated blobs; only one embeds the shopping results).
 func flightsFromHTML(html, currency string) []Flight {
 	var best []Flight
-	for _, blob := range extractInitDataBlobs(html) {
+	blobs := append(extractInitDataBlobs(html), extractDS1ScriptBlobs(html)...)
+	for _, blob := range blobs {
 		var inner []any
 		if err := json.Unmarshal([]byte(blob), &inner); err != nil {
 			continue
@@ -348,7 +396,9 @@ func searchViaHTML(ctx context.Context, opts SearchOptions, currencyCode string)
 // redesign, as opposed to a legitimately empty result set (which still embeds
 // AF_initDataCallback blobs).
 func pageMissingFlightData(html string) bool {
-	return strings.Contains(html, "consent.google.com") || !strings.Contains(html, "AF_initDataCallback(")
+	return strings.Contains(html, "consent.google.com") ||
+		strings.Contains(html, "errorHasStatus: true") ||
+		(!strings.Contains(html, "AF_initDataCallback(") && !strings.Contains(html, "ds:1"))
 }
 
 // sortFlightsClientSide orders fallback results for the sort keys the page

--- a/library/travel/flight-goat/internal/gflights/html_fallback_test.go
+++ b/library/travel/flight-goat/internal/gflights/html_fallback_test.go
@@ -186,6 +186,18 @@ func TestFlightsFromHTMLParsesStandaloneDS1ScriptPayload(t *testing.T) {
 	}
 }
 
+func TestFlightsFromHTMLSkipsUnclosedScriptBeforeDS1Payload(t *testing.T) {
+	html := `<!doctype html><html><body>
+<script class="decoy">var unfinished = true;
+<script class="ds:1">window._unused = {data:` + string(loadFixture(t, "aus_lax_embedded_ds1.json")) + `, sideChannel:{}};</script>
+</body></html>`
+
+	flights := flightsFromHTML(html, "USD")
+	if len(flights) == 0 {
+		t.Fatal("flightsFromHTML parsed 0 flights after unclosed decoy script")
+	}
+}
+
 func TestSortFlightsClientSide(t *testing.T) {
 	mk := func(price float64, duration int, dep, arr string) Flight {
 		return Flight{Price: price, DurationMinutes: duration, Legs: []Leg{{

--- a/library/travel/flight-goat/internal/gflights/html_fallback_test.go
+++ b/library/travel/flight-goat/internal/gflights/html_fallback_test.go
@@ -172,6 +172,20 @@ func TestFlightsFromHTMLParsesEmbeddedPayload(t *testing.T) {
 	}
 }
 
+func TestFlightsFromHTMLParsesStandaloneDS1ScriptPayload(t *testing.T) {
+	html := `<!doctype html><html><body>
+<script class="ds:1">window._unused = {data:` + string(loadFixture(t, "aus_lax_embedded_ds1.json")) + `, sideChannel:{}};</script>
+</body></html>`
+
+	flights := flightsFromHTML(html, "USD")
+	if len(flights) == 0 {
+		t.Fatal("flightsFromHTML parsed 0 flights from standalone script.ds:1 payload")
+	}
+	if pageMissingFlightData(html) {
+		t.Fatal("script.ds:1 payload misclassified as missing flight data")
+	}
+}
+
 func TestSortFlightsClientSide(t *testing.T) {
 	mk := func(price float64, duration int, dep, arr string) Flight {
 		return Flight{Price: price, DurationMinutes: duration, Legs: []Leg{{
@@ -221,6 +235,13 @@ func TestPageMissingFlightData(t *testing.T) {
 	}
 	if pageMissingFlightData(wrapDs1HTML([]byte(`[null,[],[]]`))) {
 		t.Fatal("page with embedded callbacks misclassified as missing data")
+	}
+}
+
+func TestPageErrorStatusIsMissingFlightData(t *testing.T) {
+	html := `<html><body><script class="ds:1">AF_initDataCallback({key:'ds:1', data:[null,[],[]], errorHasStatus: true});</script></body></html>`
+	if !pageMissingFlightData(html) {
+		t.Fatal("embedded ds:1 errorHasStatus page not detected")
 	}
 }
 

--- a/library/travel/flight-goat/internal/gflights/rpc_http.go
+++ b/library/travel/flight-goat/internal/gflights/rpc_http.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package gflights
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func postFlightsFrontendRPC(ctx context.Context, endpoint, label, body, currencyCode string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+	req.Header.Set("User-Agent", chromeUserAgent)
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	req.Header.Set("x-goog-ext-259736195-jspb", googleFlightsCurrencyHeader(currencyCode))
+
+	resp, err := utlsClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling %s endpoint: %w", label, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		snippet := string(respBody)
+		if len(snippet) > 200 {
+			snippet = snippet[:200] + "..."
+		}
+		return nil, fmt.Errorf("%s endpoint returned HTTP %d: %s", label, resp.StatusCode, snippet)
+	}
+	return respBody, nil
+}

--- a/library/travel/flight-goat/internal/gflights/rpc_retry.go
+++ b/library/travel/flight-goat/internal/gflights/rpc_retry.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package gflights
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	rpcBlockedRetryDelays = []time.Duration{
+		250 * time.Millisecond,
+		750 * time.Millisecond,
+		1500 * time.Millisecond,
+	}
+	sleepBeforeRPCBlockedRetry = sleepContext
+)
+
+func retryBlockedRPC(ctx context.Context, call func() error) error {
+	for attempt := 0; ; attempt++ {
+		err := call()
+		if !errors.Is(err, errShoppingBlocked) {
+			return err
+		}
+		if attempt >= len(rpcBlockedRetryDelays) {
+			return err
+		}
+		if sleepErr := sleepBeforeRPCBlockedRetry(ctx, rpcBlockedRetryDelays[attempt]); sleepErr != nil {
+			return sleepErr
+		}
+	}
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/library/travel/flight-goat/internal/gflights/rpc_retry_test.go
+++ b/library/travel/flight-goat/internal/gflights/rpc_retry_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package gflights
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetryBlockedRPCRetriesTransientBlockedEnvelope(t *testing.T) {
+	origSleep := sleepBeforeRPCBlockedRetry
+	sleepBeforeRPCBlockedRetry = func(context.Context, time.Duration) error { return nil }
+	defer func() { sleepBeforeRPCBlockedRetry = origSleep }()
+
+	attempts := 0
+	err := retryBlockedRPC(context.Background(), func() error {
+		attempts++
+		if attempts < 3 {
+			return errShoppingBlocked
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retryBlockedRPC returned error: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestRetryBlockedRPCStopsBeforeNonBlockedErrors(t *testing.T) {
+	origSleep := sleepBeforeRPCBlockedRetry
+	sleepBeforeRPCBlockedRetry = func(context.Context, time.Duration) error { return nil }
+	defer func() { sleepBeforeRPCBlockedRetry = origSleep }()
+
+	want := errors.New("parse drift")
+	attempts := 0
+	err := retryBlockedRPC(context.Background(), func() error {
+		attempts++
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("retryBlockedRPC error = %v, want %v", err, want)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRetryBlockedRPCReturnsBlockedAfterRetryBudget(t *testing.T) {
+	origSleep := sleepBeforeRPCBlockedRetry
+	sleepBeforeRPCBlockedRetry = func(context.Context, time.Duration) error { return nil }
+	defer func() { sleepBeforeRPCBlockedRetry = origSleep }()
+
+	attempts := 0
+	err := retryBlockedRPC(context.Background(), func() error {
+		attempts++
+		return errShoppingBlocked
+	})
+	if !errors.Is(err, errShoppingBlocked) {
+		t.Fatalf("retryBlockedRPC error = %v, want errShoppingBlocked", err)
+	}
+	if attempts != len(rpcBlockedRetryDelays)+1 {
+		t.Fatalf("attempts = %d, want %d", attempts, len(rpcBlockedRetryDelays)+1)
+	}
+}


### PR DESCRIPTION
## Summary

`flight-goat` now gives the native Google Flights RPC a short retry window before falling back to the server-rendered page path. This covers the intermittent HTTP 200 / `wrb.fr` code-13 behavior where the same valid request can alternate between a full RPC response and a transient backend rejection.

The HTML fallback is also more robust: it now parses direct `script.ds:1` data payloads in addition to `AF_initDataCallback` blobs, and treats embedded `errorHasStatus: true` pages as fallback failures rather than legitimate empty search results. That keeps usable page data flowing while making page-level Google errors explicit.

## Validation

- `go test ./internal/gflights/...`
- `go test ./...` from `library/travel/flight-goat`
- `go run ./cmd/flight-goat-pp-cli flights SEA NRT 2026-12-18 --return 2027-01-01 --passengers 4 --agent` returns `success: true` with 9 itineraries via HTML fallback after RPC retry attempts

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
