### PR TITLE
feat(granola): add folder-scoped public note listing

### DIFF
--- a/library/productivity/granola/.printing-press-patches/folder-scoped-note-listing.json
+++ b/library/productivity/granola/.printing-press-patches/folder-scoped-note-listing.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 2,
+  "id": "granola-folder-scoped-note-listing",
+  "applied_at": "2026-07-17",
+  "base_run_id": "20260511-211333",
+  "base_printing_press_version": "4.4.0",
+  "summary": "feat(granola): add folder-scoped public note listing",
+  "reason": "Granola's live OpenAPI spec added folder_id to GET /v1/notes, but the published CLI and generated MCP mirror did not expose it.",
+  "files": [
+    "README.md",
+    "SKILL.md",
+    "internal/cli/notes_list.go",
+    "internal/cli/notes_list_test.go",
+    "internal/mcp/tools.go",
+    "spec.json",
+    "tools-manifest.json"
+  ],
+  "validated_outcome": "Go tests, focused dry-run request verification, build, vet, govulncheck, help, version, and documentation flag checks passed; consolidated validation is blocked only by pre-existing manifest and canonical-SKILL drift.",
+  "findings_addressed": ["F1"]
+}

--- a/library/productivity/granola/.printing-press-patches/folder-scoped-note-listing.json
+++ b/library/productivity/granola/.printing-press-patches/folder-scoped-note-listing.json
@@ -9,12 +9,13 @@
   "files": [
     "README.md",
     "SKILL.md",
+    "internal/cli/data_source.go",
     "internal/cli/notes_list.go",
     "internal/cli/notes_list_test.go",
     "internal/mcp/tools.go",
     "spec.json",
     "tools-manifest.json"
   ],
-  "validated_outcome": "Go tests, focused dry-run request verification, build, vet, govulncheck, help, version, and documentation flag checks passed; consolidated validation is blocked only by pre-existing manifest and canonical-SKILL drift.",
+  "validated_outcome": "Go tests, focused live dry-run request verification, explicit local-scope rejection, build, vet, govulncheck, help, version, and documentation flag checks passed; consolidated validation is blocked only by pre-existing manifest and canonical-SKILL drift.",
   "findings_addressed": ["F1"]
 }

--- a/library/productivity/granola/README.md
+++ b/library/productivity/granola/README.md
@@ -250,6 +250,14 @@ These capabilities aren't available in any other tool for this API.
 
 Run `granola-pp-cli --help` for the full command reference and flag list.
 
+### List every note in a folder
+
+Use the folder ID returned by `granola-pp-cli folders` to scope the public API list call:
+
+```bash
+granola-pp-cli notes list --folder-id fol_4y6LduVdwSKC27 --all --json
+```
+
 ## Commands
 
 This CLI exposes 35+ commands. Use `granola-pp-cli --help` for the canonical tree and `granola-pp-cli which "<capability>"` to find the right command from natural language. Grouped overview:
@@ -262,7 +270,7 @@ This CLI exposes 35+ commands. Use `granola-pp-cli --help` for the canonical tre
 | **Export** | `export <id> -o FILE`, `export-all --since DATE -o DIR` |
 | **Cross-meeting analytics** | `attendee timeline / brief`, `folder stream`, `recipes coverage`, `talktime`, `calendar overlay`, `stats frequency / duration / attendees / calendar`, `collect`, `duplicates scan`, `chat list / get` |
 | **Granola entities** | `folders`, `folder list / stream`, `recipes list / describe / coverage`, `workspaces list` |
-| **Public API mirrors** | `notes list / get`, `folders` (require `GRANOLA_API_KEY`) |
+| **Public API mirrors** | `notes list / get`, `folders` (require `GRANOLA_API_KEY`; `notes list --folder-id` scopes by folder) |
 | **Sync / system** | `sync`, `sync-api`, `doctor`, `auth login / status / set-token / logout`, `which`, `agent-context`, `version`, `import` |
 | **GUI bridge (macOS only)** | `warm <id> <query>` — prints by default; `--launch` activates the Granola desktop app |
 

--- a/library/productivity/granola/README.md
+++ b/library/productivity/granola/README.md
@@ -258,6 +258,8 @@ Use the folder ID returned by `granola-pp-cli folders` to scope the public API l
 granola-pp-cli notes list --folder-id fol_4y6LduVdwSKC27 --all --json
 ```
 
+Folder scoping requires the live public API. If `--data-source local` is selected, or `auto` cannot reach Granola, the CLI rejects the request instead of returning unscoped cached notes.
+
 ## Commands
 
 This CLI exposes 35+ commands. Use `granola-pp-cli --help` for the canonical tree and `granola-pp-cli which "<capability>"` to find the right command from natural language. Grouped overview:

--- a/library/productivity/granola/SKILL.md
+++ b/library/productivity/granola/SKILL.md
@@ -194,6 +194,8 @@ Use the folder ID returned by `granola-pp-cli folders` to scope the public API l
 granola-pp-cli notes list --folder-id fol_4y6LduVdwSKC27 --all --json
 ```
 
+Folder scoping requires the live public API. If `--data-source local` is selected, or `auto` cannot reach Granola, the CLI rejects the request instead of returning unscoped cached notes.
+
 
 ### Daily MEMO loop
 

--- a/library/productivity/granola/SKILL.md
+++ b/library/productivity/granola/SKILL.md
@@ -170,7 +170,7 @@ Quick orientation by group:
 | **Export** | `export`, `export-all` | Combined three-stream markdown export, single or bulk |
 | **Cross-meeting analytics** | `attendee timeline`, `attendee brief`, `folder stream`, `recipes coverage`, `talktime`, `calendar overlay`, `stats frequency`, `stats duration`, `stats attendees`, `stats calendar`, `collect`, `duplicates scan`, `chat list`, `chat get` | Queries no per-meeting tool can answer |
 | **Folders / recipes / workspaces** | `folders` (public-API), `folder list`, `folder stream`, `recipes list`, `recipes describe`, `recipes coverage`, `workspaces list` | Granola organizational entities |
-| **Public-API mirrors** | `notes list`, `notes get`, `folders` | Typed Bearer-key endpoints |
+| **Public-API mirrors** | `notes list`, `notes get`, `folders` | Typed Bearer-key endpoints; `notes list --folder-id` scopes by folder |
 | **Sync / system** | `sync`, `sync-api`, `doctor`, `auth login`, `auth status`, `auth set-token`, `auth logout`, `which`, `agent-context`, `version`, `import` | Local store hydration, auth, capability discovery, batch import |
 | **GUI bridge** | `warm` (macOS only) | Drives Granola desktop app via AppleScript |
 
@@ -185,6 +185,14 @@ granola-pp-cli which "<capability in your own words>"
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
 
 ## Recipes
+
+### List every note in a folder
+
+Use the folder ID returned by `granola-pp-cli folders` to scope the public API list call:
+
+```bash
+granola-pp-cli notes list --folder-id fol_4y6LduVdwSKC27 --all --json
+```
 
 
 ### Daily MEMO loop

--- a/library/productivity/granola/internal/cli/data_source.go
+++ b/library/productivity/granola/internal/cli/data_source.go
@@ -207,6 +207,14 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 // filters (query params, path scoping like /teams/{id}/users) are NOT applied locally.
 // The provenance metadata includes "unscoped":true when params were present but not applied.
 func resolveLocal(ctx context.Context, resourceType string, isList bool, path string, params map[string]string, reason string) (json.RawMessage, DataProvenance, error) {
+	// The public notes endpoint defines folder_id as the requested folder plus
+	// all child folders. The generic resource cache does not retain enough
+	// folder hierarchy/membership data to reproduce that scope safely. Refuse
+	// the local path instead of returning unrelated notes.
+	if resourceType == "notes" && params["folder_id"] != "" {
+		return nil, DataProvenance{}, fmt.Errorf("folder-scoped note listing requires the live API; local data cannot safely reproduce --folder-id scope")
+	}
+
 	db, err := openStoreForRead(ctx, "granola-pp-cli")
 	if err != nil {
 		return nil, DataProvenance{}, fmt.Errorf("opening local database: %w\nRun 'granola-pp-cli sync' first.", err)

--- a/library/productivity/granola/internal/cli/notes_list.go
+++ b/library/productivity/granola/internal/cli/notes_list.go
@@ -15,6 +15,7 @@ func newNotesListCmd(flags *rootFlags) *cobra.Command {
 	var flagCreatedBefore string
 	var flagCreatedAfter string
 	var flagUpdatedAfter string
+	var flagFolderID string
 	var flagCursor string
 	var flagPageSize int
 	var flagAll bool
@@ -22,7 +23,7 @@ func newNotesListCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "list",
 		Short:       "List notes",
-		Example:     "  granola-pp-cli notes list",
+		Example:     "  granola-pp-cli notes list\n  granola-pp-cli notes list --folder-id fol_4y6LduVdwSKC27 --all",
 		Annotations: map[string]string{"pp:endpoint": "notes.list", "pp:method": "GET", "pp:path": "/v1/notes", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := flags.newClient()
@@ -35,6 +36,7 @@ func newNotesListCmd(flags *rootFlags) *cobra.Command {
 				"created_before": fmt.Sprintf("%v", flagCreatedBefore),
 				"created_after":  fmt.Sprintf("%v", flagCreatedAfter),
 				"updated_after":  fmt.Sprintf("%v", flagUpdatedAfter),
+				"folder_id":      fmt.Sprintf("%v", flagFolderID),
 				"cursor":         fmt.Sprintf("%v", flagCursor),
 				"page_size":      fmt.Sprintf("%v", flagPageSize),
 			}, nil, flagAll, "cursor", "", "hasMore")
@@ -84,6 +86,7 @@ func newNotesListCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&flagCreatedBefore, "created-before", "", "Created before")
 	cmd.Flags().StringVar(&flagCreatedAfter, "created-after", "", "Created after")
 	cmd.Flags().StringVar(&flagUpdatedAfter, "updated-after", "", "Updated after")
+	cmd.Flags().StringVar(&flagFolderID, "folder-id", "", "Filter notes by folder ID, including child folders")
 	cmd.Flags().StringVar(&flagCursor, "cursor", "", "Cursor")
 	cmd.Flags().IntVar(&flagPageSize, "page-size", 10, "Page size")
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")

--- a/library/productivity/granola/internal/cli/notes_list_test.go
+++ b/library/productivity/granola/internal/cli/notes_list_test.go
@@ -2,7 +2,11 @@
 
 package cli
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+)
 
 func TestNotesListSupportsFolderFilter(t *testing.T) {
 	cmd := newNotesListCmd(&rootFlags{})
@@ -12,5 +16,17 @@ func TestNotesListSupportsFolderFilter(t *testing.T) {
 	}
 	if flag.DefValue != "" {
 		t.Fatalf("--folder-id default = %q, want empty", flag.DefValue)
+	}
+}
+
+func TestNotesListLocalFallbackRejectsFolderScope(t *testing.T) {
+	_, _, err := resolveLocal(context.Background(), "notes", true, "/v1/notes", map[string]string{
+		"folder_id": "fol_4y6LduVdwSKC27",
+	}, "user_requested")
+	if err == nil {
+		t.Fatal("folder-scoped local note listing unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "requires the live API") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/library/productivity/granola/internal/cli/notes_list_test.go
+++ b/library/productivity/granola/internal/cli/notes_list_test.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import "testing"
+
+func TestNotesListSupportsFolderFilter(t *testing.T) {
+	cmd := newNotesListCmd(&rootFlags{})
+	flag := cmd.Flags().Lookup("folder-id")
+	if flag == nil {
+		t.Fatal("notes list is missing --folder-id")
+	}
+	if flag.DefValue != "" {
+		t.Fatalf("--folder-id default = %q, want empty", flag.DefValue)
+	}
+}

--- a/library/productivity/granola/internal/mcp/tools.go
+++ b/library/productivity/granola/internal/mcp/tools.go
@@ -48,17 +48,18 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("notes_list",
-			mcplib.WithDescription("List notes. Optional: created_before, created_after, updated_after (plus 2 more). Returns the ListNotesOutput."),
+			mcplib.WithDescription("List notes. Optional: created_before, created_after, updated_after, folder_id (plus 2 more). Returns the ListNotesOutput."),
 			mcplib.WithString("created_before", mcplib.Description("Created before")),
 			mcplib.WithString("created_after", mcplib.Description("Created after")),
 			mcplib.WithString("updated_after", mcplib.Description("Updated after")),
+			mcplib.WithString("folder_id", mcplib.Description("Filter notes by folder ID, including child folders")),
 			mcplib.WithString("cursor", mcplib.Description("Cursor")),
 			mcplib.WithString("page_size", mcplib.Description("Page size")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/v1/notes", []mcpParamBinding{{PublicName: "created_before", WireName: "created_before", Location: "query"}, {PublicName: "created_after", WireName: "created_after", Location: "query"}, {PublicName: "updated_after", WireName: "updated_after", Location: "query"}, {PublicName: "cursor", WireName: "cursor", Location: "query"}, {PublicName: "page_size", WireName: "page_size", Location: "query"}}, []string{}),
+		makeAPIHandler("GET", "/v1/notes", []mcpParamBinding{{PublicName: "created_before", WireName: "created_before", Location: "query"}, {PublicName: "created_after", WireName: "created_after", Location: "query"}, {PublicName: "updated_after", WireName: "updated_after", Location: "query"}, {PublicName: "folder_id", WireName: "folder_id", Location: "query"}, {PublicName: "cursor", WireName: "cursor", Location: "query"}, {PublicName: "page_size", WireName: "page_size", Location: "query"}}, []string{}),
 	)
 	// SQL tool — ad-hoc analysis on synced data without API calls
 	s.AddTool(

--- a/library/productivity/granola/spec.json
+++ b/library/productivity/granola/spec.json
@@ -601,6 +601,12 @@
               "2026-01-27T15:30:00Z"
             ]
           },
+          "folder_id": {
+            "type": "string",
+            "pattern": "^fol_[a-zA-Z0-9]{14}$",
+            "description": "Return notes in this folder and any of its child folders. Use the list folders endpoint to discover folder IDs.",
+            "example": "fol_4y6LduVdwSKC27"
+          },
           "cursor": {
             "type": "string",
             "description": "The cursor to continue from",
@@ -769,6 +775,17 @@
             },
             "required": false,
             "name": "updated_after",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^fol_[a-zA-Z0-9]{14}$",
+              "description": "Return notes in this folder and any of its child folders. Use the list folders endpoint to discover folder IDs.",
+              "example": "fol_4y6LduVdwSKC27"
+            },
+            "required": false,
+            "name": "folder_id",
             "in": "query"
           },
           {

--- a/library/productivity/granola/tools-manifest.json
+++ b/library/productivity/granola/tools-manifest.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "notes_list",
-      "description": "List notes. Optional: created_before, created_after, updated_after (plus 2 more). Returns the ListNotesOutput.",
+      "description": "List notes. Optional: created_before, created_after, updated_after, folder_id (plus 2 more). Returns the ListNotesOutput.",
       "method": "GET",
       "path": "/v1/notes",
       "params": [
@@ -86,6 +86,12 @@
           "type": "string",
           "location": "query",
           "description": "Updated after"
+        },
+        {
+          "name": "folder_id",
+          "type": "string",
+          "location": "query",
+          "description": "Filter notes by folder ID, including child folders"
         },
         {
           "name": "cursor",


### PR DESCRIPTION
## Summary

Granola's live OpenAPI spec supports folder-scoped note listing, but the published CLI and typed MCP mirror omitted the parameter. This adds `--folder-id` / `folder_id` parity, including Granola's child-folder semantics.

## Finding

- F1 · public API parity · feature — expose `folder_id` on `GET /v1/notes` across the CLI and typed MCP surface.

## Changes

- Add `granola-pp-cli notes list --folder-id <fol_…>`.
- Add `folder_id` to the typed `notes_list` MCP tool.
- Refresh the embedded OpenAPI definition and tool manifest.
- Add README/SKILL recipes, a focused test, and a Printing Press patch record.

## Verification

- Full Go test suite: PASS
- Focused CLI and MCP tests: PASS
- Dry-run request verification: PASS (`?folder_id=fol_4y6LduVdwSKC27`)
- Build, vet, govulncheck, help/version, and documentation flag checks: PASS
- Consolidated validator: baseline exceptions only — the published Granola artifact still uses manifest schema v1 and has pre-existing canonical install-section drift in `SKILL.md`.

## Tracking

- Linear: WRK-154
