### PR TITLE
fix(amazon-orders): reject auth-wall HTML

### DIFF
--- a/docs/plans/2026-06-30-001-fix-amazon-orders-authenticated-html-guard-plan.md
+++ b/docs/plans/2026-06-30-001-fix-amazon-orders-authenticated-html-guard-plan.md
@@ -1,0 +1,313 @@
+---
+title: "fix(amazon-orders): reject login HTML and repair authenticated order reads"
+type: fix
+created: 2026-06-30
+depth: standard
+target_repo: printing-press-library
+target_path: library/commerce/amazon-orders
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# fix(amazon-orders): reject login HTML and repair authenticated order reads
+
+## Goal Capsule
+
+| Field | Value |
+|---|---|
+| Objective | Make `amazon-orders-pp-cli` fail honestly when Amazon returns login or challenge HTML, and stop the CLI from parsing or caching that HTML as real orders, invoices, or transactions. |
+| Authority hierarchy | User runtime evidence from 2026-06-30; `library/commerce/amazon-orders/AGENTS.md`; repo patch convention in `AGENTS.md`; existing Amazon Orders CLI behavior and tests. |
+| Execution profile | Code fix in the published library CLI, with characterization tests before behavior changes where practical. |
+| Stop conditions | A live Amazon login page must never be returned as an unrelated order, a successful empty order list, an invoice page, or cached synced data. |
+| Tail ownership | LFG should continue through implementation, review, verification, commit/PR, and CI per the active pipeline. |
+
+---
+
+## Product Contract
+
+### Summary
+
+`amazon-orders-pp-cli` currently treats Amazon sign-in HTML as successful data because Amazon returns the login page with HTTP 200. In the user runtime, `doctor` reported auth as valid and cache as fresh, but `orders get 702-5010515-8774615` returned an unrelated order-like payload, `orders list` produced no useful results, `find Aqara` found nothing, and `sync` stored sign-in pages for `orders` and `transactions`.
+
+This fix makes authenticated HTML validation explicit. Commands that require logged-in Amazon pages must detect sign-in or bot-challenge pages before parsing and before writing to the local SQLite store. Local reads must also address endpoint identity correctly so order-detail cache lookups use the requested `orderID`, not the static path segment `order-details`.
+
+### Problem Frame
+
+Amazon buyer pages are authenticated, server-rendered HTML, not a documented buyer API. The current HTTP client correctly sees a network-level success when Amazon replies with status 200, but status 200 is not proof that the requested authenticated surface was delivered. The parser layer then makes the failure worse: order-detail parsing accepts any page with an order-shaped token, order-list parsing accepts a login page as an empty order list, invoice extraction reports the login page title, and sync writes raw login HTML into the local store.
+
+The bug is high-impact for finance triage because the CLI may appear authenticated and current while withholding the actual order and payment evidence needed to classify a purchase.
+
+### Requirements
+
+**Authenticated content validation**
+- R1. Authenticated Amazon HTML commands must reject login, sign-in, and bot/challenge pages before parsing user data.
+- R2. `orders get <orderID>` must never return a parsed detail whose `orderId` differs from the requested `orderID`.
+- R3. `orders list`, `find`, novel order-list commands, `transactions`, `orders invoice`, and sync must not treat sign-in HTML as successful empty data or successful page metadata.
+- R4. `doctor` must validate the same authenticated order-history surface used by real commands, not only a saved browser-session proof file or generic `/` reachability.
+
+**Cache and local-read correctness**
+- R5. `sync`, live read-through caching, and local fallback must not persist or serve sign-in HTML as trusted SQLite data, including rows written by older binaries.
+- R6. Local reads for order detail and invoice must key by the relevant request parameter, especially `orderID`, instead of deriving identity from the static path segment.
+
+**Runtime configuration and operator safety**
+- R7. The fix must preserve support for configured Amazon domains and base URLs, including Amazon Mexico setups that use `amazon.com.mx`, rather than hardcoding all validation and hints to `amazon.com`.
+- R8. Error output must be actionable and safe: no cookies or auth material in messages; remediation should point to `amazon-orders-pp-cli auth login --chrome` and `amazon-orders-pp-cli doctor`.
+- R9. Existing successful parses for legitimate order-list, order-detail, invoice, transaction, and search flows must keep working.
+
+### Acceptance Examples
+
+- AE1. Given Amazon returns `<title>Amazon Iniciar sesion</title>` or `<title>Amazon Sign-In</title>` for `/your-orders/order-details?orderID=702-5010515-8774615`, when `orders get 702-5010515-8774615 --json --data-source live --no-cache` runs, then the command exits non-zero with an auth/session hint and does not emit another order ID. The detector should handle accented and unaccented Spanish sign-in titles.
+- AE2. Given Amazon returns a sign-in page for `/your-orders/orders`, when `orders list --data-source live` runs, then the command exits non-zero instead of returning `[]` or `results: null` as a successful order list.
+- AE3. Given Amazon returns a sign-in page during `sync --resources orders,transactions`, when the sync completes, then those resources are reported as failed/auth-invalid and no sign-in page rows are written to the `resources` table.
+- AE4. Given a local SQLite store contains a real parsed order detail keyed by `702-5010515-8774615`, when `orders get 702-5010515-8774615 --data-source local` runs, then the local lookup asks for that order ID, not `order-details`.
+- AE5. Given a configured base URL of `https://www.amazon.com.mx`, when `doctor` validates credentials, then diagnostics and proof checks use the configured host/domain semantics and do not reject solely because the default spec domain is `.amazon.com`.
+- AE6. Given an older local SQLite store already contains an `orders` or `transactions` row whose body is Amazon sign-in HTML, when any local or auto-fallback command reads it, then the command rejects or skips that row instead of treating the cache as fresh usable data.
+
+### Scope Boundaries
+
+In scope:
+- Add a shared authenticated-page guard for Amazon login, sign-in, and challenge HTML.
+- Apply the guard before parsing command responses and before cache/store writes.
+- Tighten `doctor` and browser-session proof validation around real authenticated content.
+- Fix endpoint identity for local order detail/invoice reads and list-vs-detail local reads where this CLI currently misroutes them.
+- Add regression tests and a `.printing-press-patches/` entry.
+
+Outside this PR:
+- Building a new browser automation backfill flow.
+- Rewriting Amazon parsers for every locale or A/B layout.
+- Adding full CFDI/fiscal package processing. This CLI only provides the Amazon evidence surface.
+- Changing the Printing Press generator globally unless implementation proves the defect is shared and cannot be solved as a CLI-local published-library patch.
+
+### Open Questions
+
+No blocking product questions remain.
+
+Deferred:
+- DQ1. Whether the upstream Printing Press generator should learn a generic "HTML auth-wall guard" for all authenticated scraping CLIs. This PR should record the Amazon-specific patch first; upstreaming can follow once the local fix is proven.
+
+### Sources
+
+- User runtime evidence from 2026-06-30: `doctor` reported configured auth/fresh cache while live/local order reads, `find Aqara`, and `sync` returned or stored sign-in pages.
+- `AGENTS.md` for published-library patch metadata requirements.
+- `library/commerce/amazon-orders/AGENTS.md` for CLI-specific runtime discovery and patching rules.
+- `docs/patterns/authenticated-session-scraping.md` for the repo's authenticated scraping model.
+- `library/commerce/amazon-orders/internal/client/client.go`
+- `library/commerce/amazon-orders/internal/cli/data_source.go`
+- `library/commerce/amazon-orders/internal/cli/sync.go`
+- `library/commerce/amazon-orders/internal/cli/doctor.go`
+- `library/commerce/amazon-orders/internal/cli/auth.go`
+- `library/commerce/amazon-orders/internal/cli/orders_get.go`
+- `library/commerce/amazon-orders/internal/cli/orders_list.go`
+- `library/commerce/amazon-orders/internal/cli/orders_invoice.go`
+- `library/commerce/amazon-orders/internal/cli/promoted_transactions.go`
+- `library/commerce/amazon-orders/internal/parser/order_detail.go`
+- `library/commerce/amazon-orders/internal/parser/orders_list.go`
+- `library/commerce/amazon-orders/internal/parser/transactions.go`
+- `library/commerce/amazon-orders/internal/store/store.go`
+- `library/commerce/amazon-orders/spec.yaml`
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Put auth-wall detection in shared CLI/parser-adjacent code, not as one-off checks inside every command. The failure mode crosses live reads, parser entry points, doctor, sync, and cache write-through; a single tested classifier keeps behavior consistent.
+- KTD2. Treat HTTP 200 plus sign-in/challenge HTML as an auth error. For authenticated scraping, content identity is part of auth validation. A status-code-only client success is insufficient for Amazon buyer pages.
+- KTD3. Guard before persistence. It is not enough for parsers to reject login pages after the fact because `sync` and write-through caching can store raw HTML before a parser ever sees it.
+- KTD4. Keep parser-level safeguards too. Command-level guards catch the common path, but parser tests should also prove login HTML and mismatched order IDs cannot accidentally become structured user data.
+- KTD5. Repair local identity with explicit endpoint IDs. `resolveLocal` currently derives get-by-ID identity from the last path segment. Amazon detail and invoice endpoints carry the useful ID in `orderID`, so local lookup must use that parameter or a command-provided local ID.
+- KTD6. Preserve configured host/domain behavior. The implementation should derive validation URLs and cookie-domain expectations from config/spec/runtime where available, so `.amazon.com.mx` sessions are not invalidated by `.amazon.com` constants.
+- KTD7. Make auth failures durable and agent-readable. JSON mode should expose a stable error surface or existing exit-code path while human mode gives concise remediation, with no cookie leakage.
+- KTD8. Use a library-side patch record. This is a published CLI repair under `library/commerce/amazon-orders`; add one `.printing-press-patches/<id>.json` entry capturing the durable behavior a reprint must preserve.
+
+### High-Level Technical Design
+
+The fix has two guard layers:
+
+1. **Authenticated HTML classifier:** a small Amazon-specific helper inspects a bounded prefix/body text for sign-in and challenge markers, including English and Spanish titles, common sign-in form/action names, and existing interstitial markers. It returns a typed classification with a safe reason string.
+2. **Read/persistence enforcement:** live, local, and cache-backed HTML reads call the classifier before handing bytes to parsers or SQLite. Login/challenge classifications return an auth-style error that `classifyAPIError`, sync, and doctor can render.
+
+Local reads get a second correction: get-by-ID resolution accepts an explicit local ID derived from `orderID` where the endpoint uses query parameters rather than path IDs. List endpoints that naturally return pages of orders or transactions should use local list behavior instead of attempting to fetch a fake ID from the path.
+
+### Implementation Constraints
+
+- Keep edits scoped to `library/commerce/amazon-orders`.
+- Do not introduce new external services or browser dependencies.
+- Do not print cookies, raw auth headers, or full login HTML in errors.
+- Prefer fixtures or small inline HTML samples over live Amazon calls in tests.
+- Keep generated-code comments minimal and mark durable generated-tree customizations through `.printing-press-patches/`.
+
+### Sequencing
+
+1. Characterize login-page and mismatched-order failures with tests.
+2. Add the shared classifier and typed auth error surface.
+3. Apply the classifier to live reads, parsers, sync, and doctor.
+4. Repair local endpoint identity/list behavior.
+5. Add patch metadata and run verification/dogfood.
+
+---
+
+## Implementation Units
+
+### U1. Characterize authenticated HTML failure cases
+
+- **Goal:** Lock in the observed bad behavior with tests before changing production paths.
+- **Requirements:** R1, R2, R3, R5
+- **Files:**
+  - `library/commerce/amazon-orders/internal/parser/parser_test.go`
+  - `library/commerce/amazon-orders/internal/cli/data_source_test.go` (create if no better local test file exists)
+  - `library/commerce/amazon-orders/internal/cli/sync_test.go` (create or extend if test seams are practical)
+  - `library/commerce/amazon-orders/internal/cli/novel_helpers_test.go` (create if guarding `fetchOrderListPages` needs direct coverage)
+- **Approach:** Add minimal fixtures for Amazon sign-in HTML in English and Spanish, plus an order-detail HTML snippet whose body contains a different order ID than the requested one. Prefer focused unit tests over live network.
+- **Test Scenarios:**
+  - Sign-in HTML is detected as unauthenticated.
+  - Spanish sign-in titles, including accented and unaccented renderings, are detected as unauthenticated.
+  - `ParseOrderDetail` plus the command/request validation path cannot accept a mismatched order ID.
+  - `fetchOrderListPages` cannot turn sign-in HTML into an empty successful search/list result.
+  - Local/cache-backed sign-in rows written by an older binary are rejected or skipped.
+  - Empty legitimate pages and malformed HTML produce distinct errors from auth-wall pages.
+- **Verification:** `go test ./internal/parser ./internal/cli -run 'Auth|Login|Sign|OrderID|Sync'` passes from `library/commerce/amazon-orders`.
+
+### U2. Add shared Amazon authenticated-page guard
+
+- **Goal:** Provide one tested classifier/error path for sign-in, login, and challenge HTML.
+- **Requirements:** R1, R3, R8, R9
+- **Files:**
+  - `library/commerce/amazon-orders/internal/cli/authenticated_html.go` (create)
+  - `library/commerce/amazon-orders/internal/cli/authenticated_html_test.go` (create)
+  - `library/commerce/amazon-orders/internal/cli/helpers.go`
+  - `library/commerce/amazon-orders/internal/parser/parser.go` (only if parser-level reuse belongs there)
+- **Approach:** Implement a bounded-body classifier with safe markers such as Amazon sign-in titles, sign-in form/action identifiers, account login path fragments, and existing bot-interstitial markers. Return a typed error that maps to auth exit behavior and structured hints.
+- **Test Scenarios:**
+  - English `Amazon Sign-In` page is rejected.
+  - Spanish `Amazon Iniciar sesion` page is rejected.
+  - A normal order-list fixture with `order-card` content is not rejected.
+  - A normal order-detail fixture with `ORDER #` and item links is not rejected.
+  - Returned errors do not include raw cookie strings or full HTML.
+- **Verification:** `go test ./internal/cli -run AuthenticatedHTML` passes.
+
+### U3. Enforce the guard on live reads, local/cache reads, write-through, and sync
+
+- **Goal:** Stop login HTML before it reaches parsers, command output, or SQLite, regardless of whether the bytes came from live Amazon, local fallback, or older cached rows.
+- **Requirements:** R1, R3, R5, R8, R9
+- **Files:**
+  - `library/commerce/amazon-orders/internal/cli/data_source.go`
+  - `library/commerce/amazon-orders/internal/cli/sync.go`
+  - `library/commerce/amazon-orders/internal/cli/novel_helpers.go`
+  - `library/commerce/amazon-orders/internal/cli/find.go`
+  - `library/commerce/amazon-orders/internal/cli/where_is_my_stuff.go` (if direct guarding is needed beyond `fetchOrderListPages`)
+  - `library/commerce/amazon-orders/internal/cli/arriving_soon.go` (if direct guarding is needed beyond `fetchOrderListPages`)
+  - `library/commerce/amazon-orders/internal/cli/late.go` (if direct guarding is needed beyond `fetchOrderListPages`)
+  - `library/commerce/amazon-orders/internal/cli/orders_get.go`
+  - `library/commerce/amazon-orders/internal/cli/orders_list.go`
+  - `library/commerce/amazon-orders/internal/cli/orders_invoice.go`
+  - `library/commerce/amazon-orders/internal/cli/promoted_transactions.go`
+  - `library/commerce/amazon-orders/internal/cli/promoted_gift-cards.go` (if the same authenticated HTML path applies)
+  - `library/commerce/amazon-orders/internal/cli/promoted_shipments.go` (if the same authenticated HTML path applies)
+- **Approach:** Wrap HTML response handling with `ensureAuthenticatedAmazonHTML` before parsing, before local fallback output, and before `writeThroughCache`. In `syncResource`, classify each fetched page before `extractPageItems` or `upsertSingleObject`. Guard `fetchOrderListPages` because `find`, `where-is-my-stuff`, `arriving-soon`, and `late` use that helper directly instead of `resolveRead`. Decide whether sync treats auth-wall pages as hard errors rather than warnings; because this means the session is invalid, hard error is the safer default.
+- **Test Scenarios:**
+  - `resolveRead` live mode returns an auth error for sign-in HTML.
+  - `resolveRead` local mode rejects or skips a stored sign-in HTML row.
+  - Auto mode does not write a sign-in page through to the store.
+  - `syncResource` with a fake client returning sign-in HTML returns an error and stores zero rows.
+  - `find` over a sign-in first page returns an auth error, not an empty result set.
+  - Real-looking order list/detail fixtures still parse and, when eligible, write through to store.
+- **Verification:** `go test ./internal/cli ./internal/store` passes.
+
+### U4. Tighten parser and command validation for order identity
+
+- **Goal:** Prevent unrelated order IDs from being emitted for a requested order.
+- **Requirements:** R2, R8, R9
+- **Files:**
+  - `library/commerce/amazon-orders/internal/cli/orders_get.go`
+  - `library/commerce/amazon-orders/internal/parser/order_detail.go`
+  - `library/commerce/amazon-orders/internal/parser/parser_test.go`
+- **Approach:** After parsing an order detail, compare the parsed `OrderID` with the requested argument. If the parsed ID is empty or mismatched, return a specific error that says the order detail page did not match the requested order and suggests re-running auth/doctor when the page looked like login. Keep parser extraction tolerant, but make the command authoritative about request/response identity.
+- **Test Scenarios:**
+  - Requested `702-5010515-8774615`, parsed `144-5062705-8396341` fails.
+  - Requested and parsed IDs match succeeds.
+  - Empty parsed ID from non-login malformed detail fails with a parse/content error, not success.
+- **Verification:** `go test ./internal/parser ./internal/cli -run OrderDetail` passes.
+
+### U5. Repair local read identity and list semantics
+
+- **Goal:** Make local reads use meaningful Amazon resource identities.
+- **Requirements:** R3, R6, R9
+- **Files:**
+  - `library/commerce/amazon-orders/internal/cli/data_source.go`
+  - `library/commerce/amazon-orders/internal/cli/orders_get.go`
+  - `library/commerce/amazon-orders/internal/cli/orders_list.go`
+  - `library/commerce/amazon-orders/internal/cli/orders_invoice.go`
+  - `library/commerce/amazon-orders/internal/cli/promoted_transactions.go`
+  - `library/commerce/amazon-orders/internal/store/store.go` (only if store ID fallback must be extended)
+  - `library/commerce/amazon-orders/internal/cli/data_source_test.go`
+- **Approach:** Add a narrow way for generated/hand-authored commands to pass an explicit local resource ID, or teach `resolveLocal` to prefer known query parameters like `orderID` for get-by-ID HTML endpoints. Set list endpoints (`orders list`, `transactions`) to local list semantics rather than fake get-by-ID lookups. Keep the change local to Amazon Orders unless implementation reveals a safe generator-level helper already exists.
+- **Test Scenarios:**
+  - Local `orders get 702-5010515-8774615` asks the store for ID `702-5010515-8774615`.
+  - Local invoice for the same order asks the store for the same order ID or documented invoice key.
+  - Local `orders list` returns all synced order rows rather than looking up ID `orders`.
+  - Local `transactions` returns synced transaction rows rather than looking up ID `transactions`.
+- **Verification:** `go test ./internal/cli -run 'Resolve|Local|DataSource'` passes.
+
+### U6. Make doctor validate live authenticated content and configured domains
+
+- **Goal:** Make `doctor` report invalid credentials when the real order-history probe receives a login page, and preserve `.com.mx` style setups.
+- **Requirements:** R4, R7, R8
+- **Files:**
+  - `library/commerce/amazon-orders/internal/cli/doctor.go`
+  - `library/commerce/amazon-orders/internal/cli/auth.go`
+  - `library/commerce/amazon-orders/internal/config/config.go` (only if domain/config derivation needs support)
+  - `library/commerce/amazon-orders/internal/cli/doctor_test.go` (create or extend)
+  - `library/commerce/amazon-orders/internal/cli/auth_count_cookies_test.go` (extend if cookie-domain behavior changes)
+- **Approach:** Change credential validation from proof-file-only to proof plus live authenticated-content probe. The probe should use `cfg.BaseURL` and the validation path, inspect response content with the shared guard, and mark credentials invalid if sign-in/challenge HTML appears. Align browser-session proof `CookieDomain` checks with configured domain behavior instead of hardcoded `.amazon.com` where possible.
+- **Test Scenarios:**
+  - Doctor reports credentials invalid when a stub server returns sign-in HTML at `/gp/your-account/order-history`.
+  - Doctor reports credentials valid when the stub server returns a minimal authenticated order-history page.
+  - Doctor diagnostics include the configured base URL.
+  - A `.amazon.com.mx` or `https://www.amazon.com.mx` config path is not rejected solely due to the default `.amazon.com` constant.
+- **Verification:** `go test ./internal/cli -run Doctor` passes.
+
+### U7. Record the published-library patch and run CLI dogfood
+
+- **Goal:** Make the behavior durable across future reprints and prove it against the user's failure mode.
+- **Requirements:** R1, R2, R3, R4, R5, R6, R7, R8, R9
+- **Files:**
+  - `library/commerce/amazon-orders/.printing-press-patches/authenticated-html-guard.json` (create)
+  - `library/commerce/amazon-orders/README.md` (only if remediation copy needs a durable user-facing update)
+- **Approach:** Add one patch metadata file with schema version 2, `base_run_id` and `base_printing_press_version` copied from `.printing-press.json`, and a summary focused on the durable behavior. Build and run the CLI locally. If the user's current Amazon session is still invalid, the live command should fail clearly rather than returning another order or caching login HTML.
+- **Test Scenarios:**
+  - Patch metadata validates as JSON and names the changed code files.
+  - Built CLI returns a non-zero auth/content error for the known failing order when Amazon still serves login HTML.
+  - Built CLI does not create or preserve sign-in rows in the local store during the dogfood sync attempt.
+- **Verification:** `go test ./...`, `go build ./cmd/amazon-orders-pp-cli`, and targeted live smoke commands from `library/commerce/amazon-orders`.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Covers | Done Signal |
+|---|---|---|---|
+| Unit tests | `go test ./internal/parser ./internal/cli ./internal/store` from `library/commerce/amazon-orders` | U1-U6 | All targeted parser, CLI, sync, and store tests pass. |
+| Full package tests | `go test ./...` from `library/commerce/amazon-orders` | U1-U7 | Entire Amazon Orders module passes. |
+| Build | `go build ./cmd/amazon-orders-pp-cli` from `library/commerce/amazon-orders` | U7 | CLI binary builds without generated-tree compile regressions. |
+| Doctor smoke | `go run ./cmd/amazon-orders-pp-cli doctor --agent --fail-on error` from `library/commerce/amazon-orders` | U6-U7 | Either reports valid authenticated content or fails with a clear auth/session reason; it must not claim credentials are valid solely from stale proof when live content is sign-in HTML. |
+| Known order smoke | `go run ./cmd/amazon-orders-pp-cli orders get 702-5010515-8774615 --json --no-input --no-color --yes --data-source live --no-cache` from `library/commerce/amazon-orders` | U2-U4, U7 | Must not return an unrelated order ID. If auth is invalid, exits non-zero with remediation. If auth is valid, returns the requested order ID. |
+| Search smoke | `go run ./cmd/amazon-orders-pp-cli find Aqara --json --no-input --no-color --yes --max-pages 1` from `library/commerce/amazon-orders` | U3, U7 | Must not return an empty success when the first order-history page is sign-in HTML. |
+| Sync smoke | `go run ./cmd/amazon-orders-pp-cli sync --resources orders,transactions --since 90d --json --no-input --no-color --yes --strict` from `library/commerce/amazon-orders` | U3, U7 | Must not report success while storing sign-in pages. |
+| Store inspection | Query the local SQLite `resources` table after sync smoke for `Amazon Sign-In`, `Amazon Iniciar sesion`, and the known order ID | U3, U5, U7 | No sign-in page rows remain as successful synced data; real rows use meaningful IDs when available. |
+
+---
+
+## Definition of Done
+
+- Every requirement R1-R9 is satisfied or explicitly deferred with a non-blocking reason.
+- The known user failure mode no longer produces an unrelated order, a false empty result, or a fresh cache containing sign-in HTML.
+- `doctor` no longer gives a false-positive credential verdict when the live authenticated probe returns login/challenge content.
+- Local order detail lookup uses the requested order identity.
+- Tests cover English and Spanish Amazon sign-in pages, mismatched order IDs, sync/store guard behavior, and doctor live-content validation.
+- `.printing-press-patches/authenticated-html-guard.json` exists and follows the repo's schema version 2 convention.
+- `go test ./...` and `go build ./cmd/amazon-orders-pp-cli` pass from `library/commerce/amazon-orders`.
+- Any experimental code, temporary fixtures not used by tests, and local debug output are removed before commit.

--- a/library/commerce/amazon-orders/.printing-press-patches/authenticated-html-guard.json
+++ b/library/commerce/amazon-orders/.printing-press-patches/authenticated-html-guard.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 2,
+  "id": "authenticated-html-guard",
+  "applied_at": "2026-06-30",
+  "base_run_id": "20260510-105710",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Reject Amazon sign-in, claim, CAPTCHA, and identity-challenge HTML before parsing or caching authenticated buyer pages.",
+  "reason": "Amazon can return login/interstitial pages with HTTP 200, so status-code-only success made doctor, order reads, search, and sync trust unauthenticated HTML as real order data.",
+  "files": [
+    "internal/parser/auth_interstitial.go",
+    "internal/parser/auth_interstitial_test.go",
+    "internal/cli/auth.go",
+    "internal/cli/auth_guard_command_test.go",
+    "internal/cli/auth_interstitial_cli_test.go",
+    "internal/cli/channel_workflow.go",
+    "internal/cli/data_source.go",
+    "internal/cli/data_source_test.go",
+    "internal/cli/doctor.go",
+    "internal/cli/doctor_test.go",
+    "internal/cli/helpers.go",
+    "internal/cli/novel_helpers.go",
+    "internal/cli/orders_get.go",
+    "internal/cli/orders_get_test.go",
+    "internal/cli/orders_invoice.go",
+    "internal/cli/orders_list.go",
+    "internal/cli/promoted_gift-cards.go",
+    "internal/cli/promoted_shipments.go",
+    "internal/cli/promoted_transactions.go",
+    "internal/cli/sync.go",
+    "internal/cli/track.go"
+  ],
+  "validated_outcome": "Focused tests reject sign-in HTML from live reads, local cache, sync, doctor probes, and mismatched order-detail pages."
+}

--- a/library/commerce/amazon-orders/internal/cli/auth.go
+++ b/library/commerce/amazon-orders/internal/cli/auth.go
@@ -34,6 +34,11 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+const (
+	browserSessionValidationMethod = "GET"
+	browserSessionValidationPath   = "/your-orders/orders"
+)
+
 func newAuthCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
@@ -1241,7 +1246,7 @@ func browserSessionProofStatusForAuth(cfg *config.Config, authHeader string) (bo
 	if proof.APIName == "amazon-orders" && proof.CookieDomain == domain && proof.ValidationPath == "/gp/your-account/order-history" {
 		return false, "proof was written against an older validation endpoint; re-run amazon-orders-pp-cli auth login --chrome to refresh it"
 	}
-	if proof.APIName != "amazon-orders" || proof.CookieDomain != domain || proof.ValidationPath != "/your-orders/orders" {
+	if proof.APIName != "amazon-orders" || proof.CookieDomain != domain || proof.ValidationPath != browserSessionValidationPath {
 		return false, "proof does not match this CLI"
 	}
 	if authHeader != "" && proof.CredentialFingerprint != fingerprintCredential(authHeader) {
@@ -1254,11 +1259,11 @@ func browserSessionProofStatusForAuth(cfg *config.Config, authHeader string) (bo
 }
 
 func validateAndWriteBrowserSessionProof(cfg *config.Config, flags *rootFlags) error {
-	validationPath := strings.TrimSpace("/your-orders/orders")
+	validationPath := strings.TrimSpace(browserSessionValidationPath)
 	if validationPath == "" {
 		return fmt.Errorf("no browser-session validation endpoint configured in this CLI")
 	}
-	method := strings.ToUpper(strings.TrimSpace("GET"))
+	method := strings.ToUpper(strings.TrimSpace(browserSessionValidationMethod))
 	if method == "" {
 		method = "GET"
 	}
@@ -1273,18 +1278,12 @@ func validateAndWriteBrowserSessionProof(cfg *config.Config, flags *rootFlags) e
 
 	c := client.New(cfg, flags.timeout, flags.rateLimit)
 	c.NoCache = true
-	body, status, err := c.GetWithStatus(validationPath, map[string]string{"timeFilter": "months-3"})
-	if err != nil {
-		return err
-	}
-	if status < 200 || status >= 300 {
+	status, err := validateBrowserSession(c, validationPath)
+	if status != 0 && (status < 200 || status >= 300) {
 		return fmt.Errorf("validation endpoint returned HTTP %d", status)
 	}
-	// A logged-out or expired cookie jar is answered with HTTP 200 and an
-	// Amazon sign-in/claim/challenge page, not a 4xx. Treat that as an invalid
-	// session so we don't write a "valid" proof for an unauthenticated jar.
-	if ierr := parser.AuthInterstitialError(body); ierr != nil {
-		return ierr
+	if err != nil {
+		return err
 	}
 
 	domain, err := cookieDomainFromConfig(cfg)
@@ -1309,6 +1308,26 @@ func validateAndWriteBrowserSessionProof(cfg *config.Config, flags *rootFlags) e
 	}
 	data = append(data, '\n')
 	return writeBrowserSessionProof(cfg, data)
+}
+
+func validateBrowserSession(c *client.Client, validationPath string) (int, error) {
+	body, status, err := c.GetWithStatus(validationPath, map[string]string{"timeFilter": "months-3"})
+	if err != nil {
+		return status, err
+	}
+	if status < 200 || status >= 300 {
+		return status, fmt.Errorf("HTTP %d", status)
+	}
+	// A logged-out or expired cookie jar is answered with HTTP 200 and an
+	// Amazon sign-in/claim/challenge page, not a 4xx. Treat that as an invalid
+	// session so we don't write a "valid" proof for an unauthenticated jar.
+	if ierr := parser.AuthInterstitialError(body); ierr != nil {
+		return status, ierr
+	}
+	if !parser.DetectOrderHistoryPage(body) {
+		return status, fmt.Errorf("validation endpoint did not return an Amazon order-history page")
+	}
+	return status, nil
 }
 
 func validateAndWriteBrowserSessionProofWithRetry(cfg *config.Config, flags *rootFlags, timeout time.Duration) error {

--- a/library/commerce/amazon-orders/internal/cli/auth_guard_command_test.go
+++ b/library/commerce/amazon-orders/internal/cli/auth_guard_command_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/store"
+)
+
+func setupAuthGuardCommandEnv(t *testing.T, handler http.HandlerFunc) (baseURL string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AMAZON_ORDERS_CONFIG", filepath.Join(home, "missing-config.toml"))
+	t.Setenv("AMAZON_COOKIES", "session-id=test-cookie")
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	t.Setenv("AMAZON_ORDERS_BASE_URL", srv.URL)
+	return srv.URL
+}
+
+func runRootForTest(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	cmd := RootCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func TestTrackRejectsAuthInterstitial(t *testing.T) {
+	setupAuthGuardCommandEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gp/your-account/ship-track" {
+			t.Fatalf("path = %q, want ship-track", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(signInInterstitialHTML))
+	})
+
+	_, _, err := runRootForTest(t, "--json", "--no-input", "--yes", "track", "111-1111111-1111111")
+	if err == nil {
+		t.Fatal("track returned nil error for sign-in HTML")
+	}
+	if !parser.IsAuthInterstitialError(err) {
+		t.Fatalf("error = %v, want auth interstitial error", err)
+	}
+}
+
+func TestWorkflowArchiveRejectsAuthInterstitialBeforeStore(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "archive.db")
+	setupAuthGuardCommandEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(signInInterstitialHTML))
+	})
+
+	_, _, err := runRootForTest(t, "--json", "--no-input", "--yes", "workflow", "archive", "--db", dbPath)
+	if err == nil {
+		t.Fatal("workflow archive returned nil error for sign-in HTML")
+	}
+	if !parser.IsAuthInterstitialError(err) {
+		t.Fatalf("error = %v, want auth interstitial error", err)
+	}
+
+	db, openErr := store.OpenWithContext(context.Background(), dbPath)
+	if openErr != nil {
+		t.Fatalf("open store: %v", openErr)
+	}
+	defer db.Close()
+	for _, resource := range []string{"orders", "transactions"} {
+		ids, listErr := db.ListIDs(resource)
+		if listErr != nil {
+			t.Fatalf("ListIDs(%s): %v", resource, listErr)
+		}
+		if len(ids) != 0 {
+			t.Fatalf("%s IDs = %v, want none", resource, ids)
+		}
+	}
+}
+
+func TestSyncAuthInterstitialFailsEvenWhenAnotherResourceSucceeds(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sync.db")
+	setupAuthGuardCommandEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/your-orders/orders":
+			_, _ = w.Write([]byte(`[{"id":"order-1","orderId":"111-1111111-1111111"}]`))
+		case "/cpe/yourpayments/transactions":
+			_, _ = w.Write([]byte(signInInterstitialHTML))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	_, _, err := runRootForTest(t, "--json", "--no-input", "--yes", "sync", "--resources", "orders,transactions", "--db", dbPath)
+	if err == nil {
+		t.Fatal("sync returned nil error for partial auth failure")
+	}
+	if !strings.Contains(err.Error(), "critical resource") {
+		t.Fatalf("error = %v, want critical auth failure", err)
+	}
+}

--- a/library/commerce/amazon-orders/internal/cli/auth_interstitial_cli_test.go
+++ b/library/commerce/amazon-orders/internal/cli/auth_interstitial_cli_test.go
@@ -84,3 +84,29 @@ func TestFetchOrderListPages_ParsesRealOrderPage(t *testing.T) {
 		t.Errorf("currency = %q, want INR", orders[0].Currency)
 	}
 }
+
+func TestFetchOrderListPages_FailsOnLaterInterstitial(t *testing.T) {
+	calls := 0
+	firstPage := `<html><head><title>Your Orders</title></head><body>
+<div class="order-card js-order-card">ORDER PLACED May 5, 2026 TOTAL $51.46 SHIP TO Jane ORDER # 111-1111111-1111111</div>
+<li class="a-last"><a href="#">Next</a></li>
+</body></html>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			_, _ = w.Write([]byte(firstPage))
+			return
+		}
+		_, _ = w.Write([]byte(signInInterstitialHTML))
+	}))
+	defer srv.Close()
+
+	c := testClientFor(srv.URL)
+	orders, err := fetchOrderListPages(context.Background(), c, "year-2026", 3)
+	if err == nil {
+		t.Fatalf("expected auth/interstitial error, got nil (orders=%d)", len(orders))
+	}
+	if !strings.Contains(err.Error(), "sign-in/interstitial") {
+		t.Errorf("error = %v, want it to mention sign-in/interstitial", err)
+	}
+}

--- a/library/commerce/amazon-orders/internal/cli/channel_workflow.go
+++ b/library/commerce/amazon-orders/internal/cli/channel_workflow.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -80,6 +81,9 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 					if fetchErr != nil {
 						fmt.Fprintf(cmd.ErrOrStderr(), "  warning: %s: %v\n", resource, fetchErr)
 						break
+					}
+					if err := parser.AuthInterstitialError(data); err != nil {
+						return classifyAPIError(err, flags)
 					}
 					var items []json.RawMessage
 					if err := json.Unmarshal(data, &items); err != nil {

--- a/library/commerce/amazon-orders/internal/cli/data_source.go
+++ b/library/commerce/amazon-orders/internal/cli/data_source.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/store"
 )
 
@@ -91,23 +92,29 @@ func attachFreshness(prov DataProvenance, flags *rootFlags) DataProvenance {
 //     declares no per-endpoint header overrides. Without this parameter, store-backed
 //     reads on per-endpoint-versioned APIs silently get the wrong response shape
 //     (cal-com retro #334 F1).
-func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string) (json.RawMessage, DataProvenance, error) {
+func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, localID string) (json.RawMessage, DataProvenance, error) {
 	switch flags.dataSource {
 	case "local":
-		data, prov, err := resolveLocal(ctx, resourceType, isList, path, params, "user_requested")
+		data, prov, err := resolveLocal(ctx, resourceType, isList, path, params, "user_requested", localID)
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
-		data, err := c.GetWithHeaders(path, params, headers)
+		data, err := authenticatedGetWithHeaders(c, path, params, headers)
 		if err != nil {
+			return nil, DataProvenance{}, err
+		}
+		if err := parser.AuthInterstitialError(data); err != nil {
 			return nil, DataProvenance{}, err
 		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
-		data, err := c.GetWithHeaders(path, params, headers)
+		data, err := authenticatedGetWithHeaders(c, path, params, headers)
 		if err == nil {
-			writeThroughCache(ctx, resourceType, data)
+			if err := parser.AuthInterstitialError(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
+			writeThroughCacheValidated(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}
 		if !isNetworkError(err) {
@@ -115,7 +122,7 @@ func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resour
 			return nil, DataProvenance{}, err
 		}
 		// Network error — try local fallback
-		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, resourceType, isList, path, params, "api_unreachable")
+		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, resourceType, isList, path, params, "api_unreachable", localID)
 		if fallbackErr != nil {
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'amazon-orders-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
@@ -130,26 +137,32 @@ func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resour
 func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, DataProvenance, error) {
 	switch flags.dataSource {
 	case "local":
-		data, prov, err := resolveLocal(ctx, resourceType, true, path, params, "user_requested")
+		data, prov, err := resolveLocal(ctx, resourceType, true, path, params, "user_requested", "")
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
-		data, err := paginatedGet(c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
+		data, err := authenticatedPaginatedGet(c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err != nil {
+			return nil, DataProvenance{}, err
+		}
+		if err := parser.AuthInterstitialError(data); err != nil {
 			return nil, DataProvenance{}, err
 		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
-		data, err := paginatedGet(c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
+		data, err := authenticatedPaginatedGet(c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err == nil {
-			writeThroughCache(ctx, resourceType, data)
+			if err := parser.AuthInterstitialError(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
+			writeThroughCacheValidated(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}
 		if !isNetworkError(err) {
 			return nil, DataProvenance{}, err
 		}
-		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, resourceType, true, path, params, "api_unreachable")
+		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, resourceType, true, path, params, "api_unreachable", "")
 		if fallbackErr != nil {
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'amazon-orders-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
@@ -157,10 +170,35 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 	}
 }
 
+func authenticatedGet(c *client.Client, path string, params map[string]string) (json.RawMessage, error) {
+	return authenticatedGetWithHeaders(c, path, params, nil)
+}
+
+func authenticatedGetWithHeaders(c *client.Client, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	restoreNoCache := c.NoCache
+	c.NoCache = true
+	defer func() { c.NoCache = restoreNoCache }()
+	return c.GetWithHeaders(path, params, headers)
+}
+
+func authenticatedPaginatedGet(c *client.Client, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
+	restoreNoCache := c.NoCache
+	c.NoCache = true
+	defer func() { c.NoCache = restoreNoCache }()
+	return paginatedGet(c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
+}
+
 // writeThroughCache upserts live API results into the local SQLite store so
 // FTS search covers everything the user has looked up — not just explicit syncs.
 // Best-effort: failures are silently ignored (the live result already succeeded).
 func writeThroughCache(ctx context.Context, resourceType string, data json.RawMessage) {
+	if parser.AuthInterstitialError(data) != nil {
+		return
+	}
+	writeThroughCacheValidated(ctx, resourceType, data)
+}
+
+func writeThroughCacheValidated(ctx context.Context, resourceType string, data json.RawMessage) {
 	db, err := store.OpenWithContext(ctx, defaultDBPath("amazon-orders-pp-cli"))
 	if err != nil {
 		return
@@ -204,7 +242,7 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 // Note: local reads return ALL synced data for the resource type. Endpoint-specific
 // filters (query params, path scoping like /teams/{id}/users) are NOT applied locally.
 // The provenance metadata includes "unscoped":true when params were present but not applied.
-func resolveLocal(ctx context.Context, resourceType string, isList bool, path string, params map[string]string, reason string) (json.RawMessage, DataProvenance, error) {
+func resolveLocal(ctx context.Context, resourceType string, isList bool, path string, params map[string]string, reason string, localID string) (json.RawMessage, DataProvenance, error) {
 	db, err := openStoreForRead(ctx, "amazon-orders-pp-cli")
 	if err != nil {
 		return nil, DataProvenance{}, fmt.Errorf("opening local database: %w\nRun 'amazon-orders-pp-cli sync' first.", err)
@@ -229,14 +267,24 @@ func resolveLocal(ctx context.Context, resourceType string, isList bool, path st
 		// Filter out empty/invalid records (empty arrays, null, whitespace-only)
 		// that can end up in the store from pagination boundary artifacts.
 		var items []json.RawMessage
+		var authErr error
 		for _, r := range raw {
 			trimmed := strings.TrimSpace(string(r))
 			if trimmed == "" || trimmed == "null" || trimmed == "[]" || trimmed == "{}" {
 				continue
 			}
+			if err := parser.AuthInterstitialError(r); err != nil {
+				if authErr == nil {
+					authErr = err
+				}
+				continue
+			}
 			items = append(items, r)
 		}
 		if len(items) == 0 {
+			if authErr != nil {
+				return nil, DataProvenance{}, authErr
+			}
 			return nil, DataProvenance{}, fmt.Errorf("no local data for %q. Run 'amazon-orders-pp-cli sync' first", resourceType)
 		}
 		// Marshal []json.RawMessage into a single JSON array
@@ -247,9 +295,7 @@ func resolveLocal(ctx context.Context, resourceType string, isList bool, path st
 		return data, prov, nil
 	}
 
-	// Get by ID — extract the last path segment as the ID
-	parts := strings.Split(strings.TrimRight(path, "/"), "/")
-	id := parts[len(parts)-1]
+	id := localResourceID(path, localID)
 
 	item, err := db.Get(resourceType, id)
 	if err != nil {
@@ -258,7 +304,18 @@ func resolveLocal(ctx context.Context, resourceType string, isList bool, path st
 	if item == nil {
 		return nil, DataProvenance{}, fmt.Errorf("resource %q with ID %q not found in local store. Run 'amazon-orders-pp-cli sync' first", resourceType, id)
 	}
+	if err := parser.AuthInterstitialError(item); err != nil {
+		return nil, DataProvenance{}, err
+	}
 	return item, prov, nil
+}
+
+func localResourceID(path string, localID string) string {
+	if localID != "" {
+		return localID
+	}
+	parts := strings.Split(strings.TrimRight(path, "/"), "/")
+	return parts[len(parts)-1]
 }
 
 // Ensure time import is used (compilation guard).

--- a/library/commerce/amazon-orders/internal/cli/data_source.go
+++ b/library/commerce/amazon-orders/internal/cli/data_source.go
@@ -175,17 +175,15 @@ func authenticatedGet(c *client.Client, path string, params map[string]string) (
 }
 
 func authenticatedGetWithHeaders(c *client.Client, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
-	restoreNoCache := c.NoCache
-	c.NoCache = true
-	defer func() { c.NoCache = restoreNoCache }()
-	return c.GetWithHeaders(path, params, headers)
+	noCacheClient := *c
+	noCacheClient.NoCache = true
+	return noCacheClient.GetWithHeaders(path, params, headers)
 }
 
 func authenticatedPaginatedGet(c *client.Client, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
-	restoreNoCache := c.NoCache
-	c.NoCache = true
-	defer func() { c.NoCache = restoreNoCache }()
-	return paginatedGet(c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
+	noCacheClient := *c
+	noCacheClient.NoCache = true
+	return paginatedGet(&noCacheClient, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 }
 
 // writeThroughCache upserts live API results into the local SQLite store so

--- a/library/commerce/amazon-orders/internal/cli/data_source_test.go
+++ b/library/commerce/amazon-orders/internal/cli/data_source_test.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/store"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type fakeSyncClient struct {
+	body string
+	err  error
+}
+
+func (f fakeSyncClient) Get(string, map[string]string) (json.RawMessage, error) {
+	return json.RawMessage(f.body), f.err
+}
+
+func (f fakeSyncClient) RateLimit() float64 {
+	return 0
+}
+
+func testStore(t *testing.T) *store.Store {
+	t.Helper()
+	db, _ := testStoreAtHome(t)
+	return db
+}
+
+func testStoreAtHome(t *testing.T) (*store.Store, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	db, err := store.OpenWithContext(context.Background(), defaultDBPath("amazon-orders-pp-cli"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db, home
+}
+
+func TestResolveReadLocalGetPrefersOrderIDParam(t *testing.T) {
+	db := testStore(t)
+	const orderID = "702-5010515-8774615"
+	html := `<html><body>ORDER # 702-5010515-8774615</body></html>`
+	if err := db.Upsert("orders", orderID, []byte(html)); err != nil {
+		t.Fatalf("upsert order: %v", err)
+	}
+
+	flags := &rootFlags{dataSource: "local"}
+	data, _, err := resolveRead(context.Background(), nil, flags, "orders", false, "/your-orders/order-details", map[string]string{"orderID": orderID}, nil, orderID)
+	if err != nil {
+		t.Fatalf("resolveRead local: %v", err)
+	}
+	if !strings.Contains(string(data), orderID) {
+		t.Fatalf("local data = %q, want order %s", string(data), orderID)
+	}
+}
+
+func TestResolveReadLocalRejectsAuthInterstitialRow(t *testing.T) {
+	db := testStore(t)
+	if err := db.Upsert("orders", "orders", []byte(signInInterstitialHTML)); err != nil {
+		t.Fatalf("upsert interstitial: %v", err)
+	}
+
+	flags := &rootFlags{dataSource: "local"}
+	_, _, err := resolveRead(context.Background(), nil, flags, "orders", false, "/your-orders/orders", nil, nil, "")
+	if err == nil {
+		t.Fatal("resolveRead local returned nil error for stored sign-in HTML")
+	}
+	if !parser.IsAuthInterstitialError(err) {
+		t.Fatalf("error = %v, want auth interstitial error", err)
+	}
+}
+
+func TestResolveReadLiveRejectsAuthInterstitial(t *testing.T) {
+	c := client.New(&config.Config{BaseURL: "https://example.invalid"}, 0, 0)
+	c.HTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(signInInterstitialHTML)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	flags := &rootFlags{dataSource: "live"}
+	_, _, err := resolveRead(context.Background(), c, flags, "orders", false, "/your-orders/orders", nil, nil, "")
+	if err == nil {
+		t.Fatal("resolveRead live returned nil error for sign-in HTML")
+	}
+	if !parser.IsAuthInterstitialError(err) {
+		t.Fatalf("error = %v, want auth interstitial error", err)
+	}
+}
+
+func TestResolveReadAutoRejectsAuthInterstitialWithoutCaching(t *testing.T) {
+	db, home := testStoreAtHome(t)
+	c := client.New(&config.Config{BaseURL: "https://example.invalid"}, 0, 0)
+	c.HTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(signInInterstitialHTML)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	flags := &rootFlags{dataSource: "auto"}
+	_, _, err := resolveRead(context.Background(), c, flags, "orders", false, "/your-orders/orders", nil, nil, "")
+	if err == nil {
+		t.Fatal("resolveRead auto returned nil error for sign-in HTML")
+	}
+	if !parser.IsAuthInterstitialError(err) {
+		t.Fatalf("error = %v, want auth interstitial error", err)
+	}
+	ids, err := db.ListIDs("orders")
+	if err != nil {
+		t.Fatalf("ListIDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("stored IDs = %v, want none", ids)
+	}
+	cacheDir := filepath.Join(home, ".cache", "amazon-orders-pp-cli")
+	if entries, readErr := os.ReadDir(cacheDir); readErr == nil && len(entries) > 0 {
+		t.Fatalf("HTTP cache entries = %d, want none", len(entries))
+	}
+}
+
+func TestResolveReadLocalListSkipsAuthInterstitialRows(t *testing.T) {
+	db := testStore(t)
+	if err := db.Upsert("orders", "auth", []byte(signInInterstitialHTML)); err != nil {
+		t.Fatalf("upsert interstitial: %v", err)
+	}
+	if err := db.Upsert("orders", "real", []byte(`{"id":"real","orderId":"111-1111111-1111111"}`)); err != nil {
+		t.Fatalf("upsert real row: %v", err)
+	}
+
+	flags := &rootFlags{dataSource: "local"}
+	data, _, err := resolveRead(context.Background(), nil, flags, "orders", true, "/your-orders/orders", nil, nil, "")
+	if err != nil {
+		t.Fatalf("resolveRead local list: %v", err)
+	}
+	if strings.Contains(string(data), "Sign-In") {
+		t.Fatalf("local list data includes sign-in HTML: %s", data)
+	}
+	if !strings.Contains(string(data), "111-1111111-1111111") {
+		t.Fatalf("local list data = %s, want real order row", data)
+	}
+}
+
+func TestResolveReadLocalListAllAuthInterstitialRowsErrors(t *testing.T) {
+	db := testStore(t)
+	if err := db.Upsert("orders", "auth", []byte(signInInterstitialHTML)); err != nil {
+		t.Fatalf("upsert interstitial: %v", err)
+	}
+
+	flags := &rootFlags{dataSource: "local"}
+	_, _, err := resolveRead(context.Background(), nil, flags, "orders", true, "/your-orders/orders", nil, nil, "")
+	if err == nil {
+		t.Fatal("resolveRead local list returned nil error for all-tainted rows")
+	}
+	if !parser.IsAuthInterstitialError(err) {
+		t.Fatalf("error = %v, want auth interstitial error", err)
+	}
+}
+
+func TestSyncResourceRejectsAuthInterstitial(t *testing.T) {
+	db := testStore(t)
+	res := syncResource(fakeSyncClient{body: signInInterstitialHTML}, db, "orders", "", true, 1)
+	if res.Err == nil {
+		t.Fatalf("syncResource err = nil, count=%d; want auth interstitial error", res.Count)
+	}
+	if !parser.IsAuthInterstitialError(res.Err) {
+		t.Fatalf("error = %v, want auth interstitial error", res.Err)
+	}
+	ids, err := db.ListIDs("orders")
+	if err != nil {
+		t.Fatalf("ListIDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("stored IDs = %v, want none", ids)
+	}
+}

--- a/library/commerce/amazon-orders/internal/cli/doctor.go
+++ b/library/commerce/amazon-orders/internal/cli/doctor.go
@@ -305,7 +305,9 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 }
 
 func doctorLiveCredentialStatus(c *client.Client) (bool, string) {
-	status, err := validateBrowserSession(c, browserSessionValidationPath)
+	noCacheClient := *c
+	noCacheClient.NoCache = true
+	status, err := validateBrowserSession(&noCacheClient, browserSessionValidationPath)
 	if err != nil {
 		if status != 0 && (status < 200 || status >= 300) {
 			return false, fmt.Sprintf("live credential probe returned HTTP %d", status)

--- a/library/commerce/amazon-orders/internal/cli/doctor.go
+++ b/library/commerce/amazon-orders/internal/cli/doctor.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -214,8 +215,13 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					if authHeader == "" {
 						// No auth configured — skip credential validation
 					} else if proofOK, proofDetail := browserSessionProofStatus(cfg, authHeader); proofOK {
-						report["credentials"] = "valid"
-						report["credentials_detail"] = proofDetail
+						if liveOK, liveDetail := doctorLiveCredentialStatus(c); liveOK {
+							report["credentials"] = "valid"
+							report["credentials_detail"] = proofDetail + "; " + liveDetail
+						} else {
+							report["credentials"] = "invalid (live authenticated probe failed)"
+							report["credentials_detail"] = liveDetail + "; " + proofDetail
+						}
 					} else {
 						report["credentials"] = "invalid (browser-session proof missing or stale)"
 						report["credentials_detail"] = proofDetail
@@ -296,6 +302,23 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&failOn, "fail-on", "", "Exit non-zero when a health level is reached: stale, error. Default is never.")
 	return cmd
+}
+
+func doctorLiveCredentialStatus(c *client.Client) (bool, string) {
+	status, err := validateBrowserSession(c, browserSessionValidationPath)
+	if err != nil {
+		if status != 0 && (status < 200 || status >= 300) {
+			return false, fmt.Sprintf("live credential probe returned HTTP %d", status)
+		}
+		if parser.IsAuthInterstitialError(err) {
+			return false, err.Error()
+		}
+		return false, fmt.Sprintf("live credential probe failed: %v", err)
+	}
+	if status < 200 || status >= 300 {
+		return false, fmt.Sprintf("live credential probe returned HTTP %d", status)
+	}
+	return true, fmt.Sprintf("GET %s returned authenticated content (HTTP %d)", browserSessionValidationPath, status)
 }
 
 type doctorBrowserSessionProof struct {
@@ -429,6 +452,12 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 	if v, verr := s.SchemaVersion(); verr == nil {
 		report["schema_version"] = v
 	}
+	taintedRows, taintErr := cacheAuthInterstitialRows(s)
+	if taintErr != nil {
+		report["status"] = "error"
+		report["error"] = "checking cache for sign-in/interstitial HTML: " + taintErr.Error()
+		return report
+	}
 
 	staleAfter := 6 * time.Hour
 	if staleAfterSpec != "" {
@@ -439,6 +468,10 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 
 	rows, qerr := s.DB().Query(`SELECT resource_type, COALESCE(total_count, 0), last_synced_at FROM sync_state ORDER BY resource_type`)
 	if qerr != nil {
+		if len(taintedRows) > 0 {
+			markTaintedCacheReport(report, taintedRows)
+			return report
+		}
 		// sync_state may not exist on a fresh DB that has migrated but not
 		// yet had any sync runs — treat as unknown rather than error.
 		report["status"] = "unknown"
@@ -480,6 +513,8 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 	report["stale_after"] = staleAfter.String()
 
 	switch {
+	case len(taintedRows) > 0:
+		markTaintedCacheReport(report, taintedRows)
 	case !haveAny && len(resources) == 0:
 		report["status"] = "unknown"
 		report["hint"] = "sync_state is empty; run 'amazon-orders-pp-cli sync' to hydrate."
@@ -491,6 +526,48 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 		report["hint"] = "Some resources are older than stale_after; run 'amazon-orders-pp-cli sync' to refresh."
 	}
 	return report
+}
+
+func markTaintedCacheReport(report map[string]any, taintedRows []map[string]any) {
+	report["status"] = "error"
+	report["tainted_resources"] = taintedRows
+	report["hint"] = "Local cache contains Amazon sign-in/interstitial HTML; run 'amazon-orders-pp-cli auth login --chrome', then refresh with 'amazon-orders-pp-cli sync --full'."
+}
+
+func cacheAuthInterstitialRows(s *store.Store) ([]map[string]any, error) {
+	rows, err := s.DB().Query(`
+SELECT r.resource_type, r.id, r.data
+FROM resources_fts f
+JOIN resources r ON r.id = f.id
+WHERE resources_fts MATCH ?
+ORDER BY rank
+LIMIT 200`, `"sign in" OR signin OR signinsubmit OR ap_password OR iniciar OR sesion OR sesión OR "robot check" OR captcha OR captchacharacters OR validatecaptcha OR cvf OR widget OR claim OR password OR authentication`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tainted []map[string]any
+	for rows.Next() {
+		var resourceType, id, data string
+		if err := rows.Scan(&resourceType, &id, &data); err != nil {
+			continue
+		}
+		if parser.AuthInterstitialError([]byte(data)) == nil {
+			continue
+		}
+		tainted = append(tainted, map[string]any{
+			"type": resourceType,
+			"id":   id,
+		})
+		if len(tainted) >= 20 {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return tainted, nil
 }
 
 func renderCacheReport(w io.Writer, rep map[string]any) {

--- a/library/commerce/amazon-orders/internal/cli/doctor.go
+++ b/library/commerce/amazon-orders/internal/cli/doctor.go
@@ -541,7 +541,7 @@ FROM resources_fts f
 JOIN resources r ON r.id = f.id
 WHERE resources_fts MATCH ?
 ORDER BY rank
-LIMIT 200`, `"sign in" OR signin OR signinsubmit OR ap_password OR iniciar OR sesion OR sesión OR "robot check" OR captcha OR captchacharacters OR validatecaptcha OR cvf OR widget OR claim OR password OR authentication`)
+LIMIT 200`, `"sign in" OR signin OR signinsubmit OR ap_password OR ap_signin OR "ap signin" OR iniciar OR sesion OR sesión OR "robot check" OR captcha OR captchacharacters OR validatecaptcha OR cvf OR "ax claim"`)
 	if err != nil {
 		return nil, err
 	}

--- a/library/commerce/amazon-orders/internal/cli/doctor_test.go
+++ b/library/commerce/amazon-orders/internal/cli/doctor_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/config"
+)
+
+func testDoctorClient(t *testing.T, html string, status int) *client.Client {
+	t.Helper()
+	c := client.New(&config.Config{BaseURL: "https://example.invalid"}, 0, 0)
+	c.HTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != browserSessionValidationPath {
+			t.Fatalf("probe path = %q, want %q", req.URL.Path, browserSessionValidationPath)
+		}
+		if got := req.URL.Query().Get("timeFilter"); got != "months-3" {
+			t.Fatalf("timeFilter = %q, want months-3", got)
+		}
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(html)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	return c
+}
+
+func TestDoctorLiveCredentialStatusRejectsInterstitial(t *testing.T) {
+	ok, detail := doctorLiveCredentialStatus(testDoctorClient(t, signInInterstitialHTML, http.StatusOK))
+	if ok {
+		t.Fatalf("doctorLiveCredentialStatus ok=true, want false (%s)", detail)
+	}
+	if !strings.Contains(detail, "sign-in/interstitial") {
+		t.Fatalf("detail = %q, want sign-in/interstitial", detail)
+	}
+}
+
+func TestDoctorLiveCredentialStatusAcceptsAuthenticatedOrdersPage(t *testing.T) {
+	ok, detail := doctorLiveCredentialStatus(testDoctorClient(t, realOrderPageHTML, http.StatusOK))
+	if !ok {
+		t.Fatalf("doctorLiveCredentialStatus ok=false, want true (%s)", detail)
+	}
+	if !strings.Contains(detail, "/your-orders/orders") {
+		t.Fatalf("detail = %q, want validation path", detail)
+	}
+}
+
+func TestDoctorLiveCredentialStatusRejectsGenericHTML(t *testing.T) {
+	ok, detail := doctorLiveCredentialStatus(testDoctorClient(t, `<html><head><title>Amazon.com</title></head><body>hello</body></html>`, http.StatusOK))
+	if ok {
+		t.Fatalf("doctorLiveCredentialStatus ok=true, want false (%s)", detail)
+	}
+	if !strings.Contains(detail, "order-history") {
+		t.Fatalf("detail = %q, want order-history failure", detail)
+	}
+}
+
+func TestCollectCacheReportFlagsAuthInterstitialRows(t *testing.T) {
+	db := testStore(t)
+	if err := db.Upsert("orders", "orders", []byte(signInInterstitialHTML)); err != nil {
+		t.Fatalf("upsert interstitial: %v", err)
+	}
+	if err := db.SaveSyncState("orders", "", 1); err != nil {
+		t.Fatalf("SaveSyncState: %v", err)
+	}
+
+	report := collectCacheReport(context.Background(), "")
+	if got := report["status"]; got != "error" {
+		t.Fatalf("cache status = %v, want error", got)
+	}
+	if hint := report["hint"].(string); !strings.Contains(hint, "sign-in/interstitial") {
+		t.Fatalf("hint = %q, want sign-in/interstitial", hint)
+	}
+}

--- a/library/commerce/amazon-orders/internal/cli/helpers.go
+++ b/library/commerce/amazon-orders/internal/cli/helpers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/cliutil"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"io"
@@ -221,6 +222,9 @@ func writeAPIErrorEnvelope(flags *rootFlags, err error, code int) {
 func classifyAPIError(err error, flags *rootFlags) error {
 	msg := err.Error()
 	switch {
+	case parser.IsAuthInterstitialError(err):
+		return authErr(fmt.Errorf("%w\nhint: the saved browser session is missing, expired, or pointed at the wrong Amazon marketplace."+
+			"\n      Run 'amazon-orders-pp-cli auth login --chrome' and then 'amazon-orders-pp-cli doctor' to validate it.", err))
 	case strings.Contains(msg, "HTTP 409"):
 		if flags != nil && flags.idempotent {
 			return writeNoop(flags, "already_exists", "already exists (no-op)")

--- a/library/commerce/amazon-orders/internal/cli/novel_helpers.go
+++ b/library/commerce/amazon-orders/internal/cli/novel_helpers.go
@@ -34,7 +34,7 @@ func fetchOrderListPages(ctx context.Context, c *client.Client, timeFilter strin
 		if startIndex > 0 {
 			params["startIndex"] = fmt.Sprintf("%d", startIndex)
 		}
-		raw, err := c.Get("/your-orders/orders", params)
+		raw, err := authenticatedGet(c, "/your-orders/orders", params)
 		if err != nil {
 			// If the first page fails, surface; if a later page fails, stop and return what we have.
 			if page == 0 {
@@ -43,14 +43,10 @@ func fetchOrderListPages(ctx context.Context, c *client.Client, timeFilter strin
 			break
 		}
 		// A logged-out/expired session is answered with HTTP 200 and an Amazon
-		// sign-in/claim page. On the first page that's an auth failure; surface
-		// it instead of rolling up an empty spend report. On later pages, stop
-		// and return what we have.
+		// sign-in/claim page. Surface it on any page so a mid-walk reauth does
+		// not look like a complete order-history scan.
 		if ierr := parser.AuthInterstitialError(raw); ierr != nil {
-			if page == 0 {
-				return nil, ierr
-			}
-			break
+			return nil, authErr(ierr)
 		}
 		listPage, perr := parser.ParseOrderList(raw)
 		if perr != nil {

--- a/library/commerce/amazon-orders/internal/cli/orders_get.go
+++ b/library/commerce/amazon-orders/internal/cli/orders_get.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
 	"github.com/spf13/cobra"
@@ -36,7 +37,7 @@ func newOrdersGetCmd(flags *rootFlags) *cobra.Command {
 			htmlRequestParams["orderID"] = args[0]
 			params := map[string]string{}
 			params["orderID"] = args[0]
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "orders", false, path, params, nil)
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "orders", false, path, params, nil, args[0])
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
@@ -45,6 +46,9 @@ func newOrdersGetCmd(flags *rootFlags) *cobra.Command {
 				detail, perr := parser.ParseOrderDetail(data)
 				if perr != nil {
 					return fmt.Errorf("parsing Amazon order-detail HTML: %w", perr)
+				}
+				if err := validateOrderDetailMatchesRequestedID(args[0], detail); err != nil {
+					return err
 				}
 				if data, err = json.Marshal(detail); err != nil {
 					return fmt.Errorf("marshalling parsed order detail: %w", err)
@@ -90,4 +94,14 @@ func newOrdersGetCmd(flags *rootFlags) *cobra.Command {
 	}
 
 	return cmd
+}
+
+func validateOrderDetailMatchesRequestedID(requested string, detail *parser.OrderDetail) error {
+	if detail == nil || strings.TrimSpace(detail.OrderID) == "" {
+		return fmt.Errorf("Amazon order detail page did not include an order ID for requested order %s", requested)
+	}
+	if detail.OrderID != requested {
+		return fmt.Errorf("Amazon order detail page did not match requested order %s (got %s)", requested, detail.OrderID)
+	}
+	return nil
 }

--- a/library/commerce/amazon-orders/internal/cli/orders_get.go
+++ b/library/commerce/amazon-orders/internal/cli/orders_get.go
@@ -105,3 +105,10 @@ func validateOrderDetailMatchesRequestedID(requested string, detail *parser.Orde
 	}
 	return nil
 }
+
+func validatePageContainsRequestedOrderID(requested string, data []byte) error {
+	if !strings.Contains(string(data), requested) {
+		return fmt.Errorf("Amazon page did not include requested order %s", requested)
+	}
+	return nil
+}

--- a/library/commerce/amazon-orders/internal/cli/orders_get_test.go
+++ b/library/commerce/amazon-orders/internal/cli/orders_get_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
+)
+
+func TestValidateOrderDetailMatchesRequestedID(t *testing.T) {
+	const requested = "702-5010515-8774615"
+	if err := validateOrderDetailMatchesRequestedID(requested, &parser.OrderDetail{OrderID: requested}); err != nil {
+		t.Fatalf("matching order ID returned error: %v", err)
+	}
+}
+
+func TestValidateOrderDetailRejectsMismatchedID(t *testing.T) {
+	err := validateOrderDetailMatchesRequestedID("702-5010515-8774615", &parser.OrderDetail{OrderID: "144-5062705-8396341"})
+	if err == nil {
+		t.Fatal("mismatched order ID returned nil error")
+	}
+	if !strings.Contains(err.Error(), "did not match requested order") {
+		t.Fatalf("error = %v, want requested-order mismatch", err)
+	}
+}
+
+func TestValidateOrderDetailRejectsMissingID(t *testing.T) {
+	err := validateOrderDetailMatchesRequestedID("702-5010515-8774615", &parser.OrderDetail{})
+	if err == nil {
+		t.Fatal("missing order ID returned nil error")
+	}
+	if !strings.Contains(err.Error(), "did not include an order ID") {
+		t.Fatalf("error = %v, want missing-order-ID message", err)
+	}
+}

--- a/library/commerce/amazon-orders/internal/cli/orders_get_test.go
+++ b/library/commerce/amazon-orders/internal/cli/orders_get_test.go
@@ -14,6 +14,16 @@ func TestValidateOrderDetailMatchesRequestedID(t *testing.T) {
 	}
 }
 
+func TestValidatePageContainsRequestedOrderID(t *testing.T) {
+	const orderID = "702-5010515-8774615"
+	if err := validatePageContainsRequestedOrderID(orderID, []byte(`<html>Order # 702-5010515-8774615</html>`)); err != nil {
+		t.Fatalf("validatePageContainsRequestedOrderID() unexpected error: %v", err)
+	}
+	if err := validatePageContainsRequestedOrderID(orderID, []byte(`<html>Order # 111-1111111-1111111</html>`)); err == nil {
+		t.Fatal("validatePageContainsRequestedOrderID() = nil, want mismatch error")
+	}
+}
+
 func TestValidateOrderDetailRejectsMismatchedID(t *testing.T) {
 	err := validateOrderDetailMatchesRequestedID("702-5010515-8774615", &parser.OrderDetail{OrderID: "144-5062705-8396341"})
 	if err == nil {

--- a/library/commerce/amazon-orders/internal/cli/orders_invoice.go
+++ b/library/commerce/amazon-orders/internal/cli/orders_invoice.go
@@ -35,7 +35,7 @@ func newOrdersInvoiceCmd(flags *rootFlags) *cobra.Command {
 			htmlRequestParams["orderID"] = args[0]
 			params := map[string]string{}
 			params["orderID"] = args[0]
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "orders", false, path, params, nil)
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "orders", false, path, params, nil, args[0])
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/library/commerce/amazon-orders/internal/cli/orders_invoice.go
+++ b/library/commerce/amazon-orders/internal/cli/orders_invoice.go
@@ -40,6 +40,9 @@ func newOrdersInvoiceCmd(flags *rootFlags) *cobra.Command {
 				return classifyAPIError(err, flags)
 			}
 			if !flags.dryRun {
+				if err := validatePageContainsRequestedOrderID(args[0], data); err != nil {
+					return err
+				}
 				data, err = extractHTMLResponse(data, htmlExtractionOptions{
 					Mode:           "page",
 					BaseURL:        htmlExtractionRequestURL(c.BaseURL, path, htmlRequestParams),

--- a/library/commerce/amazon-orders/internal/cli/orders_list.go
+++ b/library/commerce/amazon-orders/internal/cli/orders_list.go
@@ -42,7 +42,7 @@ func newOrdersListCmd(flags *rootFlags) *cobra.Command {
 			if flagStartIndex != 0 {
 				params["startIndex"] = fmt.Sprintf("%v", flagStartIndex)
 			}
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "orders", false, path, params, nil)
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "orders", true, path, params, nil, "")
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/library/commerce/amazon-orders/internal/cli/promoted_gift-cards.go
+++ b/library/commerce/amazon-orders/internal/cli/promoted_gift-cards.go
@@ -29,7 +29,7 @@ func newGiftCardsPromotedCmd(flags *rootFlags) *cobra.Command {
 			path := "/gc/balance"
 			htmlRequestParams := map[string]string{}
 			params := map[string]string{}
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "gift_cards", false, path, params, nil)
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "gift_cards", true, path, params, nil, "")
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/library/commerce/amazon-orders/internal/cli/promoted_shipments.go
+++ b/library/commerce/amazon-orders/internal/cli/promoted_shipments.go
@@ -67,7 +67,7 @@ func newShipmentsPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flagPackageIndex != 0 {
 				params["packageIndex"] = fmt.Sprintf("%v", flagPackageIndex)
 			}
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "shipments", false, path, params, nil)
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "shipments", false, path, params, nil, "")
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/library/commerce/amazon-orders/internal/cli/promoted_transactions.go
+++ b/library/commerce/amazon-orders/internal/cli/promoted_transactions.go
@@ -29,7 +29,7 @@ func newTransactionsPromotedCmd(flags *rootFlags) *cobra.Command {
 			path := "/cpe/yourpayments/transactions"
 			htmlRequestParams := map[string]string{}
 			params := map[string]string{}
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "transactions", false, path, params, nil)
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "transactions", true, path, params, nil, "")
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/library/commerce/amazon-orders/internal/cli/sync.go
+++ b/library/commerce/amazon-orders/internal/cli/sync.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/store"
 	"github.com/spf13/cobra"
 	"net/url"
@@ -180,7 +181,7 @@ Exit codes & warnings:
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
 					}
 					errCount++
-					if criticalResources[res.Resource] {
+					if criticalResources[res.Resource] || parser.IsAuthInterstitialError(res.Err) {
 						criticalErrCount++
 					}
 				} else if res.Warn != nil {
@@ -307,6 +308,12 @@ func syncResource(c interface {
 	var extractFailureTotal int
 	var consumedTotal int
 	anomalyEmitted := false
+	returnFetchError := func(err error) syncResult {
+		if !humanFriendly {
+			fmt.Fprintf(os.Stdout, `{"event":"sync_error","resource":"%s","error":"%s"}`+"\n", resource, strings.ReplaceAll(err.Error(), `"`, `\"`))
+		}
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("fetching %s: %w", resource, err), Duration: time.Since(started)}
+	}
 
 	for {
 		params := map[string]string{}
@@ -333,10 +340,10 @@ func syncResource(c interface {
 				}
 				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
 			}
-			if !humanFriendly {
-				fmt.Fprintf(os.Stdout, `{"event":"sync_error","resource":"%s","error":"%s"}`+"\n", resource, strings.ReplaceAll(err.Error(), `"`, `\"`))
-			}
-			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("fetching %s: %w", resource, err), Duration: time.Since(started)}
+			return returnFetchError(err)
+		}
+		if err := parser.AuthInterstitialError(data); err != nil {
+			return returnFetchError(err)
 		}
 
 		// Try to extract items from the response.

--- a/library/commerce/amazon-orders/internal/cli/track.go
+++ b/library/commerce/amazon-orders/internal/cli/track.go
@@ -44,8 +44,11 @@ JSON. For multi-shipment orders use --shipment-id.`,
 			if packageIndex > 0 {
 				params["packageIndex"] = fmt.Sprintf("%d", packageIndex)
 			}
-			raw, err := c.Get("/gp/your-account/ship-track", params)
+			raw, err := authenticatedGet(c, "/gp/your-account/ship-track", params)
 			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+			if err := parser.AuthInterstitialError(raw); err != nil {
 				return classifyAPIError(err, flags)
 			}
 			track, perr := parser.ParseShipTrack(raw)

--- a/library/commerce/amazon-orders/internal/parser/auth_interstitial.go
+++ b/library/commerce/amazon-orders/internal/parser/auth_interstitial.go
@@ -30,6 +30,16 @@ var orderHistoryTitleMarkers = []string{
 	"your orders",
 	"mis pedidos",
 	"tus pedidos",
+	"meine bestellungen",
+	"ihre bestellungen",
+	"vos commandes",
+	"mes commandes",
+	"i miei ordini",
+	"meus pedidos",
+	"seus pedidos",
+	"注文履歴",
+	"我的订单",
+	"我的訂單",
 }
 
 // authInterstitialPageError describes an Amazon sign-in, account-claim, CAPTCHA,

--- a/library/commerce/amazon-orders/internal/parser/auth_interstitial.go
+++ b/library/commerce/amazon-orders/internal/parser/auth_interstitial.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -18,9 +19,32 @@ var authInterstitialTitleMarkers = []string{
 	"sign-in",
 	"sign in",
 	"signin",
+	"iniciar sesión",
+	"iniciar sesion",
 	"robot check",
 	"authentication required",
 	"captcha",
+}
+
+var orderHistoryTitleMarkers = []string{
+	"your orders",
+	"mis pedidos",
+	"tus pedidos",
+}
+
+// authInterstitialPageError describes an Amazon sign-in, account-claim, CAPTCHA,
+// or identity-verification page served in place of authenticated buyer HTML.
+type authInterstitialPageError struct {
+	Reason string
+}
+
+func (e *authInterstitialPageError) Error() string {
+	return fmt.Sprintf("amazon returned a sign-in/interstitial page (%s); the browser session is not authenticated — run 'amazon-orders-pp-cli auth login --chrome' (or 'auth refresh') and retry", e.Reason)
+}
+
+func IsAuthInterstitialError(err error) bool {
+	var target *authInterstitialPageError
+	return errors.As(err, &target)
 }
 
 // DetectAuthInterstitial reports whether htmlBytes is an Amazon sign-in,
@@ -78,13 +102,39 @@ func DetectAuthInterstitial(htmlBytes []byte) (bool, string) {
 	return false, ""
 }
 
+// DetectOrderHistoryPage reports whether htmlBytes looks like Amazon's
+// authenticated order-history surface, not just any non-login HTTP 200 HTML.
+func DetectOrderHistoryPage(htmlBytes []byte) bool {
+	if len(htmlBytes) == 0 {
+		return false
+	}
+	body := string(htmlBytes)
+	lower := strings.ToLower(body)
+
+	if m := titleRegex.FindStringSubmatch(body); len(m) > 1 {
+		title := strings.ToLower(strings.TrimSpace(m[1]))
+		for _, marker := range orderHistoryTitleMarkers {
+			if strings.Contains(title, marker) {
+				return true
+			}
+		}
+	}
+
+	return strings.Contains(lower, "order-card") ||
+		strings.Contains(lower, "js-order-card") ||
+		strings.Contains(lower, "/your-orders/order-details") ||
+		strings.Contains(lower, "order #") ||
+		strings.Contains(lower, "pedido #") ||
+		strings.Contains(lower, "pedido realizado")
+}
+
 // AuthInterstitialError returns a non-nil error describing the interstitial
 // when htmlBytes is an Amazon sign-in/claim/challenge page, and nil otherwise.
 // Callers fetching live HTML use it to fail loudly with a re-auth hint instead
 // of silently parsing zero orders out of a sign-in page.
 func AuthInterstitialError(htmlBytes []byte) error {
 	if ok, reason := DetectAuthInterstitial(htmlBytes); ok {
-		return fmt.Errorf("amazon returned a sign-in/interstitial page (%s); the browser session is not authenticated — run 'amazon-orders-pp-cli auth login --chrome' (or 'auth refresh') and retry", reason)
+		return &authInterstitialPageError{Reason: reason}
 	}
 	return nil
 }

--- a/library/commerce/amazon-orders/internal/parser/auth_interstitial_test.go
+++ b/library/commerce/amazon-orders/internal/parser/auth_interstitial_test.go
@@ -18,6 +18,16 @@ func TestDetectAuthInterstitial(t *testing.T) {
 			want: true, reason: "Amazon Sign-In",
 		},
 		{
+			name: "amazon mexico sign-in title",
+			html: `<html><head><title dir="ltr">Amazon Iniciar sesión</title></head><body>...</body></html>`,
+			want: true, reason: "Amazon Iniciar sesión",
+		},
+		{
+			name: "amazon mexico sign-in title without accent",
+			html: `<html><head><title>Amazon Iniciar sesion</title></head><body>...</body></html>`,
+			want: true, reason: "Amazon Iniciar sesion",
+		},
+		{
 			name: "ax/claim interstitial",
 			html: `<html><head><title>Amazon</title></head><body><form action="/ax/claim?arb=193cca18">...</form></body></html>`,
 			want: true, reason: "/ax/claim",
@@ -87,5 +97,42 @@ func TestDetectAuthInterstitial_DoesNotBreakRealOrderPage(t *testing.T) {
 	}
 	if len(page.Orders) != 1 {
 		t.Fatalf("expected 1 order, got %d", len(page.Orders))
+	}
+}
+
+func TestDetectOrderHistoryPage(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want bool
+	}{
+		{
+			name: "your orders title",
+			html: `<html><head><title>Your Orders</title></head><body></body></html>`,
+			want: true,
+		},
+		{
+			name: "spanish orders title",
+			html: `<html><head><title>Mis pedidos</title></head><body></body></html>`,
+			want: true,
+		},
+		{
+			name: "order card",
+			html: `<html><body><div class="order-card js-order-card">ORDER # 111-1111111-1111111</div></body></html>`,
+			want: true,
+		},
+		{
+			name: "generic html",
+			html: `<html><head><title>Amazon.com</title></head><body>hello</body></html>`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectOrderHistoryPage([]byte(tt.html)); got != tt.want {
+				t.Fatalf("DetectOrderHistoryPage() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/library/commerce/amazon-orders/internal/parser/auth_interstitial_test.go
+++ b/library/commerce/amazon-orders/internal/parser/auth_interstitial_test.go
@@ -117,6 +117,26 @@ func TestDetectOrderHistoryPage(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "german empty orders title",
+			html: `<html><head><title>Ihre Bestellungen</title></head><body></body></html>`,
+			want: true,
+		},
+		{
+			name: "french empty orders title",
+			html: `<html><head><title>Vos commandes</title></head><body></body></html>`,
+			want: true,
+		},
+		{
+			name: "japanese empty orders title",
+			html: `<html><head><title>注文履歴</title></head><body></body></html>`,
+			want: true,
+		},
+		{
+			name: "chinese empty orders title",
+			html: `<html><head><title>我的订单</title></head><body></body></html>`,
+			want: true,
+		},
+		{
 			name: "order card",
 			html: `<html><body><div class="order-card js-order-card">ORDER # 111-1111111-1111111</div></body></html>`,
 			want: true,


### PR DESCRIPTION
## Summary

Amazon Orders now fails honestly when Amazon returns sign-in, claim, CAPTCHA, or challenge HTML with HTTP 200. Before this, `doctor` could report a fresh/usable setup while order reads, search, and sync parsed or cached login pages as successful data; now those paths return auth errors and point the operator back to `auth login --chrome` and `doctor`.

The fix guards authenticated HTML before parsing, before SQLite write-through, before workflow/archive persistence, and before sync writes. `doctor` now validates the real order-history surface and flags tainted local cache rows, while local order detail/invoice lookups use the requested order ID instead of the static endpoint path.

## Validation

- `go test ./internal/parser ./internal/cli -run 'AuthInterstitial|OrderHistory|ResolveRead|SyncResource|ValidateOrderDetail|DoctorLiveCredential|CollectCacheReport|FetchOrderListPages|TrackRejects|WorkflowArchive|SyncAuthInterstitial'`
- `go test ./...`
- `go build ./cmd/amazon-orders-pp-cli`
- `go vet ./...`
- `git diff --check`
- Live smoke on current local Amazon session: `doctor --agent --fail-on error` reports stale browser proof plus tainted `orders`/`transactions` cache; `find Aqara`, `orders get 702-5010515-8774615`, and `sync --resources orders,transactions --since 90d --strict` all fail with explicit auth/interstitial errors instead of returning false data.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
