### PR TITLE
fix(google-search-console): URL-escape siteUrl/feedpath in API paths

### DIFF
--- a/library/marketing/google-search-console/internal/cli/helpers.go
+++ b/library/marketing/google-search-console/internal/cli/helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"io"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -198,7 +199,9 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 }
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", value)
+	// Percent-encode the value as a single path segment so URL-shaped path params
+	// (siteUrl "https://site/", feedpath) do not inject extra slashes -> 404 / 0 rows.
+	return strings.ReplaceAll(path, "{"+name+"}", url.QueryEscape(value))
 }
 
 // printJSONFiltered marshals a Go-typed value through the same output

--- a/library/marketing/google-search-console/internal/cli/sync.go
+++ b/library/marketing/google-search-console/internal/cli/sync.go
@@ -191,7 +191,7 @@ func syncSearchAnalytics(ctx context.Context, c apiClient, s *store.Store, site,
 		if searchType != "" {
 			body["type"] = searchType
 		}
-		path := strings.ReplaceAll("/webmasters/v3/sites/{siteUrl}/searchAnalytics/query", "{siteUrl}", site)
+		path := replacePathParam("/webmasters/v3/sites/{siteUrl}/searchAnalytics/query", "siteUrl", site)
 		data, _, err := c.Post(path, body)
 		if err != nil {
 			return total, err
@@ -262,7 +262,7 @@ func syncSearchAnalytics(ctx context.Context, c apiClient, s *store.Store, site,
 
 // syncSitemaps pulls the sitemap list for a site and snapshots every entry.
 func syncSitemaps(ctx context.Context, c apiClient, s *store.Store, site string) (int, error) {
-	path := strings.ReplaceAll("/webmasters/v3/sites/{siteUrl}/sitemaps", "{siteUrl}", site)
+	path := replacePathParam("/webmasters/v3/sites/{siteUrl}/sitemaps", "siteUrl", site)
 	data, err := c.Get(path, nil)
 	if err != nil {
 		return 0, err

--- a/library/marketing/google-search-console/internal/mcp/tools.go
+++ b/library/marketing/google-search-console/internal/mcp/tools.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -185,7 +186,7 @@ func makeAPIHandler(method, pathTemplate string, bindings []mcpParamBinding, pos
 			case "path":
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, url.QueryEscape(fmt.Sprintf("%v", v)), 1)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:
@@ -199,7 +200,7 @@ func makeAPIHandler(method, pathTemplate string, bindings []mcpParamBinding, pos
 			}
 			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, url.QueryEscape(fmt.Sprintf("%v", v)), 1)
 			}
 		}
 


### PR DESCRIPTION
## Problem

Path params (`siteUrl`, `feedpath`) are spliced into the request path with raw `strings.ReplaceAll` / `strings.Replace`, with no escaping. A real site URL like `https://www.example.com/` produces:

```
/webmasters/v3/sites/https://www.example.com//searchAnalytics/query
```

The embedded `://` and trailing `/` break the path, so the Search Console API returns 404 / 0 rows. The `{siteUrl}` segment must be percent-encoded as `https%3A%2F%2Fwww.example.com%2F`.

## Symptom

On a property with real traffic, `sync` returned **0 analytics rows** over 90 days. The sitemaps call surfaced the malformed path in a warning:

```
warning: sitemaps for https://www.example.com/ failed:
GET /webmasters/v3/sites/https://www.example.com//sitemaps returned HTTP 404
```

`webmasters list-sites` works because it has no path param; every command that injects `{siteUrl}`/`{feedpath}` is affected.

## Fix

Percent-encode path params at the chokepoints:

- `internal/cli/helpers.go` — `replacePathParam` now wraps the value in `url.QueryEscape`.
- `internal/cli/sync.go` — the two raw `strings.ReplaceAll` calls (searchAnalytics + sitemaps) now route through the fixed `replacePathParam`.
- `internal/mcp/tools.go` — both path-binding substitutions encode the value.

This covers `sync` (analytics + sitemaps), `search_analytics_workflows`, all `webmasters_*` commands, and the MCP `webmasters` tools.

## Verification

- `go build ./...`, `gofmt -l`, `go vet` all clean.
- After the fix, `sync` returns 91,183 analytics rows for a real property (was 0); `roll-up` returns correct top queries.

## Note

The root cause lives in generator-emitted code (`replacePathParam`, MCP binding loop), so this likely affects every printed CLI whose API uses URL-shaped path params. Filing a companion issue on `mvanhorn/cli-printing-press` so the generator gets fixed upstream.
