### PR TITLE
fix(ci): run Go workflows on 1.26.5

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           # Public library is a monorepo with per-CLI go.mod under library/<cat>/<slug>/.
           # Point setup-go at this matrix entry's go.sum so its module cache is keyed
           # correctly. Without this, setup-go warns "Dependencies file is not found".
@@ -235,7 +235,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache-dependency-path: library/${{ matrix.target }}/go.sum
       - name: Build CLI binary
         env:

--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           # Audit walks every CLI; no single go.sum to key the module cache on,
           # and the cache hit-rate would be near zero anyway (every CLI's go.sum
           # differs). Disable caching to silence the "Dependencies file is not

--- a/.github/workflows/generate-registry.yml
+++ b/.github/workflows/generate-registry.yml
@@ -62,7 +62,7 @@ jobs:
           token: ${{ secrets.ADMIN_PUSH_PAT }}
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
       - name: Run generator
         run: go run ./tools/generate-registry/main.go
       - name: Commit if changed

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/setup-go@v6
         if: steps.modules.outputs.count != '0'
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           # This workflow may scan several unrelated standalone modules. There
           # is no single dependency file that produces a useful setup-go cache.
           cache: false

--- a/.github/workflows/update-cli-release-ledger.yml
+++ b/.github/workflows/update-cli-release-ledger.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
       - name: Resolve release metadata
         id: meta
         env:

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -257,7 +257,7 @@ jobs:
       # binary that will run after merge.
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Validate registry source descriptions
         # Reject PRs whose .printing-press.json + .goreleaser.yaml sources would


### PR DESCRIPTION
## Summary

Go-backed library workflows now install Go 1.26.5, so CI uses the standard-library patch that clears the GO-2026-5856 `crypto/tls` finding instead of failing every PR under the pinned 1.26.4 toolchain.

This keeps `GOTOOLCHAIN=local` behavior intact while making the installed toolchain new enough for govulncheck, package loading, generated registry validation, release-ledger updates, MCPB builds, and bundle audits.

Fixes #1464.

## Validation

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'`
- `env GOTOOLCHAIN=local "$(go env GOPATH)/bin/govulncheck" ./...` in `library/media-and-entertainment/spotify`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
