### PR TITLE
chore: ignore private project skill installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,4 @@ AGENTS.override.md
 .codex/skills/
 .cursor/skills/
 .gemini/skills/
-skills-lock.json
+/skills-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,16 @@ Thumbs.db
 CLAUDE.local.md
 AGENTS.override.md
 .claude/settings.local.json
+
+# Local project-scoped agent skill/plugin installs. These let private or
+# experimental skills live next to this checkout without being published from
+# this public repo. Already-tracked files remain tracked unless intentionally
+# removed from git later.
+.claude/skills/
+.claude/plugins/
+.skills/
+.agents/skills/
+.codex/skills/
+.cursor/skills/
+.gemini/skills/
+skills-lock.json


### PR DESCRIPTION
## Summary

Project-scoped private agent skills can now live beside this public library checkout without showing up as untracked files or getting committed by accident.

This ignores only the project skill install locations, the existing Claude plugin path, and the repo-root `/skills-lock.json`, so broader agent configuration remains visible if the repo ever wants to track it intentionally. The local project install has been updated to the latest private Printing Press skills, but those private skill files stay outside the PR.

## Verification

- `git diff --check`
- `git check-ignore -v skills-lock.json .agents/skills/pp-fix-batch/SKILL.md .codex/skills/foo .claude/skills/pp-fix-batch`
- Confirmed `skills/example/skills-lock.json` is not ignored

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
