### PR TITLE
fix(function-health): hardcode completed requisition filter

### DIFF
--- a/library/other/function-health/.printing-press-patches/completed-requisitions-fixed-filter.json
+++ b/library/other/function-health/.printing-press-patches/completed-requisitions-fixed-filter.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "completed-requisitions-fixed-filter",
+  "applied_at": "2026-07-16",
+  "base_run_id": "20260528-084148",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Keep the completed-requisitions pending=false filter inside the completed command instead of exposing a caller-controlled boolean flag.",
+  "reason": "The generated false-default boolean could not send pending=false, while the common separated form --pending false was parsed as true and returned the opposite requisition set.",
+  "files": [
+    "internal/cli/requisitions_completed.go",
+    "internal/cli/requisitions_completed_test.go"
+  ],
+  "validated_outcome": "The exact evidence help shape exits successfully with the bare completed example, and a dry-run regression test proves the request includes pending=false and never pending=true."
+}

--- a/library/other/function-health/internal/cli/requisitions_completed.go
+++ b/library/other/function-health/internal/cli/requisitions_completed.go
@@ -12,33 +12,22 @@ import (
 )
 
 func newRequisitionsCompletedCmd(flags *rootFlags) *cobra.Command {
-	var flagPending bool
-
 	cmd := &cobra.Command{
 		Use:         "completed",
 		Short:       "Completed requisitions (your past test rounds, keyed by requisitionId).",
-		Example:     "  function-health-pp-cli requisitions completed --pending true",
+		Example:     "  function-health-pp-cli requisitions completed",
 		Annotations: map[string]string{"pp:endpoint": "requisitions.completed", "pp:method": "GET", "pp:path": "/requisitions", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Bare invocation of a command with required input prints help
-			// instead of pflag's terse "required flag not set" error. Optional-
-			// only read commands fall through so a bare call still executes.
-			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
-				return cmd.Help()
-			}
-			if !cmd.Flags().Changed("pending") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "pending")
-			}
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
 
 			path := "/requisitions"
-			params := map[string]string{}
-			if flagPending != false {
-				params["pending"] = fmt.Sprintf("%v", flagPending)
-			}
+			// The command name selects completed requisitions. Keep the fixed
+			// false filter inside the command so callers cannot accidentally turn
+			// `completed` into the pending query with boolean-flag syntax.
+			params := completedRequisitionParams()
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "requisitions", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
@@ -87,7 +76,10 @@ func newRequisitionsCompletedCmd(flags *rootFlags) *cobra.Command {
 			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
 		},
 	}
-	cmd.Flags().BoolVar(&flagPending, "pending", false, "Always pass false to filter to completed requisitions.")
 
 	return cmd
+}
+
+func completedRequisitionParams() map[string]string {
+	return map[string]string{"pending": "false"}
 }

--- a/library/other/function-health/internal/cli/requisitions_completed_test.go
+++ b/library/other/function-health/internal/cli/requisitions_completed_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"testing"
+)
+
+func TestRequisitionsCompletedUsesFixedCompletedFilter(t *testing.T) {
+	params := completedRequisitionParams()
+	if got := params["pending"]; got != "false" {
+		t.Fatalf("completed pending filter = %q, want false", got)
+	}
+	if len(params) != 1 {
+		t.Fatalf("completed params = %#v, want only the fixed pending filter", params)
+	}
+
+	cmd := newRequisitionsCompletedCmd(&rootFlags{})
+	if flag := cmd.Flags().Lookup("pending"); flag != nil {
+		t.Fatalf("completed command must encode its filter, not expose --pending")
+	}
+	if got, want := cmd.Example, "  function-health-pp-cli requisitions completed"; got != want {
+		t.Fatalf("completed example = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Fix `requisitions completed` so the command always sends the API's completed-round filter (`pending=false`). The previous generated boolean contract could not send false: `--pending=false` omitted the query parameter, while the common separated form `--pending false` was parsed as true and requested pending rounds.

## Findings

| Finding | Type | Resolution |
| --- | --- | --- |
| Completed-requisitions help contradicted its own flag description | Bug | Replace the misleading `--pending true` example with the intended bare command. |
| Caller-controlled boolean could select or default to the wrong result set | Bug | Encode `pending=false` inside the `completed` command and remove the ambiguous flag. |

## Changes

- Hardcode the completed filter in `requisitions completed`.
- Add a regression test for the fixed filter, command surface, and example.
- Record the behavior as a durable reprint guard.

## Verification

- `go test ./...` — pass
- `go vet ./...` — pass
- `go build -o /tmp/function-health-pp-cli-imp11548 ./cmd/function-health-pp-cli` — pass
- `govulncheck ./...` — pass, no vulnerabilities found
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/other/function-health/` — pass (one existing likely false positive for `sync check`)
- Exact evidence shape (`--version`; `requisitions completed --help`) — exit 0; corrected bare-command example
- Built-binary `requisitions completed --dry-run --json` — exit 0; emits `?pending=false`; no live request sent

The generator's consolidated `publish validate` also passes phase5, transcendence, tidy, vulnerability, vet, build, help, and version. It remains nonzero on pre-existing baseline mismatches: the published manifest is schema v1, and the generator checkout's older skill parser misattributes `export pdf-for-doctor` flags to its parent command.
