### PR TITLE
feat(giustizia-amministrativa): archive workflow — get --front-matter, corpus build --skip-existing/--plan, search --anno-from/--anno-to

### DIFF
--- a/library/productivity/giustizia-amministrativa/.printing-press-patches/archive-workflow-front-matter-and-year-sweep.json
+++ b/library/productivity/giustizia-amministrativa/.printing-press-patches/archive-workflow-front-matter-and-year-sweep.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "id": "archive-workflow-front-matter-and-year-sweep",
+  "applied_at": "2026-07-23",
+  "base_run_id": "20260621-094103",
+  "base_printing_press_version": "4.24.0",
+  "summary": "Hand-added archive-workflow capabilities the generator does not emit: a front-matter YAML header on get/corpus md output, incremental corpus build (--skip-existing/--plan), and a year-range sweep (--anno-from/--anno-to). A reprint must re-carry these flags.",
+  "reason": "The portal exposes no relevance sort and only a single-year filter, so a year-at-a-time sweep de-duplicated by id is the only way to get balanced historical coverage; and the deposit date ('Pubblicato il') lives only in the raw HTML and is dropped by the Markdown renderer, so the front-matter block makes get/corpus output self-contained and source-traceable in a single fetch.",
+  "files": [
+    "internal/gaclient/frontmatter.go",
+    "internal/gaclient/client.go",
+    "internal/cli/get.go",
+    "internal/cli/provvedimenti_get.go",
+    "internal/cli/corpus_build.go",
+    "internal/cli/search.go",
+    "internal/cli/ga_core.go"
+  ],
+  "validated_outcome": "go build/vet/test green; front-matter, --skip-existing/--plan, and --anno-from/--anno-to all verified live against the portal."
+}

--- a/library/productivity/giustizia-amministrativa/go.mod
+++ b/library/productivity/giustizia-amministrativa/go.mod
@@ -2,8 +2,6 @@ module github.com/mvanhorn/printing-press-library/library/productivity/giustizia
 
 go 1.26.5
 
-toolchain go1.26.5
-
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.9.1

--- a/library/productivity/giustizia-amministrativa/internal/cli/corpus_build.go
+++ b/library/productivity/giustizia-amministrativa/internal/cli/corpus_build.go
@@ -64,6 +64,9 @@ func newNovelCorpusBuildCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+			for _, w := range res.Warnings {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Attenzione: %s\n", w)
+			}
 			st, _ := openGAStore(cmd.Context())
 			if st != nil {
 				defer st.Close()

--- a/library/productivity/giustizia-amministrativa/internal/cli/corpus_build.go
+++ b/library/productivity/giustizia-amministrativa/internal/cli/corpus_build.go
@@ -25,7 +25,7 @@ var reUnsafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
 func newNovelCorpusBuildCmd(flags *rootFlags) *cobra.Command {
 	var f searchFlags
 	var out string
-	var skipExisting, plan bool
+	var skipExisting, plan, frontMatter bool
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Assembla N provvedimenti su un tema in Markdown + un CSV manifest.",
@@ -33,12 +33,14 @@ func newNovelCorpusBuildCmd(flags *rootFlags) *cobra.Command {
 			"una cartella con un file .md per provvedimento più un manifest.csv (ECLI, tipo, sede, data, url).\n" +
 			"Con --skip-existing i provvedimenti il cui .md è già presente in --out non vengono riscaricati\n" +
 			"(corpus incrementale), restando comunque elencati nel manifest. Con --plan non scarica nulla:\n" +
-			"scrive solo il manifest delle candidate, per rivedere la query prima di impegnare N richieste.",
+			"scrive solo il manifest delle candidate, per rivedere la query prima di impegnare N richieste.\n" +
+			"Con --front-matter l'intestazione di ogni .md è il blocco YAML di `get --front-matter`\n" +
+			"invece dell'intestazione Markdown predefinita.",
 		Example: strings.Trim(`
   giustizia-amministrativa-pp-cli corpus build --testo "soccorso istruttorio" --tipo sentenza --limit 3 --out ./corpus
   giustizia-amministrativa-pp-cli corpus build --all "clausola sociale" --sede roma --limit 20 --out ./clausola-sociale
   giustizia-amministrativa-pp-cli corpus build --all "accesso generalizzato" --plan --out ./corpus
-  giustizia-amministrativa-pp-cli corpus build --all "accesso generalizzato" --skip-existing --out ./corpus`, "\n"),
+  giustizia-amministrativa-pp-cli corpus build --all "accesso generalizzato" --skip-existing --front-matter --out ./corpus`, "\n"),
 		Annotations: map[string]string{"mcp:read-only": "false"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if gaSkip(flags) {
@@ -122,7 +124,13 @@ func newNovelCorpusBuildCmd(flags *rootFlags) *cobra.Command {
 				if st != nil {
 					persistProvvedimenti(st, []gaclient.Provvedimento{p})
 				}
-				header := gaclient.FrontMatter(p) + "\n"
+				var header string
+				if frontMatter {
+					header = gaclient.FrontMatter(p) + "\n"
+				} else {
+					header = fmt.Sprintf("# %s\n\n- Tipo: %s\n- Sede: %s %s\n- Data deposito: %s\n- NRG: %s\n- URL: %s\n\n---\n\n",
+						provID(p), p.Tipo, p.Sede, p.Sezione, p.DataDeposito, p.Nrg, p.URL)
+				}
 				if werr := os.WriteFile(fpath, []byte(header+md+"\n"), 0o644); werr != nil {
 					return werr
 				}
@@ -157,6 +165,7 @@ func newNovelCorpusBuildCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&out, "out", "", "Cartella di destinazione del corpus (richiesto).")
 	cmd.Flags().BoolVar(&skipExisting, "skip-existing", false, "Non riscaricare i provvedimenti il cui .md è già presente in --out.")
 	cmd.Flags().BoolVar(&plan, "plan", false, "Non scaricare: elenca solo le candidate nel manifest, per revisione.")
+	cmd.Flags().BoolVar(&frontMatter, "front-matter", false, "Usa il blocco YAML (come `get --front-matter`) come intestazione dei .md, invece dell'header Markdown predefinito.")
 	return cmd
 }
 

--- a/library/productivity/giustizia-amministrativa/internal/cli/corpus_build.go
+++ b/library/productivity/giustizia-amministrativa/internal/cli/corpus_build.go
@@ -25,14 +25,20 @@ var reUnsafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
 func newNovelCorpusBuildCmd(flags *rootFlags) *cobra.Command {
 	var f searchFlags
 	var out string
+	var skipExisting, plan bool
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Assembla N provvedimenti su un tema in Markdown + un CSV manifest.",
 		Long: "Esegue una ricerca, scarica il testo integrale di ogni provvedimento in Markdown e scrive\n" +
-			"una cartella con un file .md per provvedimento più un manifest.csv (ECLI, tipo, sede, data, url).",
+			"una cartella con un file .md per provvedimento più un manifest.csv (ECLI, tipo, sede, data, url).\n" +
+			"Con --skip-existing i provvedimenti il cui .md è già presente in --out non vengono riscaricati\n" +
+			"(corpus incrementale), restando comunque elencati nel manifest. Con --plan non scarica nulla:\n" +
+			"scrive solo il manifest delle candidate, per rivedere la query prima di impegnare N richieste.",
 		Example: strings.Trim(`
   giustizia-amministrativa-pp-cli corpus build --testo "soccorso istruttorio" --tipo sentenza --limit 3 --out ./corpus
-  giustizia-amministrativa-pp-cli corpus build --all "clausola sociale" --sede roma --limit 20 --out ./clausola-sociale`, "\n"),
+  giustizia-amministrativa-pp-cli corpus build --all "clausola sociale" --sede roma --limit 20 --out ./clausola-sociale
+  giustizia-amministrativa-pp-cli corpus build --all "accesso generalizzato" --plan --out ./corpus
+  giustizia-amministrativa-pp-cli corpus build --all "accesso generalizzato" --skip-existing --out ./corpus`, "\n"),
 		Annotations: map[string]string{"mcp:read-only": "false"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if gaSkip(flags) {
@@ -75,8 +81,34 @@ func newNovelCorpusBuildCmd(flags *rootFlags) *cobra.Command {
 				File string `json:"file"`
 				URL  string `json:"url"`
 			}
+			manifestRow := func(p gaclient.Provvedimento, fname string) {
+				_ = w.Write([]string{p.Ecli, p.Tipo, p.Sede, p.Sezione, strconv.Itoa(p.Anno), strconv.Itoa(p.Numero), p.Nrg, p.DataDeposito, p.URL, fname})
+			}
+
 			var summary []built
+			var skipped, planned int
 			for _, p := range res.Items {
+				fname := sanitizeFilename(provID(p)) + ".md"
+				fpath := filepath.Join(out, fname)
+
+				// --plan: list candidates only, no document fetch, no .md written.
+				if plan {
+					manifestRow(p, fname)
+					summary = append(summary, built{Ecli: p.Ecli, File: fname, URL: p.URL})
+					planned++
+					continue
+				}
+				// --skip-existing: already-downloaded provvedimenti stay in the
+				// manifest (from search metadata) but are not refetched.
+				if skipExisting {
+					if _, statErr := os.Stat(fpath); statErr == nil {
+						manifestRow(p, fname)
+						summary = append(summary, built{Ecli: p.Ecli, File: fname, URL: p.URL})
+						skipped++
+						continue
+					}
+				}
+
 				docHTML, ferr := c.FullText(cmd.Context(), p)
 				if ferr != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(), "salto %s: %v\n", provID(p), ferr)
@@ -90,13 +122,11 @@ func newNovelCorpusBuildCmd(flags *rootFlags) *cobra.Command {
 				if st != nil {
 					persistProvvedimenti(st, []gaclient.Provvedimento{p})
 				}
-				fname := sanitizeFilename(provID(p)) + ".md"
-				header := fmt.Sprintf("# %s\n\n- Tipo: %s\n- Sede: %s %s\n- Data deposito: %s\n- NRG: %s\n- URL: %s\n\n---\n\n",
-					provID(p), p.Tipo, p.Sede, p.Sezione, p.DataDeposito, p.Nrg, p.URL)
-				if werr := os.WriteFile(filepath.Join(out, fname), []byte(header+md+"\n"), 0o644); werr != nil {
+				header := gaclient.FrontMatter(p) + "\n"
+				if werr := os.WriteFile(fpath, []byte(header+md+"\n"), 0o644); werr != nil {
 					return werr
 				}
-				_ = w.Write([]string{p.Ecli, p.Tipo, p.Sede, p.Sezione, strconv.Itoa(p.Anno), strconv.Itoa(p.Numero), p.Nrg, p.DataDeposito, p.URL, fname})
+				manifestRow(p, fname)
 				summary = append(summary, built{Ecli: p.Ecli, File: fname, URL: p.URL})
 			}
 			w.Flush()
@@ -105,10 +135,18 @@ func newNovelCorpusBuildCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Corpus creato in %s: %d provvedimenti, manifest %s.\n", out, len(summary), manifestPath)
+				switch {
+				case plan:
+					fmt.Fprintf(cmd.ErrOrStderr(), "Piano: %d candidate elencate in %s (nessun download).\n", planned, manifestPath)
+				case skipped > 0:
+					fmt.Fprintf(cmd.ErrOrStderr(), "Corpus aggiornato in %s: %d provvedimenti (%d già presenti, saltati), manifest %s.\n", out, len(summary), skipped, manifestPath)
+				default:
+					fmt.Fprintf(cmd.ErrOrStderr(), "Corpus creato in %s: %d provvedimenti, manifest %s.\n", out, len(summary), manifestPath)
+				}
 			}
 			result := map[string]any{
 				"out": out, "manifest": manifestPath, "count": len(summary),
+				"skipped": skipped, "plan": plan,
 				"generated_at": time.Now().UTC().Format(time.RFC3339), "items": summary,
 			}
 			data, _ := json.Marshal(result)
@@ -117,6 +155,8 @@ func newNovelCorpusBuildCmd(flags *rootFlags) *cobra.Command {
 	}
 	addSearchFlags(cmd, &f)
 	cmd.Flags().StringVar(&out, "out", "", "Cartella di destinazione del corpus (richiesto).")
+	cmd.Flags().BoolVar(&skipExisting, "skip-existing", false, "Non riscaricare i provvedimenti il cui .md è già presente in --out.")
+	cmd.Flags().BoolVar(&plan, "plan", false, "Non scaricare: elenca solo le candidate nel manifest, per revisione.")
 	return cmd
 }
 

--- a/library/productivity/giustizia-amministrativa/internal/cli/ga_core.go
+++ b/library/productivity/giustizia-amministrativa/internal/cli/ga_core.go
@@ -119,8 +119,10 @@ func resolveProvvedimento(ctx context.Context, st *store.Store, id string) (gacl
 }
 
 // runGAGet fetches the full text of a provvedimento and renders it in the
-// requested format (md, text, html, json).
-func runGAGet(cmd *cobra.Command, flags *rootFlags, id, format, sede, nrg, file string) error {
+// requested format (md, text, html, json). When frontMatter is set and the
+// format is md/text, a YAML front-matter block with the provvedimento metadata
+// is prepended (no-op for json/html, which already carry the fields).
+func runGAGet(cmd *cobra.Command, flags *rootFlags, id, format, sede, nrg, file string, frontMatter bool) error {
 	if gaSkip(flags) {
 		return nil
 	}
@@ -170,8 +172,14 @@ func runGAGet(cmd *cobra.Command, flags *rootFlags, id, format, sede, nrg, file 
 	}
 	switch strings.ToLower(format) {
 	case "", "md", "markdown":
+		if frontMatter {
+			fmt.Fprintln(cmd.OutOrStdout(), gaclient.FrontMatter(p))
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), markdown)
 	case "text", "txt":
+		if frontMatter {
+			fmt.Fprintln(cmd.OutOrStdout(), gaclient.FrontMatter(p))
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), gaclient.HTMLToText(docHTML))
 	case "html":
 		fmt.Fprintln(cmd.OutOrStdout(), docHTML)

--- a/library/productivity/giustizia-amministrativa/internal/cli/ga_core.go
+++ b/library/productivity/giustizia-amministrativa/internal/cli/ga_core.go
@@ -79,6 +79,9 @@ func runGASearch(cmd *cobra.Command, flags *rootFlags, opts gaclient.SearchOptio
 	if err != nil {
 		return classifyAPIError(err, flags)
 	}
+	for _, w := range res.Warnings {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Attenzione: %s\n", w)
+	}
 	// Best-effort persistence (offline search, watch, grep, stats build on this).
 	if st, serr := openGAStore(cmd.Context()); serr == nil {
 		persistProvvedimenti(st, res.Items)

--- a/library/productivity/giustizia-amministrativa/internal/cli/ga_core.go
+++ b/library/productivity/giustizia-amministrativa/internal/cli/ga_core.go
@@ -88,7 +88,10 @@ func runGASearch(cmd *cobra.Command, flags *rootFlags, opts gaclient.SearchOptio
 		_ = st.Close()
 	}
 	if wantsHumanTable(cmd.OutOrStdout(), flags) && res.Total > 0 {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Trovati %d risultati (mostrati %d).\n", res.Total, len(res.Items))
+		// Total is the match count declared by the portal (summed per year in a
+		// sweep), not the number of rows returned: say so, or the two numbers
+		// look contradictory whenever Total exceeds --limit.
+		fmt.Fprintf(cmd.ErrOrStderr(), "Trovati %d risultati sul portale (mostrati %d).\n", res.Total, len(res.Items))
 	}
 	data, err := json.Marshal(res.Items)
 	if err != nil {

--- a/library/productivity/giustizia-amministrativa/internal/cli/get.go
+++ b/library/productivity/giustizia-amministrativa/internal/cli/get.go
@@ -12,15 +12,19 @@ import (
 
 func newNovelGetCmd(flags *rootFlags) *cobra.Command {
 	var format, sede, nrg, file string
+	var frontMatter bool
 
 	cmd := &cobra.Command{
 		Use:   "get [id]",
 		Short: "Scarica il testo completo di un provvedimento e lo restituisce in Markdown pulito.",
 		Long: "Recupera il testo integrale di una sentenza/ordinanza/decreto/parere (per ECLI o idprovv,\n" +
 			"da una ricerca precedente) e lo restituisce in Markdown pulito. Usa --format per text/html/json,\n" +
-			"oppure --sede/--nrg/--file per il fetch diretto senza ricerca.",
+			"oppure --sede/--nrg/--file per il fetch diretto senza ricerca.\n" +
+			"Con --front-matter l'output md/text è preceduto da un blocco YAML con i metadati\n" +
+			"(ecli, sede, sezione, numero, anno, nrg, data_deposito, formato, url), pronto per l'archiviazione.",
 		Example: strings.Trim(`
   giustizia-amministrativa-pp-cli get IT:TARLAZ:2026:11307SENT --format md
+  giustizia-amministrativa-pp-cli get IT:TARLAZ:2026:11307SENT --front-matter
   giustizia-amministrativa-pp-cli get IT:TARLAZ:2026:11307SENT --json
   giustizia-amministrativa-pp-cli get --sede tar_rm --nrg 202600422 --file 202611307_01.html`, "\n"),
 		Annotations: map[string]string{"mcp:read-only": "true"},
@@ -32,12 +36,13 @@ func newNovelGetCmd(flags *rootFlags) *cobra.Command {
 			if id == "" && sede == "" {
 				return cmd.Help()
 			}
-			return runGAGet(cmd, flags, id, format, sede, nrg, file)
+			return runGAGet(cmd, flags, id, format, sede, nrg, file, frontMatter)
 		},
 	}
 	cmd.Flags().StringVar(&format, "format", "md", "Formato di output: md, text, html, json.")
 	cmd.Flags().StringVar(&sede, "sede", "", "Schema sede (es. tar_rm) per il fetch diretto senza ricerca.")
 	cmd.Flags().StringVar(&nrg, "nrg", "", "NRG per il fetch diretto.")
 	cmd.Flags().StringVar(&file, "file", "", "nomeFile per il fetch diretto (es. 202611307_01.html).")
+	cmd.Flags().BoolVar(&frontMatter, "front-matter", false, "Anteponi un blocco YAML con i metadati (solo output md/text).")
 	return cmd
 }

--- a/library/productivity/giustizia-amministrativa/internal/cli/provvedimenti_get.go
+++ b/library/productivity/giustizia-amministrativa/internal/cli/provvedimenti_get.go
@@ -9,6 +9,7 @@ import (
 
 func newProvvedimentiGetCmd(flags *rootFlags) *cobra.Command {
 	var format, sede, nrg, file string
+	var frontMatter bool
 	cmd := &cobra.Command{
 		Use:         "get [id]",
 		Short:       "Scarica il testo integrale di un provvedimento (per ECLI o idprovv).",
@@ -22,12 +23,13 @@ func newProvvedimentiGetCmd(flags *rootFlags) *cobra.Command {
 			if id == "" && sede == "" {
 				return cmd.Help()
 			}
-			return runGAGet(cmd, flags, id, format, sede, nrg, file)
+			return runGAGet(cmd, flags, id, format, sede, nrg, file, frontMatter)
 		},
 	}
 	cmd.Flags().StringVar(&format, "format", "md", "Formato di output: md, text, html, json.")
 	cmd.Flags().StringVar(&sede, "sede", "", "Schema sede (es. tar_rm) per il fetch diretto senza ricerca.")
 	cmd.Flags().StringVar(&nrg, "nrg", "", "NRG per il fetch diretto.")
 	cmd.Flags().StringVar(&file, "file", "", "nomeFile per il fetch diretto (es. 202611307_01.html).")
+	cmd.Flags().BoolVar(&frontMatter, "front-matter", false, "Anteponi un blocco YAML con i metadati (solo output md/text).")
 	return cmd
 }

--- a/library/productivity/giustizia-amministrativa/internal/cli/search.go
+++ b/library/productivity/giustizia-amministrativa/internal/cli/search.go
@@ -13,18 +13,20 @@ import (
 
 // searchFlags holds the bound values for a provvedimenti search.
 type searchFlags struct {
-	testo   string
-	all     string
-	any     string
-	not     string
-	phrase  string
-	tipo    string
-	sede    string
-	anno    int
-	numero  int
-	nrg     int
-	annoNrg int
-	limit   int
+	testo    string
+	all      string
+	any      string
+	not      string
+	phrase   string
+	tipo     string
+	sede     string
+	anno     int
+	annoFrom int
+	annoTo   int
+	numero   int
+	nrg      int
+	annoNrg  int
+	limit    int
 }
 
 // addSearchFlags binds the common search flags onto a command.
@@ -37,6 +39,8 @@ func addSearchFlags(cmd *cobra.Command, f *searchFlags) {
 	cmd.Flags().StringVar(&f.tipo, "tipo", "", "Tipo: sentenza, ordinanza, decreto, parere, plenaria, generale.")
 	cmd.Flags().StringVar(&f.sede, "sede", "", "Sede: roma, milano, consiglio-di-stato, cgars, ... (28 TAR + CdS).")
 	cmd.Flags().IntVar(&f.anno, "anno", 0, "Anno del provvedimento.")
+	cmd.Flags().IntVar(&f.annoFrom, "anno-from", 0, "Sweep storico: primo anno (incluso). Itera il filtro anno; --limit vale per anno.")
+	cmd.Flags().IntVar(&f.annoTo, "anno-to", 0, "Sweep storico: ultimo anno (incluso).")
 	cmd.Flags().IntVar(&f.numero, "numero", 0, "Numero del provvedimento.")
 	cmd.Flags().IntVar(&f.nrg, "nrg", 0, "Numero di registro generale (ricorso).")
 	cmd.Flags().IntVar(&f.annoNrg, "anno-nrg", 0, "Anno del registro generale (per la ricerca per NRG).")
@@ -50,7 +54,8 @@ func (f *searchFlags) opts(positional string) gaclient.SearchOptions {
 	}
 	return gaclient.SearchOptions{
 		Testo: testo, All: f.all, Any: f.any, Not: f.not, Phrase: f.phrase,
-		Tipo: f.tipo, Sede: f.sede, Anno: f.anno, Numero: f.numero,
+		Tipo: f.tipo, Sede: f.sede, Anno: f.anno,
+		AnnoFrom: f.annoFrom, AnnoTo: f.annoTo, Numero: f.numero,
 		Nrg: f.nrg, AnnoNrg: f.annoNrg, Limit: f.limit,
 	}
 }

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/client.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/client.go
@@ -307,6 +307,16 @@ func (c *Client) searchSweep(ctx context.Context, opts SearchOptions) (*SearchRe
 	})
 }
 
+// appendSkippedWarning records the years dropped by a transient failure, so a
+// gap in the swept range is never silent — including when the sweep later
+// aborts for a different reason.
+func appendSkippedWarning(warnings, skipped []string, lastErr error) []string {
+	if len(skipped) == 0 {
+		return warnings
+	}
+	return append(warnings, fmt.Sprintf("anni non recuperati: %s (ultimo errore: %v)", strings.Join(skipped, ", "), lastErr))
+}
+
 // sweepYears merges the per-year results of fetch over an inclusive year span,
 // applying the skip/abort policy described on searchSweep.
 func sweepYears(ctx context.Context, from, to int, fetch func(year int) (*SearchResult, error)) (*SearchResult, error) {
@@ -321,7 +331,8 @@ func sweepYears(ctx context.Context, from, to int, fetch func(year int) (*Search
 				if len(res.Items) == 0 {
 					return nil, err
 				}
-				res.Warnings = append(res.Warnings, fmt.Sprintf("sweep interrotto all'anno %d: %v; risultati parziali (anni %d-%d)", y, err, from, y-1))
+				res.Warnings = append(res.Warnings, fmt.Sprintf("sweep interrotto all'anno %d: %v; risultati parziali dagli anni %d-%d", y, err, from, y-1))
+				res.Warnings = appendSkippedWarning(res.Warnings, skipped, lastErr)
 				return res, nil
 			}
 			lastErr = err
@@ -338,12 +349,10 @@ func sweepYears(ctx context.Context, from, to int, fetch func(year int) (*Search
 			res.Items = append(res.Items, p)
 		}
 	}
-	if len(skipped) > 0 {
-		if len(res.Items) == 0 {
-			return nil, lastErr
-		}
-		res.Warnings = append(res.Warnings, fmt.Sprintf("anni non recuperati: %s (ultimo errore: %v)", strings.Join(skipped, ", "), lastErr))
+	if len(skipped) > 0 && len(res.Items) == 0 {
+		return nil, lastErr
 	}
+	res.Warnings = appendSkippedWarning(res.Warnings, skipped, lastErr)
 	return res, nil
 }
 

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/client.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/client.go
@@ -57,18 +57,20 @@ func New() *Client {
 
 // SearchOptions describes a provvedimenti query.
 type SearchOptions struct {
-	Testo   string // simple full-text
-	All     string // advanced: all of these words
-	Any     string // advanced: any of these words
-	Not     string // advanced: none of these words
-	Phrase  string // advanced: exact phrase
-	Tipo    string // sentenza|ordinanza|decreto|parere|plenaria|generale
-	Sede    string // roma|milano|consiglio-di-stato|...
-	Anno    int
-	Numero  int
-	Nrg     int
-	AnnoNrg int
-	Limit   int // max results to return
+	Testo    string // simple full-text
+	All      string // advanced: all of these words
+	Any      string // advanced: any of these words
+	Not      string // advanced: none of these words
+	Phrase   string // advanced: exact phrase
+	Tipo     string // sentenza|ordinanza|decreto|parere|plenaria|generale
+	Sede     string // roma|milano|consiglio-di-stato|...
+	Anno     int
+	AnnoFrom int // year-range sweep: first year (inclusive)
+	AnnoTo   int // year-range sweep: last year (inclusive)
+	Numero   int
+	Nrg      int
+	AnnoNrg  int
+	Limit    int // max results to return (per year when sweeping a year range)
 }
 
 func (c *Client) get(ctx context.Context, rawURL string) ([]byte, int, error) {
@@ -220,17 +222,80 @@ type SearchResult struct {
 	Total int
 }
 
-// Search runs a query, paginating until Limit results are collected. It performs
-// the session handshake on first use and retries once on a 403 (expired token).
+// Search runs a query and returns up to Limit results. It performs the session
+// handshake on first use. When a year range (AnnoFrom/AnnoTo) is set it sweeps
+// the years one by one — the portal has no relevance sort and only a single-year
+// filter, so historical coverage requires iterating the year filter — applying
+// Limit per year and de-duplicating the union by id.
 func (c *Client) Search(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
 	if opts.Limit <= 0 {
 		opts.Limit = defaultPageSize
+	}
+	if opts.Anno != 0 && (opts.AnnoFrom != 0 || opts.AnnoTo != 0) {
+		return nil, fmt.Errorf("usa --anno oppure --anno-from/--anno-to, non entrambi")
 	}
 	if c.token() == "" {
 		if err := c.handshake(ctx); err != nil {
 			return nil, err
 		}
 	}
+	if opts.AnnoFrom != 0 || opts.AnnoTo != 0 {
+		return c.searchSweep(ctx, opts)
+	}
+	return c.searchOnce(ctx, opts)
+}
+
+// yearRange normalizes an inclusive year span: a missing bound mirrors the
+// other, and a reversed span is swapped so from <= to.
+func yearRange(from, to int) (int, int) {
+	if from == 0 {
+		from = to
+	}
+	if to == 0 {
+		to = from
+	}
+	if from > to {
+		from, to = to, from
+	}
+	return from, to
+}
+
+// searchSweep iterates the year filter from AnnoFrom to AnnoTo (inclusive),
+// running searchOnce per year and de-duplicating the union by id (ECLI, else
+// idprovv). Limit applies per year. Total is the sum of per-year totals.
+func (c *Client) searchSweep(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
+	from, to := yearRange(opts.AnnoFrom, opts.AnnoTo)
+	res := &SearchResult{}
+	seen := map[string]bool{}
+	yearOpts := opts
+	yearOpts.AnnoFrom, yearOpts.AnnoTo = 0, 0
+	for y := from; y <= to; y++ {
+		yearOpts.Anno = y
+		part, err := c.searchOnce(ctx, yearOpts)
+		if err != nil {
+			return nil, err
+		}
+		res.Total += part.Total
+		for _, p := range part.Items {
+			id := p.Ecli
+			if id == "" {
+				id = p.Idprovv
+			}
+			if id != "" {
+				if seen[id] {
+					continue
+				}
+				seen[id] = true
+			}
+			res.Items = append(res.Items, p)
+		}
+	}
+	return res, nil
+}
+
+// searchOnce paginates a single query until Limit results are collected,
+// retrying once on a 403 (expired token).
+func (c *Client) searchOnce(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
 	res := &SearchResult{}
 	maxPages := (opts.Limit + defaultPageSize - 1) / defaultPageSize
 	for page := 1; page <= maxPages; page++ {

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/client.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/client.go
@@ -260,9 +260,23 @@ func yearRange(from, to int) (int, int) {
 	return from, to
 }
 
+// dedupKey identifies a provvedimento for de-duplication: ECLI, else idprovv,
+// else the document coordinates (schema|nrg|nome_file). It never returns "" for
+// a real result, so items lacking an ECLI/idprovv still de-duplicate instead of
+// being appended once per swept year.
+func dedupKey(p Provvedimento) string {
+	if p.Ecli != "" {
+		return p.Ecli
+	}
+	if p.Idprovv != "" {
+		return p.Idprovv
+	}
+	return p.Schema + "|" + p.Nrg + "|" + p.NomeFile
+}
+
 // searchSweep iterates the year filter from AnnoFrom to AnnoTo (inclusive),
-// running searchOnce per year and de-duplicating the union by id (ECLI, else
-// idprovv). Limit applies per year. Total is the sum of per-year totals.
+// running searchOnce per year and de-duplicating the union by dedupKey. Limit
+// applies per year. Total is the sum of per-year totals.
 func (c *Client) searchSweep(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
 	from, to := yearRange(opts.AnnoFrom, opts.AnnoTo)
 	res := &SearchResult{}
@@ -277,16 +291,11 @@ func (c *Client) searchSweep(ctx context.Context, opts SearchOptions) (*SearchRe
 		}
 		res.Total += part.Total
 		for _, p := range part.Items {
-			id := p.Ecli
-			if id == "" {
-				id = p.Idprovv
+			key := dedupKey(p)
+			if seen[key] {
+				continue
 			}
-			if id != "" {
-				if seen[id] {
-					continue
-				}
-				seen[id] = true
-			}
+			seen[key] = true
 			res.Items = append(res.Items, p)
 		}
 	}

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/client.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/client.go
@@ -2,6 +2,7 @@ package gaclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -216,10 +217,13 @@ func (c *Client) buildSearchURL(opts SearchOptions, cur int) string {
 	return BaseURL + formPath + "?" + v.Encode()
 }
 
-// SearchResult bundles the rows of a search with the reported total.
+// SearchResult bundles the rows of a search with the reported total. Warnings
+// carries non-fatal notices (a year skipped during a sweep) for the caller to
+// surface on stderr; results are still usable.
 type SearchResult struct {
-	Items []Provvedimento
-	Total int
+	Items    []Provvedimento
+	Total    int
+	Warnings []string
 }
 
 // Search runs a query and returns up to Limit results. It performs the session
@@ -274,20 +278,55 @@ func dedupKey(p Provvedimento) string {
 	return p.Schema + "|" + p.Nrg + "|" + p.NomeFile
 }
 
+// fatalSweepError reports whether an error must abort a whole sweep instead of
+// skipping the failing year: rate limiting (further years would only hit more
+// of it) and a cancelled/expired context.
+func fatalSweepError(ctx context.Context, err error) bool {
+	var rle *cliutil.RateLimitError
+	if errors.As(err, &rle) {
+		return true
+	}
+	return ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
 // searchSweep iterates the year filter from AnnoFrom to AnnoTo (inclusive),
 // running searchOnce per year and de-duplicating the union by dedupKey. Limit
 // applies per year. Total is the sum of per-year totals.
+//
+// A transient failure on one year (timeout, network) does not discard the years
+// already collected: that year is skipped and reported in Warnings. Rate limits
+// and a cancelled context abort the sweep, and an error is returned only when no
+// year succeeded at all.
 func (c *Client) searchSweep(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
 	from, to := yearRange(opts.AnnoFrom, opts.AnnoTo)
-	res := &SearchResult{}
-	seen := map[string]bool{}
 	yearOpts := opts
 	yearOpts.AnnoFrom, yearOpts.AnnoTo = 0, 0
-	for y := from; y <= to; y++ {
+	return sweepYears(ctx, from, to, func(y int) (*SearchResult, error) {
 		yearOpts.Anno = y
-		part, err := c.searchOnce(ctx, yearOpts)
+		return c.searchOnce(ctx, yearOpts)
+	})
+}
+
+// sweepYears merges the per-year results of fetch over an inclusive year span,
+// applying the skip/abort policy described on searchSweep.
+func sweepYears(ctx context.Context, from, to int, fetch func(year int) (*SearchResult, error)) (*SearchResult, error) {
+	res := &SearchResult{}
+	seen := map[string]bool{}
+	var skipped []string
+	var lastErr error
+	for y := from; y <= to; y++ {
+		part, err := fetch(y)
 		if err != nil {
-			return nil, err
+			if fatalSweepError(ctx, err) {
+				if len(res.Items) == 0 {
+					return nil, err
+				}
+				res.Warnings = append(res.Warnings, fmt.Sprintf("sweep interrotto all'anno %d: %v; risultati parziali (anni %d-%d)", y, err, from, y-1))
+				return res, nil
+			}
+			lastErr = err
+			skipped = append(skipped, strconv.Itoa(y))
+			continue
 		}
 		res.Total += part.Total
 		for _, p := range part.Items {
@@ -298,6 +337,12 @@ func (c *Client) searchSweep(ctx context.Context, opts SearchOptions) (*SearchRe
 			seen[key] = true
 			res.Items = append(res.Items, p)
 		}
+	}
+	if len(skipped) > 0 {
+		if len(res.Items) == 0 {
+			return nil, lastErr
+		}
+		res.Warnings = append(res.Warnings, fmt.Sprintf("anni non recuperati: %s (ultimo errore: %v)", strings.Join(skipped, ", "), lastErr))
 	}
 	return res, nil
 }

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/frontmatter.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/frontmatter.go
@@ -39,10 +39,30 @@ func FrontMatter(p Provvedimento) string {
 	return b.String()
 }
 
-// yamlQuote returns s as a YAML double-quoted scalar, escaping backslashes and
-// double quotes.
+// yamlQuote returns s as a YAML double-quoted scalar. Besides backslash and
+// double quote, it escapes the control characters that are invalid inside a
+// double-quoted scalar (newline, carriage return, tab) so a stray CR/LF from
+// CRLF-encoded HTML can never produce syntactically invalid YAML.
 func yamlQuote(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	return `"` + s + `"`
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/frontmatter.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/frontmatter.go
@@ -1,0 +1,48 @@
+package gaclient
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FrontMatter renders a YAML front-matter block (delimited by ---) describing a
+// provvedimento, emitting only the non-empty mechanical fields. It is meant to
+// be prepended to the Markdown/text full text so the output is directly
+// archivable with structured, source-traceable metadata.
+//
+// String values are always double-quoted (sede/sezione/tipo may contain spaces
+// and ecli/url contain ':' '/' '&' '=' which are unsafe as bare YAML scalars).
+func FrontMatter(p Provvedimento) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	addStr := func(k, v string) {
+		if v != "" {
+			fmt.Fprintf(&b, "%s: %s\n", k, yamlQuote(v))
+		}
+	}
+	addInt := func(k string, v int) {
+		if v != 0 {
+			fmt.Fprintf(&b, "%s: %d\n", k, v)
+		}
+	}
+	addStr("ecli", p.Ecli)
+	addStr("tipo", p.Tipo)
+	addStr("sede", p.Sede)
+	addStr("sezione", p.Sezione)
+	addInt("numero", p.Numero)
+	addInt("anno", p.Anno)
+	addStr("nrg", p.Nrg)
+	addStr("data_deposito", p.DataDeposito)
+	addStr("formato", p.Formato)
+	addStr("url", p.URL)
+	b.WriteString("---\n")
+	return b.String()
+}
+
+// yamlQuote returns s as a YAML double-quoted scalar, escaping backslashes and
+// double quotes.
+func yamlQuote(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/frontmatter_test.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/frontmatter_test.go
@@ -1,0 +1,60 @@
+package gaclient
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFrontMatter(t *testing.T) {
+	p := Provvedimento{
+		Ecli:         "ECLI:IT:TARNA:2021:6765SENT",
+		Tipo:         "Sentenza",
+		Sede:         "NAPOLI",
+		Sezione:      "SEZIONE 6",
+		Numero:       6765,
+		Anno:         2021,
+		Nrg:          "202102978",
+		DataDeposito: "28/10/2021",
+		Formato:      "html",
+		URL:          "https://mdp.giustizia-amministrativa.it/visualizzah2/?schema=tar_na&nrg=202102978&nomeFile=202106765_01.html",
+	}
+	fm := FrontMatter(p)
+
+	if !strings.HasPrefix(fm, "---\n") || !strings.HasSuffix(fm, "---\n") {
+		t.Fatalf("front matter must be delimited by ---:\n%s", fm)
+	}
+	for _, want := range []string{
+		`ecli: "ECLI:IT:TARNA:2021:6765SENT"`,
+		`tipo: "Sentenza"`,
+		`sede: "NAPOLI"`,
+		`sezione: "SEZIONE 6"`,
+		"numero: 6765",
+		"anno: 2021",
+		`nrg: "202102978"`,
+		`data_deposito: "28/10/2021"`,
+		`formato: "html"`,
+		`url: "https://mdp.giustizia-amministrativa.it/visualizzah2/?schema=tar_na&nrg=202102978&nomeFile=202106765_01.html"`,
+	} {
+		if !strings.Contains(fm, want) {
+			t.Errorf("front matter missing %q in:\n%s", want, fm)
+		}
+	}
+}
+
+// Empty fields must be omitted; ints at zero must not appear.
+func TestFrontMatterOmitsEmpty(t *testing.T) {
+	fm := FrontMatter(Provvedimento{Nrg: "202102978"})
+	if strings.Contains(fm, "ecli:") || strings.Contains(fm, "numero:") || strings.Contains(fm, "anno:") {
+		t.Errorf("empty/zero fields should be omitted:\n%s", fm)
+	}
+	if !strings.Contains(fm, `nrg: "202102978"`) {
+		t.Errorf("present field nrg should be emitted:\n%s", fm)
+	}
+}
+
+// String values containing quotes/backslashes must be escaped.
+func TestYAMLQuoteEscaping(t *testing.T) {
+	if got := yamlQuote(`a"b\c`); got != `"a\"b\\c"` {
+		t.Errorf("yamlQuote = %s", got)
+	}
+}

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/frontmatter_test.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/frontmatter_test.go
@@ -58,3 +58,19 @@ func TestYAMLQuoteEscaping(t *testing.T) {
 		t.Errorf("yamlQuote = %s", got)
 	}
 }
+
+// Control characters (CR/LF/TAB) must be escaped so a stray CR from CRLF HTML
+// cannot produce invalid YAML. A real front-matter value carrying a CR must
+// keep the block on a single logical line (no raw newline leaks).
+func TestYAMLQuoteControlChars(t *testing.T) {
+	if got := yamlQuote("a\r\nb\tc"); got != `"a\r\nb\tc"` {
+		t.Errorf("yamlQuote control chars = %s", got)
+	}
+	fm := FrontMatter(Provvedimento{DataDeposito: "28/10/2021\r"})
+	if strings.Contains(fm, "\r") {
+		t.Errorf("front matter leaked a raw CR:\n%q", fm)
+	}
+	if !strings.Contains(fm, `data_deposito: "28/10/2021\r"`) {
+		t.Errorf("CR not escaped in front matter:\n%s", fm)
+	}
+}

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/sweep_test.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/sweep_test.go
@@ -1,0 +1,22 @@
+package gaclient
+
+import "testing"
+
+func TestYearRange(t *testing.T) {
+	cases := []struct {
+		from, to     int
+		wantF, wantT int
+	}{
+		{2016, 2026, 2016, 2026}, // normal span
+		{2020, 0, 2020, 2020},    // only from → single year
+		{0, 2020, 2020, 2020},    // only to → single year
+		{2026, 2016, 2016, 2026}, // reversed → swapped
+		{2021, 2021, 2021, 2021}, // single year
+	}
+	for _, c := range cases {
+		f, to := yearRange(c.from, c.to)
+		if f != c.wantF || to != c.wantT {
+			t.Errorf("yearRange(%d,%d) = (%d,%d), want (%d,%d)", c.from, c.to, f, to, c.wantF, c.wantT)
+		}
+	}
+}

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/sweep_test.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/sweep_test.go
@@ -1,6 +1,16 @@
 package gaclient
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/giustizia-amministrativa/internal/cliutil"
+)
 
 func TestYearRange(t *testing.T) {
 	cases := []struct {
@@ -37,5 +47,95 @@ func TestDedupKey(t *testing.T) {
 	}
 	if dedupKey(noID) != dedupKey(noID) {
 		t.Errorf("dedupKey not stable for identical items")
+	}
+}
+
+func TestSweepYearsKeepsResultsWhenAYearFails(t *testing.T) {
+	// A transient failure on 2021 must not discard 2020 and 2022: the year is
+	// skipped, the union is still returned, and the gap is reported in Warnings.
+	fetch := func(y int) (*SearchResult, error) {
+		if y == 2021 {
+			return nil, errors.New("timeout")
+		}
+		return &SearchResult{
+			Items: []Provvedimento{{Ecli: fmt.Sprintf("ECLI:%d", y)}, {Ecli: "ECLI:DUP"}},
+			Total: 10,
+		}, nil
+	}
+	res, err := sweepYears(context.Background(), 2020, 2022, fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 2020 + 2022, with the shared ECLI:DUP de-duplicated across years.
+	if len(res.Items) != 3 {
+		t.Errorf("got %d items, want 3", len(res.Items))
+	}
+	if res.Total != 20 {
+		t.Errorf("got Total %d, want 20 (only the years that succeeded)", res.Total)
+	}
+	if len(res.Warnings) != 1 || !strings.Contains(res.Warnings[0], "2021") {
+		t.Errorf("expected a warning naming 2021, got %v", res.Warnings)
+	}
+}
+
+func TestSweepYearsErrorsWhenNoYearSucceeds(t *testing.T) {
+	// Nothing collected: the caller must see the failure, not an empty result.
+	fetch := func(int) (*SearchResult, error) { return nil, errors.New("boom") }
+	if _, err := sweepYears(context.Background(), 2020, 2022, fetch); err == nil {
+		t.Error("expected an error when every year fails")
+	}
+}
+
+func TestSweepYearsAbortsOnRateLimit(t *testing.T) {
+	// Rate limiting stops the sweep (more years mean more 429s) but keeps what
+	// was already collected.
+	calls := 0
+	fetch := func(y int) (*SearchResult, error) {
+		calls++
+		if y == 2021 {
+			return nil, &cliutil.RateLimitError{URL: "https://x", RetryAfter: time.Second}
+		}
+		return &SearchResult{Items: []Provvedimento{{Ecli: fmt.Sprintf("ECLI:%d", y)}}, Total: 5}, nil
+	}
+	res, err := sweepYears(context.Background(), 2020, 2025, fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("sweep did not stop at the rate limit: %d fetches", calls)
+	}
+	if len(res.Items) != 1 {
+		t.Errorf("got %d items, want the 2020 result kept", len(res.Items))
+	}
+	if len(res.Warnings) == 0 {
+		t.Error("expected a warning about the interrupted sweep")
+	}
+}
+
+func TestFatalSweepError(t *testing.T) {
+	// A transient per-year failure must not abort the sweep (the years already
+	// collected would be lost); rate limiting and a cancelled context must.
+	live := context.Background()
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{"network timeout", live, &net.DNSError{Err: "timeout", IsTimeout: true}, false},
+		{"generic parse failure", live, errors.New("nessun risultato nella pagina"), false},
+		{"wrapped transient", live, fmt.Errorf("anno 2019: %w", errors.New("EOF")), false},
+		{"rate limit", live, &cliutil.RateLimitError{URL: "https://x", RetryAfter: time.Second}, true},
+		{"wrapped rate limit", live, fmt.Errorf("anno 2019: %w", &cliutil.RateLimitError{URL: "https://x"}), true},
+		{"context cancelled", cancelled, errors.New("request failed"), true},
+		{"deadline exceeded", live, context.DeadlineExceeded, true},
+	}
+	for _, c := range cases {
+		if got := fatalSweepError(c.ctx, c.err); got != c.want {
+			t.Errorf("%s: fatalSweepError = %v, want %v", c.name, got, c.want)
+		}
 	}
 }

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/sweep_test.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/sweep_test.go
@@ -20,3 +20,22 @@ func TestYearRange(t *testing.T) {
 		}
 	}
 }
+
+func TestDedupKey(t *testing.T) {
+	// ECLI wins; then idprovv; then the document coordinates. An item lacking
+	// every identifier must still yield a stable, non-empty key so the sweep
+	// de-duplicates it instead of repeating it once per year.
+	if got := dedupKey(Provvedimento{Ecli: "E", Idprovv: "I"}); got != "E" {
+		t.Errorf("ecli should win, got %q", got)
+	}
+	if got := dedupKey(Provvedimento{Idprovv: "I"}); got != "I" {
+		t.Errorf("idprovv fallback, got %q", got)
+	}
+	noID := Provvedimento{Schema: "tar_na", Nrg: "202102978", NomeFile: "202106765_01.html"}
+	if got := dedupKey(noID); got != "tar_na|202102978|202106765_01.html" {
+		t.Errorf("coordinate fallback, got %q", got)
+	}
+	if dedupKey(noID) != dedupKey(noID) {
+		t.Errorf("dedupKey not stable for identical items")
+	}
+}

--- a/library/productivity/giustizia-amministrativa/internal/gaclient/sweep_test.go
+++ b/library/productivity/giustizia-amministrativa/internal/gaclient/sweep_test.go
@@ -112,6 +112,31 @@ func TestSweepYearsAbortsOnRateLimit(t *testing.T) {
 	}
 }
 
+func TestSweepYearsReportsSkippedYearsWhenItLaterAborts(t *testing.T) {
+	// 2021 skipped (transient), 2022 aborts (rate limit): the abort must not
+	// hide the fact that 2021 is missing from the range too.
+	fetch := func(y int) (*SearchResult, error) {
+		switch y {
+		case 2021:
+			return nil, errors.New("timeout")
+		case 2022:
+			return nil, &cliutil.RateLimitError{URL: "https://x"}
+		}
+		return &SearchResult{Items: []Provvedimento{{Ecli: fmt.Sprintf("ECLI:%d", y)}}, Total: 5}, nil
+	}
+	res, err := sweepYears(context.Background(), 2020, 2025, fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(res.Warnings, " | ")
+	if !strings.Contains(joined, "2021") {
+		t.Errorf("the transiently skipped year vanished from the warnings: %q", joined)
+	}
+	if !strings.Contains(joined, "2022") {
+		t.Errorf("the aborting year is not reported: %q", joined)
+	}
+}
+
 func TestFatalSweepError(t *testing.T) {
 	// A transient per-year failure must not abort the sweep (the years already
 	// collected would be lost); rate limiting and a cancelled context must.


### PR DESCRIPTION
Improvements to the **giustizia-amministrativa** CLI around discovering and archiving rulings. Three related parts.

## 1. `get --front-matter`

Prepends a YAML block (ecli, tipo, sede, sezione, numero, anno, nrg, data_deposito, formato, url) to `md`/`text` output, so a single `get` produces a self-contained, archivable, source-traceable file. **Why:** `get` already extracts the deposit date (`Pubblicato il`) into `data_deposito`, but it lives only in the raw HTML and the Markdown renderer drops it — archiving previously required a second HTTP fetch just for the date. No-op for `--json`/`--format html`; strings are double-quoted and control characters (`\n \r \t`) escaped.

## 2. `corpus build` — incremental + dry-run

- `--skip-existing`: provvedimenti whose `.md` already exists in `--out` are not refetched (incremental corpus); they stay in the manifest from search metadata.
- `--plan`: list candidates into the manifest without downloading, to review a query before committing N requests.
- `--front-matter` (opt-in): use the same YAML block as `get --front-matter` as the per-file header. Default keeps the previous Markdown header (no format change for existing consumers).

## 3. `search` / `corpus build` — `--anno-from` / `--anno-to` (historical sweep)

The portal exposes **no relevance sort** and only a **single-year filter**, so date-desc results bury older rulings on a theme. The range flags sweep the year filter one year at a time, applying `--limit` per year and de-duplicating the union by id — the only way to get balanced historical coverage. `--anno` and the range are mutually exclusive.

## Tests

New unit tests: `FrontMatter` (fields, omission, quote + control-char escaping) and `TestYearRange` (range normalization). `go build ./...`, `go vet`, `go test ./...` all green; all three features verified live.