### PR TITLE
fix(ci): scope govulncheck to live base

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -38,7 +38,7 @@ jobs:
         id: modules
         env:
           EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.base_ref || 'main' }}
           DISPATCH_SCOPE: ${{ inputs.scope }}
         run: |
           set -euo pipefail
@@ -52,13 +52,9 @@ jobs:
               | sed 's#/go.mod$##' \
               | sort > "$dirs"
           else
-            if [ "$EVENT_NAME" = "pull_request" ]; then
-              git diff --name-status "${PR_BASE_SHA}...HEAD" -- library > "$changed"
-            else
-              git fetch origin main
-              base=$(git merge-base origin/main HEAD)
-              git diff --name-status "${base}...HEAD" -- library > "$changed"
-            fi
+            git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            base=$(git merge-base "origin/${BASE_REF}" HEAD)
+            git diff --name-status "${base}...HEAD" -- library > "$changed"
 
             awk '
               function emit(path, parts) {


### PR DESCRIPTION
## Summary
- diff Govulncheck PR runs against the live base branch merge-base
- prevent stale PRs from scanning unrelated catalog modules after broad mainline Go-floor changes

## Validation
- simulated PR #1458 head checkout: selected 1 module (`library/marketing/umami`)
- simulated PR #1458 merge checkout: selected 1 module (`library/marketing/umami`)
- failing run previously selected 323 modules and failed on unrelated `go mod tidy` drift
