### PR TITLE
fix(sentry): resolve live issue triage with which

### DIFF
--- a/library/monitoring/sentry/.printing-press-patches/sentry-which-resolves-live-issue-triage.json
+++ b/library/monitoring/sentry/.printing-press-patches/sentry-which-resolves-live-issue-triage.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "sentry-which-resolves-live-issue-triage",
+  "applied_at": "2026-07-16",
+  "base_run_id": "20260502-124520",
+  "base_printing_press_version": "3.4.3",
+  "summary": "Keep the live organization issue-list command discoverable from natural-language incident-triage queries.",
+  "reason": "Sentry's core incident path is a generated API command rather than a novel local command; omitting it from the curated index makes agents traverse several help levels before listing current issues.",
+  "files": [
+    "internal/cli/which.go",
+    "internal/cli/which_test.go"
+  ],
+  "validated_outcome": "The previously failing live-issue query resolves to organizations issues list-an-organization-s on its first invocation."
+}

--- a/library/monitoring/sentry/internal/cli/which.go
+++ b/library/monitoring/sentry/internal/cli/which.go
@@ -14,8 +14,9 @@ import (
 
 // whichEntry is one row of the curated capability index. The index is
 // seeded at generation time from the same NovelFeature list that drives
-// the SKILL.md feature section, so the command a `which` query returns
-// is guaranteed to exist and to match what the skill advertises.
+// the SKILL.md feature section. Catalog patches may add essential API
+// routes that agents need to discover without traversing the help tree.
+// Every indexed command must exist in the generated command tree.
 type whichEntry struct {
 	Command      string `json:"command"`
 	Description  string `json:"description"`
@@ -24,10 +25,11 @@ type whichEntry struct {
 }
 
 // whichIndex is the curated list of capabilities this CLI advertises as
-// its hero features. Endpoint-level commands are discoverable via
-// `--help`; `which` exists to resolve a natural-language capability
-// query to one of the commands the skill says matter most.
+// its hero features plus essential incident-response routes. The full
+// endpoint tree remains discoverable via `--help`; `which` resolves the
+// small set of commands that agents most often need to find directly.
 var whichIndex = []whichEntry{
+	{Command: "organizations issues list-an-organization-s", Description: "List live Sentry issues for an organization or project, including unresolved issues, first seen, last seen, event counts, and user counts.", Group: "Live issue triage", WhyItMatters: "Use this for current issue triage with project, environment, time-window, query, and sort filters."},
 	{Command: "search", Description: "Search synchronized Sentry issues, projects, releases, and operational records from a local index.", Group: "Local incident memory", WhyItMatters: "Use this when an agent needs fast incident context without repeatedly paging the API."},
 	{Command: "analytics", Description: "Run grouped counts and summaries over synced Sentry resources.", Group: "Local incident memory", WhyItMatters: "Use this when a debugging or audit question needs aggregation over synced data."},
 	{Command: "agent-context", Description: "Print the command, auth, output, and endpoint context an agent needs before choosing Sentry operations.", Group: "Agent-native plumbing", WhyItMatters: "Use this before delegating Sentry tasks to an agent that must pick the right command safely."},

--- a/library/monitoring/sentry/internal/cli/which_test.go
+++ b/library/monitoring/sentry/internal/cli/which_test.go
@@ -96,3 +96,16 @@ func TestWhichIndex_ExistsAndIsWellFormed(t *testing.T) {
 		}
 	}
 }
+
+// Regression: a real incident-triage query should resolve directly to the
+// live issues endpoint instead of forcing an agent through the help tree.
+func TestWhichIndex_ResolvesLiveIssueTriage(t *testing.T) {
+	query := "list unresolved issues for a mobile app with firstSeen lastSeen user counts"
+	got := rankWhich(whichIndex, query, 3)
+	if len(got) == 0 {
+		t.Fatal("expected a match for live issue triage, got none")
+	}
+	if got[0].Entry.Command != "organizations issues list-an-organization-s" {
+		t.Fatalf("top match: want live organization issues command, got %s", got[0].Entry.Command)
+	}
+}


### PR DESCRIPTION
## Summary

- add the live organization issue-list route to Sentry's curated `which` index
- preserve the discovery contract in patch metadata for future reprints
- cover the real multi-token incident-triage query shape with a regression test

## Verification

- `go build ./...`
- `go vet ./...`
- `GOMAXPROCS=1 go test -p 1 ./...`
- `govulncheck ./...` (0 reachable vulnerabilities)
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/monitoring/sentry/` (0 errors; 4 pre-existing likely false positives)
- rebuilt binary on the remote evidence host: the previously unmatched live-issue query resolves on its first invocation to `organizations issues list-an-organization-s`

A default parallel `go test ./...` run also exposed the pre-existing `TestMigrate_ConcurrentFreshDB` SQLite contention flake; the isolated serial run passes the complete suite.