### PR TITLE
fix(ebay): preserve commerce fields in agent compact output

### DIFF
--- a/library/commerce/ebay/.printing-press-patches/agent-compact-preserves-commerce-fields.json
+++ b/library/commerce/ebay/.printing-press-patches/agent-compact-preserves-commerce-fields.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "agent-compact-preserves-commerce-fields",
+  "applied_at": "2026-07-02",
+  "base_run_id": "2026-04-30T15:53:54.784232Z",
+  "base_printing_press_version": "3.0.1",
+  "summary": "eBay agent compact output must preserve commerce-critical listing and comp fields such as price, condition, bids, sold_price, currency, and comp statistics.",
+  "reason": "The generic compact allow-list made --agent unusable for commerce commands by keeping title/url while stripping the pricing and auction fields agents need; consumers misread the result as parser drift or missing vendor data.",
+  "files": [
+    "internal/cli/helpers.go",
+    "internal/cli/helpers_compact_test.go"
+  ],
+  "validated_outcome": "library/commerce/ebay/internal/cli helpers_compact_test.go verifies listing/sold/auction fields and comp summary fields survive compact output while verbose fields are stripped."
+}

--- a/library/commerce/ebay/README.md
+++ b/library/commerce/ebay/README.md
@@ -201,9 +201,9 @@ ebay-pp-cli comp "Zion Williamson rookie" --condition graded --json
 ebay-pp-cli auctions "PSA Mariners 1980" --has-bids --max-price 30 --json | \
   jq '.[] | {title, price, bids, ends_at, url}'
 
-# Save a search and re-run it
-ebay-pp-cli saved-search create vintage-mariners --query "PSA Mariners Griffey" --max-price 30
-ebay-pp-cli feed vintage-mariners --since 1h
+# Save a search and re-run it (stubbed commands; inspect current planned shape)
+ebay-pp-cli saved-search --help
+ebay-pp-cli feed --help
 ```
 
 ## Known Limitations

--- a/library/commerce/ebay/internal/cli/helpers.go
+++ b/library/commerce/ebay/internal/cli/helpers.go
@@ -515,6 +515,7 @@ func compactListFields(items []map[string]any) json.RawMessage {
 		"condition": true, "seller": true, "bids": true, "best_offer": true,
 		"auction": true, "buy_it_now": true, "time_left": true, "ends_at": true,
 		"sold_date": true, "image_url": true, "location": true, "shipping": true,
+		// Comp-summary statistical fields (listings/comp command).
 		"mean": true, "median": true, "sample_size": true, "p25": true,
 		"p75": true, "std_dev": true,
 	}

--- a/library/commerce/ebay/internal/cli/helpers.go
+++ b/library/commerce/ebay/internal/cli/helpers.go
@@ -507,6 +507,16 @@ func compactListFields(items []map[string]any) json.RawMessage {
 		"status": true, "state": true, "type": true, "priority": true,
 		"url": true, "email": true, "key": true,
 		"created_at": true, "updated_at": true, "createdAt": true, "updatedAt": true,
+		// Commerce/search result fields. eBay's `listings`, `sold`, `comp`, and
+		// `auctions` commands are useless to agents if compact mode strips the
+		// price/condition/bid fields. `--agent` implies `--compact`, so these must
+		// survive the generic allow-list.
+		"item_id": true, "price": true, "sold_price": true, "currency": true,
+		"condition": true, "seller": true, "bids": true, "best_offer": true,
+		"auction": true, "buy_it_now": true, "time_left": true, "ends_at": true,
+		"sold_date": true, "image_url": true, "location": true, "shipping": true,
+		"mean": true, "median": true, "sample_size": true, "p25": true,
+		"p75": true, "std_dev": true,
 	}
 
 	filtered := make([]map[string]any, 0, len(items))

--- a/library/commerce/ebay/internal/cli/helpers_compact_test.go
+++ b/library/commerce/ebay/internal/cli/helpers_compact_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCompactListFieldsPreservesCommerceFields(t *testing.T) {
+	input := []map[string]any{
+		{
+			"item_id":     "398130961247",
+			"title":       "NVIDIA GeForce RTX 5090 Founders Edition",
+			"price":       3999.99,
+			"sold_price":  3825.00,
+			"currency":    "USD",
+			"condition":   "new",
+			"seller":      "example-seller",
+			"bids":        float64(12),
+			"best_offer":  true,
+			"auction":     true,
+			"buy_it_now":  false,
+			"time_left":   "1h 12m",
+			"ends_at":     "2026-07-02T20:00:00Z",
+			"sold_date":   "2026-07-01T00:00:00Z",
+			"url":         "https://www.ebay.com/itm/398130961247",
+			"image_url":   "https://i.ebayimg.com/images/example.webp",
+			"location":    "Madison, Wisconsin",
+			"shipping":    "Free shipping",
+			"description": "large verbose body should not survive compact list output",
+		},
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal(compactListFields(input), &got); err != nil {
+		t.Fatalf("unmarshal compact output: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one compact row, got %d", len(got))
+	}
+	row := got[0]
+	for _, key := range []string{
+		"item_id", "title", "price", "sold_price", "currency", "condition",
+		"seller", "bids", "best_offer", "auction", "buy_it_now", "time_left",
+		"ends_at", "sold_date", "url", "image_url", "location", "shipping",
+	} {
+		if _, ok := row[key]; !ok {
+			t.Fatalf("compact output dropped commerce field %q; row=%v", key, row)
+		}
+	}
+	if _, ok := row["description"]; ok {
+		t.Fatalf("compact output kept verbose field description; row=%v", row)
+	}
+}
+
+func TestCompactListFieldsPreservesCompSummaryFields(t *testing.T) {
+	input := []map[string]any{{
+		"mean": 3200.0, "median": 3150.0, "sample_size": float64(24),
+		"p25": 2900.0, "p75": 3500.0, "std_dev": 180.0,
+		"notes": "verbose diagnostic",
+	}}
+
+	var got []map[string]any
+	if err := json.Unmarshal(compactListFields(input), &got); err != nil {
+		t.Fatalf("unmarshal compact output: %v", err)
+	}
+	row := got[0]
+	for _, key := range []string{"mean", "median", "sample_size", "p25", "p75", "std_dev"} {
+		if _, ok := row[key]; !ok {
+			t.Fatalf("compact output dropped comp field %q; row=%v", key, row)
+		}
+	}
+	if _, ok := row["notes"]; ok {
+		t.Fatalf("compact output kept verbose field notes; row=%v", row)
+	}
+}


### PR DESCRIPTION
## Summary

- keep eBay commerce fields in compact list output so --agent does not strip price/condition/bid data
- adds regression coverage for listing/sold/auction and comp summary fields
 
## Why
- The eBay CLI documents --agent as JSON + compact + non-interactive. For commerce commands like listings/sold/auctions/comp, the generic compact allow-list kept title/url but dropped the fields agents actually need: price, condition, currency, bids, sold_price, etc. Downstream consumers had to avoid --agent to get usable pricing data.

## Test
- cd library/commerce/ebay && go test ./...