### PR TITLE
chore: limit private skill ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,12 +62,11 @@ CLAUDE.local.md
 AGENTS.override.md
 .claude/settings.local.json
 
-# Local project-scoped agent skill/plugin installs. These let private or
+# Local project-scoped agent skill installs. These let private or
 # experimental skills live next to this checkout without being published from
 # this public repo. Already-tracked files remain tracked unless intentionally
 # removed from git later.
 .claude/skills/
-.claude/plugins/
 .skills/
 .agents/skills/
 .codex/skills/


### PR DESCRIPTION
## Summary

Private project skill installs stay local without also hiding plugin directories that this repo is not using for the install flow.

This keeps the project-scoped skill ignore paths and repo-root `/skills-lock.json`, while removing the leftover Claude plugin ignore from the previous setup PR. Plugin directories remain visible for intentional tracking or review.

## Verification

- `git diff --check`
- `git check-ignore -v .claude/skills/example .agents/skills/example .codex/skills/example .cursor/skills/example .gemini/skills/example skills-lock.json`
- Confirmed plugin paths and nested `skills/example/skills-lock.json` are not ignored

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
