### PR TITLE
fix(vagaro): resolve rebook availability ids

### DIFF
--- a/library/health/vagaro/.printing-press-patches/vagaro-me-rebook-id-resolution.json
+++ b/library/health/vagaro/.printing-press-patches/vagaro-me-rebook-id-resolution.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "vagaro-me-rebook-id-resolution",
+  "applied_at": "2026-07-08",
+  "base_run_id": "20260701-143117-d22a0c47",
+  "base_printing_press_version": "4.27.1",
+  "summary": "me rebook now resolves a past appointment's business slug/URL, or exact/unique cached business name, to the public business id; maps appointment-history service/provider ids onto the public availability ids when they match; falls back to exact or unique service/provider names when history ids are encrypted or stale; and queries every weekly availability window covered by --from/--to.",
+  "reason": "Appointment-history ids can differ from the public getavailablemultiappointments service/provider ids, causing me rebook to return zero slots even when business availability with the same business/service/provider names finds openings.",
+  "files": [
+    "internal/cli/me_rebook.go",
+    "internal/cli/me_rebook_behavior_test.go"
+  ]
+}

--- a/library/health/vagaro/internal/cli/me_rebook.go
+++ b/library/health/vagaro/internal/cli/me_rebook.go
@@ -260,7 +260,7 @@ func extractAppointment(obj map[string]any) rebookAppointment {
 	if a.ProviderName == "" {
 		a.ProviderName = strings.TrimSpace(firstScalar(obj, "serviceProviderFirstName", "providerFirstName") + " " + firstScalar(obj, "serviceProviderLastName", "providerLastName"))
 	}
-	a.BusinessSlug = firstNonEmpty(a.BusinessSlug, slugFromAppointmentURL(firstScalar(obj, "businessUrl", "businessURL", "business_url", "shopUrl", "shopURL", "url", "bookingUrl", "bookingURL")))
+	a.BusinessSlug = firstNonEmpty(a.BusinessSlug, slugFromAppointmentURL(firstScalar(obj, "businessUrl", "businessURL", "business_url", "shopUrl", "shopURL", "bookingUrl", "bookingURL")))
 	// Descend into nested objects when flat keys were absent. Always check for a
 	// nested business URL/slug because the history payload may include flat ids
 	// but only expose the public Vagaro slug under business.url.
@@ -305,7 +305,7 @@ func resolveRebookBusiness(ctx context.Context, c *vagaro.Client, flags *rootFla
 	if strings.TrimSpace(a.BusinessID) != "" {
 		return strings.TrimSpace(a.BusinessID), "", nil
 	}
-	return "", "", fmt.Errorf("business name %q was not found uniquely in the local Vagaro cache; pass an explicit business slug", a.BusinessName)
+	return "", "", fmt.Errorf("business name %q was not found in the local Vagaro cache; run 'vagaro-pp-cli sync' first or pass an explicit business slug", a.BusinessName)
 }
 
 func resolveRebookBusinessFromCache(ctx context.Context, name string) (string, string, error) {
@@ -405,6 +405,10 @@ func slugFromAppointmentURL(raw string) string {
 	if err != nil {
 		return ""
 	}
+	host := strings.ToLower(u.Hostname())
+	if host != "" && host != "vagaro.com" && !strings.HasSuffix(host, ".vagaro.com") {
+		return ""
+	}
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 	for _, p := range parts {
 		p = strings.TrimSpace(p)
@@ -450,33 +454,4 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
-}
-
-// filterGroupsToWindow drops slot times whose parseable date falls outside
-// [fromDate, toDate]. Groups whose dates cannot be parsed pass through
-// unchanged so the HTML-fragment fallback still surfaces times.
-func filterGroupsToWindow(groups []vagaro.SlotGroup, fromDate, toDate time.Time) []vagaro.SlotGroup {
-	fromDay := time.Date(fromDate.Year(), fromDate.Month(), fromDate.Day(), 0, 0, 0, 0, time.UTC)
-	toDay := time.Date(toDate.Year(), toDate.Month(), toDate.Day(), 23, 59, 59, 0, time.UTC)
-	out := make([]vagaro.SlotGroup, 0, len(groups))
-	for _, g := range groups {
-		kept := make([]string, 0, len(g.Times))
-		for _, t := range g.Times {
-			dt, ok := vagaro.ParseSlotDateTime(g.Date, t)
-			if !ok {
-				kept = append(kept, t) // undateable: keep rather than silently drop
-				continue
-			}
-			if dt.Before(fromDay) || dt.After(toDay) {
-				continue
-			}
-			kept = append(kept, t)
-		}
-		if len(kept) > 0 {
-			ng := g
-			ng.Times = kept
-			out = append(out, ng)
-		}
-	}
-	return out
 }

--- a/library/health/vagaro/internal/cli/me_rebook.go
+++ b/library/health/vagaro/internal/cli/me_rebook.go
@@ -8,8 +8,11 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,6 +28,7 @@ const appointmentsPath = "https://api.vagaro.com/us02/api/v2/myaccount/purchases
 type rebookAppointment struct {
 	AppointmentID string `json:"appointment_id,omitempty"`
 	BusinessID    string `json:"business_id,omitempty"`
+	BusinessSlug  string `json:"business_slug,omitempty"`
 	BusinessName  string `json:"business_name,omitempty"`
 	ServiceID     string `json:"service_id,omitempty"`
 	ServiceName   string `json:"service_name,omitempty"`
@@ -79,11 +83,6 @@ reads and lists slots — use 'vagaro-pp-cli book' to place the appointment.`,
 			if err != nil {
 				return usageErr(err)
 			}
-			appDate, err := vagaro.FormatAppDate(fromDate.Format("2006-01-02"))
-			if err != nil {
-				return err
-			}
-
 			ctx, cancel := boundCtx(cmd.Context(), flags)
 			defer cancel()
 
@@ -140,30 +139,59 @@ reads and lists slots — use 'vagaro-pp-cli book' to place the appointment.`,
 				Window: fmt.Sprintf("%s .. %s", fromDate.Format("2006-01-02"), toDate.Format("2006-01-02")),
 				Groups: []vagaro.SlotGroup{},
 			}
-			if chosen.BusinessID == "" || chosen.ServiceID == "" {
-				out.Note = "the past appointment did not include a resolvable business/service id, so slots can't be looked up"
+			if chosen.BusinessID == "" && chosen.BusinessSlug == "" && chosen.BusinessName == "" {
+				out.Note = rebookDiagnostic(chosen, "the past appointment did not include a resolvable business id, Vagaro business URL, or business name")
 				return emitVagaro(cmd, flags, out)
 			}
 
 			vc := newVagaroClient(flags)
-			groups, err := vc.Availability(ctx, chosen.BusinessID, chosen.ServiceID, chosen.ProviderID, appDate)
+			businessID, businessSlug, err := resolveRebookBusiness(ctx, vc, flags, chosen)
+			if err != nil {
+				out.Note = rebookDiagnostic(chosen, err.Error())
+				return emitVagaro(cmd, flags, out)
+			}
+			services, err := vc.Services(ctx, businessID)
 			if err != nil {
 				return classifyVagaroError(err, flags)
 			}
-			out.Groups = filterGroupsToWindow(groups, fromDate, toDate)
+			service, err := resolveRebookService(services, chosen)
+			if err != nil {
+				out.Note = rebookDiagnostic(chosen, err.Error())
+				return emitVagaro(cmd, flags, out)
+			}
+			providerID := ""
+			if strings.TrimSpace(chosen.ProviderID) != "" || strings.TrimSpace(chosen.ProviderName) != "" {
+				providers, err := vc.Staff(ctx, businessID)
+				if err != nil {
+					return classifyVagaroError(err, flags)
+				}
+				providerID, _, err = resolveRebookProvider(providers, chosen)
+				if err != nil {
+					out.Note = rebookDiagnostic(chosen, err.Error())
+					return emitVagaro(cmd, flags, out)
+				}
+			}
+			serviceID := strconv.FormatInt(service.ServiceID, 10)
+			for _, weekDate := range availabilityWeekDates(fromDate, toDate) {
+				groups, err := vc.Availability(ctx, businessID, serviceID, providerID, formatAvailabilityDate(weekDate))
+				if err != nil {
+					return classifyVagaroError(err, flags)
+				}
+				out.Groups = append(out.Groups, filterAvailabilityGroups(groups, providerID, dateOnly(fromDate), dateOnly(toDate))...)
+			}
 			for _, g := range out.Groups {
 				out.TotalSlots += len(g.Times)
 			}
 			if out.TotalSlots == 0 {
 				out.Note = "no open slots for that provider in the window — widen --from/--to"
 			} else {
-				svcArg := chosen.ServiceID
+				svcArg := serviceID
 				provArg := ""
-				if chosen.ProviderID != "" {
-					provArg = " --provider " + chosen.ProviderID
+				if providerID != "" {
+					provArg = " --provider " + providerID
 				}
 				out.NextStep = fmt.Sprintf("book with: vagaro-pp-cli book %s --service %s%s --at <YYYY-MM-DDTHH:MM>",
-					firstNonEmpty(chosen.BusinessName, chosen.BusinessID), svcArg, provArg)
+					firstNonEmpty(businessSlug, chosen.BusinessName, businessID), svcArg, provArg)
 			}
 			return emitVagaro(cmd, flags, out)
 		},
@@ -221,6 +249,7 @@ func extractAppointment(obj map[string]any) rebookAppointment {
 	a := rebookAppointment{
 		AppointmentID: firstScalar(obj, "appointmentId", "appointmentID", "appointment_id", "appNo", "id"),
 		BusinessID:    firstScalar(obj, "businessId", "businessID", "business_id", "merchantId"),
+		BusinessSlug:  firstScalar(obj, "businessSlug", "business_slug", "shopSlug", "merchantSlug", "slug", "vagaroURL", "vagaroUrl", "vagaro_url"),
 		BusinessName:  firstScalar(obj, "businessName", "business_name", "merchantName"),
 		ServiceID:     firstScalar(obj, "serviceId", "serviceID", "service_id"),
 		ServiceName:   firstScalar(obj, "serviceName", "serviceTitle", "service_name"),
@@ -228,12 +257,17 @@ func extractAppointment(obj map[string]any) rebookAppointment {
 		ProviderName:  firstScalar(obj, "serviceProviderName", "providerName", "provider_name", "staffName"),
 		Date:          firstScalar(obj, "appointmentDate", "startDate", "date", "appDate"),
 	}
-	// Descend into nested objects when flat keys were absent.
-	if a.BusinessID == "" || a.BusinessName == "" {
-		if nested, ok := obj["business"].(map[string]any); ok {
-			a.BusinessID = firstNonEmpty(a.BusinessID, firstScalar(nested, "id", "businessId", "businessID"))
-			a.BusinessName = firstNonEmpty(a.BusinessName, firstScalar(nested, "name", "businessName"))
-		}
+	if a.ProviderName == "" {
+		a.ProviderName = strings.TrimSpace(firstScalar(obj, "serviceProviderFirstName", "providerFirstName") + " " + firstScalar(obj, "serviceProviderLastName", "providerLastName"))
+	}
+	a.BusinessSlug = firstNonEmpty(a.BusinessSlug, slugFromAppointmentURL(firstScalar(obj, "businessUrl", "businessURL", "business_url", "shopUrl", "shopURL", "url", "bookingUrl", "bookingURL")))
+	// Descend into nested objects when flat keys were absent. Always check for a
+	// nested business URL/slug because the history payload may include flat ids
+	// but only expose the public Vagaro slug under business.url.
+	if nested, ok := obj["business"].(map[string]any); ok {
+		a.BusinessID = firstNonEmpty(a.BusinessID, firstScalar(nested, "id", "businessId", "businessID"))
+		a.BusinessName = firstNonEmpty(a.BusinessName, firstScalar(nested, "name", "businessName"))
+		a.BusinessSlug = firstNonEmpty(a.BusinessSlug, firstScalar(nested, "slug", "businessSlug"), slugFromAppointmentURL(firstScalar(nested, "url", "businessUrl", "bookingUrl")))
 	}
 	if a.ServiceID == "" || a.ServiceName == "" {
 		if nested, ok := obj["service"].(map[string]any); ok {
@@ -250,6 +284,136 @@ func extractAppointment(obj map[string]any) rebookAppointment {
 		}
 	}
 	return a
+}
+
+func resolveRebookBusiness(ctx context.Context, c *vagaro.Client, flags *rootFlags, a rebookAppointment) (string, string, error) {
+	if a.BusinessSlug != "" {
+		id, err := resolveBusinessID(ctx, c, flags, a.BusinessSlug)
+		return id, a.BusinessSlug, err
+	}
+	if strings.TrimSpace(a.BusinessName) != "" {
+		if slug, id, err := resolveRebookBusinessFromCache(ctx, a.BusinessName); err != nil {
+			return "", "", err
+		} else if slug != "" {
+			if id != "" {
+				return id, slug, nil
+			}
+			id, err := resolveBusinessID(ctx, c, flags, slug)
+			return id, slug, err
+		}
+	}
+	if strings.TrimSpace(a.BusinessID) != "" {
+		return strings.TrimSpace(a.BusinessID), "", nil
+	}
+	return "", "", fmt.Errorf("business name %q was not found uniquely in the local Vagaro cache; pass an explicit business slug", a.BusinessName)
+}
+
+func resolveRebookBusinessFromCache(ctx context.Context, name string) (string, string, error) {
+	db, err := openStoreForRead(ctx, "vagaro-pp-cli")
+	if err != nil || db == nil {
+		return "", "", nil
+	}
+	defer db.Close()
+	businesses, err := db.ListBusinesses(ctx)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table") {
+			return "", "", nil
+		}
+		return "", "", err
+	}
+	want := normalizeRebookBusinessName(name)
+	var exactSlug, exactID string
+	for _, b := range businesses {
+		if normalizeRebookBusinessName(b.Name) == want {
+			if exactSlug != "" {
+				return "", "", fmt.Errorf("business name %q matched multiple cached businesses; pass an explicit business slug", name)
+			}
+			exactSlug, exactID = b.Slug, b.BusinessID
+		}
+	}
+	if exactSlug != "" {
+		return exactSlug, exactID, nil
+	}
+	var matchSlug, matchID string
+	for _, b := range businesses {
+		have := normalizeRebookBusinessName(b.Name)
+		if have == "" || (want != "" && !strings.Contains(want, have) && !strings.Contains(have, want)) {
+			continue
+		}
+		if matchSlug != "" {
+			return "", "", fmt.Errorf("business name %q matched multiple cached businesses; pass an explicit business slug", name)
+		}
+		matchSlug, matchID = b.Slug, b.BusinessID
+	}
+	return matchSlug, matchID, nil
+}
+
+func normalizeRebookBusinessName(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(s))), " ")
+}
+
+func resolveRebookService(services []vagaro.ServiceRow, a rebookAppointment) (vagaro.ServiceRow, error) {
+	if id, err := strconv.ParseInt(strings.TrimSpace(a.ServiceID), 10, 64); err == nil {
+		for _, s := range services {
+			if s.ServiceID == id {
+				return s, nil
+			}
+		}
+	}
+	if strings.TrimSpace(a.ServiceName) != "" {
+		return resolveAvailabilityService(services, a.ServiceName)
+	}
+	if strings.TrimSpace(a.ServiceID) != "" {
+		return vagaro.ServiceRow{}, fmt.Errorf("appointment service id could not be resolved to a public availability service; no service name was available for fallback")
+	}
+	return vagaro.ServiceRow{}, fmt.Errorf("the past appointment did not include a service id or service name")
+}
+
+func resolveRebookProvider(providers []vagaro.Provider, a rebookAppointment) (string, string, error) {
+	if id, err := strconv.ParseInt(strings.TrimSpace(a.ProviderID), 10, 64); err == nil {
+		for _, p := range providers {
+			if p.ServiceProviderID == id {
+				return strconv.FormatInt(p.ServiceProviderID, 10), p.Name, nil
+			}
+		}
+	}
+	if strings.TrimSpace(a.ProviderName) != "" {
+		return resolveAvailabilityProvider(providers, a.ProviderName)
+	}
+	if strings.TrimSpace(a.ProviderID) != "" {
+		return "", "", fmt.Errorf("appointment provider id could not be resolved to a public availability provider; no provider name was available for fallback")
+	}
+	return "", "", nil
+}
+
+func rebookDiagnostic(a rebookAppointment, reason string) string {
+	slug := firstNonEmpty(a.BusinessSlug, "<business-slug>")
+	service := firstNonEmpty(a.ServiceName, "<service-name>")
+	provider := firstNonEmpty(a.ProviderName, "<provider-name>")
+	return fmt.Sprintf("%s. Try the explicit query: vagaro-pp-cli business availability %s --service %q --provider %q --from <YYYY-MM-DD> --to <YYYY-MM-DD> --agent", reason, slug, service, provider)
+}
+
+func slugFromAppointmentURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + strings.TrimLeft(raw, "/")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || strings.EqualFold(p, "users") || strings.EqualFold(p, "book-now") {
+			continue
+		}
+		return p
+	}
+	return ""
 }
 
 // firstScalar returns the first present key's value rendered as a string.

--- a/library/health/vagaro/internal/cli/me_rebook_behavior_test.go
+++ b/library/health/vagaro/internal/cli/me_rebook_behavior_test.go
@@ -5,7 +5,6 @@ package cli
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/mvanhorn/printing-press-library/library/health/vagaro/internal/vagaro"
 	"github.com/stretchr/testify/assert"
@@ -54,19 +53,6 @@ func TestParseAppointments_empty(t *testing.T) {
 	// Non-JSON (e.g. an auth HTML page) is an error, not a silent empty.
 	_, err = parseAppointments(json.RawMessage(`<html>login</html>`))
 	assert.Error(t, err)
-}
-
-func TestFilterGroupsToWindow(t *testing.T) {
-	groups := []vagaro.SlotGroup{
-		{Date: "24 Jul 2026", Provider: "Ronnel", Times: []string{"10:00 AM", "11:00 AM"}},
-		{Date: "31 Jul 2026", Provider: "George", Times: []string{"09:00 AM"}}, // outside window
-	}
-	from := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
-	to := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
-	out := filterGroupsToWindow(groups, from, to)
-	require.Len(t, out, 1)
-	assert.Equal(t, "24 Jul 2026", out[0].Date)
-	assert.Equal(t, []string{"10:00 AM", "11:00 AM"}, out[0].Times)
 }
 
 func TestResolveRebookServiceAndProviderFallsBackFromAppointmentIDsToNames(t *testing.T) {
@@ -129,5 +115,17 @@ func TestResolveRebookServiceReportsActionableAmbiguity(t *testing.T) {
 func TestSlugFromAppointmentURL(t *testing.T) {
 	assert.Equal(t, "centralbarber", slugFromAppointmentURL("https://www.vagaro.com/centralbarber/book-now"))
 	assert.Equal(t, "centralbarber", slugFromAppointmentURL("www.vagaro.com/centralbarber"))
+	assert.Equal(t, "", slugFromAppointmentURL("https://centralbarber.com/contact"))
 	assert.Equal(t, "", slugFromAppointmentURL(""))
+}
+
+func TestParseAppointmentsGenericURLDoesNotBecomeBusinessSlug(t *testing.T) {
+	data := json.RawMessage(`{"data":[
+		{"appointmentId":9001,"businessId":93458,"businessName":"Central Barber","url":"https://centralbarber.com/contact","serviceName":"Skin Fade"}
+	]}`)
+	appts, err := parseAppointments(data)
+	require.NoError(t, err)
+	require.Len(t, appts, 1)
+	assert.Equal(t, "93458", appts[0].BusinessID)
+	assert.Equal(t, "", appts[0].BusinessSlug)
 }

--- a/library/health/vagaro/internal/cli/me_rebook_behavior_test.go
+++ b/library/health/vagaro/internal/cli/me_rebook_behavior_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestParseAppointments_flat(t *testing.T) {
 	data := json.RawMessage(`{"status":"success","data":[
-		{"appointmentId":9001,"businessId":93458,"businessName":"Central Barber","serviceId":34098477,"serviceName":"Skin Fade","serviceProviderId":43931725,"serviceProviderName":"Ronnel Getz","startDate":"2026-06-01"},
+		{"appointmentId":9001,"businessId":93458,"businessName":"Central Barber","vagaroURL":"centralbarber","serviceId":34098477,"serviceName":"Skin Fade","serviceProviderId":43931725,"serviceProviderFirstName":"Ronnel","serviceProviderLastName":"Getz","startDate":"2026-06-01"},
 		{"appointmentId":9002,"businessId":55,"serviceId":66,"providerId":77}
 	]}`)
 	appts, err := parseAppointments(data)
@@ -23,6 +23,7 @@ func TestParseAppointments_flat(t *testing.T) {
 
 	assert.Equal(t, "9001", appts[0].AppointmentID)
 	assert.Equal(t, "93458", appts[0].BusinessID)
+	assert.Equal(t, "centralbarber", appts[0].BusinessSlug)
 	assert.Equal(t, "Central Barber", appts[0].BusinessName)
 	assert.Equal(t, "34098477", appts[0].ServiceID)
 	assert.Equal(t, "Skin Fade", appts[0].ServiceName)
@@ -66,4 +67,67 @@ func TestFilterGroupsToWindow(t *testing.T) {
 	require.Len(t, out, 1)
 	assert.Equal(t, "24 Jul 2026", out[0].Date)
 	assert.Equal(t, []string{"10:00 AM", "11:00 AM"}, out[0].Times)
+}
+
+func TestResolveRebookServiceAndProviderFallsBackFromAppointmentIDsToNames(t *testing.T) {
+	services := []vagaro.ServiceRow{
+		{ServiceID: 101, ServiceTitle: "Classic Cut"},
+		{ServiceID: 202, ServiceTitle: "Skin Fade"},
+	}
+	providers := []vagaro.Provider{
+		{ServiceProviderID: 301, Name: "Ronnel Getz"},
+		{ServiceProviderID: 302, Name: "Alex Rivera"},
+	}
+	appt := rebookAppointment{
+		BusinessSlug: "centralbarber",
+		ServiceID:    "encrypted-service-id-from-history",
+		ServiceName:  "Skin Fade",
+		ProviderID:   "999999999", // numeric, but not the public availability provider id
+		ProviderName: "Ronnel",
+	}
+
+	service, err := resolveRebookService(services, appt)
+	require.NoError(t, err)
+	assert.Equal(t, int64(202), service.ServiceID)
+
+	providerID, providerName, err := resolveRebookProvider(providers, appt)
+	require.NoError(t, err)
+	assert.Equal(t, "301", providerID)
+	assert.Equal(t, "Ronnel Getz", providerName)
+}
+
+func TestResolveRebookServiceAndProviderPreferMatchingPublicIDs(t *testing.T) {
+	services := []vagaro.ServiceRow{{ServiceID: 202, ServiceTitle: "Skin Fade"}}
+	providers := []vagaro.Provider{{ServiceProviderID: 301, Name: "Ronnel Getz"}}
+	appt := rebookAppointment{ServiceID: "202", ServiceName: "Wrong Name", ProviderID: "301", ProviderName: "Wrong Provider"}
+
+	service, err := resolveRebookService(services, appt)
+	require.NoError(t, err)
+	assert.Equal(t, int64(202), service.ServiceID)
+
+	providerID, providerName, err := resolveRebookProvider(providers, appt)
+	require.NoError(t, err)
+	assert.Equal(t, "301", providerID)
+	assert.Equal(t, "Ronnel Getz", providerName)
+}
+
+func TestResolveRebookServiceReportsActionableAmbiguity(t *testing.T) {
+	services := []vagaro.ServiceRow{
+		{ServiceID: 101, ServiceTitle: "Kids Skin Fade"},
+		{ServiceID: 202, ServiceTitle: "Adult Skin Fade"},
+	}
+	appt := rebookAppointment{BusinessSlug: "centralbarber", ServiceID: "encrypted", ServiceName: "Skin Fade", ProviderName: "Ronnel"}
+
+	_, err := resolveRebookService(services, appt)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matched multiple services")
+	diag := rebookDiagnostic(appt, err.Error())
+	assert.Contains(t, diag, "vagaro-pp-cli business availability centralbarber")
+	assert.Contains(t, diag, `--service "Skin Fade"`)
+}
+
+func TestSlugFromAppointmentURL(t *testing.T) {
+	assert.Equal(t, "centralbarber", slugFromAppointmentURL("https://www.vagaro.com/centralbarber/book-now"))
+	assert.Equal(t, "centralbarber", slugFromAppointmentURL("www.vagaro.com/centralbarber"))
+	assert.Equal(t, "", slugFromAppointmentURL(""))
 }


### PR DESCRIPTION
## Summary
- Fixes #1473.
- Resolves `me rebook` appointment-history business slug/URL, or exact/unique cached business name, to the public business id before availability lookup.
- Maps appointment-history service/provider ids onto public availability ids when they match, and falls back to exact/unique service/provider names when history ids are encrypted or stale.
- Extracts Vagaro's `vagaroURL` appointment-history field and provider first/last name fields, covering the observed live Central Barber / Ronnel payload.
- Queries every weekly availability window covered by `--from`/`--to`, matching `business availability` behavior for multi-week ranges.
- Addresses Greptile feedback: non-Vagaro generic `url` no longer becomes `BusinessSlug`, the cache-miss diagnostic is explicit, and dead `filterGroupsToWindow` code/test were removed.

## Verification
- `go test ./internal/cli -run 'Test(ParseAppointments|ResolveRebook|SlugFromAppointmentURL|BuildAvailabilityPlan|FilterAvailabilityGroups)'`
- `go test ./internal/cli`
- `go build ./cmd/vagaro-pp-cli ./cmd/vagaro-pp-mcp`
- `go test ./...`
- `git diff --check`
- `python3 .github/scripts/verify-skill/check_skill_guard_literals.py library/health/vagaro/SKILL.md && python3 .github/scripts/verify-skill/verify_skill.py --dir library/health/vagaro`
- `python3 -m json.tool library/health/vagaro/.printing-press-patches/vagaro-me-rebook-id-resolution.json >/dev/null`
- Read-only live smoke test against the reporter's authenticated account:
  - `go run ./cmd/vagaro-pp-cli me rebook --last --from 2026-07-08 --to 2026-08-08 --agent`
  - Result: `total_slots: 58`, with `next_step` using `centralbarber`, service `34098477`, provider `43931725`.

## Notes
- No booking submission, checkout, or account mutation was attempted.
- Regression coverage uses mock appointment/service/provider data; live smoke test was read-only and did not include secrets.
