### PR TITLE
feat(ticktick): note edit --section inserts into a chosen heading's block

### DIFF
--- a/library/productivity/ticktick/.printing-press-patches/ticktick-note-section-insert.json
+++ b/library/productivity/ticktick/.printing-press-patches/ticktick-note-section-insert.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "ticktick-note-section-insert",
+  "applied_at": "2026-07-09",
+  "base_run_id": "20260707-201031-0987b304",
+  "base_printing_press_version": "4.27.1",
+  "summary": "Add `note edit --section <heading>` and `--section-map` so an appended line lands at the end of a chosen heading's block instead of the end of the note.",
+  "reason": "`--append` writes to the end of note content. A daily note divided into headings therefore files every entry under the last heading — in practice, anything logged after noon landed under 'Evening'. TickTick has no native daily note (a new account is a blank slate), so the note and its headings are a user convention: `--section` matches arbitrary heading text and detects block boundaries structurally (ATX heading, fully-bold line, horizontal rule) rather than assuming any block names. `--section auto` maps the local hour onto a heading, with remappable defaults. An absent or ambiguous heading is a usage error, never a silent end-of-note append, because that silent fallback is the bug itself. Only heading-shaped lines are match candidates, so a body line such as '- [x] Morning: pull agenda' is never mistaken for a '~Morning~' heading. Flag validation was also moved above the --dry-run short-circuit, which previously reported 'would edit' for commands that could only ever fail.",
+  "files": [
+    "internal/cli/note_edit.go",
+    "README.md",
+    "SKILL.md",
+    "AGENTS.md"
+  ],
+  "validated_outcome": "go vet + go build clean. The pure insert/parse functions were copied into a scratch module outside this tree (the generated framework tests clobber the real credentials file on Windows, so `go test` must never run here) and exercised by 10 cases: correct block targeted; blank-line style preserved; flush style preserved; single-entry block inherits document style; last-section append; absent heading errors; ambiguous heading errors and lists matches; arbitrary ATX headings; heading-shaped lines only (a body line mentioning 'Morning' is not a heading); heading detection for #, bold-only, and rule lines. Verified live against a real daily note: `--section auto` inserted into the Afternoon block, a replay returned already_applied without duplicating, and `--section \"~\"` correctly reported 3 matching headings rather than silently taking the first. noteUpdateWhitelist and the `kind` guard are untouched."
+}

--- a/library/productivity/ticktick/README.md
+++ b/library/productivity/ticktick/README.md
@@ -155,6 +155,26 @@ These capabilities aren't available in any other tool for this API.
   ticktick-pp-cli note edit --date today --append "20:15 wrapped the printing-press build" --dry-run
   ```
 
+  **Writing into a heading.** `--append` adds to the **end of the note**, which files every entry
+  under the last heading if your note has any. `--section` inserts at the end of a chosen heading's
+  block instead, matched on any text in the heading line. An absent **or ambiguous** heading is an
+  error - never a silent append at the end.
+
+  ```bash
+  ticktick-pp-cli note edit --date today --section "## Log" --append "- shipped the parser"
+  ```
+
+  TickTick has no built-in daily note: the note and any headings in it are a convention you invent.
+  `--section auto` is a convenience for the common Morning/Afternoon/Evening journal, picking a
+  heading from the local clock (before 12:00 / 12:00-17:59 / 18:00+). Its defaults are `~Morning~`,
+  `~Afternoon~`, `~Evening~`, and they are remappable:
+
+  ```bash
+  ticktick-pp-cli note edit --date today --section auto --append "- *afternoon entry*"
+  ticktick-pp-cli note edit --date today --section auto     --section-map "morning=## AM,afternoon=## PM,evening=## Night" --append "- entry"
+  # or: export TICKTICK_NOTE_SECTIONS="morning=## AM,afternoon=## PM,evening=## Night"
+  ```
+
 ### Local state that compounds
 - **`agenda`** — One command returns today's tasks, habits with checkin state, and focus sessions together.
 

--- a/library/productivity/ticktick/SKILL.md
+++ b/library/productivity/ticktick/SKILL.md
@@ -63,6 +63,27 @@ These capabilities aren't available in any other tool for this API.
   ticktick-pp-cli note edit --date today --append "20:15 wrapped the printing-press build" --dry-run
   ```
 
+  **Writing into a heading.** `--append` adds to the **end of the note**. If your note is divided
+  into headings, that files every entry under the last one. Use `--section` to insert at the end of
+  a heading's block instead - matched on any text in the heading line:
+
+  ```bash
+  ticktick-pp-cli note edit --date today --section "## Log" --append "- shipped the parser"
+  ```
+
+  An absent **or ambiguous** heading is an error, never a silent append at the end.
+
+  **`--section auto`** is a convenience for the common Morning/Afternoon/Evening journal: it picks a
+  heading from the local clock (before 12:00 / 12:00-17:59 / 18:00+). TickTick has no built-in daily
+  note - the note and its headings are your own convention - so `auto` ships defaults (`~Morning~`,
+  `~Afternoon~`, `~Evening~`) you can remap:
+
+  ```bash
+  ticktick-pp-cli note edit --date today --section auto --append "- *afternoon entry*"
+  ticktick-pp-cli note edit --date today --section auto     --section-map "morning=## AM,afternoon=## PM,evening=## Night" --append "- entry"
+  # or export TICKTICK_NOTE_SECTIONS="morning=## AM,afternoon=## PM,evening=## Night"
+  ```
+
 ### Local state that compounds
 - **`agenda`** — One command returns today's tasks, habits with checkin state, and focus sessions together.
 

--- a/library/productivity/ticktick/internal/cli/note_edit.go
+++ b/library/productivity/ticktick/internal/cli/note_edit.go
@@ -32,30 +32,54 @@ func newNovelNoteEditCmd(flags *rootFlags) *cobra.Command {
 	var flagSetContent string
 	var flagTaskID string
 	var flagProjectID string
+	var flagSection string
+	var flagSectionMap string
 
 	cmd := &cobra.Command{
 		Use:   "edit",
 		Short: "Edit a daily note's content via a corruption-proof field whitelist",
 		Long: "Use this command for editing the daily note's content safely. Do NOT use it for generic task field updates; use 'tasks batch' instead.\n" +
-			"The update payload is built from a strict field whitelist and never includes 'kind', so the note's TEXT kind and subtasks cannot be corrupted. The current etag is carried automatically, with one retry on conflict.",
-		Example: "  ticktick-pp-cli note edit --date today --append \"20:15 wrapped the printing-press build\" --dry-run",
+			"The update payload is built from a strict field whitelist and never includes 'kind', so the note's TEXT kind and subtasks cannot be corrupted. The current etag is carried automatically, with one retry on conflict.\n\n" +
+			"Bare --append adds the line to the END of the note. If your note is divided into headings, use --section \"<heading text>\" to insert at the end of that heading's block instead — an absent or ambiguous heading is an error, never a silent append at the end.\n\n" +
+			"TickTick has no native daily note; any headings are your own convention. --section auto is a convenience for the common Morning/Afternoon/Evening journal: it picks a heading from the clock (before 12:00 / 12:00-17:59 / 18:00+). Remap it with --section-map or TICKTICK_NOTE_SECTIONS.",
+		Example: "  ticktick-pp-cli note edit --date today --section \"## Log\" --append \"- shipped the section flag\"\n" +
+			"  ticktick-pp-cli note edit --date today --section auto --append \"- *afternoon entry*\"\n" +
+			"  ticktick-pp-cli note edit --date today --section auto --section-map \"afternoon=## Afternoon\" --append \"- entry\"\n" +
+			"  ticktick-pp-cli note edit --date today --append \"20:15 wrapped the printing-press build\" --dry-run",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
 				return cmd.Help()
 			}
-			if dryRunOK(flags) {
-				if flags.asJSON || flags.agent {
-					return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
-						"dry_run": true,
-						"action":  "would edit the daily note via the whitelisted field set (never sends kind)",
-					}, flags)
-				}
-				fmt.Fprintln(cmd.OutOrStdout(), "would edit the daily note via the whitelisted field set (never sends kind)")
-				return nil
-			}
+			// Validate flags BEFORE the dry-run short-circuit. A --dry-run that
+			// skips validation reports "would edit" for a command that could only
+			// ever fail, which makes it useless as a pre-flight check.
 			if flagAppend == "" && flagSetContent == "" {
 				_ = cmd.Usage()
 				return usageErr(fmt.Errorf("--append or --set-content is required"))
+			}
+			if flagSection != "" && flagSetContent != "" {
+				_ = cmd.Usage()
+				return usageErr(fmt.Errorf("--section cannot be combined with --set-content (set-content replaces the whole note)"))
+			}
+			usedAuto := strings.EqualFold(strings.TrimSpace(flagSection), "auto")
+			section, err := resolveSection(flagSection, flagSectionMap)
+			if err != nil {
+				return err
+			}
+			if dryRunOK(flags) {
+				action := "would edit the daily note via the whitelisted field set (never sends kind)"
+				if section != "" {
+					action = fmt.Sprintf("would insert the appended line at the end of the %q block (never sends kind); the block must exist or the real run errors", section)
+				}
+				if flags.asJSON || flags.agent {
+					return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"dry_run": true,
+						"section": section,
+						"action":  action,
+					}, flags)
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), action)
+				return nil
 			}
 			ctx, cancel := boundCtx(cmd.Context(), flags)
 			defer cancel()
@@ -83,8 +107,15 @@ func newNovelNoteEditCmd(flags *rootFlags) *cobra.Command {
 				return usageErr(fmt.Errorf("--project-id is required when using --task-id"))
 			}
 
-			result, err := editNoteContent(ctx, c, taskID, projectID, flagAppend, flagSetContent, true)
+			result, err := editNoteContent(ctx, c, taskID, projectID, flagAppend, flagSetContent, section, true)
 			if err != nil {
+				if usedAuto {
+					// TickTick has no native daily note, so `auto`'s default
+					// headers are a convention, not a guarantee. Say so here
+					// rather than leaving the user staring at a header they
+					// never chose.
+					return usageErr(fmt.Errorf("%w\n\n--section auto resolved the current hour to the heading %q, which this note does not contain.\nTickTick has no built-in daily-note headings — set your own with --section-map \"morning=<hdr>,afternoon=<hdr>,evening=<hdr>\"\nor the TICKTICK_NOTE_SECTIONS env var, or pass --section \"<heading text>\" directly", err, section))
+				}
 				return err
 			}
 			if flags.asJSON {
@@ -99,7 +130,194 @@ func newNovelNoteEditCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&flagSetContent, "set-content", "", "Replace the entire note content with this text")
 	cmd.Flags().StringVar(&flagTaskID, "task-id", "", "Target task id directly (skips date-based lookup)")
 	cmd.Flags().StringVar(&flagProjectID, "project-id", "", "Project id containing the note (or set TICKTICK_NOTES_PROJECT)")
+	cmd.Flags().StringVar(&flagSection, "section", "", "Insert --append text at the end of the note heading containing this text (e.g. \"~Afternoon~\", \"## Log\"). The reserved value \"auto\" picks a heading from the clock. Default: append at end of note")
+	cmd.Flags().StringVar(&flagSectionMap, "section-map", "", "Headings --section auto maps to, e.g. \"morning=~Morning~,afternoon=~Afternoon~,evening=~Evening~\" (or set TICKTICK_NOTE_SECTIONS)")
 	return cmd
+}
+
+// defaultSectionMap is the time-of-day → header mapping used by `--section
+// auto`. TickTick has no native "daily note": the note, and any headings inside
+// it, are a convention the user invents. These defaults describe one common
+// journal layout, and are entirely overridable — see resolveAutoSection. They
+// are a default, never an assumption: if the note has no matching header, auto
+// fails loudly rather than filing the entry somewhere plausible.
+var defaultSectionMap = [3]string{"~Morning~", "~Afternoon~", "~Evening~"}
+
+// sectionMapFromSpec parses "morning=<hdr>,afternoon=<hdr>,evening=<hdr>".
+// Missing keys keep their default.
+func sectionMapFromSpec(spec string) ([3]string, error) {
+	out := defaultSectionMap
+	if strings.TrimSpace(spec) == "" {
+		return out, nil
+	}
+	for _, part := range strings.Split(spec, ",") {
+		k, v, ok := strings.Cut(part, "=")
+		if !ok || strings.TrimSpace(v) == "" {
+			return out, usageErr(fmt.Errorf("--section-map entries must look like morning=<header text> (got %q)", part))
+		}
+		switch strings.ToLower(strings.TrimSpace(k)) {
+		case "morning":
+			out[0] = strings.TrimSpace(v)
+		case "afternoon":
+			out[1] = strings.TrimSpace(v)
+		case "evening":
+			out[2] = strings.TrimSpace(v)
+		default:
+			return out, usageErr(fmt.Errorf("--section-map key must be morning, afternoon, or evening (got %q)", k))
+		}
+	}
+	return out, nil
+}
+
+// resolveAutoSection turns `auto` into the header text for the current local
+// hour. Precedence: --section-map flag, then TICKTICK_NOTE_SECTIONS, then the
+// built-in default.
+func resolveAutoSection(mapSpec string) (string, error) {
+	if strings.TrimSpace(mapSpec) == "" {
+		mapSpec = os.Getenv("TICKTICK_NOTE_SECTIONS")
+	}
+	m, err := sectionMapFromSpec(mapSpec)
+	if err != nil {
+		return "", err
+	}
+	switch h := time.Now().Hour(); {
+	case h < 12:
+		return m[0], nil
+	case h < 18:
+		return m[1], nil
+	default:
+		return m[2], nil
+	}
+}
+
+// resolveSection normalizes --section into the header text to search for. ""
+// means "append at the end of the note" (the original behavior). Any other
+// value is matched literally against the note's headers, except the reserved
+// word `auto`, which is resolved from the clock.
+func resolveSection(spec, mapSpec string) (string, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		if strings.TrimSpace(mapSpec) != "" {
+			return "", usageErr(fmt.Errorf("--section-map has no effect without --section auto"))
+		}
+		return "", nil
+	}
+	if strings.EqualFold(spec, "auto") {
+		return resolveAutoSection(mapSpec)
+	}
+	return spec, nil
+}
+
+// isHeadingLine reports whether a line reads as a section heading in a Markdown
+// note: an ATX heading (`## Foo`), a fully-bold line (`**🌙 ~Evening~**`), or a
+// horizontal rule. Deliberately structural — the CLI must not care what a
+// user's headings are named.
+func isHeadingLine(line string) bool {
+	t := strings.TrimSpace(line)
+	if t == "" {
+		return false
+	}
+	if t == "---" || t == "***" || t == "___" {
+		return true
+	}
+	if strings.HasPrefix(t, "#") {
+		return true
+	}
+	if len(t) >= 4 && strings.HasPrefix(t, "**") && strings.HasSuffix(t, "**") {
+		return true
+	}
+	return false
+}
+
+// sectionHeaderIdxs returns the index of every *heading* line containing needle
+// (case-insensitive). Only headings are candidates: a note's body freely
+// mentions the same words as its headings — a checklist item reading
+// "📥 Morning: pull agenda" must never be mistaken for the "~Morning~" header.
+// More than one match is ambiguous and must not be silently resolved to the first.
+func sectionHeaderIdxs(lines []string, needle string) []int {
+	n := strings.ToLower(needle)
+	var out []int
+	for i, l := range lines {
+		if isHeadingLine(l) && strings.Contains(strings.ToLower(l), n) {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// insertIntoSection places text at the end of the block whose header contains
+// `header` — after the block's last non-blank line, before the next heading.
+//
+// It errors when the header is absent or ambiguous rather than falling back to
+// an end-of-note append. That silent fallback is what quietly filed afternoon
+// entries under Evening (real incident, 2026-07-09), and picking the first of
+// several matches would be the same mistake wearing a different hat.
+func insertIntoSection(content, header, text string) (string, error) {
+	lines := strings.Split(content, "\n")
+	hits := sectionHeaderIdxs(lines, header)
+	if len(hits) == 0 {
+		return "", usageErr(fmt.Errorf("note has no heading containing %q; refusing to append at the end of the note instead. Pass --section with text that matches one of this note's headings", header))
+	}
+	if len(hits) > 1 {
+		found := make([]string, 0, len(hits))
+		for _, i := range hits {
+			found = append(found, strings.TrimSpace(lines[i]))
+		}
+		return "", usageErr(fmt.Errorf("%q matches %d headings (%s); pass a more specific --section", header, len(hits), strings.Join(found, " | ")))
+	}
+	start := hits[0]
+
+	// Walk to the block's end: the next heading of any kind, or EOF.
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if isHeadingLine(lines[i]) {
+			end = i
+			break
+		}
+	}
+	// Back off trailing blank lines so the insert lands after real content.
+	last := end
+	for last > start+1 && strings.TrimSpace(lines[last-1]) == "" {
+		last--
+	}
+
+	// Match the block's own spacing. A block with fewer than two entries offers
+	// no evidence, so fall back to the document's prevailing style rather than
+	// silently defaulting to flush. (A note can carry both styles — plain
+	// --append joins with a single newline, --set-content preserves blanks.)
+	blank, decided := blankLineStyle(lines[start+1 : last])
+	if !decided {
+		blank, _ = blankLineStyle(lines)
+	}
+	ins := []string{text}
+	if blank {
+		ins = []string{"", text}
+	}
+
+	out := append([]string{}, lines[:last]...)
+	out = append(out, ins...)
+	out = append(out, lines[last:]...)
+	return strings.Join(out, "\n"), nil
+}
+
+// blankLineStyle reports whether seg separates its list entries with blank
+// lines, judged by the majority of the gaps between them. `decided` is false
+// when seg holds fewer than two entries, i.e. there is no gap to sample and the
+// caller should look at a wider scope rather than assume.
+func blankLineStyle(seg []string) (blank bool, decided bool) {
+	gaps, blanks := 0, 0
+	for i := 1; i < len(seg)-1; i++ {
+		if strings.HasPrefix(seg[i-1], "- ") && strings.HasPrefix(seg[i+1], "- ") {
+			gaps++
+			if strings.TrimSpace(seg[i]) == "" {
+				blanks++
+			}
+		}
+	}
+	if gaps == 0 {
+		return false, false
+	}
+	return blanks*2 > gaps, true
 }
 
 // locateNoteTask finds the note task in projectID whose startDate matches the
@@ -156,7 +374,7 @@ func locateNoteTask(ctx context.Context, c *client.Client, projectID, dateSpec s
 
 // editNoteContent fetches the full task, mutates content, and sends a
 // whitelist-filtered batch update. Retries once on per-item errors (etag races).
-func editNoteContent(ctx context.Context, c *client.Client, taskID, projectID, appendText, setContent string, allowRetry bool) (map[string]any, error) {
+func editNoteContent(ctx context.Context, c *client.Client, taskID, projectID, appendText, setContent, section string, allowRetry bool) (map[string]any, error) {
 	raw, err := c.GetNoCache(ctx, "/task/"+taskID, map[string]string{"projectId": projectID})
 	if err != nil {
 		return nil, apiErr(fmt.Errorf("fetching task %s: %w", taskID, err))
@@ -177,10 +395,13 @@ func editNoteContent(ctx context.Context, c *client.Client, taskID, projectID, a
 		content = setContent
 	}
 	if appendText != "" {
-		// Idempotent append: if the content already ends with the append text
-		// (e.g. a retry after the server applied the update but returned a
-		// per-item error), do not append it again.
-		if strings.HasSuffix(strings.TrimRight(content, "\n"), appendText) {
+		// Idempotent append. A plain append lands at the tail, so HasSuffix is
+		// enough; a section insert lands mid-document, so it needs Contains.
+		applied := strings.HasSuffix(strings.TrimRight(content, "\n"), appendText)
+		if section != "" {
+			applied = strings.Contains(content, appendText)
+		}
+		if applied {
 			return map[string]any{
 				"updated":         false,
 				"already_applied": true,
@@ -191,10 +412,18 @@ func editNoteContent(ctx context.Context, c *client.Client, taskID, projectID, a
 				"content_bytes":   len(content),
 			}, nil
 		}
-		if content != "" && !strings.HasSuffix(content, "\n") {
-			content += "\n"
+		if section != "" {
+			updated, err := insertIntoSection(content, section, appendText)
+			if err != nil {
+				return nil, err
+			}
+			content = updated
+		} else {
+			if content != "" && !strings.HasSuffix(content, "\n") {
+				content += "\n"
+			}
+			content += appendText
 		}
-		content += appendText
 	}
 
 	update := map[string]any{}
@@ -220,7 +449,7 @@ func editNoteContent(ctx context.Context, c *client.Client, taskID, projectID, a
 	_ = json.Unmarshal(respRaw, &resp)
 	if len(resp.ID2Error) > 0 {
 		if allowRetry {
-			return editNoteContent(ctx, c, taskID, projectID, appendText, setContent, false)
+			return editNoteContent(ctx, c, taskID, projectID, appendText, setContent, section, false)
 		}
 		return nil, apiErr(fmt.Errorf("note update failed per-item: %v", resp.ID2Error))
 	}


### PR DESCRIPTION
## ticktick

Adds `note edit --section` so an appended line lands at the end of a chosen heading's block instead of the end of the note.

**API:** ticktick | **Category:** productivity | **Press version:** 4.27.1
**Spec:** internal (TickTick V2)

### Publication Path

**Reprint/replace** — updates the merged `library/productivity/ticktick` (originally #1455). Branch is timestamped because `feat/ticktick` was already merged. Release ledger (`CHANGELOG.md`, `.printing-press-release.json`) and runtime version strings are preserved untouched; `registry.json` and `cli-skills/` are not touched.

### The bug

`note edit --append` appends to the **end of the note's content**. When a note is divided into headings, every entry lands under the last heading. A daily journal with Morning / Afternoon / Evening blocks silently filed every afternoon entry under *Evening*. The same command is exposed as the `note_edit` MCP tool, so a wrapper script would not have fixed the agent path.

### The fix

`--section "<heading text>"` inserts at the end of the matching heading's block. `--section-map` (or `TICKTICK_NOTE_SECTIONS`) remaps `--section auto`.

- **TickTick has no native daily note.** A new account is a blank slate, so a note and its headings are a convention the *user* invents. `--section` matches **arbitrary heading text**, and block boundaries are detected **structurally** (`isHeadingLine`: ATX `#`, a fully-bold line, or a horizontal rule) — no block names are hardcoded.
- **`--section auto`** maps the local hour (`<12` / `12–17:59` / `18+`) onto a heading. Its defaults (`~Morning~`, `~Afternoon~`, `~Evening~`) are **a default, never an assumption**. When the mapped heading is absent, the error says TickTick has no built-in headings and names both override paths.
- **Never silently fall back.** An absent heading errors. An **ambiguous** heading errors and lists the matches — resolving to the first match would be the same bug wearing a hat.
- **Only heading-shaped lines are candidates.** A body line such as `- [x] Morning: pull agenda` must not be mistaken for a `~Morning~` heading. (Found live: `--section "~"` matched 5 lines before this was fixed, 3 after.)
- **Blank-line style is inherited** from the target block, falling back to the document when the block holds fewer than two entries.
- **Idempotency** widens from `HasSuffix` to `Contains` on the section path only, since a section insert no longer lands at the tail.
- `--section` + `--set-content` is a usage error; `--section-map` without `--section auto` is too.
- **Flag validation moved above the `--dry-run` short-circuit**, which previously printed "would edit" for commands that could only ever fail.

`noteUpdateWhitelist` and the `kind` guard are **untouched**.

### CLI Shape

```
      --append string        Append this text as a new line at the end of the note content
      --date string          Note date to locate: 'today', 'yesterday', or YYYY-MM-DD (default "today")
      --project-id string    Project id containing the note (or set TICKTICK_NOTES_PROJECT)
      --section string       Insert --append text at the end of the note heading containing this text
                             (e.g. "~Afternoon~", "## Log"). The reserved value "auto" picks a heading
                             from the clock. Default: append at end of note
      --section-map string   Headings --section auto maps to, e.g.
                             "morning=~Morning~,afternoon=~Afternoon~,evening=~Evening~"
                             (or set TICKTICK_NOTE_SECTIONS)
      --set-content string   Replace the entire note content with this text
      --task-id string       Target task id directly (skips date-based lookup)
```

### Testing

The generated framework tests clobber the real credentials file on Windows, so `go test` must never run in this tree (noted in the CLI's own guidance). The pure insert/parse functions were copied into a scratch module outside the tree and exercised by **10 cases**, all passing:

correct block targeted · blank-line style preserved · flush style preserved · single-entry block inherits document style · last-section append · absent heading errors · ambiguous heading errors and lists matches · arbitrary ATX headings · heading-shaped lines only · heading detection for `#`, bold-only, and rule lines.

Verified live against a real note: `--section auto` inserted into the Afternoon block; a replay returned `already_applied` without duplicating; `--section "~"` reported 3 matching headings rather than silently taking the first.

### Manuscripts

- [Research Brief](https://github.com/mvanhorn/printing-press-library/blob/42a61d59d69cd4c36ace6f753924cd6f0d3e7a54/library/productivity/ticktick/.manuscripts/20260707-201031-0987b304/research/2026-07-07-201500-feat-ticktick-pp-cli-brief.md)
- [Absorb Manifest](https://github.com/mvanhorn/printing-press-library/blob/42a61d59d69cd4c36ace6f753924cd6f0d3e7a54/library/productivity/ticktick/.manuscripts/20260707-201031-0987b304/research/2026-07-07-202500-feat-ticktick-pp-cli-absorb-manifest.md)
- [Novel Features Brainstorm](https://github.com/mvanhorn/printing-press-library/blob/42a61d59d69cd4c36ace6f753924cd6f0d3e7a54/library/productivity/ticktick/.manuscripts/20260707-201031-0987b304/research/2026-07-07-202500-novel-features-brainstorm.md)
- [Dogfood Results](https://github.com/mvanhorn/printing-press-library/blob/42a61d59d69cd4c36ace6f753924cd6f0d3e7a54/library/productivity/ticktick/.manuscripts/20260707-201031-0987b304/proofs/2026-07-07-dogfood-results.json)
- [Phase 5 Acceptance](https://github.com/mvanhorn/printing-press-library/blob/42a61d59d69cd4c36ace6f753924cd6f0d3e7a54/library/productivity/ticktick/.manuscripts/20260707-201031-0987b304/proofs/phase5-acceptance.json)
- [Publish Live Gate](https://github.com/mvanhorn/printing-press-library/blob/42a61d59d69cd4c36ace6f753924cd6f0d3e7a54/library/productivity/ticktick/.manuscripts/20260707-201031-0987b304/proofs/publish-live-gate.json)

### Validation Results

| Check | Result |
|-------|--------|
| Manifest | PASS |
| Transcendence | PASS |
| Phase 5 | PASS |
| go mod tidy | PASS |
| govulncheck (this CLI only, reachable findings) | PASS |
| go vet | PASS |
| go build | PASS |
| --help | PASS |
| --version | PASS |
| verify-skill | PASS |
| Manuscripts | PRESENT |

### Publish Live Gate

Full live dogfood reran at publish time against the real TickTick API: **88 pass / 49 skip / 0 fail**.

The raw gate JSON is **deliberately not committed**. It captures `output_sample` from live read commands, which on a real account contains personal task titles. The proof files already in this PR's manuscripts are the previously scrubbed ones and are left untouched. Reviewers can reproduce with:

```
cli-printing-press dogfood --dir library/productivity/ticktick --live --level full --auth-env TICKTICK_SESSION_TOKEN
```

Account state was diffed before and after the gate: 105 tasks before, 105 after, none created or deleted, daily note byte-identical.

### Notes for review

- The local tree that produced this change was a **stale snapshot**: it predated `catalog-go-1265-vuln-floor`, `ticktick-note-edit-kind-guard`, and `ticktick-x-device-header`, and carried dev version strings. Rather than overwrite `main` with it, the CLI directory was reset to `upstream/main` and only the `--section` change was applied on top. That is why this diff is 4 files and contains **no deletions**.
- A `go.mod` bump to `go 1.26.5` was prepared locally, then dropped: `upstream/main` already declares it via `catalog-go-1265-vuln-floor`.
