### PR TITLE
fix(klaviyo): repair audit reports and pagination

### DIFF
--- a/library/marketing/klaviyo/.printing-press-patches/audit-report-reliability.json
+++ b/library/marketing/klaviyo/.printing-press-patches/audit-report-reliability.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "audit-report-reliability",
+  "applied_at": "2026-07-12",
+  "base_run_id": "2026-05-02T18:02:09.219489Z",
+  "base_printing_press_version": "3.5.0",
+  "summary": "Keep Klaviyo audit reports aligned with current field names, metric identities, endpoint pagination limits, and denominator coverage.",
+  "reason": "Live consulting audits otherwise fail on invalid form/template requests, silently truncate JSON:API collections, misidentify unsubscribe metrics, or overstate domain deliverability from a sparse subset of received events.",
+  "files": [
+    "internal/cli/helpers.go",
+    "internal/cli/novel_computed_analytics.go",
+    "internal/cli/novel_segments_reports.go",
+    "internal/cli/novel_klaviyo_test.go"
+  ],
+  "validated_outcome": "Focused regression tests cover multi-page JSON:API collection reads, valid form/template query parameters, current unsubscribe metric names, non-empty subject-line output, and explicit deliverability denominator coverage."
+}

--- a/library/marketing/klaviyo/.printing-press-patches/audit-report-reliability.json
+++ b/library/marketing/klaviyo/.printing-press-patches/audit-report-reliability.json
@@ -12,5 +12,5 @@
     "internal/cli/novel_segments_reports.go",
     "internal/cli/novel_klaviyo_test.go"
   ],
-  "validated_outcome": "Focused regression tests cover multi-page JSON:API collection reads, valid form/template query parameters, current unsubscribe metric names, non-empty subject-line output, and explicit deliverability denominator coverage."
+  "validated_outcome": "Focused regression tests cover multi-page JSON:API reads, repeated-cursor rejection, valid form/template parameters, incomplete metric handling, non-empty subject-line output, and explicit deliverability denominator coverage."
 }

--- a/library/marketing/klaviyo/internal/cli/helpers.go
+++ b/library/marketing/klaviyo/internal/cli/helpers.go
@@ -274,6 +274,10 @@ func paginatedGet(c interface {
 
 	// Fetch all pages
 	var allItems []json.RawMessage
+	seenCursors := map[string]bool{}
+	if cursor := clean[cursorParam]; cursor != "" {
+		seenCursors[cursor] = true
+	}
 	page := 0
 	for {
 		page++
@@ -312,6 +316,10 @@ func paginatedGet(c interface {
 					if tokenRaw, ok := obj[nextCursorPath]; ok {
 						var token string
 						if json.Unmarshal(tokenRaw, &token) == nil && token != "" {
+							if seenCursors[token] {
+								return nil, fmt.Errorf("pagination cursor %q repeated for %s", token, path)
+							}
+							seenCursors[token] = true
 							clean[cursorParam] = token
 							continue
 						}
@@ -338,7 +346,11 @@ func paginatedGet(c interface {
 						if json.Unmarshal(linksRaw, &links) == nil {
 							var nextLink string
 							if json.Unmarshal(links["next"], &nextLink) == nil {
-								if nextCursor := cursorFromNextLink(nextLink, cursorParam); nextCursor != "" && nextCursor != clean[cursorParam] {
+								if nextCursor := cursorFromNextLink(nextLink, cursorParam); nextCursor != "" {
+									if seenCursors[nextCursor] {
+										return nil, fmt.Errorf("pagination cursor %q repeated for %s", nextCursor, path)
+									}
+									seenCursors[nextCursor] = true
 									clean[cursorParam] = nextCursor
 									continue
 								}

--- a/library/marketing/klaviyo/internal/cli/helpers.go
+++ b/library/marketing/klaviyo/internal/cli/helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -326,6 +327,25 @@ func paginatedGet(c interface {
 						}
 					}
 				}
+
+				// JSON:API pagination carries the next cursor in links.next.
+				// Generated Klaviyo commands use page[cursor] but do not set a
+				// top-level nextCursorPath, so without this fallback --all stops
+				// after the first page even when the response advertises another.
+				if cursorParam != "" {
+					if linksRaw, ok := obj["links"]; ok {
+						var links map[string]json.RawMessage
+						if json.Unmarshal(linksRaw, &links) == nil {
+							var nextLink string
+							if json.Unmarshal(links["next"], &nextLink) == nil {
+								if nextCursor := cursorFromNextLink(nextLink, cursorParam); nextCursor != "" && nextCursor != clean[cursorParam] {
+									clean[cursorParam] = nextCursor
+									continue
+								}
+							}
+						}
+					}
+				}
 			}
 			// No more pages
 			break
@@ -342,6 +362,17 @@ func paginatedGet(c interface {
 	}
 	result, _ := json.Marshal(allItems)
 	return json.RawMessage(result), nil
+}
+
+func cursorFromNextLink(nextLink, cursorParam string) string {
+	if nextLink == "" || cursorParam == "" {
+		return ""
+	}
+	parsed, err := url.Parse(nextLink)
+	if err != nil {
+		return ""
+	}
+	return parsed.Query().Get(cursorParam)
 }
 
 // printJSONFiltered marshals a Go-typed value through the same output

--- a/library/marketing/klaviyo/internal/cli/novel_computed_analytics.go
+++ b/library/marketing/klaviyo/internal/cli/novel_computed_analytics.go
@@ -554,6 +554,10 @@ type subjectEmail struct {
 	OpenRate, ClickRate             float64
 }
 
+type subjectMessage struct {
+	ID, Subject string
+}
+
 func subjectLineAnalysis(c flowClient, since, until time.Time, source string) (map[string]any, error) {
 	emails, err := collectSubjectEmails(c, source)
 	if err != nil {
@@ -598,53 +602,88 @@ func subjectLineAnalysis(c flowClient, since, until time.Time, source string) (m
 
 func collectSubjectEmails(c flowClient, source string) ([]subjectEmail, error) {
 	source = strings.ToLower(source)
+	if source != "all" && source != "flow" && source != "campaign" {
+		return nil, usageErr(fmt.Errorf("--source must be flow, campaign, or all"))
+	}
 	var out []subjectEmail
 	if source == "all" || source == "flow" {
-		flows, err := fetchAllJSONAPI(c, "/api/flows", map[string]string{"fields[flow]": "name,status", "page[size]": "50"}, 0)
+		flows, actions, err := fetchAllJSONAPIWithIncluded(c, "/api/flows", map[string]string{
+			"fields[flow]":        "name,status",
+			"fields[flow-action]": "definition",
+			"include":             "flow-actions",
+			"page[size]":          "50",
+		})
 		if err != nil {
 			return nil, err
 		}
+		flowNames := map[string]string{}
 		for _, flow := range flows {
 			if status := strings.ToLower(stringFromMapPath(flow, "attributes.status")); status != "" && status != "live" {
 				continue
 			}
-			flowID := fmt.Sprint(flow["id"])
-			def, name, err := fetchAndTransformFlow(c, flowID, true)
-			if err != nil {
+			flowNames[fmt.Sprint(flow["id"])] = stringFromMapPath(flow, "attributes.name")
+		}
+		for _, action := range actions {
+			name, live := flowNames[relationshipID(action, "flow")]
+			if !live {
 				continue
 			}
-			for _, action := range mapSlice(def["actions"]) {
-				if fmt.Sprint(action["type"]) != "send-email" {
-					continue
+			for i, message := range collectSubjectMessages(action) {
+				id := message.ID
+				if id == "" {
+					id = fmt.Sprintf("%s:%d", action["id"], i)
 				}
-				msg, _ := anyPath(action, "data.message").(map[string]any)
-				subject := firstNonEmptyString(fmt.Sprint(msg["subject"]), fmt.Sprint(anyPath(action, "data.message.content.subject")), fmt.Sprint(anyPath(action, "data.message.definition.content.subject")), fmt.Sprint(msg["name"]))
-				if subject == "" || subject == "<nil>" {
-					continue
-				}
-				out = append(out, subjectEmail{ID: fmt.Sprint(action["id"]), Subject: subject, Source: name, SourceType: "flow"})
+				out = append(out, subjectEmail{ID: id, Subject: message.Subject, Source: name, SourceType: "flow"})
 			}
 		}
 	}
 	if source == "all" || source == "campaign" {
-		campaigns, err := fetchAllJSONAPI(c, "/api/campaigns", map[string]string{"filter": `equals(messages.channel,'email')`, "fields[campaign]": "name,status,send_time", "page[size]": "50"}, 200)
+		campaigns, messages, err := fetchAllJSONAPIWithIncluded(c, "/api/campaigns", map[string]string{
+			"filter":                   `equals(messages.channel,"email")`,
+			"fields[campaign]":         "name,status,send_time",
+			"fields[campaign-message]": "definition",
+			"include":                  "campaign-messages",
+			"page[size]":               "100",
+		})
 		if err != nil {
 			return nil, err
 		}
+		campaignNames := map[string]string{}
 		for _, campaign := range campaigns {
-			campaignID := fmt.Sprint(campaign["id"])
-			name := stringFromMapPath(campaign, "attributes.name")
-			messages, err := fetchAllJSONAPI(c, "/api/campaigns/"+url.PathEscape(campaignID)+"/campaign-messages", map[string]string{}, 0)
-			if err != nil {
-				continue
-			}
-			for _, msg := range messages {
-				subject := firstNonEmptyString(stringFromMapPath(msg, "attributes.subject"), stringFromMapPath(msg, "attributes.definition.content.subject"), stringFromMapPath(msg, "attributes.definition.label"), stringFromMapPath(msg, "attributes.label"), name)
+			campaignNames[fmt.Sprint(campaign["id"])] = stringFromMapPath(campaign, "attributes.name")
+		}
+		for _, msg := range messages {
+			name := campaignNames[relationshipID(msg, "campaign")]
+			subject := firstNonEmptyString(stringFromMapPath(msg, "attributes.definition.content.subject"), stringFromMapPath(msg, "attributes.definition.label"), name)
+			if subject != "" {
 				out = append(out, subjectEmail{ID: fmt.Sprint(msg["id"]), Subject: subject, Source: name, SourceType: "campaign"})
 			}
 		}
 	}
 	return out, nil
+}
+
+func collectSubjectMessages(value any) []subjectMessage {
+	var out []subjectMessage
+	var walk func(any)
+	walk = func(current any) {
+		switch v := current.(type) {
+		case map[string]any:
+			if subject, ok := v["subject_line"].(string); ok && strings.TrimSpace(subject) != "" {
+				id, _ := v["id"].(string)
+				out = append(out, subjectMessage{ID: id, Subject: strings.TrimSpace(subject)})
+			}
+			for _, child := range v {
+				walk(child)
+			}
+		case []any:
+			for _, child := range v {
+				walk(child)
+			}
+		}
+	}
+	walk(value)
+	return out
 }
 
 func subjectPatterns(emails []subjectEmail) []map[string]any {

--- a/library/marketing/klaviyo/internal/cli/novel_computed_analytics.go
+++ b/library/marketing/klaviyo/internal/cli/novel_computed_analytics.go
@@ -617,18 +617,34 @@ func collectSubjectEmails(c flowClient, source string) ([]subjectEmail, error) {
 			return nil, err
 		}
 		flowNames := map[string]string{}
+		flowNamesByActionID := map[string]string{}
 		for _, flow := range flows {
 			if status := strings.ToLower(stringFromMapPath(flow, "attributes.status")); status != "" && status != "live" {
 				continue
 			}
-			flowNames[fmt.Sprint(flow["id"])] = stringFromMapPath(flow, "attributes.name")
+			name := stringFromMapPath(flow, "attributes.name")
+			flowNames[fmt.Sprint(flow["id"])] = name
+			for _, actionID := range relationshipIDs(flow, "flow-actions") {
+				flowNamesByActionID[actionID] = name
+			}
 		}
 		for _, action := range actions {
-			name, live := flowNames[relationshipID(action, "flow")]
-			if !live {
+			messages := collectSubjectMessages(action)
+			if len(messages) == 0 {
 				continue
 			}
-			for i, message := range collectSubjectMessages(action) {
+			flowID := relationshipID(action, "flow")
+			name, live := flowNames[flowID]
+			if flowID != "" && !live {
+				continue
+			}
+			if !live {
+				name, live = flowNamesByActionID[fmt.Sprint(action["id"])]
+			}
+			if !live {
+				return nil, fmt.Errorf("included flow action %s cannot be associated with a flow", action["id"])
+			}
+			for i, message := range messages {
 				id := message.ID
 				if id == "" {
 					id = fmt.Sprintf("%s:%d", action["id"], i)

--- a/library/marketing/klaviyo/internal/cli/novel_computed_analytics.go
+++ b/library/marketing/klaviyo/internal/cli/novel_computed_analytics.go
@@ -665,13 +665,24 @@ func collectSubjectEmails(c flowClient, source string) ([]subjectEmail, error) {
 			return nil, err
 		}
 		campaignNames := map[string]string{}
+		campaignNamesByMessageID := map[string]string{}
 		for _, campaign := range campaigns {
-			campaignNames[fmt.Sprint(campaign["id"])] = stringFromMapPath(campaign, "attributes.name")
+			name := stringFromMapPath(campaign, "attributes.name")
+			campaignNames[fmt.Sprint(campaign["id"])] = name
+			for _, messageID := range relationshipIDs(campaign, "campaign-messages") {
+				campaignNamesByMessageID[messageID] = name
+			}
 		}
 		for _, msg := range messages {
-			name := campaignNames[relationshipID(msg, "campaign")]
+			name, associated := campaignNames[relationshipID(msg, "campaign")]
+			if !associated {
+				name, associated = campaignNamesByMessageID[fmt.Sprint(msg["id"])]
+			}
 			subject := firstNonEmptyString(stringFromMapPath(msg, "attributes.definition.content.subject"), stringFromMapPath(msg, "attributes.definition.label"), name)
 			if subject != "" {
+				if !associated {
+					return nil, fmt.Errorf("included campaign message %s cannot be associated with a campaign", msg["id"])
+				}
 				out = append(out, subjectEmail{ID: fmt.Sprint(msg["id"]), Subject: subject, Source: name, SourceType: "campaign"})
 			}
 		}

--- a/library/marketing/klaviyo/internal/cli/novel_klaviyo_test.go
+++ b/library/marketing/klaviyo/internal/cli/novel_klaviyo_test.go
@@ -106,6 +106,21 @@ func TestPaginatedGetFollowsJSONAPINextLink(t *testing.T) {
 	}
 }
 
+func TestPaginatedGetRejectsCursorCycles(t *testing.T) {
+	c := &fakePaginatedClient{responses: []json.RawMessage{
+		rawJSON(`{"data":[{"id":"flow-1"}],"links":{"next":"https://example.test/api/flows?page%5Bcursor%5D=A"}}`),
+		rawJSON(`{"data":[{"id":"flow-2"}],"links":{"next":"https://example.test/api/flows?page%5Bcursor%5D=B"}}`),
+		rawJSON(`{"data":[{"id":"flow-3"}],"links":{"next":"https://example.test/api/flows?page%5Bcursor%5D=A"}}`),
+	}}
+
+	if _, err := paginatedGet(c, "/api/flows", map[string]string{"page[size]": "50"}, nil, true, "page[cursor]", "", ""); err == nil || !strings.Contains(err.Error(), "cursor") {
+		t.Fatalf("expected cursor-cycle error, got %v", err)
+	}
+	if len(c.params) != 3 {
+		t.Fatalf("request params = %#v", c.params)
+	}
+}
+
 func TestAuditFetchersUseValidKlaviyoParametersAndAllPages(t *testing.T) {
 	formsClient := &fakeCouponPoolClient{responses: []json.RawMessage{
 		rawJSON(`{"data":[{"id":"form-1"}],"links":{"next":"https://example.test/api/forms?page%5Bcursor%5D=forms-2"}}`),
@@ -232,6 +247,19 @@ func TestCollectSubjectEmailsUsesIncludedFlowMessageIDs(t *testing.T) {
 		t.Fatalf("collectSubjectEmails() error = %v", err)
 	}
 	if len(emails) != 1 || emails[0].ID != "message-1" || emails[0].Subject != "Welcome home" || emails[0].Source != "Welcome" {
+		t.Fatalf("emails = %#v", emails)
+	}
+}
+
+func TestCollectSubjectEmailsUsesCampaignForwardRelationship(t *testing.T) {
+	c := &fakeCouponPoolClient{responses: []json.RawMessage{
+		rawJSON(`{"data":[{"id":"campaign-1","attributes":{"name":"Launch"},"relationships":{"campaign-messages":{"data":[{"id":"message-1"}]}}}],"included":[{"id":"message-1","attributes":{"definition":{"content":{"subject":"New collection"}}}}],"links":{}}`),
+	}}
+	emails, err := collectSubjectEmails(c, "campaign")
+	if err != nil {
+		t.Fatalf("collectSubjectEmails() error = %v", err)
+	}
+	if len(emails) != 1 || emails[0].ID != "message-1" || emails[0].Subject != "New collection" || emails[0].Source != "Launch" {
 		t.Fatalf("emails = %#v", emails)
 	}
 }

--- a/library/marketing/klaviyo/internal/cli/novel_klaviyo_test.go
+++ b/library/marketing/klaviyo/internal/cli/novel_klaviyo_test.go
@@ -149,8 +149,27 @@ func TestListGrowthUsesCurrentKlaviyoMetricNames(t *testing.T) {
 		{"metric": "Unsubscribed from List", "count": 25},
 		{"metric": "Unsubscribed from Email Marketing", "count": 10},
 	}
-	if got := metricRowCount(rows, "Subscribed to List") - metricRowCount(rows, "Unsubscribed from List"); got != 95 {
-		t.Fatalf("net list growth = %d, want 95", got)
+	report := buildListGrowthReport(rows, "90d")
+	if got := report["net_list_growth"]; got != 95 {
+		t.Fatalf("net list growth = %v, want 95", got)
+	}
+	if report["derived_metrics_complete"] != true {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestListGrowthDoesNotDeriveFromMissingMetrics(t *testing.T) {
+	rows := []map[string]any{
+		{"metric": "Subscribed to List", "count": 120},
+		{"metric": "Unsubscribed from List", "error": "metric not found"},
+		{"metric": "Unsubscribed from Email Marketing", "count": 10},
+	}
+	report := buildListGrowthReport(rows, "90d")
+	if report["net_list_growth"] != nil || report["list_unsubscriptions"] != nil {
+		t.Fatalf("missing metric produced derived counts: %#v", report)
+	}
+	if report["derived_metrics_complete"] != false || report["warning"] == nil {
+		t.Fatalf("missing metric should be explicit: %#v", report)
 	}
 }
 
@@ -206,7 +225,7 @@ func TestCollectReferencedTemplateIDsUsesIncludedResources(t *testing.T) {
 
 func TestCollectSubjectEmailsUsesIncludedFlowMessageIDs(t *testing.T) {
 	c := &fakeCouponPoolClient{responses: []json.RawMessage{
-		rawJSON(`{"data":[{"id":"flow-1","attributes":{"name":"Welcome","status":"live"}}],"included":[{"id":"action-1","relationships":{"flow":{"data":{"id":"flow-1"}}},"attributes":{"definition":{"data":{"message":{"id":"message-1","subject_line":"Welcome home"}}}}}],"links":{}}`),
+		rawJSON(`{"data":[{"id":"flow-1","attributes":{"name":"Welcome","status":"live"},"relationships":{"flow-actions":{"data":[{"id":"action-1"}]}}}],"included":[{"id":"action-1","attributes":{"definition":{"data":{"message":{"id":"message-1","subject_line":"Welcome home"}}}}}],"links":{}}`),
 	}}
 	emails, err := collectSubjectEmails(c, "flow")
 	if err != nil {
@@ -214,6 +233,19 @@ func TestCollectSubjectEmailsUsesIncludedFlowMessageIDs(t *testing.T) {
 	}
 	if len(emails) != 1 || emails[0].ID != "message-1" || emails[0].Subject != "Welcome home" || emails[0].Source != "Welcome" {
 		t.Fatalf("emails = %#v", emails)
+	}
+}
+
+func TestFetchAllJSONAPIWithIncludedRejectsRepeatedCursor(t *testing.T) {
+	c := &fakeCouponPoolClient{responses: []json.RawMessage{
+		rawJSON(`{"data":[{"id":"flow-1"}],"links":{"next":"https://example.test/api/flows?page%5Bcursor%5D=repeat"}}`),
+		rawJSON(`{"data":[{"id":"flow-2"}],"links":{"next":"https://example.test/api/flows?page%5Bcursor%5D=repeat"}}`),
+	}}
+	if _, _, err := fetchAllJSONAPIWithIncluded(c, "/api/flows", map[string]string{"page[size]": "50"}); err == nil || !strings.Contains(err.Error(), "cursor") {
+		t.Fatalf("expected repeated-cursor error, got %v", err)
+	}
+	if len(c.requests) != 2 {
+		t.Fatalf("requests = %#v", c.requests)
 	}
 }
 

--- a/library/marketing/klaviyo/internal/cli/novel_klaviyo_test.go
+++ b/library/marketing/klaviyo/internal/cli/novel_klaviyo_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -80,6 +81,164 @@ func TestNovelCommandsRegistered(t *testing.T) {
 		if findCommand(root, path) == nil {
 			t.Fatalf("command %v not registered", path)
 		}
+	}
+}
+
+func TestPaginatedGetFollowsJSONAPINextLink(t *testing.T) {
+	c := &fakePaginatedClient{responses: []json.RawMessage{
+		rawJSON(`{"data":[{"id":"flow-1"}],"links":{"next":"https://example.test/api/flows?page%5Bcursor%5D=next-page"}}`),
+		rawJSON(`{"data":[{"id":"flow-2"}],"links":{"next":null}}`),
+	}}
+
+	got, err := paginatedGet(c, "/api/flows", map[string]string{"page[size]": "50"}, nil, true, "page[cursor]", "", "")
+	if err != nil {
+		t.Fatalf("paginatedGet() error = %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(got, &items); err != nil {
+		t.Fatalf("unmarshal paginated result: %v", err)
+	}
+	if len(items) != 2 || items[0]["id"] != "flow-1" || items[1]["id"] != "flow-2" {
+		t.Fatalf("items = %#v", items)
+	}
+	if len(c.params) != 2 || c.params[1]["page[cursor]"] != "next-page" {
+		t.Fatalf("request params = %#v", c.params)
+	}
+}
+
+func TestAuditFetchersUseValidKlaviyoParametersAndAllPages(t *testing.T) {
+	formsClient := &fakeCouponPoolClient{responses: []json.RawMessage{
+		rawJSON(`{"data":[{"id":"form-1"}],"links":{"next":"https://example.test/api/forms?page%5Bcursor%5D=forms-2"}}`),
+		rawJSON(`{"data":[{"id":"form-2"}],"links":{}}`),
+	}}
+	forms, err := fetchReportForms(formsClient)
+	if err != nil {
+		t.Fatalf("fetchReportForms() error = %v", err)
+	}
+	if len(forms) != 2 {
+		t.Fatalf("forms = %#v", forms)
+	}
+	if got := formsClient.requests[0].params["fields[form]"]; got != "name,status,created_at,updated_at" {
+		t.Fatalf("forms fields = %q", got)
+	}
+	if got := formsClient.requests[1].params["page[cursor]"]; got != "forms-2" {
+		t.Fatalf("forms second-page cursor = %q", got)
+	}
+
+	templatesClient := &fakeCouponPoolClient{responses: []json.RawMessage{
+		rawJSON(`{"data":[{"id":"template-1"}],"links":{}}`),
+	}}
+	if _, err := fetchTemplateAuditItems(templatesClient); err != nil {
+		t.Fatalf("fetchTemplateAuditItems() error = %v", err)
+	}
+	if got := templatesClient.requests[0].params["page[size]"]; got != "10" {
+		t.Fatalf("template page size = %q, want 10", got)
+	}
+	if got := templatesClient.requests[0].params["fields[template]"]; got != "name,updated" {
+		t.Fatalf("template fields = %q", got)
+	}
+}
+
+func TestListGrowthUsesCurrentKlaviyoMetricNames(t *testing.T) {
+	want := []string{"Subscribed to List", "Unsubscribed from List", "Unsubscribed from Email Marketing"}
+	if fmt.Sprint(listGrowthMetricNames) != fmt.Sprint(want) {
+		t.Fatalf("listGrowthMetricNames = %#v, want %#v", listGrowthMetricNames, want)
+	}
+	rows := []map[string]any{
+		{"metric": "Subscribed to List", "count": 120},
+		{"metric": "Unsubscribed from List", "count": 25},
+		{"metric": "Unsubscribed from Email Marketing", "count": 10},
+	}
+	if got := metricRowCount(rows, "Subscribed to List") - metricRowCount(rows, "Unsubscribed from List"); got != 95 {
+		t.Fatalf("net list growth = %d, want 95", got)
+	}
+}
+
+func TestSubjectLineAnalysisProducesNonEmptyOutput(t *testing.T) {
+	c := &fakeCouponPoolClient{responses: []json.RawMessage{
+		rawJSON(`{"data":[{"id":"campaign-1","attributes":{"name":"Campaign One"}}],"included":[{"id":"message-1","relationships":{"campaign":{"data":{"id":"campaign-1"}}},"attributes":{"definition":{"content":{"subject":"A useful subject"}}}}],"links":{}}`),
+		metricListResponse("received", "Received Email"),
+		metricListResponse("opened", "Opened Email"),
+		metricListResponse("clicked", "Clicked Email"),
+	}}
+	result, err := subjectLineAnalysis(c, time.Now().AddDate(0, 0, -30), time.Now(), "campaign")
+	if err != nil {
+		t.Fatalf("subjectLineAnalysis() error = %v", err)
+	}
+	var out bytes.Buffer
+	if err := printJSONFiltered(&out, result, &rootFlags{asJSON: true, compact: true}); err != nil {
+		t.Fatalf("printJSONFiltered() error = %v", err)
+	}
+	if out.Len() == 0 {
+		t.Fatal("subject-line analysis produced empty stdout")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("subject-line output is not JSON: %v", err)
+	}
+	if _, ok := decoded["total_emails_analyzed"]; !ok {
+		t.Fatalf("subject-line output = %#v", decoded)
+	}
+	if decoded["total_emails_analyzed"] != float64(1) {
+		t.Fatalf("subject-line output = %#v", decoded)
+	}
+}
+
+func TestCollectReferencedTemplateIDsUsesIncludedResources(t *testing.T) {
+	c := &fakeCouponPoolClient{responses: []json.RawMessage{
+		rawJSON(`{"data":[{"id":"flow-1"}],"included":[{"id":"action-1","attributes":{"definition":{"data":{"message":{"template_id":"flow-template"}}}}}],"links":{}}`),
+		rawJSON(`{"data":[{"id":"campaign-1"}],"included":[{"id":"message-1","relationships":{"template":{"data":{"id":"campaign-template"}}}}],"links":{}}`),
+	}}
+	refs, err := collectReferencedTemplateIDs(c)
+	if err != nil {
+		t.Fatalf("collectReferencedTemplateIDs() error = %v", err)
+	}
+	if !refs["flow-template"] || !refs["campaign-template"] || len(refs) != 2 {
+		t.Fatalf("refs = %#v", refs)
+	}
+	if len(c.requests) != 2 || c.requests[0].params["include"] != "flow-actions" || c.requests[1].params["include"] != "campaign-messages" {
+		t.Fatalf("requests = %#v", c.requests)
+	}
+	if got := c.requests[1].params["fields[campaign-message]"]; got != "id" {
+		t.Fatalf("campaign message fields = %q", got)
+	}
+}
+
+func TestCollectSubjectEmailsUsesIncludedFlowMessageIDs(t *testing.T) {
+	c := &fakeCouponPoolClient{responses: []json.RawMessage{
+		rawJSON(`{"data":[{"id":"flow-1","attributes":{"name":"Welcome","status":"live"}}],"included":[{"id":"action-1","relationships":{"flow":{"data":{"id":"flow-1"}}},"attributes":{"definition":{"data":{"message":{"id":"message-1","subject_line":"Welcome home"}}}}}],"links":{}}`),
+	}}
+	emails, err := collectSubjectEmails(c, "flow")
+	if err != nil {
+		t.Fatalf("collectSubjectEmails() error = %v", err)
+	}
+	if len(emails) != 1 || emails[0].ID != "message-1" || emails[0].Subject != "Welcome home" || emails[0].Source != "Welcome" {
+		t.Fatalf("emails = %#v", emails)
+	}
+}
+
+func TestDeliverabilityReportIncludesDenominatorCoverage(t *testing.T) {
+	c := &fakeCouponPoolClient{
+		responses: []json.RawMessage{
+			metricListResponse("received", "Received Email"),
+			metricListResponse("bounced", "Bounced Email"),
+		},
+		postResponses: []json.RawMessage{
+			metricAggregateResponse("gmail.com", 7000),
+			metricAggregateResponse("gmail.com", 70),
+			metricAggregateResponse("", 1800000),
+		},
+	}
+	report, err := buildDeliverabilityReport(c, time.Now().AddDate(0, 0, -30), time.Now())
+	if err != nil {
+		t.Fatalf("buildDeliverabilityReport() error = %v", err)
+	}
+	coverage := report["coverage"].(map[string]any)
+	if coverage["account_received"] != 1800000 || coverage["domain_attributed_received"] != 7000 {
+		t.Fatalf("coverage = %#v", coverage)
+	}
+	if coverage["complete"] != false || coverage["warning"] == nil {
+		t.Fatalf("sparse coverage should be explicit: %#v", coverage)
 	}
 }
 
@@ -836,6 +995,22 @@ type fakeCouponPoolClient struct {
 	deletes       []string
 }
 
+type fakePaginatedClient struct {
+	responses []json.RawMessage
+	params    []map[string]string
+}
+
+func (f *fakePaginatedClient) GetWithHeaders(_ string, params map[string]string, _ map[string]string) (json.RawMessage, error) {
+	copied := map[string]string{}
+	for k, v := range params {
+		copied[k] = v
+	}
+	f.params = append(f.params, copied)
+	resp := f.responses[0]
+	f.responses = f.responses[1:]
+	return resp, nil
+}
+
 type fakeCouponPoolRequest struct {
 	path   string
 	params map[string]string
@@ -875,6 +1050,18 @@ func (f *fakeCouponPoolClient) Delete(path string) (json.RawMessage, int, error)
 
 func rawJSON(s string) json.RawMessage {
 	return json.RawMessage(s)
+}
+
+func metricListResponse(id, name string) json.RawMessage {
+	return rawJSON(fmt.Sprintf(`{"data":[{"id":%q,"attributes":{"name":%q}}],"links":{}}`, id, name))
+}
+
+func metricAggregateResponse(dimension string, count float64) json.RawMessage {
+	dimensions := "[]"
+	if dimension != "" {
+		dimensions = fmt.Sprintf(`[%q]`, dimension)
+	}
+	return rawJSON(fmt.Sprintf(`{"data":{"attributes":{"data":[{"dimensions":%s,"measurements":{"count":[%v]}}]}}}`, dimensions, count))
 }
 
 func containsString(values []string, target string) bool {

--- a/library/marketing/klaviyo/internal/cli/novel_segments_reports.go
+++ b/library/marketing/klaviyo/internal/cli/novel_segments_reports.go
@@ -1178,9 +1178,13 @@ func buildDeliverabilityReport(c flowClient, since, until time.Time) (map[string
 		domains[k] = true
 	}
 	var rows []map[string]any
+	domainReceivedTotal := 0.0
+	domainBouncedTotal := 0.0
 	for domain := range domains {
 		r := received[domain]
 		b := bounced[domain]
+		domainReceivedTotal += r
+		domainBouncedTotal += b
 		rate := 0.0
 		if r > 0 {
 			rate = b / r * 100
@@ -1190,7 +1194,30 @@ func buildDeliverabilityReport(c flowClient, since, until time.Time) (map[string
 	sort.Slice(rows, func(i, j int) bool {
 		return anyFloat(rows[i]["bounce_rate"]) > anyFloat(rows[j]["bounce_rate"])
 	})
-	return map[string]any{"since": since.Format("2006-01-02"), "until": until.Format("2006-01-02"), "threshold": 2.0, "rows": rows}, nil
+	accountReceivedTotal, err := aggregateTotal(c, receivedID, since, until)
+	if err != nil {
+		return nil, err
+	}
+	coveragePct := 0.0
+	if accountReceivedTotal > 0 {
+		coveragePct = domainReceivedTotal / accountReceivedTotal * 100
+	}
+	weightedBounceRate := 0.0
+	if domainReceivedTotal > 0 {
+		weightedBounceRate = domainBouncedTotal / domainReceivedTotal * 100
+	}
+	coverage := map[string]any{
+		"account_received":                    int(accountReceivedTotal),
+		"domain_attributed_received":          int(domainReceivedTotal),
+		"domain_received_coverage_percentage": round3(coveragePct),
+		"weighted_bounce_rate":                round3(weightedBounceRate),
+		"weighted_rate_denominator":           "domain_attributed_received",
+		"complete":                            coveragePct >= 95,
+	}
+	if coveragePct < 95 {
+		coverage["warning"] = "domain-level rates cover less than 95% of account Received Email events; do not treat the weighted rate as account-wide"
+	}
+	return map[string]any{"since": since.Format("2006-01-02"), "until": until.Format("2006-01-02"), "threshold": 2.0, "coverage": coverage, "rows": rows}, nil
 }
 
 func aggregateByDimension(c flowClient, metricID, dimension string, since, until time.Time) (map[string]float64, error) {
@@ -1200,6 +1227,14 @@ func aggregateByDimension(c flowClient, metricID, dimension string, since, until
 		return nil, classifyAPIError(err)
 	}
 	return metricAggregateRows(resp, "count"), nil
+}
+
+func aggregateTotal(c flowClient, metricID string, since, until time.Time) (float64, error) {
+	resp, _, err := c.Post("/api/metric-aggregates", metricAggregateBody(metricID, []string{"count"}, nil, since, until))
+	if err != nil {
+		return 0, classifyAPIError(err)
+	}
+	return sumMeasurement(resp, "count"), nil
 }
 
 func newUniversalContentCmd(flags *rootFlags) *cobra.Command {
@@ -1722,6 +1757,69 @@ func fetchAllJSONAPI(c flowClient, path string, params map[string]string, limit 
 	return items, nil
 }
 
+func fetchAllJSONAPIWithIncluded(c flowClient, path string, params map[string]string) ([]map[string]any, []map[string]any, error) {
+	var primary, included []map[string]any
+	cursor := ""
+	for {
+		p := map[string]string{}
+		for k, v := range params {
+			p[k] = v
+		}
+		if cursor != "" {
+			p["page[cursor]"] = cursor
+		}
+		resp, err := c.Get(path, p)
+		if err != nil {
+			return nil, nil, classifyAPIError(err)
+		}
+		var envelope map[string]any
+		if err := json.Unmarshal(resp, &envelope); err != nil {
+			return nil, nil, err
+		}
+		primary = append(primary, mapSlice(envelope["data"])...)
+		included = append(included, mapSlice(envelope["included"])...)
+		links, _ := envelope["links"].(map[string]any)
+		nextLink, _ := links["next"].(string)
+		cursor = extractCursor(nextLink)
+		if cursor == "" {
+			break
+		}
+	}
+	return primary, included, nil
+}
+
+func relationshipID(item map[string]any, relationship string) string {
+	id := strings.TrimSpace(fmt.Sprint(anyPath(item, "relationships."+relationship+".data.id")))
+	if id == "<nil>" {
+		return ""
+	}
+	return id
+}
+
+func collectStringsByKey(value any, wanted string) []string {
+	var out []string
+	var walk func(any)
+	walk = func(current any) {
+		switch v := current.(type) {
+		case map[string]any:
+			for key, child := range v {
+				if key == wanted {
+					if s, ok := child.(string); ok && strings.TrimSpace(s) != "" {
+						out = append(out, strings.TrimSpace(s))
+					}
+				}
+				walk(child)
+			}
+		case []any:
+			for _, child := range v {
+				walk(child)
+			}
+		}
+	}
+	walk(value)
+	return out
+}
+
 func metricAggregateBody(metricID string, measurements []string, by []string, since, until time.Time) map[string]any {
 	attrs := map[string]any{
 		"metric_id":    metricID,
@@ -2215,16 +2313,13 @@ func newTemplatesAuditCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			templates, err := fetchAllJSONAPI(c, "/api/templates", map[string]string{"fields[template]": "name,updated,html", "page[size]": "50"}, 0)
+			templates, err := fetchTemplateAuditItems(c)
 			if err != nil {
 				return err
 			}
-			refs := map[string]bool{}
-			for _, scope := range []string{"flow", "campaign"} {
-				msgTemplates, _ := collectMessageTemplates(c, scope)
-				for _, tmpl := range msgTemplates {
-					refs[fmt.Sprint(tmpl["id"])] = true
-				}
+			refs, err := collectReferencedTemplateIDs(c)
+			if err != nil {
+				return err
 			}
 			cutoff := time.Now().AddDate(-1, 0, 0)
 			var rows []map[string]any
@@ -2246,6 +2341,48 @@ func newTemplatesAuditCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	return cmd
+}
+
+func fetchTemplateAuditItems(c flowClient) ([]map[string]any, error) {
+	return fetchAllJSONAPI(c, "/api/templates", map[string]string{"fields[template]": "name,updated", "page[size]": "10"}, 0)
+}
+
+func collectReferencedTemplateIDs(c flowClient) (map[string]bool, error) {
+	refs := map[string]bool{}
+	_, flowActions, err := fetchAllJSONAPIWithIncluded(c, "/api/flows", map[string]string{
+		"fields[flow]":        "name",
+		"fields[flow-action]": "definition",
+		"include":             "flow-actions",
+		"page[size]":          "50",
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, action := range flowActions {
+		for _, id := range collectStringsByKey(action, "template_id") {
+			refs[id] = true
+		}
+	}
+
+	_, campaignMessages, err := fetchAllJSONAPIWithIncluded(c, "/api/campaigns", map[string]string{
+		"fields[campaign]":         "name,status",
+		"fields[campaign-message]": "id",
+		"filter":                   `equals(messages.channel,"email")`,
+		"include":                  "campaign-messages",
+		"page[size]":               "100",
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, message := range campaignMessages {
+		if id := relationshipID(message, "template"); id != "" {
+			refs[id] = true
+		}
+		for _, id := range collectStringsByKey(message, "template_id") {
+			refs[id] = true
+		}
+	}
+	return refs, nil
 }
 
 func newTagsAuditCmd(flags *rootFlags) *cobra.Command {
@@ -2409,12 +2546,33 @@ func newReportListGrowthCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			rows := metricTotalsByName(c, []string{"Subscribed to List", "Unsubscribed Email"}, since, until)
-			return printJSONFiltered(cmd.OutOrStdout(), map[string]any{"last": last, "rows": rows, "note": "full-window net growth totals"}, flags)
+			rows := metricTotalsByName(c, listGrowthMetricNames, since, until)
+			subscribed := metricRowCount(rows, "Subscribed to List")
+			unsubscribedFromList := metricRowCount(rows, "Unsubscribed from List")
+			return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+				"last":                         last,
+				"rows":                         rows,
+				"list_subscriptions":           subscribed,
+				"list_unsubscriptions":         unsubscribedFromList,
+				"net_list_growth":              subscribed - unsubscribedFromList,
+				"global_email_unsubscriptions": metricRowCount(rows, "Unsubscribed from Email Marketing"),
+				"note":                         "net list growth uses Subscribed to List minus Unsubscribed from List; global email unsubscriptions are reported separately",
+			}, flags)
 		},
 	}
 	cmd.Flags().StringVar(&last, "last", "90d", "Lookback window")
 	return cmd
+}
+
+var listGrowthMetricNames = []string{"Subscribed to List", "Unsubscribed from List", "Unsubscribed from Email Marketing"}
+
+func metricRowCount(rows []map[string]any, name string) int {
+	for _, row := range rows {
+		if fmt.Sprint(row["metric"]) == name {
+			return anyInt(row["count"])
+		}
+	}
+	return 0
 }
 
 func newReportDomainReputationCmd(flags *rootFlags) *cobra.Command {
@@ -2517,7 +2675,7 @@ func newReportFormsCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			forms, err := fetchAllJSONAPI(c, "/api/forms", map[string]string{"fields[form]": "name,status,created,updated", "page[size]": "50"}, 0)
+			forms, err := fetchReportForms(c)
 			if err != nil {
 				return err
 			}
@@ -2527,6 +2685,10 @@ func newReportFormsCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&last, "last", "30d", "Requested lookback label; forms are not filtered by submission date")
 	return cmd
+}
+
+func fetchReportForms(c flowClient) ([]map[string]any, error) {
+	return fetchAllJSONAPI(c, "/api/forms", map[string]string{"fields[form]": "name,status,created_at,updated_at", "page[size]": "50"}, 0)
 }
 
 func newReportSignupSourcesCmd(flags *rootFlags) *cobra.Command {

--- a/library/marketing/klaviyo/internal/cli/novel_segments_reports.go
+++ b/library/marketing/klaviyo/internal/cli/novel_segments_reports.go
@@ -1760,6 +1760,7 @@ func fetchAllJSONAPI(c flowClient, path string, params map[string]string, limit 
 func fetchAllJSONAPIWithIncluded(c flowClient, path string, params map[string]string) ([]map[string]any, []map[string]any, error) {
 	var primary, included []map[string]any
 	cursor := ""
+	seenCursors := map[string]bool{}
 	for {
 		p := map[string]string{}
 		for k, v := range params {
@@ -1780,10 +1781,15 @@ func fetchAllJSONAPIWithIncluded(c flowClient, path string, params map[string]st
 		included = append(included, mapSlice(envelope["included"])...)
 		links, _ := envelope["links"].(map[string]any)
 		nextLink, _ := links["next"].(string)
-		cursor = extractCursor(nextLink)
-		if cursor == "" {
+		nextCursor := extractCursor(nextLink)
+		if nextCursor == "" {
 			break
 		}
+		if nextCursor == cursor || seenCursors[nextCursor] {
+			return nil, nil, fmt.Errorf("pagination cursor %q repeated for %s", nextCursor, path)
+		}
+		seenCursors[nextCursor] = true
+		cursor = nextCursor
 	}
 	return primary, included, nil
 }
@@ -1794,6 +1800,24 @@ func relationshipID(item map[string]any, relationship string) string {
 		return ""
 	}
 	return id
+}
+
+func relationshipIDs(item map[string]any, relationship string) []string {
+	data := anyPath(item, "relationships."+relationship+".data")
+	var ids []string
+	for _, related := range mapSlice(data) {
+		if id := strings.TrimSpace(fmt.Sprint(related["id"])); id != "" && id != "<nil>" {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		if related, ok := data.(map[string]any); ok {
+			if id := strings.TrimSpace(fmt.Sprint(related["id"])); id != "" && id != "<nil>" {
+				ids = append(ids, id)
+			}
+		}
+	}
+	return ids
 }
 
 func collectStringsByKey(value any, wanted string) []string {
@@ -2547,17 +2571,7 @@ func newReportListGrowthCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			rows := metricTotalsByName(c, listGrowthMetricNames, since, until)
-			subscribed := metricRowCount(rows, "Subscribed to List")
-			unsubscribedFromList := metricRowCount(rows, "Unsubscribed from List")
-			return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
-				"last":                         last,
-				"rows":                         rows,
-				"list_subscriptions":           subscribed,
-				"list_unsubscriptions":         unsubscribedFromList,
-				"net_list_growth":              subscribed - unsubscribedFromList,
-				"global_email_unsubscriptions": metricRowCount(rows, "Unsubscribed from Email Marketing"),
-				"note":                         "net list growth uses Subscribed to List minus Unsubscribed from List; global email unsubscriptions are reported separately",
-			}, flags)
+			return printJSONFiltered(cmd.OutOrStdout(), buildListGrowthReport(rows, last), flags)
 		},
 	}
 	cmd.Flags().StringVar(&last, "last", "90d", "Lookback window")
@@ -2566,13 +2580,55 @@ func newReportListGrowthCmd(flags *rootFlags) *cobra.Command {
 
 var listGrowthMetricNames = []string{"Subscribed to List", "Unsubscribed from List", "Unsubscribed from Email Marketing"}
 
-func metricRowCount(rows []map[string]any, name string) int {
-	for _, row := range rows {
-		if fmt.Sprint(row["metric"]) == name {
-			return anyInt(row["count"])
+func buildListGrowthReport(rows []map[string]any, last string) map[string]any {
+	report := map[string]any{
+		"last": last,
+		"rows": rows,
+		"note": "net list growth uses Subscribed to List minus Unsubscribed from List; global email unsubscriptions are reported separately",
+	}
+	subscribed, subscribedOK := metricRowCount(rows, "Subscribed to List")
+	unsubscribedFromList, unsubscribedOK := metricRowCount(rows, "Unsubscribed from List")
+	globalUnsubscribed, globalUnsubscribedOK := metricRowCount(rows, "Unsubscribed from Email Marketing")
+	report["list_subscriptions"] = nil
+	report["list_unsubscriptions"] = nil
+	report["net_list_growth"] = nil
+	report["global_email_unsubscriptions"] = nil
+	if subscribedOK {
+		report["list_subscriptions"] = subscribed
+	}
+	if unsubscribedOK {
+		report["list_unsubscriptions"] = unsubscribedFromList
+	}
+	if subscribedOK && unsubscribedOK {
+		report["net_list_growth"] = subscribed - unsubscribedFromList
+	}
+	if globalUnsubscribedOK {
+		report["global_email_unsubscriptions"] = globalUnsubscribed
+	}
+	var missing []string
+	for _, name := range listGrowthMetricNames {
+		if _, ok := metricRowCount(rows, name); !ok {
+			missing = append(missing, name)
 		}
 	}
-	return 0
+	report["derived_metrics_complete"] = len(missing) == 0
+	if len(missing) > 0 {
+		report["missing_metrics"] = missing
+		report["warning"] = "unavailable derived fields are null because required metrics could not be resolved: " + strings.Join(missing, ", ")
+	}
+	return report
+}
+
+func metricRowCount(rows []map[string]any, name string) (int, bool) {
+	for _, row := range rows {
+		if fmt.Sprint(row["metric"]) == name {
+			if _, ok := row["count"]; !ok {
+				return 0, false
+			}
+			return anyInt(row["count"]), true
+		}
+	}
+	return 0, false
 }
 
 func newReportDomainReputationCmd(flags *rootFlags) *cobra.Command {


### PR DESCRIPTION
## Summary

- follow JSON:API `links.next` cursors so `--all` collects every page
- use valid form fields, template page limits, and current unsubscribe metric names
- make subject-line analysis collect included message data and emit non-empty results
- report domain deliverability denominator coverage explicitly
- add regression coverage and catalog the published-library patch

## Testing

- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/marketing/klaviyo`
- `git diff --check`