### PR TITLE
fix(ci): retry generated artifact pushes

### DIFF
--- a/.github/scripts/push-generated-artifact/push.sh
+++ b/.github/scripts/push-generated-artifact/push.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+branch="${1:-main}"
+max_attempts="${PUSH_RETRY_MAX_ATTEMPTS:-5}"
+delay_seconds="${PUSH_RETRY_DELAY_SECONDS:-2}"
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  git fetch origin "$branch"
+  git rebase "origin/$branch"
+
+  if git push origin "HEAD:$branch"; then
+    exit 0
+  fi
+
+  if ((attempt == max_attempts)); then
+    echo "::error::generated-artifact push failed after $max_attempts attempts"
+    exit 1
+  fi
+
+  echo "Push raced with another main-branch writer; retrying ($attempt/$max_attempts)."
+  sleep "$delay_seconds"
+done

--- a/.github/scripts/push-generated-artifact/push.sh
+++ b/.github/scripts/push-generated-artifact/push.sh
@@ -5,19 +5,29 @@ branch="${1:-main}"
 max_attempts="${PUSH_RETRY_MAX_ATTEMPTS:-5}"
 delay_seconds="${PUSH_RETRY_DELAY_SECONDS:-2}"
 
-for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-  git fetch origin "$branch"
-  git rebase "origin/$branch"
-
-  if git push origin "HEAD:$branch"; then
-    exit 0
-  fi
+retry_or_fail() {
+  local reason="$1"
 
   if ((attempt == max_attempts)); then
     echo "::error::generated-artifact push failed after $max_attempts attempts"
     exit 1
   fi
 
-  echo "Push raced with another main-branch writer; retrying ($attempt/$max_attempts)."
+  echo "$reason; retrying ($attempt/$max_attempts)."
   sleep "$delay_seconds"
+}
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  if ! git fetch origin "$branch"; then
+    retry_or_fail "Fetch failed"
+    continue
+  fi
+
+  git rebase "origin/$branch"
+
+  if git push origin "HEAD:$branch"; then
+    exit 0
+  fi
+
+  retry_or_fail "Push raced with another main-branch writer"
 done

--- a/.github/scripts/push-generated-artifact/push_test.py
+++ b/.github/scripts/push-generated-artifact/push_test.py
@@ -1,0 +1,100 @@
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("push.sh")
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class PushGeneratedArtifactTest(unittest.TestCase):
+    def test_retries_when_main_moves_between_rebase_and_push(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            log = root / "git.log"
+            state = root / "push-count"
+            fake_git = bin_dir / "git"
+            fake_git.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_GIT_LOG"
+if [ "$1" != "push" ]; then
+  exit 0
+fi
+count=0
+if [ -f "$FAKE_GIT_STATE" ]; then
+  count=$(<"$FAKE_GIT_STATE")
+fi
+count=$((count + 1))
+printf '%s\\n' "$count" > "$FAKE_GIT_STATE"
+if [ "$count" -le "${FAKE_PUSH_FAILURES:-0}" ]; then
+  echo "remote moved before push" >&2
+  exit 1
+fi
+""",
+                encoding="utf-8",
+            )
+            fake_git.chmod(fake_git.stat().st_mode | stat.S_IXUSR)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{bin_dir}:{env['PATH']}",
+                    "FAKE_GIT_LOG": str(log),
+                    "FAKE_GIT_STATE": str(state),
+                    "FAKE_PUSH_FAILURES": "1",
+                    "PUSH_RETRY_DELAY_SECONDS": "0",
+                }
+            )
+
+            result = subprocess.run(
+                ["bash", str(SCRIPT), "main"],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual(
+                [
+                    "fetch origin main",
+                    "rebase origin/main",
+                    "push origin HEAD:main",
+                    "fetch origin main",
+                    "rebase origin/main",
+                    "push origin HEAD:main",
+                ],
+                log.read_text(encoding="utf-8").splitlines(),
+            )
+
+    def test_all_main_branch_writers_use_retry_helper(self) -> None:
+        workflows = [
+            "generate-registry.yml",
+            "generate-skills.yml",
+            "normalize-patches.yml",
+            "update-cli-release-ledger.yml",
+        ]
+
+        for name in workflows:
+            with self.subTest(workflow=name):
+                body = (REPO_ROOT / ".github" / "workflows" / name).read_text(
+                    encoding="utf-8"
+                )
+                self.assertIn(
+                    "bash .github/scripts/push-generated-artifact/push.sh main",
+                    body,
+                )
+                self.assertIn(
+                    "- '.github/scripts/push-generated-artifact/**'",
+                    body,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/push-generated-artifact/push_test.py
+++ b/.github/scripts/push-generated-artifact/push_test.py
@@ -11,29 +11,42 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 class PushGeneratedArtifactTest(unittest.TestCase):
-    def test_retries_when_main_moves_between_rebase_and_push(self) -> None:
+    def run_with_failures(
+        self,
+        *,
+        fetch_failures: int = 0,
+        push_failures: int = 0,
+        max_attempts: int = 5,
+    ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             bin_dir = root / "bin"
             bin_dir.mkdir()
             log = root / "git.log"
-            state = root / "push-count"
             fake_git = bin_dir / "git"
             fake_git.write_text(
                 """#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$*" >> "$FAKE_GIT_LOG"
-if [ "$1" != "push" ]; then
-  exit 0
-fi
+case "$1" in
+  fetch)
+    state="$FAKE_FETCH_STATE"
+    failures="${FAKE_FETCH_FAILURES:-0}"
+    ;;
+  push)
+    state="$FAKE_PUSH_STATE"
+    failures="${FAKE_PUSH_FAILURES:-0}"
+    ;;
+  *) exit 0 ;;
+esac
 count=0
-if [ -f "$FAKE_GIT_STATE" ]; then
-  count=$(<"$FAKE_GIT_STATE")
+if [ -f "$state" ]; then
+  count=$(<"$state")
 fi
 count=$((count + 1))
-printf '%s\\n' "$count" > "$FAKE_GIT_STATE"
-if [ "$count" -le "${FAKE_PUSH_FAILURES:-0}" ]; then
-  echo "remote moved before push" >&2
+printf '%s\\n' "$count" > "$state"
+if [ "$count" -le "$failures" ]; then
+  echo "transient $1 failure" >&2
   exit 1
 fi
 """,
@@ -46,8 +59,11 @@ fi
                 {
                     "PATH": f"{bin_dir}:{env['PATH']}",
                     "FAKE_GIT_LOG": str(log),
-                    "FAKE_GIT_STATE": str(state),
-                    "FAKE_PUSH_FAILURES": "1",
+                    "FAKE_FETCH_STATE": str(root / "fetch-count"),
+                    "FAKE_PUSH_STATE": str(root / "push-count"),
+                    "FAKE_FETCH_FAILURES": str(fetch_failures),
+                    "FAKE_PUSH_FAILURES": str(push_failures),
+                    "PUSH_RETRY_MAX_ATTEMPTS": str(max_attempts),
                     "PUSH_RETRY_DELAY_SECONDS": "0",
                 }
             )
@@ -60,18 +76,47 @@ fi
                 check=False,
             )
 
-            self.assertEqual(0, result.returncode, result.stderr)
-            self.assertEqual(
-                [
-                    "fetch origin main",
-                    "rebase origin/main",
-                    "push origin HEAD:main",
-                    "fetch origin main",
-                    "rebase origin/main",
-                    "push origin HEAD:main",
-                ],
-                log.read_text(encoding="utf-8").splitlines(),
-            )
+            return result, log.read_text(encoding="utf-8").splitlines()
+
+    def test_retries_when_main_moves_between_rebase_and_push(self) -> None:
+        result, commands = self.run_with_failures(push_failures=1)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            [
+                "fetch origin main",
+                "rebase origin/main",
+                "push origin HEAD:main",
+                "fetch origin main",
+                "rebase origin/main",
+                "push origin HEAD:main",
+            ],
+            commands,
+        )
+
+    def test_retries_a_transient_fetch_failure(self) -> None:
+        result, commands = self.run_with_failures(fetch_failures=1)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            [
+                "fetch origin main",
+                "fetch origin main",
+                "rebase origin/main",
+                "push origin HEAD:main",
+            ],
+            commands,
+        )
+
+    def test_stops_after_the_retry_budget_is_exhausted(self) -> None:
+        result, commands = self.run_with_failures(
+            fetch_failures=3,
+            max_attempts=3,
+        )
+
+        self.assertEqual(1, result.returncode)
+        self.assertEqual(["fetch origin main"] * 3, commands)
+        self.assertIn("failed after 3 attempts", result.stdout)
 
     def test_all_main_branch_writers_use_retry_helper(self) -> None:
         workflows = [

--- a/.github/workflows/generate-registry.yml
+++ b/.github/workflows/generate-registry.yml
@@ -32,6 +32,7 @@ on:
       - 'registry.json'
       - 'README.md'
       - 'tools/generate-registry/**'
+      - '.github/scripts/push-generated-artifact/**'
       - '.github/workflows/generate-registry.yml'
   workflow_dispatch:
 
@@ -46,7 +47,7 @@ jobs:
     # generated-artifact workflows. GitHub keeps only one pending run per
     # concurrency group, so a shared group lets a skills or release-ledger run
     # evict the pending registry run and leave registry.json stale. Push races
-    # with sibling workflows are handled by the rebase-before-push step below.
+    # with sibling workflows are handled by the bounded retry below.
     concurrency:
       group: generate-registry-main
       cancel-in-progress: false
@@ -82,9 +83,7 @@ jobs:
           # the sentinel region would normally re-trigger; this commit
           # itself is suppressed by [skip ci] so we don't loop.
           git commit -m "chore(registry): regenerate from library/ [skip ci]"
-          # Defense-in-depth against sibling generated-artifact workflows
-          # landing between our checkout and push. They touch disjoint paths
-          # (registry.json + README.md vs cli-skills/ or library release
-          # metadata), so the rebase is conflict-free in practice.
-          git pull --rebase origin main
-          git push
+          # A sibling writer can land after a rebase but before the push. Retry
+          # the complete fetch/rebase/push sequence so that race cannot leave
+          # the generated registry stale.
+          bash .github/scripts/push-generated-artifact/push.sh main

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -9,6 +9,8 @@ on:
       - 'library/**/SKILL.md'
       - 'library/**/README.md'
       - 'tools/generate-skills/main.go'
+      - '.github/scripts/push-generated-artifact/**'
+      - '.github/workflows/generate-skills.yml'
   workflow_dispatch:
 
 jobs:
@@ -20,7 +22,7 @@ jobs:
     # generated-artifact workflows. GitHub keeps only one pending run per
     # concurrency group, so a shared group lets unrelated workflows evict a
     # pending skills run. Push races with sibling workflows are handled by the
-    # rebase-before-push step below.
+    # bounded retry below.
     concurrency:
       group: generate-skills-main
       cancel-in-progress: false
@@ -49,10 +51,7 @@ jobs:
             echo "No skill changes to commit"
           else
             git commit -m "chore(skills): regenerate per-app skills [skip ci]"
-            # Defense-in-depth against sibling generated-artifact workflows
-            # landing between our checkout and push. They touch disjoint paths
-            # (cli-skills/ vs registry.json + README.md or library release
-            # metadata), so the rebase is conflict-free in practice.
-            git pull --rebase origin main
-            git push
+            # A sibling writer can land after a rebase but before the push.
+            # Retry the complete fetch/rebase/push sequence.
+            bash .github/scripts/push-generated-artifact/push.sh main
           fi

--- a/.github/workflows/normalize-patches.yml
+++ b/.github/workflows/normalize-patches.yml
@@ -33,6 +33,7 @@ on:
     paths:
       - 'library/**/.printing-press-patches.json'
       - '.github/scripts/normalize-patches/**'
+      - '.github/scripts/push-generated-artifact/**'
       - '.github/workflows/normalize-patches.yml'
   workflow_dispatch:
     inputs:
@@ -52,7 +53,7 @@ jobs:
     # generated-artifact workflows. GitHub keeps only one pending run per
     # concurrency group, so a shared group lets unrelated workflows evict a
     # pending normalizer run. Push races with sibling workflows are handled by
-    # the rebase-before-push step below.
+    # the bounded retry below.
     concurrency:
       group: normalize-patches-main
       cancel-in-progress: false
@@ -142,8 +143,6 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           # [skip ci] suppresses a re-trigger of this workflow on its own commit.
           git commit -m "chore(patches): normalize patches manifests to per-patch dirs [skip ci]"
-          # Defense-in-depth against sibling generated-artifact workflows
-          # landing between checkout and push. Paths are disjoint, so the rebase
-          # is conflict-free.
-          git pull --rebase origin main
-          git push
+          # A sibling writer can land after a rebase but before the push.
+          # Retry the complete fetch/rebase/push sequence.
+          bash .github/scripts/push-generated-artifact/push.sh main

--- a/.github/workflows/update-cli-release-ledger.yml
+++ b/.github/workflows/update-cli-release-ledger.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - 'library/**'
       - 'tools/release-ledger/**'
+      - '.github/scripts/push-generated-artifact/**'
       - '.github/workflows/update-cli-release-ledger.yml'
   workflow_dispatch:
     inputs:
@@ -35,7 +36,7 @@ jobs:
     # generated-artifact workflows. GitHub keeps only one pending run per
     # concurrency group, so a shared group lets unrelated workflows evict a
     # pending release-ledger run. Push races with sibling workflows are handled
-    # by the rebase-before-push step below.
+    # by the bounded retry below.
     concurrency:
       group: update-cli-release-ledger-main
       cancel-in-progress: false
@@ -118,5 +119,6 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add library
           git commit -m "chore(releases): update CLI release ledger [skip ci]"
-          git pull --rebase origin main
-          git push
+          # A sibling writer can land after a rebase but before the push.
+          # Retry the complete fetch/rebase/push sequence.
+          bash .github/scripts/push-generated-artifact/push.sh main


### PR DESCRIPTION
## Summary

- Prevent post-merge catalog and skill updates from remaining stale when another automation commit lands between rebase and push.
- Add one bounded fetch/rebase/push retry helper and use it from all four main-branch generated-artifact writers.
- Keep genuine rebase conflicts fail-closed instead of forcing a push.

## What Changed

- Retry transient fetch failures and raced pushes up to five times, rebasing onto the latest `origin/main` before each push attempt.
- Use the helper for registry, per-app skill, patches normalization, and per-CLI release-ledger commits.
- Trigger each consumer workflow when the shared helper changes.
- Add fake-git regression coverage for the post-rebase push race, transient fetch recovery, retry exhaustion, and adoption by all four writers.

## Validation

- [x] `python3 -m unittest push_test.py`
- [x] `bash -n .github/scripts/push-generated-artifact/push.sh`
- [x] `shellcheck .github/scripts/push-generated-artifact/push.sh`
- [x] `actionlint` on all four changed workflows
- [x] `python3 -m unittest scan_test` (72 tests)
- [x] `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`
- [x] `git diff --check`

## Gaps / Follow-Up

- None.

Related incident: https://github.com/mvanhorn/printing-press-library/actions/runs/29549084661
