### PR TITLE
fix(linear): support reliable agent issue reads

### DIFF
--- a/.github/scripts/verify-skill/test_resolve_command_path.py
+++ b/.github/scripts/verify-skill/test_resolve_command_path.py
@@ -423,8 +423,7 @@ func newAppointmentsCmd() *cobra.Command {
     cmd := &cobra.Command{Use: "appointments [ID]"}
     upcoming := &cobra.Command{Use: "upcoming"}
     past := &cobra.Command{Use: "past"}
-    cmd.AddCommand(upcoming)
-    cmd.AddCommand(past)
+    cmd.AddCommand(upcoming, past)
     return cmd
 }
 func newOtherCmd() *cobra.Command {

--- a/.github/scripts/verify-skill/test_resolve_command_path.py
+++ b/.github/scripts/verify-skill/test_resolve_command_path.py
@@ -405,6 +405,48 @@ func newSyncDiffCmd() *cobra.Command {
             self.assertEqual([], positional)
             self.assertEqual(["--agent"], flags)
 
+    def test_variable_wired_child_under_constructor_parent_remains_resolvable(self):
+        with tempfile.TemporaryDirectory() as td:
+            cli_dir = _write_cli(Path(td), {
+                "root.go": '''package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+    rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+    rootCmd.AddCommand(newAppointmentsCmd())
+    rootCmd.AddCommand(newUpcomingCmd())
+    return rootCmd.Execute()
+}
+func newUpcomingCmd() *cobra.Command {
+    return &cobra.Command{Use: "upcoming"}
+}
+''',
+                "appointments.go": '''package cli
+import "github.com/spf13/cobra"
+func newAppointmentsCmd() *cobra.Command {
+    cmd := &cobra.Command{Use: "appointments [ID]"}
+    upcoming := &cobra.Command{Use: "upcoming"}
+    cmd.AddCommand(upcoming)
+    return cmd
+}
+''',
+            })
+
+            cmd_path, positional, flags = _cli_invocation_from_tokens(
+                ["appointments", "upcoming", "--all-clinics"], cli_dir,
+            )
+            self.assertEqual(["appointments", "upcoming"], cmd_path)
+            self.assertEqual([], positional)
+            self.assertEqual(["--all-clinics"], flags)
+
+            # A same-named top-level command from another file must not be
+            # promoted beneath a parent that has no such child.
+            cmd_path, positional, flags = _cli_invocation_from_tokens(
+                ["appointments", "other", "--json"], cli_dir,
+            )
+            self.assertEqual(["appointments"], cmd_path)
+            self.assertEqual(["other"], positional)
+            self.assertEqual(["--json"], flags)
+
     def test_optional_positionals_are_bound_before_sibling_resolution(self):
         with tempfile.TemporaryDirectory() as td:
             cli_dir = _write_cli(Path(td), {

--- a/.github/scripts/verify-skill/test_resolve_command_path.py
+++ b/.github/scripts/verify-skill/test_resolve_command_path.py
@@ -339,6 +339,44 @@ func newSearchCmd() *cobra.Command {
 
 
 class TestInvocationParsing(unittest.TestCase):
+    def test_child_command_wins_over_parent_optional_positional(self):
+        with tempfile.TemporaryDirectory() as td:
+            cli_dir = _write_cli(Path(td), {
+                "root.go": '''package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+    rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+    rootCmd.AddCommand(newIssuesCmd())
+    return rootCmd.Execute()
+}
+''',
+                "issues.go": '''package cli
+import "github.com/spf13/cobra"
+func newIssuesCmd() *cobra.Command {
+    cmd := &cobra.Command{Use: "issues [ID]"}
+    cmd.AddCommand(newIssuesCreateCmd())
+    return cmd
+}
+func newIssuesCreateCmd() *cobra.Command {
+    return &cobra.Command{Use: "create"}
+}
+''',
+            })
+
+            cmd_path, positional, flags = _cli_invocation_from_tokens(
+                ["issues", "create", "--title", "Ticket"], cli_dir,
+            )
+            self.assertEqual(["issues", "create"], cmd_path)
+            self.assertEqual([], positional)
+            self.assertEqual(["--title"], flags)
+
+            cmd_path, positional, flags = _cli_invocation_from_tokens(
+                ["issues", "MOB-1", "--json"], cli_dir,
+            )
+            self.assertEqual(["issues"], cmd_path)
+            self.assertEqual(["MOB-1"], positional)
+            self.assertEqual(["--json"], flags)
+
     def test_optional_positionals_are_bound_before_sibling_resolution(self):
         with tempfile.TemporaryDirectory() as td:
             cli_dir = _write_cli(Path(td), {

--- a/.github/scripts/verify-skill/test_resolve_command_path.py
+++ b/.github/scripts/verify-skill/test_resolve_command_path.py
@@ -377,6 +377,34 @@ func newIssuesCreateCmd() *cobra.Command {
             self.assertEqual(["MOB-1"], positional)
             self.assertEqual(["--json"], flags)
 
+    def test_legacy_variable_wired_child_remains_resolvable(self):
+        with tempfile.TemporaryDirectory() as td:
+            cli_dir = _write_cli(Path(td), {
+                "root.go": '''package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+    rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+    syncParent := &cobra.Command{Use: "sync"}
+    syncParent.AddCommand(newSyncDiffCmd())
+    rootCmd.AddCommand(syncParent)
+    return rootCmd.Execute()
+}
+''',
+                "sync_diff.go": '''package cli
+import "github.com/spf13/cobra"
+func newSyncDiffCmd() *cobra.Command {
+    return &cobra.Command{Use: "diff"}
+}
+''',
+            })
+
+            cmd_path, positional, flags = _cli_invocation_from_tokens(
+                ["sync", "diff", "--agent"], cli_dir,
+            )
+            self.assertEqual(["sync", "diff"], cmd_path)
+            self.assertEqual([], positional)
+            self.assertEqual(["--agent"], flags)
+
     def test_optional_positionals_are_bound_before_sibling_resolution(self):
         with tempfile.TemporaryDirectory() as td:
             cli_dir = _write_cli(Path(td), {

--- a/.github/scripts/verify-skill/test_resolve_command_path.py
+++ b/.github/scripts/verify-skill/test_resolve_command_path.py
@@ -413,11 +413,8 @@ import "github.com/spf13/cobra"
 func Execute() error {
     rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
     rootCmd.AddCommand(newAppointmentsCmd())
-    rootCmd.AddCommand(newUpcomingCmd())
+    rootCmd.AddCommand(newOtherCmd())
     return rootCmd.Execute()
-}
-func newUpcomingCmd() *cobra.Command {
-    return &cobra.Command{Use: "upcoming"}
 }
 ''',
                 "appointments.go": '''package cli
@@ -425,8 +422,13 @@ import "github.com/spf13/cobra"
 func newAppointmentsCmd() *cobra.Command {
     cmd := &cobra.Command{Use: "appointments [ID]"}
     upcoming := &cobra.Command{Use: "upcoming"}
+    past := &cobra.Command{Use: "past"}
     cmd.AddCommand(upcoming)
+    cmd.AddCommand(past)
     return cmd
+}
+func newOtherCmd() *cobra.Command {
+    return &cobra.Command{Use: "other"}
 }
 ''',
             })
@@ -438,8 +440,15 @@ func newAppointmentsCmd() *cobra.Command {
             self.assertEqual([], positional)
             self.assertEqual(["--all-clinics"], flags)
 
-            # A same-named top-level command from another file must not be
-            # promoted beneath a parent that has no such child.
+            cmd_path, positional, flags = _cli_invocation_from_tokens(
+                ["appointments", "past", "--all-clinics"], cli_dir,
+            )
+            self.assertEqual(["appointments", "past"], cmd_path)
+            self.assertEqual([], positional)
+            self.assertEqual(["--all-clinics"], flags)
+
+            # A top-level sibling declared in the same file must not be
+            # promoted beneath a parent that never attaches it.
             cmd_path, positional, flags = _cli_invocation_from_tokens(
                 ["appointments", "other", "--json"], cli_dir,
             )

--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -171,7 +171,7 @@ ADDCMD_CHILD_RE = re.compile(r'\.AddCommand\s*\(\s*(new[A-Z]\w*Cmd)\s*\(')
 ROOT_ADDCMD_RE = re.compile(r'rootCmd\.AddCommand\s*\(\s*(new[A-Z]\w*Cmd)\s*\(')
 LOCAL_COMMAND_RE = re.compile(r'(?m)^\s*(\w+)\s*:=\s*&cobra\.Command\s*\{')
 RETURN_VARIABLE_RE = re.compile(r'(?m)^\s*return\s+(\w+)\s*$')
-VARIABLE_ADDCMD_RE = re.compile(r'\b(\w+)\.AddCommand\s*\(\s*(\w+)\s*\)')
+VARIABLE_ADDCMD_RE = re.compile(r'\b(\w+)\.AddCommand\s*\(([^)]*)\)')
 
 
 def _extract_function_body(text: str, start_offset: int) -> str | None:
@@ -265,21 +265,25 @@ def _inline_command_children(
     child_names: list[str] = []
     children: dict[str, CommandConstructor] = {}
     for match in VARIABLE_ADDCMD_RE.finditer(body):
-        receiver, child_variable = match.groups()
-        if receiver != parent_variable or child_variable not in variables:
+        receiver, arguments = match.groups()
+        if receiver != parent_variable:
             continue
-        use, args_info = variables[child_variable]
-        synthetic_name = f"{fn_name}__inline__{child_variable}"
-        if synthetic_name in children:
-            continue
-        child_names.append(synthetic_name)
-        children[synthetic_name] = CommandConstructor(
-            name=synthetic_name,
-            file=go_file,
-            use=use,
-            args_info=args_info,
-            children=[],
-        )
+        for raw_argument in arguments.split(","):
+            child_variable = raw_argument.strip()
+            if child_variable not in variables:
+                continue
+            use, args_info = variables[child_variable]
+            synthetic_name = f"{fn_name}__inline__{child_variable}"
+            if synthetic_name in children:
+                continue
+            child_names.append(synthetic_name)
+            children[synthetic_name] = CommandConstructor(
+                name=synthetic_name,
+                file=go_file,
+                use=use,
+                args_info=args_info,
+                children=[],
+            )
     return child_names, children
 
 

--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -714,18 +714,17 @@ def _cli_invocation_from_tokens(
                     cmd_path.append(t)
                     i += 1
                     continue
-                # Preserve legacy command trees that do not expose constructor
-                # edges (for example, AddCommand called with a variable). Only
-                # use the fallback when the current parent is itself absent
-                # from the graph; otherwise a same-named sibling could be
-                # mistaken for a child.
+                # Preserve variable-wired child commands that do not expose a
+                # constructor edge. For a graph-resolved parent, accept the
+                # legacy child only when it is declared in the same file; this
+                # covers local `cmd.AddCommand(child)` variables without
+                # mistaking a same-named top-level sibling for a child.
                 current_file, _, _ = resolve_command_path(cli_dir, cmd_path)
-                if current_file is None:
-                    child_files, _, _ = find_command_source(cli_dir, trial)
-                    if child_files:
-                        cmd_path.append(t)
-                        i += 1
-                        continue
+                child_files, _, _ = find_command_source(cli_dir, trial)
+                if child_files and (current_file is None or current_file in child_files):
+                    cmd_path.append(t)
+                    i += 1
+                    continue
                 break
             cmd_path.append(t)
             i += 1

--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -714,14 +714,18 @@ def _cli_invocation_from_tokens(
                     cmd_path.append(t)
                     i += 1
                     continue
-                # Cobra resolves a matching child before binding a parent's
-                # optional positional. With no child match, keep this token as
-                # an argument to the current command.
-                _files, use_str, _args_info = find_command_source(cli_dir, cmd_path)
-                if use_str:
-                    _, _, optional, variadic = parse_use(use_str)
-                    if optional > 0 or variadic:
-                        break
+                # Preserve legacy command trees that do not expose constructor
+                # edges (for example, AddCommand called with a variable). Only
+                # use the fallback when the current parent is itself absent
+                # from the graph; otherwise a same-named sibling could be
+                # mistaken for a child.
+                current_file, _, _ = resolve_command_path(cli_dir, cmd_path)
+                if current_file is None:
+                    child_files, _, _ = find_command_source(cli_dir, trial)
+                    if child_files:
+                        cmd_path.append(t)
+                        i += 1
+                        continue
                 break
             cmd_path.append(t)
             i += 1

--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -169,6 +169,9 @@ CONSTRUCTOR_RE = re.compile(
 )
 ADDCMD_CHILD_RE = re.compile(r'\.AddCommand\s*\(\s*(new[A-Z]\w*Cmd)\s*\(')
 ROOT_ADDCMD_RE = re.compile(r'rootCmd\.AddCommand\s*\(\s*(new[A-Z]\w*Cmd)\s*\(')
+LOCAL_COMMAND_RE = re.compile(r'(?m)^\s*(\w+)\s*:=\s*&cobra\.Command\s*\{')
+RETURN_VARIABLE_RE = re.compile(r'(?m)^\s*return\s+(\w+)\s*$')
+VARIABLE_ADDCMD_RE = re.compile(r'\b(\w+)\.AddCommand\s*\(\s*(\w+)\s*\)')
 
 
 def _extract_function_body(text: str, start_offset: int) -> str | None:
@@ -229,6 +232,57 @@ def _extract_function_body(text: str, start_offset: int) -> str | None:
     return text[start_offset:i - 1]
 
 
+def _inline_command_children(
+    body: str,
+    fn_name: str,
+    go_file: Path,
+) -> tuple[list[str], dict[str, "CommandConstructor"]]:
+    """Collect local cobra.Command variables attached to a constructor's
+    returned parent variable.
+
+    Generated-then-curated CLIs sometimes build children inline and call
+    `cmd.AddCommand(child)` instead of using a `newChildCmd` constructor. Those
+    are real Cobra edges and must participate in command-path resolution; a
+    same-file `Use:` declaration without that edge must not.
+    """
+    variables: dict[str, tuple[str, tuple | None]] = {}
+    for match in LOCAL_COMMAND_RE.finditer(body):
+        command_body = _extract_function_body(body, match.end())
+        if command_body is None:
+            continue
+        use_match = USE_RE.search(command_body)
+        if use_match is None:
+            continue
+        args_match = ARGS_RE.search(command_body)
+        args_info = (args_match.group(1), args_match.group(2)) if args_match else None
+        variables[match.group(1)] = (use_match.group(1), args_info)
+
+    returned = [match.group(1) for match in RETURN_VARIABLE_RE.finditer(body)]
+    parent_variable = next((name for name in reversed(returned) if name in variables), None)
+    if parent_variable is None:
+        return [], {}
+
+    child_names: list[str] = []
+    children: dict[str, CommandConstructor] = {}
+    for match in VARIABLE_ADDCMD_RE.finditer(body):
+        receiver, child_variable = match.groups()
+        if receiver != parent_variable or child_variable not in variables:
+            continue
+        use, args_info = variables[child_variable]
+        synthetic_name = f"{fn_name}__inline__{child_variable}"
+        if synthetic_name in children:
+            continue
+        child_names.append(synthetic_name)
+        children[synthetic_name] = CommandConstructor(
+            name=synthetic_name,
+            file=go_file,
+            use=use,
+            args_info=args_info,
+            children=[],
+        )
+    return child_names, children
+
+
 @dataclass
 class CommandConstructor:
     name: str
@@ -277,6 +331,8 @@ def collect_command_constructors(cli_dir: Path) -> dict[str, CommandConstructor]
             children = list(dict.fromkeys(
                 child.group(1) for child in ADDCMD_CHILD_RE.finditer(body)
             ))
+            inline_names, inline_children = _inline_command_children(body, fn_name, go_file)
+            children.extend(name for name in inline_names if name not in children)
             constructors[fn_name] = CommandConstructor(
                 name=fn_name,
                 file=go_file,
@@ -284,6 +340,7 @@ def collect_command_constructors(cli_dir: Path) -> dict[str, CommandConstructor]
                 args_info=args_info,
                 children=children,
             )
+            constructors.update(inline_children)
     return constructors
 
 
@@ -714,17 +771,18 @@ def _cli_invocation_from_tokens(
                     cmd_path.append(t)
                     i += 1
                     continue
-                # Preserve variable-wired child commands that do not expose a
-                # constructor edge. For a graph-resolved parent, accept the
-                # legacy child only when it is declared in the same file; this
-                # covers local `cmd.AddCommand(child)` variables without
-                # mistaking a same-named top-level sibling for a child.
+                # Preserve wholly legacy command trees whose parent is not in
+                # the constructor graph. Graph-resolved parents include local
+                # variable-wired children collected by
+                # _inline_command_children, so they never need a file-proximity
+                # heuristic that could promote an unwired sibling.
                 current_file, _, _ = resolve_command_path(cli_dir, cmd_path)
-                child_files, _, _ = find_command_source(cli_dir, trial)
-                if child_files and (current_file is None or current_file in child_files):
-                    cmd_path.append(t)
-                    i += 1
-                    continue
+                if current_file is None:
+                    child_files, _, _ = find_command_source(cli_dir, trial)
+                    if child_files:
+                        cmd_path.append(t)
+                        i += 1
+                        continue
                 break
             cmd_path.append(t)
             i += 1

--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -708,18 +708,21 @@ def _cli_invocation_from_tokens(
             break
         if len(cmd_path) < 3 and re.match(r"^[a-z][a-z0-9-]*$", t):
             if cli_dir is not None:
+                trial = cmd_path + [t]
+                child_file, _, _ = resolve_command_path(cli_dir, trial)
+                if child_file is not None:
+                    cmd_path.append(t)
+                    i += 1
+                    continue
+                # Cobra resolves a matching child before binding a parent's
+                # optional positional. With no child match, keep this token as
+                # an argument to the current command.
                 _files, use_str, _args_info = find_command_source(cli_dir, cmd_path)
                 if use_str:
                     _, _, optional, variadic = parse_use(use_str)
                     if optional > 0 or variadic:
                         break
-            # Verify adding this token still maps to a valid command. If the
-            # extended path has no source match, this token is an argument.
-            if cli_dir is not None:
-                trial = cmd_path + [t]
-                files, _, _ = find_command_source(cli_dir, trial)
-                if not files:
-                    break
+                break
             cmd_path.append(t)
             i += 1
             continue

--- a/library/project-management/linear/.printing-press-patches/mob-1122-multi-issue-read-and-global-flags.json
+++ b/library/project-management/linear/.printing-press-patches/mob-1122-multi-issue-read-and-global-flags.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "mob-1122-multi-issue-read-and-global-flags",
+  "applied_at": "2026-07-12",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "Issue reads must accept comma-separated identifiers in caller order while preserving the single-issue response contract, and root output flags must work at every Cobra-supported command position.",
+  "reason": "Agents commonly hydrate several linked tickets and place global output flags after positional arguments; treating a comma list as one identifier or rejecting valid persistent-flag placement turns routine closeout reads into typed blockers.",
+  "files": [
+    "internal/cli/issues.go",
+    "internal/cli/issues_multi_test.go"
+  ],
+  "validated_outcome": "Focused tests cover before/between/after --json placement, comma parsing, whitespace, de-duplication, caller order, fail-closed missing members, and the unchanged single-object envelope."
+}

--- a/library/project-management/linear/README.md
+++ b/library/project-management/linear/README.md
@@ -303,8 +303,11 @@ These capabilities aren't available in any other tool for this API.
 
   ```bash
   linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.name,url
+  linear-pp-cli issues ENG-123,ENG-124 --agent --data-source live --select identifier,title,description,state.name,url
   linear-pp-cli comments list --issue ENG-123 --agent
   ```
+
+  Comma-separated issue reads preserve caller order, de-duplicate identifiers, and fail the whole request when any member cannot be read. A single identifier keeps the existing object-shaped `results`; multiple identifiers return an array.
 
 ## Usage
 
@@ -528,6 +531,9 @@ Agent recipes:
 # Full current issue body; compact output strips descriptions unless selected
 linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.name,url
 
+# Several current issue bodies in caller order
+linear-pp-cli issues ENG-123,ENG-124 --agent --data-source live --select identifier,title,description,state.name,url
+
 # Safe multiline writes; body files preserve shell snippets literally
 linear-pp-cli comments add --issue ENG-123 --body-file /tmp/comment.md --agent
 ```
@@ -585,10 +591,10 @@ linear-pp-cli bottleneck --team ENG --data-source local
 linear-pp-cli issues list --assignee me --data-source local
 
 # Mutate — write-back keeps the store fresh, no re-sync needed
-linear-pp-cli issues create --title "..." --team ENG --pp-session $SESSION
+linear-pp-cli issues create --title "..." --team ENG --pp-session "$SESSION"
 
 # Verify from local
-linear-pp-cli issues list --data-source local --pp-session $SESSION
+linear-pp-cli issues list --data-source local --pp-session "$SESSION"
 
 # Refresh every ~30 minutes for long sessions
 linear-pp-cli sync

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -38,6 +38,7 @@ If `--version` reports "command not found" after install, the runtime cannot see
 - Add `--agent` to commands unless a human-readable table is explicitly needed. It implies JSON, compact output, non-interactive mode, no color, and confirmation-safe scripting.
 - Use `--data-source live` for closeout/state/description checks where current truth matters. Use `issues search` for duplicate checks; it refreshes stale issue search data or fails visibly. Use `--data-source local` or `similar` only when stale/offline local duplicate search is intentional.
 - A missing `description` in compact output does not mean an empty issue body. Request it explicitly: `linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.name,url`.
+- Fetch several known issues in one call with comma-separated identifiers: `linear-pp-cli issues ENG-123,ENG-124 --agent`. The result array preserves caller order and removes duplicate identifiers; a missing member fails the whole read instead of returning a partial set.
 - Before passing label UUIDs to `issues create` or `issues edit`, run `linear-pp-cli labels list --team ENG --agent --select id,name,global,team.key`. Use only global labels or labels owned by the target issue team; the CLI preflights label ownership and refuses cross-team labels before mutating.
 - Never pass multiline Markdown, shell snippets, GraphQL, logs, backticks, `$()` expansions, or media-rich content as inline shell arguments. Write the body to a file or stdin and use the `*-file` / `*-stdin` flags below.
 
@@ -203,6 +204,7 @@ These capabilities aren't available in any other tool for this API.
 
   ```bash
   linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.id,state.name,url
+  linear-pp-cli issues ENG-123,ENG-124 --agent --data-source live --select identifier,title,description,state.name,url
   linear-pp-cli comments list ENG-123 --agent
   linear-pp-cli comments list --issue ENG-123 --agent --limit 100
   ```
@@ -486,10 +488,10 @@ linear-pp-cli today
 linear-pp-cli bottleneck --team ENG --data-source local
 
 # 3. Mutate — write-back keeps the store fresh
-linear-pp-cli issues create --title "..." --team ENG --pp-session $SESSION
+linear-pp-cli issues create --title "..." --team ENG --pp-session "$SESSION"
 
 # 4. Verify the mutation from local (no extra API call)
-linear-pp-cli issues list --data-source local --pp-session $SESSION
+linear-pp-cli issues list --data-source local --pp-session "$SESSION"
 
 # 5. Re-sync every ~30 minutes if the session is long
 linear-pp-cli sync

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -83,11 +83,12 @@ parent and sub-issue links.`,
 			if cliutil.IsVerifyEnv() {
 				return nil
 			}
+			commaList := strings.Contains(args[0], ",")
 			identifiers, err := parseIssueIdentifiers(args[0])
 			if err != nil {
 				return err
 			}
-			if len(identifiers) == 1 {
+			if !commaList {
 				return runIssuesGet(cmd, flags, resolveDBPath(dbPath), identifiers[0])
 			}
 			return runIssuesMultiGet(cmd, flags, resolveDBPath(dbPath), identifiers)

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -61,10 +61,12 @@ Single-issue get resolution order (with --data-source auto, the default):
   2. live Linear GraphQL query
   3. on live failure with a fresh store, return the store miss as not found
 
+Pass comma-separated identifiers to fetch several issues in one ordered response.
 Use 'issues list' for filtered listing against the local sqlite store.
 Use 'issues create --parent' or 'issues edit --parent/--no-parent' to manage
 parent and sub-issue links.`,
 		Example: `  linear-pp-cli issues ESP-1155
+  linear-pp-cli issues ESP-1155,ESP-1156 --agent
   linear-pp-cli issues list
   linear-pp-cli issues list --assignee me
   linear-pp-cli issues list --assignee me --state started
@@ -81,7 +83,14 @@ parent and sub-issue links.`,
 			if cliutil.IsVerifyEnv() {
 				return nil
 			}
-			return runIssuesGet(cmd, flags, resolveDBPath(dbPath), args[0])
+			identifiers, err := parseIssueIdentifiers(args[0])
+			if err != nil {
+				return err
+			}
+			if len(identifiers) == 1 {
+				return runIssuesGet(cmd, flags, resolveDBPath(dbPath), identifiers[0])
+			}
+			return runIssuesMultiGet(cmd, flags, resolveDBPath(dbPath), identifiers)
 		},
 	}
 	cmd.PersistentFlags().StringVar(&dbPath, "db", "", "Database path")
@@ -91,6 +100,25 @@ parent and sub-issue links.`,
 	cmd.AddCommand(newIssuesCreateCmd(flags))
 	cmd.AddCommand(newIssuesEditCmd(flags, &dbPath))
 	return cmd
+}
+
+func parseIssueIdentifiers(raw string) ([]string, error) {
+	parts := strings.Split(raw, ",")
+	identifiers := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		identifier := strings.TrimSpace(part)
+		if identifier == "" {
+			return nil, usageErr(fmt.Errorf("issue identifier list contains an empty value"))
+		}
+		key := strings.ToUpper(identifier)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		identifiers = append(identifiers, identifier)
+	}
+	return identifiers, nil
 }
 
 func resolveDBPath(override string) string {
@@ -186,7 +214,63 @@ func runIssuesGet(cmd *cobra.Command, flags *rootFlags, dbPath, identifier strin
 			return renderIssue(cmd, flags, rows[0], DataProvenance{Source: "local", ResourceType: "issues", Reason: "api_unreachable"})
 		}
 	}
-	return classifyAPIError(liveErr, flags)
+	return classifyLiveReadError(liveErr, flags)
+}
+
+func runIssuesMultiGet(cmd *cobra.Command, flags *rootFlags, dbPath string, identifiers []string) error {
+	db, openErr := openStoreAt(dbPath)
+	if db != nil {
+		defer db.Close()
+	}
+
+	if flags.dataSource != "live" && db != nil {
+		rows, missing, err := loadIssuesFromStore(db, identifiers)
+		if err != nil {
+			return err
+		}
+		if missing == "" {
+			return renderIssues(cmd, flags, rows, DataProvenance{Source: "local", ResourceType: "issues"})
+		}
+		if flags.dataSource == "local" {
+			return notFoundErr(fmt.Errorf("issue %q not found in local store. Run 'linear-pp-cli sync' first", missing))
+		}
+	}
+
+	if flags.dataSource == "local" {
+		if openErr != nil {
+			return notFoundErr(fmt.Errorf("one or more requested issues were not found in local store (and store unavailable: %v). Run 'linear-pp-cli sync' first", openErr))
+		}
+		return notFoundErr(fmt.Errorf("one or more requested issues were not found in local store. Run 'linear-pp-cli sync' first"))
+	}
+
+	c, err := flags.newClient()
+	if err != nil {
+		return err
+	}
+	rows := make([]json.RawMessage, 0, len(identifiers))
+	for _, identifier := range identifiers {
+		row, fetchErr := fetchIssueLive(c, identifier)
+		if fetchErr != nil {
+			return classifyLiveReadError(fetchErr, flags)
+		}
+		rows = append(rows, row)
+	}
+	return renderIssues(cmd, flags, rows, DataProvenance{Source: "live", ResourceType: "issues"})
+}
+
+func loadIssuesFromStore(db *store.Store, identifiers []string) ([]json.RawMessage, string, error) {
+	rows := make([]json.RawMessage, 0, len(identifiers))
+	for _, identifier := range identifiers {
+		matches, err := db.ListIssues(map[string]string{"identifier": identifier}, 1)
+		if err != nil {
+			return nil, "", err
+		}
+		if len(matches) == 0 {
+			return nil, identifier, nil
+		}
+		rows = append(rows, matches[0])
+	}
+	return rows, "", nil
 }
 
 // fetchIssueLive fetches a single issue by UUID or identifier via the Linear
@@ -581,19 +665,16 @@ func resolveProjectFilter(db *store.Store, input string) (string, error) {
 
 func renderIssue(cmd *cobra.Command, flags *rootFlags, data json.RawMessage, prov DataProvenance) error {
 	printProvenance(cmd, 1, prov)
-	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
-		if flags.selectFields != "" {
-			data = filterFields(data, flags.selectFields)
-		} else if flags.compact {
-			data = compactFields(data)
-		}
-		wrapped, err := wrapWithProvenance(data, prov)
-		if err != nil {
-			return err
-		}
-		return printOutput(cmd.OutOrStdout(), wrapped, true)
+	return renderPayloadWithProvenance(cmd, flags, data, prov, true)
+}
+
+func renderIssues(cmd *cobra.Command, flags *rootFlags, issues []json.RawMessage, prov DataProvenance) error {
+	data, err := json.Marshal(issues)
+	if err != nil {
+		return fmt.Errorf("marshaling issues: %w", err)
 	}
-	return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+	printProvenance(cmd, len(issues), prov)
+	return renderPayloadWithProvenance(cmd, flags, data, prov, true)
 }
 
 // fetchIssuesLive queries Linear's `issues(filter:...)` GraphQL endpoint

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -117,7 +117,7 @@ func parseIssueIdentifiers(raw string) ([]string, error) {
 			continue
 		}
 		seen[key] = struct{}{}
-		identifiers = append(identifiers, identifier)
+		identifiers = append(identifiers, key)
 	}
 	return identifiers, nil
 }

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -112,7 +112,12 @@ func parseIssueIdentifiers(raw string) ([]string, error) {
 		if identifier == "" {
 			return nil, usageErr(fmt.Errorf("issue identifier list contains an empty value"))
 		}
-		key := strings.ToUpper(identifier)
+		key := identifier
+		if !store.IsUUID(identifier) {
+			if _, _, ok := parseIssueIdentifier(identifier); ok {
+				key = strings.ToUpper(identifier)
+			}
+		}
 		if _, ok := seen[key]; ok {
 			continue
 		}

--- a/library/project-management/linear/internal/cli/issues_multi_test.go
+++ b/library/project-management/linear/internal/cli/issues_multi_test.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+)
+
+func TestParseIssueIdentifiers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		raw     string
+		want    []string
+		wantErr bool
+	}{
+		{name: "single", raw: "MOB-1", want: []string{"MOB-1"}},
+		{name: "ordered and trimmed", raw: "MOB-2, MOB-1", want: []string{"MOB-2", "MOB-1"}},
+		{name: "deduplicated case-insensitively", raw: "MOB-2,mob-2,MOB-1", want: []string{"MOB-2", "MOB-1"}},
+		{name: "empty middle", raw: "MOB-1,,MOB-2", wantErr: true},
+		{name: "empty trailing", raw: "MOB-1,", wantErr: true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseIssueIdentifiers(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseIssueIdentifiers(%q) error = %v, wantErr %v", tt.raw, err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseIssueIdentifiers(%q) = %#v, want %#v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssuesGlobalOutputFlagPlacement(t *testing.T) {
+	dbPath := issueMultiTestDB(t)
+	placements := [][]string{
+		{"--json", "issues", "MOB-1", "--data-source", "local", "--db", dbPath},
+		{"issues", "--json", "MOB-1", "--data-source", "local", "--db", dbPath},
+		{"issues", "MOB-1", "--json", "--data-source", "local", "--db", dbPath},
+		{"--agent", "issues", "MOB-1", "--data-source", "local", "--db", dbPath},
+		{"issues", "--agent", "MOB-1", "--data-source", "local", "--db", dbPath},
+		{"issues", "MOB-1", "--agent", "--data-source", "local", "--db", dbPath},
+	}
+	for _, args := range placements {
+		out, err := executeRootForTest(args...)
+		if err != nil {
+			t.Fatalf("%s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		var payload struct {
+			Results struct {
+				Identifier string `json:"identifier"`
+			} `json:"results"`
+		}
+		if err := json.Unmarshal([]byte(out), &payload); err != nil || payload.Results.Identifier != "MOB-1" {
+			t.Fatalf("%s returned unexpected payload: err=%v output=%s", strings.Join(args, " "), err, out)
+		}
+	}
+}
+
+func TestIssuesCommaSeparatedReadPreservesOrderAndSingleContract(t *testing.T) {
+	dbPath := issueMultiTestDB(t)
+
+	out, err := executeRootForTest("issues", "MOB-2, MOB-1,MOB-2", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier,title")
+	if err != nil {
+		t.Fatalf("multi issue read failed: %v\n%s", err, out)
+	}
+	var multi struct {
+		Results []struct {
+			Identifier string `json:"identifier"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out), &multi); err != nil {
+		t.Fatalf("multi output is not JSON: %v\n%s", err, out)
+	}
+	if got := []string{multi.Results[0].Identifier, multi.Results[1].Identifier}; !reflect.DeepEqual(got, []string{"MOB-2", "MOB-1"}) {
+		t.Fatalf("multi identifiers = %v, want caller order without duplicates", got)
+	}
+
+	out, err = executeRootForTest("issues", "MOB-1", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier")
+	if err != nil {
+		t.Fatalf("single issue read failed: %v\n%s", err, out)
+	}
+	var single struct {
+		Results struct {
+			Identifier string `json:"identifier"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out), &single); err != nil || single.Results.Identifier != "MOB-1" {
+		t.Fatalf("single issue contract changed: err=%v output=%s", err, out)
+	}
+}
+
+func TestIssuesCommaSeparatedReadFailsClosedOnMissingIssue(t *testing.T) {
+	dbPath := issueMultiTestDB(t)
+	out, err := executeRootForTest("issues", "MOB-1,MOB-404", "--agent", "--data-source", "local", "--db", dbPath)
+	if err == nil {
+		t.Fatalf("multi issue read unexpectedly succeeded: %s", out)
+	}
+	if ExitCode(err) != 3 {
+		t.Fatalf("missing multi issue exit code = %d, want 3: %v", ExitCode(err), err)
+	}
+	if strings.Contains(out, "MOB-1") {
+		t.Fatalf("partial issue data leaked before failure: %s", out)
+	}
+}
+
+func TestIssuesCommaSeparatedLiveReadDeduplicatesAndFailsClosed(t *testing.T) {
+	calls := map[int]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		number := int(req.Variables["number"].(float64))
+		calls[number]++
+		if number == 404 {
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[]}}}`)
+			return
+		}
+		fmt.Fprintf(w, `{"data":{"issues":{"nodes":[{"id":"issue-%d","identifier":"MOB-%d","title":"Issue %d"}]}}}`, number, number, number)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "MOB-2,MOB-1,MOB-2", "--agent", "--data-source", "live", "--select", "identifier")
+	if err != nil {
+		t.Fatalf("live multi issue read failed: %v\n%s", err, out)
+	}
+	var payload struct {
+		Results []struct {
+			Identifier string `json:"identifier"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("live multi output is not JSON: %v\n%s", err, out)
+	}
+	if got := []string{payload.Results[0].Identifier, payload.Results[1].Identifier}; !reflect.DeepEqual(got, []string{"MOB-2", "MOB-1"}) {
+		t.Fatalf("live identifiers = %v, want caller order", got)
+	}
+	if calls[2] != 1 || calls[1] != 1 {
+		t.Fatalf("duplicate identifiers triggered duplicate API work: calls=%v", calls)
+	}
+
+	out, err = executeRootForTest("issues", "MOB-1,MOB-404", "--agent", "--data-source", "live")
+	if err == nil || ExitCode(err) != 3 {
+		t.Fatalf("partial live read error = %v (code %d), want not-found code 3; output=%s", err, ExitCode(err), out)
+	}
+	if strings.Contains(out, "MOB-1") {
+		t.Fatalf("partial live issue data leaked before failure: %s", out)
+	}
+}
+
+func issueMultiTestDB(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	for _, issue := range []struct {
+		id, identifier, title string
+	}{
+		{id: "issue-1", identifier: "MOB-1", title: "First"},
+		{id: "issue-2", identifier: "MOB-2", title: "Second"},
+	} {
+		raw, err := json.Marshal(map[string]any{"id": issue.id, "identifier": issue.identifier, "title": issue.title})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := db.UpsertIssue(issue.id, issue.identifier, issue.title, raw); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dbPath
+}

--- a/library/project-management/linear/internal/cli/issues_multi_test.go
+++ b/library/project-management/linear/internal/cli/issues_multi_test.go
@@ -24,7 +24,7 @@ func TestParseIssueIdentifiers(t *testing.T) {
 	}{
 		{name: "single", raw: "MOB-1", want: []string{"MOB-1"}},
 		{name: "ordered and trimmed", raw: "MOB-2, MOB-1", want: []string{"MOB-2", "MOB-1"}},
-		{name: "deduplicated case-insensitively", raw: "MOB-2,mob-2,MOB-1", want: []string{"MOB-2", "MOB-1"}},
+		{name: "canonicalized and deduplicated case-insensitively", raw: "mob-2,MOB-2,mob-1", want: []string{"MOB-2", "MOB-1"}},
 		{name: "empty middle", raw: "MOB-1,,MOB-2", wantErr: true},
 		{name: "empty trailing", raw: "MOB-1,", wantErr: true},
 	}
@@ -88,7 +88,7 @@ func TestIssuesCommaSeparatedReadPreservesOrderAndSingleContract(t *testing.T) {
 		t.Fatalf("multi identifiers = %v, want caller order without duplicates", got)
 	}
 
-	out, err = executeRootForTest("issues", "MOB-1,MOB-1", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier")
+	out, err = executeRootForTest("issues", "mob-1,MOB-1", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier")
 	if err != nil {
 		t.Fatalf("deduplicated comma-list read failed: %v\n%s", err, out)
 	}

--- a/library/project-management/linear/internal/cli/issues_multi_test.go
+++ b/library/project-management/linear/internal/cli/issues_multi_test.go
@@ -88,6 +88,19 @@ func TestIssuesCommaSeparatedReadPreservesOrderAndSingleContract(t *testing.T) {
 		t.Fatalf("multi identifiers = %v, want caller order without duplicates", got)
 	}
 
+	out, err = executeRootForTest("issues", "MOB-1,MOB-1", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier")
+	if err != nil {
+		t.Fatalf("deduplicated comma-list read failed: %v\n%s", err, out)
+	}
+	var deduplicated struct {
+		Results []struct {
+			Identifier string `json:"identifier"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out), &deduplicated); err != nil || len(deduplicated.Results) != 1 || deduplicated.Results[0].Identifier != "MOB-1" {
+		t.Fatalf("comma-list contract changed after deduplication: err=%v output=%s", err, out)
+	}
+
 	out, err = executeRootForTest("issues", "MOB-1", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier")
 	if err != nil {
 		t.Fatalf("single issue read failed: %v\n%s", err, out)

--- a/library/project-management/linear/internal/cli/issues_multi_test.go
+++ b/library/project-management/linear/internal/cli/issues_multi_test.go
@@ -25,6 +25,7 @@ func TestParseIssueIdentifiers(t *testing.T) {
 		{name: "single", raw: "MOB-1", want: []string{"MOB-1"}},
 		{name: "ordered and trimmed", raw: "MOB-2, MOB-1", want: []string{"MOB-2", "MOB-1"}},
 		{name: "canonicalized and deduplicated case-insensitively", raw: "mob-2,MOB-2,mob-1", want: []string{"MOB-2", "MOB-1"}},
+		{name: "UUID remains opaque", raw: "4a09c2e6-3a25-4cb8-ab63-9c9f6754b24e", want: []string{"4a09c2e6-3a25-4cb8-ab63-9c9f6754b24e"}},
 		{name: "empty middle", raw: "MOB-1,,MOB-2", wantErr: true},
 		{name: "empty trailing", raw: "MOB-1,", wantErr: true},
 	}
@@ -101,7 +102,7 @@ func TestIssuesCommaSeparatedReadPreservesOrderAndSingleContract(t *testing.T) {
 		t.Fatalf("comma-list contract changed after deduplication: err=%v output=%s", err, out)
 	}
 
-	out, err = executeRootForTest("issues", "MOB-1", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier")
+	out, err = executeRootForTest("issues", "mob-1", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier")
 	if err != nil {
 		t.Fatalf("single issue read failed: %v\n%s", err, out)
 	}


### PR DESCRIPTION
## Summary

Agents can now fetch several known Linear issues in one ordered call with `linear-pp-cli issues MOB-123,MOB-124 --agent`; duplicate identifiers are fetched once, and any missing member fails the whole request instead of silently returning incomplete context. Single-issue output remains object-shaped, while multi-issue output uses the normal provenance envelope with an ordered results array.

The CLI now pins root `--json` and `--agent` flags before, within, and after the issue command so a parser regression cannot strand closeout workers again. The skill verifier also resolves real child commands before binding a parent's optional positional, allowing the updated Linear skill to pass the publication gate without misclassifying `issues create`, `issues edit`, or `issues search` as issue identifiers.

## Tests

- `go build ./...`
- `go vet ./...`
- `govulncheck ./...` (0 reachable vulnerabilities)
- `go test ./...`
- `python3 .github/scripts/verify-skill/test_resolve_command_path.py`
- `python3 .github/scripts/verify-skill/test_skill_guard_literals.py`
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/project-management/linear`
- Branch binary smoke: post-command `--json` succeeds; `MOB-123,MOB-104,MOB-123` returns `MOB-123,MOB-104` in order.

Fixes MOB-1122.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
