### PR TITLE
fix(vagaro): target business availability filters

### DIFF
--- a/library/health/vagaro/.printing-press-patches/vagaro-business-availability-filters.json
+++ b/library/health/vagaro/.printing-press-patches/vagaro-business-availability-filters.json
@@ -4,7 +4,7 @@
   "applied_at": "2026-07-08",
   "base_run_id": "20260701-143117-d22a0c47",
   "base_printing_press_version": "4.27.1",
-  "summary": "business availability now accepts --service, --provider, --from, --to, and --weeks so callers can target a concrete service/provider/date window. Requested service/provider filters resolve by ID, exact name, or unique substring and fail on missing or ambiguous matches instead of silently falling back.",
+  "summary": "business availability now accepts --service, --provider, --from, --to, and --weeks so callers can target a concrete service/provider/date window. Requested service/provider filters resolve by ID, exact name, or unique substring and fail on missing or ambiguous matches instead of silently falling back; businesses with no services still return the structured no-services summary.",
   "reason": "The shipped command always queried the first service, any provider, and the current week, which made provider-specific booking workflows return coarse or wrong availability.",
   "files": [
     "internal/cli/business_availability.go",

--- a/library/health/vagaro/.printing-press-patches/vagaro-business-availability-filters.json
+++ b/library/health/vagaro/.printing-press-patches/vagaro-business-availability-filters.json
@@ -4,7 +4,7 @@
   "applied_at": "2026-07-08",
   "base_run_id": "20260701-143117-d22a0c47",
   "base_printing_press_version": "4.27.1",
-  "summary": "business availability now accepts --service, --provider, --from, --to, and --weeks so callers can target a concrete service/provider/date window. Requested service/provider filters resolve by ID, exact name, or unique substring and fail on missing or ambiguous matches instead of silently falling back; businesses with no services still return the structured no-services summary.",
+  "summary": "business availability now accepts --service, --provider, --from, --to, and --weeks so callers can target a concrete service/provider/date window. Requested service/provider filters resolve by ID, exact name, or unique substring, returned groups are filtered to the resolved provider ID, and empty-service businesses still return the structured no-services summary.",
   "reason": "The shipped command always queried the first service, any provider, and the current week, which made provider-specific booking workflows return coarse or wrong availability.",
   "files": [
     "internal/cli/business_availability.go",

--- a/library/health/vagaro/.printing-press-patches/vagaro-business-availability-filters.json
+++ b/library/health/vagaro/.printing-press-patches/vagaro-business-availability-filters.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "vagaro-business-availability-filters",
+  "applied_at": "2026-07-08",
+  "base_run_id": "20260701-143117-d22a0c47",
+  "base_printing_press_version": "4.27.1",
+  "summary": "business availability now accepts --service, --provider, --from, --to, and --weeks so callers can target a concrete service/provider/date window. Requested service/provider filters resolve by ID, exact name, or unique substring and fail on missing or ambiguous matches instead of silently falling back.",
+  "reason": "The shipped command always queried the first service, any provider, and the current week, which made provider-specific booking workflows return coarse or wrong availability.",
+  "files": [
+    "internal/cli/business_availability.go",
+    "internal/cli/business_availability_test.go",
+    "README.md",
+    "SKILL.md"
+  ]
+}

--- a/library/health/vagaro/README.md
+++ b/library/health/vagaro/README.md
@@ -201,6 +201,13 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   vagaro-pp-cli watch centralbarber --service haircut --before 2026-07-05 --agent
   ```
+- **`business availability`** — Query one known business for available slots, scoped to a service, provider, and date range.
+
+  _Use when the user already knows the business and needs a precise provider/service/window answer._
+
+  ```bash
+  vagaro-pp-cli business availability sample-shop --service haircut --provider alex --from 2026-07-20 --to 2026-07-31 --agent
+  ```
 
 ## Recipes
 
@@ -227,6 +234,14 @@ vagaro-pp-cli me rebook --last --from thu --to sat --agent
 ```
 
 Reads your last appointment's business/service/provider and lists that provider's open times so you can pick one.
+
+### Check a known business for one provider's openings
+
+```bash
+vagaro-pp-cli business availability sample-shop --service haircut --provider alex --from 2026-07-20 --weeks 2 --agent
+```
+
+Resolves the service and provider by exact ID, exact name, or a unique name substring, then queries the requested weekly availability window. If a requested service or provider cannot be resolved uniquely, the command fails instead of falling back to the first service or any provider. Omit all flags to preserve the legacy behavior: first listed service, any provider, current week.
 
 ### Check if a haircut price is fair in your city
 
@@ -295,7 +310,7 @@ Existing installs keep working because the platform-default rung matches the leg
 
 Look up a Vagaro business (salon/spa/barber/fitness) by its slug
 
-- **`vagaro-pp-cli business availability`** - Get a business's next-available booking summary
+- **`vagaro-pp-cli business availability`** - Get a business's next-available booking summary; supports `--service <name-or-id>`, `--provider <name-or-id>`, `--from <date>`, `--to <date>`, and `--weeks <n>`
 - **`vagaro-pp-cli business get`** - Get a business profile (name, rating, address, categories)
 - **`vagaro-pp-cli business services`** - List a business's services with prices and durations
 

--- a/library/health/vagaro/SKILL.md
+++ b/library/health/vagaro/SKILL.md
@@ -106,12 +106,19 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   vagaro-pp-cli watch centralbarber --service haircut --before 2026-07-05 --agent
   ```
+- **`business availability`** — Query one known business for available slots, scoped to a service, provider, and date range.
+
+  _Use when the user already knows the business and needs a precise provider/service/window answer._
+
+  ```bash
+  vagaro-pp-cli business availability sample-shop --service haircut --provider alex --from 2026-07-20 --to 2026-07-31 --agent
+  ```
 
 ## Command Reference
 
 **business** — Look up a Vagaro business (salon/spa/barber/fitness) by its slug
 
-- `vagaro-pp-cli business availability` — Get a business's next-available booking summary
+- `vagaro-pp-cli business availability` — Get a business's next-available booking summary; supports `--service <name-or-id>`, `--provider <name-or-id>`, `--from <date>`, `--to <date>`, and `--weeks <n>`
 - `vagaro-pp-cli business get` — Get a business profile (name, rating, address, categories)
 - `vagaro-pp-cli business services` — List a business's services with prices and durations
 

--- a/library/health/vagaro/internal/cli/business_availability.go
+++ b/library/health/vagaro/internal/cli/business_availability.go
@@ -126,7 +126,7 @@ func newBusinessAvailabilityCmd(flags *rootFlags) *cobra.Command {
 				if err != nil {
 					return classifyVagaroError(err, flags)
 				}
-				for _, g := range filterAvailabilityGroups(groups, plan.From, plan.To) {
+				for _, g := range filterAvailabilityGroups(groups, plan.ProviderID, plan.From, plan.To) {
 					summary.TotalSlots += len(g.Times)
 					summary.Groups = append(summary.Groups, g)
 				}
@@ -274,9 +274,12 @@ func availabilityWeekDates(from, to time.Time) []time.Time {
 	return weeks
 }
 
-func filterAvailabilityGroups(groups []vagaro.SlotGroup, from, to time.Time) []vagaro.SlotGroup {
+func filterAvailabilityGroups(groups []vagaro.SlotGroup, providerID string, from, to time.Time) []vagaro.SlotGroup {
 	out := make([]vagaro.SlotGroup, 0, len(groups))
 	for _, g := range groups {
+		if providerID != "" && strings.TrimSpace(g.ProviderID) != providerID {
+			continue
+		}
 		kept := g
 		kept.Times = nil
 		for _, slot := range g.Times {

--- a/library/health/vagaro/internal/cli/business_availability.go
+++ b/library/health/vagaro/internal/cli/business_availability.go
@@ -85,7 +85,7 @@ func newBusinessAvailabilityCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyVagaroError(err, flags)
 			}
-			if len(services) == 0 && strings.TrimSpace(opts.Service) == "" && strings.TrimSpace(opts.Provider) == "" {
+			if len(services) == 0 {
 				summary := availabilitySummary{Slug: slug, BusinessID: businessID, Groups: []vagaro.SlotGroup{}, Note: "business has no bookable services"}
 				return emitVagaro(cmd, flags, summary)
 			}

--- a/library/health/vagaro/internal/cli/business_availability.go
+++ b/library/health/vagaro/internal/cli/business_availability.go
@@ -6,6 +6,7 @@ package cli
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,21 +16,50 @@ import (
 
 // availabilitySummary is the compact next-available view for a business.
 type availabilitySummary struct {
-	Slug        string             `json:"slug"`
-	BusinessID  string             `json:"business_id"`
-	ServiceID   int64              `json:"service_id,omitempty"`
-	ServiceName string             `json:"service,omitempty"`
-	WeekOf      string             `json:"week_of"`
-	TotalSlots  int                `json:"total_slots"`
-	Groups      []vagaro.SlotGroup `json:"groups"`
-	Note        string             `json:"note,omitempty"`
+	Slug         string             `json:"slug"`
+	BusinessID   string             `json:"business_id"`
+	ServiceID    int64              `json:"service_id,omitempty"`
+	ServiceName  string             `json:"service,omitempty"`
+	ProviderID   string             `json:"provider_id,omitempty"`
+	ProviderName string             `json:"provider,omitempty"`
+	WeekOf       string             `json:"week_of"`
+	From         string             `json:"from,omitempty"`
+	To           string             `json:"to,omitempty"`
+	Weeks        []string           `json:"weeks,omitempty"`
+	TotalSlots   int                `json:"total_slots"`
+	Groups       []vagaro.SlotGroup `json:"groups"`
+	Note         string             `json:"note,omitempty"`
+}
+
+type availabilityOptions struct {
+	Service  string
+	Provider string
+	From     string
+	To       string
+	Weeks    int
+}
+
+type availabilityPlan struct {
+	Service      vagaro.ServiceRow
+	ProviderID   string
+	ProviderName string
+	From         time.Time
+	To           time.Time
+	WeekDates    []time.Time
+	ExplicitFrom bool
+	ExplicitTo   bool
 }
 
 func newBusinessAvailabilityCmd(flags *rootFlags) *cobra.Command {
+	var opts availabilityOptions
 	cmd := &cobra.Command{
-		Use:     "availability <slug>",
-		Short:   "Summarize a business's next-available slots for the current week",
-		Example: "  vagaro-pp-cli business availability centralbarber",
+		Use:   "availability <slug>",
+		Short: "Summarize a business's next-available slots, optionally scoped by service, provider, and date window",
+		Example: strings.Join([]string{
+			"  vagaro-pp-cli business availability sample-shop",
+			"  vagaro-pp-cli business availability sample-shop --service haircut --provider alex --from 2026-07-20 --to 2026-07-31",
+			"  vagaro-pp-cli business availability sample-shop --service 12345 --weeks 3 --agent",
+		}, "\n"),
 		// pp:data-source live
 		Annotations: map[string]string{"mcp:read-only": "true", "pp:data-source": "live", "pp:happy-args": "slug=centralbarber"},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -55,33 +85,220 @@ func newBusinessAvailabilityCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyVagaroError(err, flags)
 			}
-			summary := availabilitySummary{Slug: slug, BusinessID: businessID, Groups: []vagaro.SlotGroup{}}
-			if len(services) == 0 {
-				summary.Note = "business has no bookable services"
+			if len(services) == 0 && strings.TrimSpace(opts.Service) == "" && strings.TrimSpace(opts.Provider) == "" {
+				summary := availabilitySummary{Slug: slug, BusinessID: businessID, Groups: []vagaro.SlotGroup{}, Note: "business has no bookable services"}
 				return emitVagaro(cmd, flags, summary)
 			}
-			svc := services[0]
-			summary.ServiceID = svc.ServiceID
-			summary.ServiceName = svc.ServiceTitle
+			providers := []vagaro.Provider(nil)
+			if strings.TrimSpace(opts.Provider) != "" {
+				providers, err = c.Staff(ctx, businessID)
+				if err != nil {
+					return classifyVagaroError(err, flags)
+				}
+			}
 
-			appDate, err := vagaro.FormatAppDate(time.Now().Format("2006-01-02"))
+			plan, err := buildAvailabilityPlan(services, providers, opts, time.Now())
 			if err != nil {
-				return err
+				return usageErr(err)
 			}
-			summary.WeekOf = appDate
-			groups, err := c.Availability(ctx, businessID, fmt.Sprintf("%d", svc.ServiceID), "", appDate)
-			if err != nil {
-				return classifyVagaroError(err, flags)
+			summary := availabilitySummary{
+				Slug:         slug,
+				BusinessID:   businessID,
+				ServiceID:    plan.Service.ServiceID,
+				ServiceName:  plan.Service.ServiceTitle,
+				ProviderID:   plan.ProviderID,
+				ProviderName: plan.ProviderName,
+				WeekOf:       formatAvailabilityDate(plan.WeekDates[0]),
+				From:         plan.From.Format("2006-01-02"),
+				To:           plan.To.Format("2006-01-02"),
+				Groups:       []vagaro.SlotGroup{},
 			}
-			summary.Groups = groups
-			for _, g := range groups {
-				summary.TotalSlots += len(g.Times)
+			if len(plan.WeekDates) > 1 {
+				for _, d := range plan.WeekDates {
+					summary.Weeks = append(summary.Weeks, formatAvailabilityDate(d))
+				}
+			}
+
+			serviceID := strconv.FormatInt(plan.Service.ServiceID, 10)
+			for _, weekDate := range plan.WeekDates {
+				appDate := formatAvailabilityDate(weekDate)
+				groups, err := c.Availability(ctx, businessID, serviceID, plan.ProviderID, appDate)
+				if err != nil {
+					return classifyVagaroError(err, flags)
+				}
+				for _, g := range filterAvailabilityGroups(groups, plan.From, plan.To) {
+					summary.TotalSlots += len(g.Times)
+					summary.Groups = append(summary.Groups, g)
+				}
 			}
 			if summary.TotalSlots == 0 {
-				summary.Note = "no availability found for the current week"
+				if plan.ProviderID != "" || opts.Service != "" || plan.ExplicitFrom || plan.ExplicitTo || opts.Weeks != 0 {
+					summary.Note = "no availability found for the requested service/provider/date window"
+				} else {
+					summary.Note = "no availability found for the current week"
+				}
 			}
 			return emitVagaro(cmd, flags, summary)
 		},
 	}
+	cmd.Flags().StringVar(&opts.Service, "service", "", "Service name or ID to query (default: first service)")
+	cmd.Flags().StringVar(&opts.Provider, "provider", "", "Provider/staff name or ID to require (default: any provider)")
+	cmd.Flags().StringVar(&opts.From, "from", "", "Start date YYYY-MM-DD or weekday name (default: today)")
+	cmd.Flags().StringVar(&opts.To, "to", "", "End date YYYY-MM-DD or weekday name (default: end of selected week window)")
+	cmd.Flags().IntVar(&opts.Weeks, "weeks", 0, "Number of weekly availability windows to query from --from (default: 1; cannot be combined with --to)")
 	return cmd
+}
+
+func buildAvailabilityPlan(services []vagaro.ServiceRow, providers []vagaro.Provider, opts availabilityOptions, now time.Time) (availabilityPlan, error) {
+	if len(services) == 0 {
+		return availabilityPlan{}, fmt.Errorf("business has no bookable services")
+	}
+	if opts.Weeks < 0 {
+		return availabilityPlan{}, fmt.Errorf("--weeks must be greater than 0")
+	}
+	if opts.Weeks > 0 && strings.TrimSpace(opts.To) != "" {
+		return availabilityPlan{}, fmt.Errorf("use either --to or --weeks, not both")
+	}
+
+	today := dateOnly(now)
+	from, err := resolveDay(opts.From, today, today)
+	if err != nil {
+		return availabilityPlan{}, err
+	}
+	from = dateOnly(from)
+
+	weeks := opts.Weeks
+	if weeks == 0 {
+		weeks = 1
+	}
+	defaultTo := from.AddDate(0, 0, weeks*7-1)
+	to, err := resolveDay(opts.To, today, defaultTo)
+	if err != nil {
+		return availabilityPlan{}, err
+	}
+	to = dateOnly(to)
+	if to.Before(from) {
+		return availabilityPlan{}, fmt.Errorf("--to must be on or after --from")
+	}
+
+	svc, err := resolveAvailabilityService(services, opts.Service)
+	if err != nil {
+		return availabilityPlan{}, err
+	}
+	providerID, providerName, err := resolveAvailabilityProvider(providers, opts.Provider)
+	if err != nil {
+		return availabilityPlan{}, err
+	}
+
+	return availabilityPlan{
+		Service:      svc,
+		ProviderID:   providerID,
+		ProviderName: providerName,
+		From:         from,
+		To:           to,
+		WeekDates:    availabilityWeekDates(from, to),
+		ExplicitFrom: strings.TrimSpace(opts.From) != "",
+		ExplicitTo:   strings.TrimSpace(opts.To) != "",
+	}, nil
+}
+
+func resolveAvailabilityService(services []vagaro.ServiceRow, query string) (vagaro.ServiceRow, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return services[0], nil
+	}
+	if id, err := strconv.ParseInt(query, 10, 64); err == nil {
+		for _, s := range services {
+			if s.ServiceID == id {
+				return s, nil
+			}
+		}
+		return vagaro.ServiceRow{}, fmt.Errorf("service %q was not found for this business", query)
+	}
+	matches := make([]vagaro.ServiceRow, 0)
+	q := strings.ToLower(query)
+	for _, s := range services {
+		if strings.EqualFold(s.ServiceTitle, query) {
+			return s, nil
+		}
+		if strings.Contains(strings.ToLower(s.ServiceTitle), q) {
+			matches = append(matches, s)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		return vagaro.ServiceRow{}, fmt.Errorf("service %q matched multiple services; pass a service ID", query)
+	}
+	return vagaro.ServiceRow{}, fmt.Errorf("service %q was not found for this business", query)
+}
+
+func resolveAvailabilityProvider(providers []vagaro.Provider, query string) (string, string, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return "", "", nil
+	}
+	if id, err := strconv.ParseInt(query, 10, 64); err == nil {
+		for _, p := range providers {
+			if p.ServiceProviderID == id {
+				return strconv.FormatInt(p.ServiceProviderID, 10), p.Name, nil
+			}
+		}
+		return "", "", fmt.Errorf("provider %q was not found for this business", query)
+	}
+	matches := make([]vagaro.Provider, 0)
+	q := strings.ToLower(query)
+	for _, p := range providers {
+		if strings.EqualFold(p.Name, query) {
+			return strconv.FormatInt(p.ServiceProviderID, 10), p.Name, nil
+		}
+		if strings.Contains(strings.ToLower(p.Name), q) {
+			matches = append(matches, p)
+		}
+	}
+	if len(matches) == 1 {
+		return strconv.FormatInt(matches[0].ServiceProviderID, 10), matches[0].Name, nil
+	}
+	if len(matches) > 1 {
+		return "", "", fmt.Errorf("provider %q matched multiple providers; pass a provider ID", query)
+	}
+	return "", "", fmt.Errorf("provider %q was not found for this business", query)
+}
+
+func availabilityWeekDates(from, to time.Time) []time.Time {
+	weeks := []time.Time{}
+	for d := from; !d.After(to); d = d.AddDate(0, 0, 7) {
+		weeks = append(weeks, d)
+	}
+	return weeks
+}
+
+func filterAvailabilityGroups(groups []vagaro.SlotGroup, from, to time.Time) []vagaro.SlotGroup {
+	out := make([]vagaro.SlotGroup, 0, len(groups))
+	for _, g := range groups {
+		kept := g
+		kept.Times = nil
+		for _, slot := range g.Times {
+			if dt, ok := vagaro.ParseSlotDateTime(g.Date, slot); ok {
+				day := dateOnly(dt)
+				if day.Before(from) || day.After(to) {
+					continue
+				}
+			}
+			kept.Times = append(kept.Times, slot)
+		}
+		if len(kept.Times) > 0 {
+			out = append(out, kept)
+		}
+	}
+	return out
+}
+
+func formatAvailabilityDate(d time.Time) string {
+	return d.Format("Mon Jan-02-2006")
+}
+
+func dateOnly(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
 }

--- a/library/health/vagaro/internal/cli/business_availability_test.go
+++ b/library/health/vagaro/internal/cli/business_availability_test.go
@@ -120,8 +120,26 @@ func TestFilterAvailabilityGroupsHonorsDateWindow(t *testing.T) {
 	from := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC)
 
-	got := filterAvailabilityGroups(groups, from, to)
+	got := filterAvailabilityGroups(groups, "", from, to)
 	require.Len(t, got, 1)
 	assert.Equal(t, "Mon Jul-27-2026", got[0].Date)
 	assert.Equal(t, []string{"10:00 AM"}, got[0].Times)
+}
+
+func TestFilterAvailabilityGroupsHonorsProvider(t *testing.T) {
+	groups := []vagaro.SlotGroup{
+		{Date: "Mon Jul-20-2026", ProviderID: "301", Times: []string{"9:00 AM"}},
+		{Date: "Mon Jul-20-2026", ProviderID: "302", Times: []string{"10:00 AM"}},
+		{Date: "Mon Jul-20-2026", Times: []string{"11:00 AM"}},
+	}
+	from := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+
+	got := filterAvailabilityGroups(groups, "301", from, to)
+	require.Len(t, got, 1)
+	assert.Equal(t, "301", got[0].ProviderID)
+	assert.Equal(t, []string{"9:00 AM"}, got[0].Times)
+
+	got = filterAvailabilityGroups(groups, "", from, to)
+	require.Len(t, got, 3)
 }

--- a/library/health/vagaro/internal/cli/business_availability_test.go
+++ b/library/health/vagaro/internal/cli/business_availability_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Trevin Chow and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/vagaro"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAvailabilityPlanDefaultBehavior(t *testing.T) {
+	services := []vagaro.ServiceRow{
+		{ServiceID: 101, ServiceTitle: "Haircut"},
+		{ServiceID: 202, ServiceTitle: "Color"},
+	}
+	now := time.Date(2026, 7, 8, 13, 30, 0, 0, time.UTC)
+
+	plan, err := buildAvailabilityPlan(services, nil, availabilityOptions{}, now)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(101), plan.Service.ServiceID)
+	assert.Equal(t, "", plan.ProviderID)
+	assert.Equal(t, "", plan.ProviderName)
+	assert.Equal(t, "2026-07-08", plan.From.Format("2006-01-02"))
+	assert.Equal(t, "2026-07-14", plan.To.Format("2006-01-02"))
+	require.Len(t, plan.WeekDates, 1)
+	assert.Equal(t, "Wed Jul-08-2026", formatAvailabilityDate(plan.WeekDates[0]))
+	assert.False(t, plan.ExplicitFrom)
+	assert.False(t, plan.ExplicitTo)
+}
+
+func TestBuildAvailabilityPlanResolvesServiceProviderAndWeeks(t *testing.T) {
+	services := []vagaro.ServiceRow{
+		{ServiceID: 101, ServiceTitle: "Classic Haircut"},
+		{ServiceID: 202, ServiceTitle: "Color"},
+	}
+	providers := []vagaro.Provider{
+		{ServiceProviderID: 301, Name: "Alex Rivera"},
+		{ServiceProviderID: 302, Name: "Jordan Lee"},
+	}
+	now := time.Date(2026, 7, 8, 13, 30, 0, 0, time.UTC)
+
+	plan, err := buildAvailabilityPlan(services, providers, availabilityOptions{
+		Service:  "haircut",
+		Provider: "alex",
+		From:     "2026-07-20",
+		Weeks:    3,
+	}, now)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(101), plan.Service.ServiceID)
+	assert.Equal(t, "301", plan.ProviderID)
+	assert.Equal(t, "Alex Rivera", plan.ProviderName)
+	assert.Equal(t, "2026-07-20", plan.From.Format("2006-01-02"))
+	assert.Equal(t, "2026-08-09", plan.To.Format("2006-01-02"))
+	require.Len(t, plan.WeekDates, 3)
+	assert.Equal(t, []string{"Mon Jul-20-2026", "Mon Jul-27-2026", "Mon Aug-03-2026"}, []string{
+		formatAvailabilityDate(plan.WeekDates[0]),
+		formatAvailabilityDate(plan.WeekDates[1]),
+		formatAvailabilityDate(plan.WeekDates[2]),
+	})
+	assert.True(t, plan.ExplicitFrom)
+	assert.False(t, plan.ExplicitTo)
+}
+
+func TestBuildAvailabilityPlanRejectsUnresolvedOrAmbiguousFilters(t *testing.T) {
+	services := []vagaro.ServiceRow{
+		{ServiceID: 101, ServiceTitle: "Kids Haircut"},
+		{ServiceID: 202, ServiceTitle: "Adult Haircut"},
+	}
+	providers := []vagaro.Provider{
+		{ServiceProviderID: 301, Name: "Alex Rivera"},
+		{ServiceProviderID: 302, Name: "Alex Lee"},
+	}
+	now := time.Date(2026, 7, 8, 13, 30, 0, 0, time.UTC)
+
+	_, err := buildAvailabilityPlan(services, providers, availabilityOptions{Service: "haircut"}, now)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matched multiple services")
+
+	_, err = buildAvailabilityPlan(services, providers, availabilityOptions{Service: "999"}, now)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service \"999\" was not found")
+
+	_, err = buildAvailabilityPlan(services, providers, availabilityOptions{Provider: "alex"}, now)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matched multiple providers")
+
+	_, err = buildAvailabilityPlan(services, providers, availabilityOptions{Provider: "999"}, now)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider \"999\" was not found")
+}
+
+func TestBuildAvailabilityPlanDateValidation(t *testing.T) {
+	services := []vagaro.ServiceRow{{ServiceID: 101, ServiceTitle: "Haircut"}}
+	now := time.Date(2026, 7, 8, 13, 30, 0, 0, time.UTC)
+
+	_, err := buildAvailabilityPlan(services, nil, availabilityOptions{From: "2026-07-20", To: "2026-07-19"}, now)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--to must be on or after --from")
+
+	_, err = buildAvailabilityPlan(services, nil, availabilityOptions{To: "2026-07-20", Weeks: 2}, now)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use either --to or --weeks")
+
+	_, err = buildAvailabilityPlan(services, nil, availabilityOptions{Weeks: -1}, now)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--weeks must be greater than 0")
+}
+
+func TestFilterAvailabilityGroupsHonorsDateWindow(t *testing.T) {
+	groups := []vagaro.SlotGroup{
+		{Date: "Mon Jul-20-2026", ProviderID: "301", Times: []string{"9:00 AM", "1:00 PM"}},
+		{Date: "Mon Jul-27-2026", ProviderID: "301", Times: []string{"10:00 AM"}},
+		{Date: "Mon Aug-03-2026", ProviderID: "301", Times: []string{"11:00 AM"}},
+	}
+	from := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC)
+
+	got := filterAvailabilityGroups(groups, from, to)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Mon Jul-27-2026", got[0].Date)
+	assert.Equal(t, []string{"10:00 AM"}, got[0].Times)
+}


### PR DESCRIPTION
## Summary

Fixes #1462.

- adds `--service`, `--provider`, `--from`, `--to`, and `--weeks` to `vagaro-pp-cli business availability <slug>`
- resolves requested service/provider by ID, exact name, or unique substring and fails on missing/ambiguous matches instead of silently falling back
- keeps legacy default behavior when no filters are provided: first listed service, any provider, current week
- updates README/SKILL guidance and records the generated-tree hand edit in `.printing-press-patches/`

## Verification

```text
$ go test ./internal/cli -run 'TestBuildAvailabilityPlan|TestFilterAvailabilityGroups' -count=1
ok  	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/cli	0.010s

$ go test ./...
?   	github.com/mvanhorn/printing-press-library/library/health/vagaro/cmd/vagaro-pp-cli	[no test files]
?   	github.com/mvanhorn/printing-press-library/library/health/vagaro/cmd/vagaro-pp-mcp	[no test files]
?   	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/cache	[no test files]
ok  	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/cli	0.024s
ok  	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/client	(cached)
ok  	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/cliutil	(cached)
?   	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/config	[no test files]
ok  	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/mcp	0.026s
ok  	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/mcp/bound	(cached)
ok  	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/mcp/cobratree	(cached)
ok  	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/store	(cached)
?   	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/types	[no test files]
ok  	github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/vagaro	(cached)

$ go build ./cmd/vagaro-pp-cli
# passed; produced local ./vagaro-pp-cli, then removed

$ git diff --check
# passed

$ python3 .github/scripts/verify-skill/verify_skill.py --dir library/health/vagaro/
=== vagaro ===
  ✓ All checks passed (flag-names, flag-commands, positional-args, shell-var-quotes, unknown-command)

$ python3 .github/scripts/verify-publish-package/verify_publish_package.py --base-ref origin/main
Publish-package verifier selected 1 touched CLI dir(s); 0 new.
::group::library/health/vagaro
::endgroup::
Publish-package verifier passed.
```

## Notes / risks

- This intentionally patches the published generated tree first and records the patch metadata; no generated `cli-skills/` mirror or registry files were hand-edited.
- Date-window tests cover command planning/filtering without hitting live Vagaro endpoints; live endpoint behavior still depends on Vagaro's current website API response shape.
