### PR TITLE
fix(trustpilot): 404 error names the missing domain; help text says reviews-fetch

### DIFF
--- a/library/marketing/trustpilot/.printing-press-patches/reviews-404-means-missing-domain-not-stale-auth.json
+++ b/library/marketing/trustpilot/.printing-press-patches/reviews-404-means-missing-domain-not-stale-auth.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "id": "reviews-404-means-missing-domain-not-stale-auth",
+  "applied_at": "2026-07-03",
+  "base_run_id": "20260515-075905",
+  "base_printing_press_version": "4.6.1",
+  "summary": "A reviews-endpoint 404 must lead with 'no Trustpilot review page for this domain - find it with search' and mention stale-build-id second; the search endpoint's 404 (no domain in path) keeps the stale-build-id message, and both retry helpers keep matching the shared error type. All help/MCP text must spell the real command 'reviews-fetch', never 'reviews fetch'.",
+  "reason": "Review pages are keyed by domain, so bare company names and wrong domains 404 constantly; the old 're-run auth login' message sent callers (including the last30days engine) chasing auth failures that were never auth, and the 'reviews fetch' spelling routed agents to the raw build-id passthrough instead of the working reviews-fetch command.",
+  "files": [
+    "internal/trustpilot/transport.go",
+    "internal/trustpilot/transport_test.go",
+    "internal/cli/promoted_reviews.go",
+    "internal/cli/promoted_companies.go",
+    "internal/mcp/tools.go",
+    "README.md",
+    "SKILL.md"
+  ],
+  "validated_outcome": "go build/vet pass; go test 170 passed incl. new transport error-message contract tests; verify_skill.py all checks pass."
+}

--- a/library/marketing/trustpilot/README.md
+++ b/library/marketing/trustpilot/README.md
@@ -248,13 +248,13 @@ Run `trustpilot-pp-cli --help` for the full command reference and flag list.
 
 Search Trustpilot for companies by name and resolve to their canonical domain
 
-- **`trustpilot-pp-cli companies search`** - Search for companies matching a name; returns identifyingName domains usable with reviews fetch
+- **`trustpilot-pp-cli companies search`** - Search for companies matching a name; returns identifyingName domains usable with reviews-fetch
 
 ### reviews
 
 Fetch Trustpilot reviews for a company
 
-- **`trustpilot-pp-cli reviews list`** - Fetch a page of reviews for a company by domain (use 'reviews fetch <domain>' from the CLI). Authenticated via aws-waf-token cookie harvested with auth login.
+- **`trustpilot-pp-cli reviews list`** - Fetch a page of reviews for a company by domain (use 'reviews-fetch <domain>' from the CLI). Authenticated via aws-waf-token cookie harvested with auth login.
 
 ## Output Formats
 

--- a/library/marketing/trustpilot/SKILL.md
+++ b/library/marketing/trustpilot/SKILL.md
@@ -143,11 +143,11 @@ This CLI uses Chrome-compatible HTTP transport for browser-facing endpoints. It 
 
 **companies** — Search Trustpilot for companies by name and resolve to their canonical domain
 
-- `trustpilot-pp-cli companies <search_build_id>` — Search for companies matching a name; returns identifyingName domains usable with reviews fetch
+- `trustpilot-pp-cli companies <search_build_id>` — Search for companies matching a name; returns identifyingName domains usable with reviews-fetch
 
 **reviews** — Fetch Trustpilot reviews for a company
 
-- `trustpilot-pp-cli reviews <review_build_id> <domain>` — Fetch a page of reviews for a company by domain (use 'reviews fetch <domain>' from the CLI). Authenticated via...
+- `trustpilot-pp-cli reviews <review_build_id> <domain>` — Fetch a page of reviews for a company by domain (use 'reviews-fetch <domain>' from the CLI). Authenticated via...
 
 
 ### Finding the right command

--- a/library/marketing/trustpilot/internal/cli/promoted_companies.go
+++ b/library/marketing/trustpilot/internal/cli/promoted_companies.go
@@ -16,8 +16,8 @@ func newCompaniesPromotedCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:         "companies <search_build_id>",
-		Short:       "Search for companies matching a name; returns identifyingName domains usable with reviews fetch",
-		Long:        "Shortcut for 'companies search'. Search for companies matching a name; returns identifyingName domains usable with reviews fetch",
+		Short:       "Search for companies matching a name; returns identifyingName domains usable with reviews-fetch",
+		Long:        "Shortcut for 'companies search'. Search for companies matching a name; returns identifyingName domains usable with reviews-fetch",
 		Example:     "  trustpilot-pp-cli companies 550e8400-e29b-41d4-a716-446655440000 --query example-value",
 		Annotations: map[string]string{"pp:endpoint": "companies.search", "pp:method": "GET", "pp:path": "/_next/data/{search_build_id}/search.json", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/library/marketing/trustpilot/internal/cli/promoted_reviews.go
+++ b/library/marketing/trustpilot/internal/cli/promoted_reviews.go
@@ -22,8 +22,8 @@ func newReviewsPromotedCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:         "reviews <review_build_id> <domain>",
-		Short:       "Fetch a page of reviews for a company by domain (use 'reviews fetch <domain>' from the CLI). Authenticated via...",
-		Long:        "Shortcut for 'reviews list'. Fetch a page of reviews for a company by domain (use 'reviews fetch <domain>' from the CLI). Authenticated via...",
+		Short:       "Fetch a page of reviews for a company by domain (use 'reviews-fetch <domain>' from the CLI). Authenticated via...",
+		Long:        "Shortcut for 'reviews list'. Fetch a page of reviews for a company by domain (use 'reviews-fetch <domain>' from the CLI). Authenticated via...",
 		Example:     "  trustpilot-pp-cli reviews 550e8400-e29b-41d4-a716-446655440000 example-value --business-unit example-value",
 		Annotations: map[string]string{"pp:endpoint": "reviews.list", "pp:method": "GET", "pp:path": "/_next/data/{review_build_id}/review/{domain}.json", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/library/marketing/trustpilot/internal/mcp/tools.go
+++ b/library/marketing/trustpilot/internal/mcp/tools.go
@@ -25,7 +25,7 @@ import (
 func RegisterTools(s *server.MCPServer) {
 	s.AddTool(
 		mcplib.NewTool("companies_search",
-			mcplib.WithDescription("Search for companies matching a name; returns identifyingName domains usable with reviews fetch. Required: search_build_id, query."),
+			mcplib.WithDescription("Search for companies matching a name; returns identifyingName domains usable with reviews-fetch. Required: search_build_id, query."),
 			mcplib.WithString("search_build_id", mcplib.Required(), mcplib.Description("Next.js search-pages build id")),
 			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Company name or fragment")),
 			mcplib.WithReadOnlyHintAnnotation(true),
@@ -36,7 +36,7 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("reviews_list",
-			mcplib.WithDescription("Fetch a page of reviews for a company by domain (use 'reviews fetch <domain>' from the CLI). Authenticated via aws-waf-token cookie harvested with auth login. Required: review_build_id, domain, businessUnit. Optional: page (default: 1), stars, languages (plus 3 more). Returns the ReviewPage."),
+			mcplib.WithDescription("Fetch a page of reviews for a company by domain (use 'reviews-fetch <domain>' from the CLI). Authenticated via aws-waf-token cookie harvested with auth login. Required: review_build_id, domain, businessUnit. Optional: page (default: 1), stars, languages (plus 3 more). Returns the ReviewPage."),
 			mcplib.WithString("review_build_id", mcplib.Required(), mcplib.Description("Next.js review-pages build id (harvested at session start)")),
 			mcplib.WithString("domain", mcplib.Required(), mcplib.Description("Trustpilot company domain (e.g. www.thriftbooks.com)")),
 			mcplib.WithString("businessUnit", mcplib.Required(), mcplib.Description("Same as domain; Trustpilot wire param")),

--- a/library/marketing/trustpilot/internal/trustpilot/transport.go
+++ b/library/marketing/trustpilot/internal/trustpilot/transport.go
@@ -106,7 +106,7 @@ func (c *Client) FetchPage(ctx context.Context, domain string, filters PageFilte
 		if err := json.Unmarshal(body, &redirectEnvelope); err == nil && redirectEnvelope.PageProps.NRedirect != "" {
 			return ReviewsPage{}, &FilterUnsupportedError{ParamHint: filterParamHint(filters)}
 		}
-		return ReviewsPage{}, &BuildIDStaleError{Status: resp.StatusCode}
+		return ReviewsPage{}, &BuildIDStaleError{Status: resp.StatusCode, Domain: domain}
 	}
 	if resp.StatusCode/100 != 2 {
 		return ReviewsPage{}, fmt.Errorf("trustpilot reviews returned HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
@@ -200,11 +200,25 @@ func (e *CookieExpiredError) Error() string {
 	return fmt.Sprintf("aws-waf-token rejected (HTTP %d); re-run auth login", e.Status)
 }
 
-// BuildIDStaleError signals that the Next.js build id baked into the URL is
-// no longer recognized; the caller should re-harvest both build ids.
-type BuildIDStaleError struct{ Status int }
+// BuildIDStaleError signals an HTTP 404 from a Next.js data endpoint. On the
+// reviews endpoint (Domain set) the likelier cause is that no Trustpilot
+// review page exists for that domain -- review pages are keyed by domain, so
+// a company name or a lookalike domain 404s here; a stale build id is the
+// rarer alternative. On the search endpoint (Domain empty) the path has no
+// domain component, so a 404 is the stale-build-id signal itself. One type
+// covers both because the retry helpers key on it to trigger a re-harvest.
+type BuildIDStaleError struct {
+	Status int
+	Domain string
+}
 
 func (e *BuildIDStaleError) Error() string {
+	if e.Domain != "" {
+		return fmt.Sprintf(
+			"no Trustpilot review page found for %q (HTTP %d) - find the canonical domain with: trustpilot-pp-cli search '<company name>'; if the domain is correct, the build id may be stale - re-run auth login",
+			e.Domain, e.Status,
+		)
+	}
 	return fmt.Sprintf("Next.js build id rejected (HTTP %d); re-run auth login to refresh", e.Status)
 }
 

--- a/library/marketing/trustpilot/internal/trustpilot/transport_test.go
+++ b/library/marketing/trustpilot/internal/trustpilot/transport_test.go
@@ -1,0 +1,52 @@
+package trustpilot
+
+import (
+	"strings"
+	"testing"
+)
+
+// A reviews-endpoint 404 (Domain set) usually means the domain has no
+// Trustpilot review page -- the message must lead with that hypothesis and
+// point at `search`, mentioning the stale-build-id alternative second. The
+// pre-patch message ("re-run auth login") sent callers chasing auth when the
+// domain was simply wrong.
+func TestBuildIDStaleErrorWithDomainLeadsWithDomainGuidance(t *testing.T) {
+	err := &BuildIDStaleError{Status: 404, Domain: "nosuchbrandxyz"}
+	msg := err.Error()
+	if !strings.Contains(msg, `"nosuchbrandxyz"`) {
+		t.Fatalf("message must name the missing domain, got: %s", msg)
+	}
+	if !strings.Contains(msg, "no Trustpilot review page found") {
+		t.Fatalf("message must lead with the domain-not-found hypothesis, got: %s", msg)
+	}
+	if !strings.Contains(msg, "trustpilot-pp-cli search") {
+		t.Fatalf("message must suggest the search command, got: %s", msg)
+	}
+	if !strings.Contains(msg, "auth login") {
+		t.Fatalf("message must still mention the stale-build-id remediation, got: %s", msg)
+	}
+}
+
+// The search endpoint's path has no domain component, so its 404 stays the
+// stale-build-id signal with the original message (Domain empty).
+func TestBuildIDStaleErrorWithoutDomainKeepsBuildIDMessage(t *testing.T) {
+	err := &BuildIDStaleError{Status: 404}
+	msg := err.Error()
+	if !strings.Contains(msg, "build id rejected") {
+		t.Fatalf("domain-less 404 must keep the stale-build-id message, got: %s", msg)
+	}
+	if strings.Contains(msg, "review page") {
+		t.Fatalf("domain-less 404 must not claim a missing review page, got: %s", msg)
+	}
+}
+
+// Regression guards: the sibling error types' messages are matched by callers
+// and user muscle memory; this patch must not drift them.
+func TestSiblingErrorMessagesUnchanged(t *testing.T) {
+	if msg := (&CookieExpiredError{Status: 403}).Error(); !strings.Contains(msg, "aws-waf-token rejected") {
+		t.Fatalf("CookieExpiredError message drifted: %s", msg)
+	}
+	if msg := (&FilterUnsupportedError{ParamHint: "date=last30days"}).Error(); !strings.Contains(msg, "unsupported filter") {
+		t.Fatalf("FilterUnsupportedError message drifted: %s", msg)
+	}
+}


### PR DESCRIPTION
## Summary

A reviews-endpoint 404 was reported as `Next.js build id rejected (HTTP 404); re-run auth login to refresh`, sending callers chasing auth failures when the real problem was a domain with no Trustpilot review page. Review pages are keyed by domain, so bare company names and lookalike domains 404 constantly - this misdiagnosis cost a full debugging session in the last30days engine integration (companion PR: mvanhorn/last30days-skill#745).

Separately, help/MCP/README/SKILL text told users to run `reviews fetch <domain>` - a command that does not exist (the real spelling is `reviews-fetch`), routing users and agents to the raw build-id passthrough instead of the working high-level command.

## Changes

- `internal/trustpilot/transport.go`: `BuildIDStaleError` gains a `Domain` field. `FetchPage`'s plain-404 path sets it, producing: `no Trustpilot review page found for "<domain>" (HTTP 404) - find the canonical domain with: trustpilot-pp-cli search '<company name>'; if the domain is correct, the build id may be stale - re-run auth login`. `FetchSearch`'s 404 (no domain in its path - a genuine stale-build-id signal) keeps the original message. One shared type means both retry helpers (`fetchPageWithRetry`, `fetchSearchWithRetry`) keep their re-harvest contracts unchanged.
- `internal/trustpilot/transport_test.go` (new): error-message contract tests - domain-404 guidance, domain-less 404 unchanged, sibling error messages (`CookieExpiredError`, `FilterUnsupportedError`) regression-guarded.
- `reviews fetch` -> `reviews-fetch` in `internal/cli/promoted_reviews.go`, `internal/cli/promoted_companies.go`, `internal/mcp/tools.go`, `README.md`, `SKILL.md` (zero remaining occurrences).
- Patch recorded at `.printing-press-patches/reviews-404-means-missing-domain-not-stale-auth.json` per the reprint-guard convention.

## Testing

- `go build ./...`, `go vet ./...` clean; `go test ./...` 170 passed (including the new transport tests).
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/marketing/trustpilot/` - all checks pass.
- Manual: `trustpilot-pp-cli info NoSuchBrandXYZ` (fresh session) now surfaces the domain-not-found guidance instead of only re-run-auth-login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhBKEWrZV9cpfzNu7rmRzR