### PR TITLE
fix(bambu): discover X1C root archive previews

### DIFF
--- a/library/devices/bambu/.printing-press-patches/bambu-x1c-root-archive-discovery.json
+++ b/library/devices/bambu/.printing-press-patches/bambu-x1c-root-archive-discovery.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "bambu-x1c-root-archive-discovery",
+  "applied_at": "2026-07-11",
+  "base_run_id": "20260711-063302-c519dd7c",
+  "base_printing_press_version": "4.28.0",
+  "summary": "Legacy X1 Carbon printers must discover current root-level 3MF archives when MQTT exposes only plate_1.gcode.",
+  "reason": "An X1C Studio print stored the current archive under its project-derived root filename while MQTT reported only the generic G-code name and print-profile title, so exact filename guesses could not find its preview or weight.",
+  "files": [
+    "internal/bambu/ftps.go",
+    "internal/bambu/bambu_test.go"
+  ],
+  "validated_outcome": "Fallback discovery considers only bounded recent root 3MF files, orders them newest first, and accepts metadata only when its embedded project or profile title matches the active MQTT job."
+}

--- a/library/devices/bambu/.printing-press-patches/bambu-x1c-root-archive-discovery.json
+++ b/library/devices/bambu/.printing-press-patches/bambu-x1c-root-archive-discovery.json
@@ -10,5 +10,5 @@
     "internal/bambu/ftps.go",
     "internal/bambu/bambu_test.go"
   ],
-  "validated_outcome": "Fallback discovery rejects reliably stale root 3MF files, retains candidates with missing or clock-skewed timestamps, caps and orders attempts, and accepts metadata only when its embedded project or profile title matches the active MQTT job."
+  "validated_outcome": "Fallback discovery rejects reliably stale root 3MF files, retains and prioritizes every candidate with a missing timestamp, orders dated attempts newest first, and accepts metadata only when its embedded project or profile title matches the active MQTT job. The existing 1,000-entry listing, archive-size limits, and command deadline bound the search."
 }

--- a/library/devices/bambu/.printing-press-patches/bambu-x1c-root-archive-discovery.json
+++ b/library/devices/bambu/.printing-press-patches/bambu-x1c-root-archive-discovery.json
@@ -10,5 +10,5 @@
     "internal/bambu/ftps.go",
     "internal/bambu/bambu_test.go"
   ],
-  "validated_outcome": "Fallback discovery considers only bounded recent root 3MF files, orders them newest first, and accepts metadata only when its embedded project or profile title matches the active MQTT job."
+  "validated_outcome": "Fallback discovery rejects reliably stale root 3MF files, retains candidates with missing or clock-skewed timestamps, caps and orders attempts, and accepts metadata only when its embedded project or profile title matches the active MQTT job."
 }

--- a/library/devices/bambu/internal/bambu/bambu_test.go
+++ b/library/devices/bambu/internal/bambu/bambu_test.go
@@ -184,7 +184,7 @@ func TestLegacyArchiveCandidatesRetainMissingAndSkewedTimestamps(t *testing.T) {
 		{Path: "/notes.txt", Name: "notes.txt", Size: 100, ModTime: observedAt, Type: "file"},
 	}
 	got := LegacyArchiveCandidates(snapshot, files)
-	want := []string{"/future.gcode.3mf", "/newer.gcode.3mf", "/current.gcode.3mf", "/unknown.gcode.3mf"}
+	want := []string{"/unknown.gcode.3mf", "/future.gcode.3mf", "/newer.gcode.3mf", "/current.gcode.3mf"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("legacy candidates = %#v, want %#v", got, want)
 	}
@@ -215,8 +215,15 @@ func TestLegacyArchiveCandidatesAreBounded(t *testing.T) {
 			Type:    "file",
 		}
 	}
-	if got := len(LegacyArchiveCandidates(Snapshot{ObservedAt: observedAt}, files)); got != MaxLegacyArchiveCandidates {
-		t.Fatalf("legacy candidate count = %d, want %d", got, MaxLegacyArchiveCandidates)
+	files[len(files)-1].Path = "/unknown-time-active.3mf"
+	files[len(files)-1].Name = "unknown-time-active.3mf"
+	files[len(files)-1].ModTime = time.Time{}
+	got := LegacyArchiveCandidates(Snapshot{ObservedAt: observedAt}, files)
+	if len(got) != MaxLegacyArchiveCandidates {
+		t.Fatalf("legacy candidate count = %d, want %d", len(got), MaxLegacyArchiveCandidates)
+	}
+	if got[0] != "/unknown-time-active.3mf" {
+		t.Fatalf("missing-timestamp candidate was capped out: %#v", got)
 	}
 }
 

--- a/library/devices/bambu/internal/bambu/bambu_test.go
+++ b/library/devices/bambu/internal/bambu/bambu_test.go
@@ -203,27 +203,25 @@ func TestMetadataMatchesSnapshotProfileOrProject(t *testing.T) {
 	}
 }
 
-func TestLegacyArchiveCandidatesAreBounded(t *testing.T) {
+func TestLegacyArchiveCandidatesRetainAllUnknownTimestamps(t *testing.T) {
 	observedAt := time.Date(2026, 7, 12, 5, 0, 0, 0, time.UTC)
-	files := make([]File, MaxLegacyArchiveCandidates+5)
+	files := make([]File, 25)
 	for index := range files {
 		files[index] = File{
-			Path:    fmt.Sprintf("/candidate-%02d.3mf", index),
-			Name:    fmt.Sprintf("candidate-%02d.3mf", index),
-			Size:    100,
-			ModTime: observedAt.Add(-time.Duration(index) * time.Minute),
-			Type:    "file",
+			Path: fmt.Sprintf("/candidate-%02d.3mf", index),
+			Name: fmt.Sprintf("candidate-%02d.3mf", index),
+			Size: 100,
+			Type: "file",
 		}
 	}
-	files[len(files)-1].Path = "/unknown-time-active.3mf"
-	files[len(files)-1].Name = "unknown-time-active.3mf"
-	files[len(files)-1].ModTime = time.Time{}
+	files[len(files)-1].Path = "/zzzz-active.3mf"
+	files[len(files)-1].Name = "zzzz-active.3mf"
 	got := LegacyArchiveCandidates(Snapshot{ObservedAt: observedAt}, files)
-	if len(got) != MaxLegacyArchiveCandidates {
-		t.Fatalf("legacy candidate count = %d, want %d", len(got), MaxLegacyArchiveCandidates)
+	if len(got) != len(files) {
+		t.Fatalf("legacy candidate count = %d, want %d", len(got), len(files))
 	}
-	if got[0] != "/unknown-time-active.3mf" {
-		t.Fatalf("missing-timestamp candidate was capped out: %#v", got)
+	if got[len(got)-1] != "/zzzz-active.3mf" {
+		t.Fatalf("last missing-timestamp candidate was dropped: %#v", got)
 	}
 }
 

--- a/library/devices/bambu/internal/bambu/bambu_test.go
+++ b/library/devices/bambu/internal/bambu/bambu_test.go
@@ -171,7 +171,7 @@ func TestArchiveCandidatesPreferCurrentRootArchiveOverCache(t *testing.T) {
 	}
 }
 
-func TestLegacyArchiveCandidatesPreferNewestBounded3MF(t *testing.T) {
+func TestLegacyArchiveCandidatesRetainMissingAndSkewedTimestamps(t *testing.T) {
 	observedAt := time.Date(2026, 7, 12, 5, 0, 0, 0, time.UTC)
 	percent, remaining := 40, 30
 	snapshot := Snapshot{ObservedAt: observedAt, Percent: &percent, RemainingMinutes: &remaining}
@@ -180,10 +180,11 @@ func TestLegacyArchiveCandidatesPreferNewestBounded3MF(t *testing.T) {
 		{Path: "/current.gcode.3mf", Name: "current.gcode.3mf", Size: 100, ModTime: observedAt.Add(-20 * time.Minute), Type: "file"},
 		{Path: "/newer.gcode.3mf", Name: "newer.gcode.3mf", Size: 100, ModTime: observedAt.Add(-10 * time.Minute), Type: "file"},
 		{Path: "/future.gcode.3mf", Name: "future.gcode.3mf", Size: 100, ModTime: observedAt.Add(10 * time.Minute), Type: "file"},
+		{Path: "/unknown.gcode.3mf", Name: "unknown.gcode.3mf", Size: 100, Type: "file"},
 		{Path: "/notes.txt", Name: "notes.txt", Size: 100, ModTime: observedAt, Type: "file"},
 	}
 	got := LegacyArchiveCandidates(snapshot, files)
-	want := []string{"/newer.gcode.3mf", "/current.gcode.3mf"}
+	want := []string{"/future.gcode.3mf", "/newer.gcode.3mf", "/current.gcode.3mf", "/unknown.gcode.3mf"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("legacy candidates = %#v, want %#v", got, want)
 	}

--- a/library/devices/bambu/internal/bambu/bambu_test.go
+++ b/library/devices/bambu/internal/bambu/bambu_test.go
@@ -8,8 +8,10 @@ import (
 	"image"
 	"image/color"
 	"image/png"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestMonitorMergesSparseReportsAndTransitions(t *testing.T) {
@@ -166,6 +168,54 @@ func TestArchiveCandidatesPreferCurrentRootArchiveOverCache(t *testing.T) {
 		if candidates[index] != want[index] {
 			t.Fatalf("candidates = %#v, want %#v", candidates, want)
 		}
+	}
+}
+
+func TestLegacyArchiveCandidatesPreferNewestBounded3MF(t *testing.T) {
+	observedAt := time.Date(2026, 7, 12, 5, 0, 0, 0, time.UTC)
+	percent, remaining := 40, 30
+	snapshot := Snapshot{ObservedAt: observedAt, Percent: &percent, RemainingMinutes: &remaining}
+	files := []File{
+		{Path: "/old.gcode.3mf", Name: "old.gcode.3mf", Size: 100, ModTime: observedAt.Add(-72 * time.Hour), Type: "file"},
+		{Path: "/current.gcode.3mf", Name: "current.gcode.3mf", Size: 100, ModTime: observedAt.Add(-20 * time.Minute), Type: "file"},
+		{Path: "/newer.gcode.3mf", Name: "newer.gcode.3mf", Size: 100, ModTime: observedAt.Add(-10 * time.Minute), Type: "file"},
+		{Path: "/future.gcode.3mf", Name: "future.gcode.3mf", Size: 100, ModTime: observedAt.Add(10 * time.Minute), Type: "file"},
+		{Path: "/notes.txt", Name: "notes.txt", Size: 100, ModTime: observedAt, Type: "file"},
+	}
+	got := LegacyArchiveCandidates(snapshot, files)
+	want := []string{"/newer.gcode.3mf", "/current.gcode.3mf"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("legacy candidates = %#v, want %#v", got, want)
+	}
+}
+
+func TestMetadataMatchesSnapshotProfileOrProject(t *testing.T) {
+	snapshot := Snapshot{JobName: "12min42s, Bambu PLA Basic, A1 mini", SubtaskName: "fallback project"}
+	if !MetadataMatchesSnapshot(Metadata{ProfileName: "12min42s Bambu PLA Basic A1 Mini"}, snapshot) {
+		t.Fatal("normalized profile title must match current MQTT job")
+	}
+	if !MetadataMatchesSnapshot(Metadata{ProjectName: "Fallback_Project"}, snapshot) {
+		t.Fatal("normalized project title must match current MQTT subtask")
+	}
+	if MetadataMatchesSnapshot(Metadata{ProfileName: "another print"}, snapshot) {
+		t.Fatal("unrelated archive metadata must not match current MQTT job")
+	}
+}
+
+func TestLegacyArchiveCandidatesAreBounded(t *testing.T) {
+	observedAt := time.Date(2026, 7, 12, 5, 0, 0, 0, time.UTC)
+	files := make([]File, MaxLegacyArchiveCandidates+5)
+	for index := range files {
+		files[index] = File{
+			Path:    fmt.Sprintf("/candidate-%02d.3mf", index),
+			Name:    fmt.Sprintf("candidate-%02d.3mf", index),
+			Size:    100,
+			ModTime: observedAt.Add(-time.Duration(index) * time.Minute),
+			Type:    "file",
+		}
+	}
+	if got := len(LegacyArchiveCandidates(Snapshot{ObservedAt: observedAt}, files)); got != MaxLegacyArchiveCandidates {
+		t.Fatalf("legacy candidate count = %d, want %d", got, MaxLegacyArchiveCandidates)
 	}
 }
 

--- a/library/devices/bambu/internal/bambu/ftps.go
+++ b/library/devices/bambu/internal/bambu/ftps.go
@@ -25,12 +25,11 @@ import (
 )
 
 const (
-	MaxArchiveBytes            = 128 << 20
-	MaxArchiveEntries          = 10000
-	MaxCentralDirectoryBytes   = 8 << 20
-	MaxConfigBytes             = 2 << 20
-	MaxThumbnailBytes          = 12 << 20
-	MaxLegacyArchiveCandidates = 20
+	MaxArchiveBytes          = 128 << 20
+	MaxArchiveEntries        = 10000
+	MaxCentralDirectoryBytes = 8 << 20
+	MaxConfigBytes           = 2 << 20
+	MaxThumbnailBytes        = 12 << 20
 )
 
 type File struct {
@@ -261,9 +260,6 @@ func LegacyArchiveCandidates(snapshot Snapshot, files []File) []string {
 	})
 	paths := make([]string, 0, len(eligible))
 	for _, file := range eligible {
-		if len(paths) >= MaxLegacyArchiveCandidates {
-			break
-		}
 		paths = append(paths, file.Path)
 	}
 	return paths

--- a/library/devices/bambu/internal/bambu/ftps.go
+++ b/library/devices/bambu/internal/bambu/ftps.go
@@ -240,13 +240,12 @@ func LegacyArchiveCandidates(snapshot Snapshot, files []File) []string {
 		}
 	}
 	oldest := observedAt.Add(-maxAge)
-	newest := observedAt.Add(5 * time.Minute)
 	eligible := make([]File, 0, len(files))
 	for _, file := range files {
 		if file.Type != "file" || file.Size == 0 || file.Size > MaxArchiveBytes || !strings.HasSuffix(strings.ToLower(file.Name), ".3mf") {
 			continue
 		}
-		if file.ModTime.IsZero() || file.ModTime.Before(oldest) || file.ModTime.After(newest) {
+		if !file.ModTime.IsZero() && file.ModTime.Before(oldest) {
 			continue
 		}
 		eligible = append(eligible, file)

--- a/library/devices/bambu/internal/bambu/ftps.go
+++ b/library/devices/bambu/internal/bambu/ftps.go
@@ -14,20 +14,23 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/jlaffaye/ftp"
 )
 
 const (
-	MaxArchiveBytes          = 128 << 20
-	MaxArchiveEntries        = 10000
-	MaxCentralDirectoryBytes = 8 << 20
-	MaxConfigBytes           = 2 << 20
-	MaxThumbnailBytes        = 12 << 20
+	MaxArchiveBytes            = 128 << 20
+	MaxArchiveEntries          = 10000
+	MaxCentralDirectoryBytes   = 8 << 20
+	MaxConfigBytes             = 2 << 20
+	MaxThumbnailBytes          = 12 << 20
+	MaxLegacyArchiveCandidates = 20
 )
 
 type File struct {
@@ -177,6 +180,18 @@ func (f *FTPS) Download(remotePath, outputPath string, maxBytes int64) (int64, e
 
 func (f *FTPS) JobMetadata(snapshot Snapshot) (Metadata, error) {
 	candidates := ArchiveCandidates(snapshot)
+	fallbackCandidates := map[string]bool{}
+	if f != nil && f.conn != nil {
+		files, err := f.List("/", 1000)
+		if err == nil {
+			for _, candidate := range LegacyArchiveCandidates(snapshot, files) {
+				if !containsString(candidates, candidate) {
+					candidates = append(candidates, candidate)
+					fallbackCandidates[candidate] = true
+				}
+			}
+		}
+	}
 	metadata := Metadata{CandidatePaths: candidates, PlateNumber: snapshot.PlateNumber, Objects: []Object{}}
 	for _, candidate := range candidates {
 		size, err := f.conn.FileSize(candidate)
@@ -199,6 +214,9 @@ func (f *FTPS) JobMetadata(snapshot Snapshot) (Metadata, error) {
 		if err != nil {
 			continue
 		}
+		if fallbackCandidates[candidate] && !MetadataMatchesSnapshot(parsed, snapshot) {
+			continue
+		}
 		parsed.SourcePath = candidate
 		parsed.CandidatePaths = candidates
 		return parsed, nil
@@ -207,6 +225,80 @@ func (f *FTPS) JobMetadata(snapshot Snapshot) (Metadata, error) {
 		return metadata, fmt.Errorf("current print exposes printer-resident G-code (%s), not a 3MF available over FTPS; display-started built-in prints may not provide weight or preview metadata", safeBasename(rawPath))
 	}
 	return metadata, fmt.Errorf("current 3MF metadata unavailable after checking %d candidate paths", len(candidates))
+}
+
+func LegacyArchiveCandidates(snapshot Snapshot, files []File) []string {
+	observedAt := snapshot.ObservedAt
+	if observedAt.IsZero() {
+		return nil
+	}
+	maxAge := 48 * time.Hour
+	if snapshot.Percent != nil && *snapshot.Percent > 0 && *snapshot.Percent < 100 && snapshot.RemainingMinutes != nil {
+		elapsed := time.Duration(float64(*snapshot.RemainingMinutes)*float64(*snapshot.Percent)/float64(100-*snapshot.Percent)) * time.Minute
+		if elapsed+6*time.Hour > maxAge {
+			maxAge = elapsed + 6*time.Hour
+		}
+	}
+	oldest := observedAt.Add(-maxAge)
+	newest := observedAt.Add(5 * time.Minute)
+	eligible := make([]File, 0, len(files))
+	for _, file := range files {
+		if file.Type != "file" || file.Size == 0 || file.Size > MaxArchiveBytes || !strings.HasSuffix(strings.ToLower(file.Name), ".3mf") {
+			continue
+		}
+		if file.ModTime.IsZero() || file.ModTime.Before(oldest) || file.ModTime.After(newest) {
+			continue
+		}
+		eligible = append(eligible, file)
+	}
+	sort.Slice(eligible, func(i, j int) bool {
+		if eligible[i].ModTime.Equal(eligible[j].ModTime) {
+			return eligible[i].Path < eligible[j].Path
+		}
+		return eligible[i].ModTime.After(eligible[j].ModTime)
+	})
+	paths := make([]string, 0, len(eligible))
+	for _, file := range eligible {
+		if len(paths) >= MaxLegacyArchiveCandidates {
+			break
+		}
+		paths = append(paths, file.Path)
+	}
+	return paths
+}
+
+func MetadataMatchesSnapshot(metadata Metadata, snapshot Snapshot) bool {
+	want := []string{canonicalJobLabel(snapshot.JobName), canonicalJobLabel(snapshot.SubtaskName)}
+	got := []string{canonicalJobLabel(metadata.ProfileName), canonicalJobLabel(metadata.ProjectName)}
+	for _, candidate := range got {
+		if candidate == "" {
+			continue
+		}
+		for _, expected := range want {
+			if expected != "" && candidate == expected {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func canonicalJobLabel(value string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			return unicode.ToLower(r)
+		}
+		return -1
+	}, value)
+}
+
+func containsString(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
 }
 
 func ArchiveCandidates(snapshot Snapshot) []string {

--- a/library/devices/bambu/internal/bambu/ftps.go
+++ b/library/devices/bambu/internal/bambu/ftps.go
@@ -251,6 +251,9 @@ func LegacyArchiveCandidates(snapshot Snapshot, files []File) []string {
 		eligible = append(eligible, file)
 	}
 	sort.Slice(eligible, func(i, j int) bool {
+		if eligible[i].ModTime.IsZero() != eligible[j].ModTime.IsZero() {
+			return eligible[i].ModTime.IsZero()
+		}
 		if eligible[i].ModTime.Equal(eligible[j].ModTime) {
 			return eligible[i].Path < eligible[j].Path
 		}


### PR DESCRIPTION
## Summary

Fix X1 Carbon preview and weight discovery when the printer stores the active 3MF under a project-derived root filename but MQTT reports only `plate_1.gcode` and the print-profile title.

## Root Cause

The X1C exposed the active archive as `/Benchy_Bambu_Pla_Basic.gcode.3mf`. Existing candidate generation tried only filenames derived from MQTT's profile and generic G-code fields, so lifecycle payloads had no attachment even though the archive was available over normal local FTPS.

## Fix

- List bounded root-level 3MF candidates when exact MQTT-derived paths fail.
- Consider only non-empty archives, rejecting reliably stale timestamps while retaining missing or clock-skewed values.
- Prioritize missing timestamps, then sort dated candidates newest first; the 1,000-entry listing and command deadline bound the search.
- Accept fallback metadata only when its embedded project or profile title matches the active MQTT job.
- Record the customization in the [Printing Press patch ledger](https://github.com/mvanhorn/printing-press-library/blob/267e08ec001ba5093a6d788a122031ff19f9222a/library/devices/bambu/.printing-press-patches/bambu-x1c-root-archive-discovery.json).

## Validation

| Check | Result |
|-------|--------|
| `go test ./...` | PASS |
| `go vet ./...` | PASS |
| Manifest | PASS |
| Phase 5 | PASS |
| `go mod tidy` | PASS |
| `govulncheck` | PASS |
| `go build` | PASS |
| `--help` / `--version` | PASS |
| Strict skill verification | PASS |
| Manuscripts | PRESENT |

## Live X1C Gate

Reran against an active X1C print using normal local access:

- State: `RUNNING`, 80%, layer 135/192
- Selected archive: `/Benchy_Bambu_Pla_Basic.gcode.3mf`
- Project: `Benchy Bambu Pla Basic`
- Profile: `12min42s, Bambu PLA Basic, A1 mini`
- Object: `3DBenchy.stl`
- Weight: 10.99 g
- Preview: 22,138-byte, 512×512 RGBA PNG

No printer credentials, serials, private IPs, registry files, or shared skills are included in this change.
