### PR TITLE
fix(soccer-goat): survive Transfermarkt source outages (--base-url + failover)

### DIFF
--- a/library/media-and-entertainment/soccer-goat/.printing-press-patches/transfermarkt-base-url-must-be-overridable-and-failover-capable.json
+++ b/library/media-and-entertainment/soccer-goat/.printing-press-patches/transfermarkt-base-url-must-be-overridable-and-failover-capable.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 2,
+  "id": "transfermarkt-base-url-must-be-overridable-and-failover-capable",
+  "applied_at": "2026-07-18",
+  "base_run_id": "20260712-074136",
+  "base_printing_press_version": "4.27.1",
+  "summary": "The Transfermarkt base URL must be user-overridable (--base-url flag / SOCCER_GOAT_BASE_URL / base_url) and support an ordered failover list (SOCCER_GOAT_BASE_URLS / base_urls / compiled default), because pinning the CLI to a single hardcoded free mirror takes every command down when that mirror 5xxes.",
+  "reason": "The generated client hardcoded one base URL (transfermarkt-api.fly.dev) with no flag or list override, so a multi-day upstream 5xx outage on that instance dead-lined player/team/compare with a raw 'HTTP 500' and no recovery path. The fix adds a --base-url flag and an ordered candidate list with lazy client-side failover (advance only on 5xx-after-retries or transport error, never on a 4xx/empty answer), refreshes the default to a failover list, surfaces per-source health in doctor, and maps exhausted-source 5xx to a friendly 'data source unavailable' hint. A regen must preserve the override + failover contract, not just re-pin a single URL. The specific mirror hosts are moving targets — the durable point is that the source is swappable and self-hostable (felipeall/transfermarkt-api), not any particular URL.",
+  "files": [
+    "internal/config/config.go",
+    "internal/client/client.go",
+    "internal/cli/root.go",
+    "internal/cli/helpers.go",
+    "internal/cli/player.go",
+    "internal/cli/team.go",
+    "internal/cli/compare.go",
+    "internal/cli/doctor.go"
+  ],
+  "validated_outcome": "With the default list and the reference mirror down (HTTP 500), 'player \"Jhon Duran\"' fails over to a working source and returns market value €15.00m; '--base-url' at a single dead source exits 5 with the actionable hint and does not fan out; doctor's Sources block marks the primary FAIL (HTTP 500) and mirrors OK. go build/vet/test and govulncheck pass.",
+  "upstream_issue": "generator-shaped: the single-hardcoded-base-URL pattern is template-wide (every printed CLI pins one client base URL with no override/failover); worth a --base-url flag + optional failover list in cli-printing-press's client/config templates."
+}

--- a/library/media-and-entertainment/soccer-goat/README.md
+++ b/library/media-and-entertainment/soccer-goat/README.md
@@ -222,6 +222,40 @@ Young, high-potential, rising-value players in one filtered list.
 
 Run `soccer-goat-pp-cli --help` for the full command reference and flag list.
 
+## Data source (Transfermarkt)
+
+Market value, squad, and identity data come from a [Transfermarkt API](https://github.com/felipeall/transfermarkt-api) instance. The CLI ships an ordered list of public instances and **fails over automatically**: if the first source returns a server error (5xx) or is unreachable, it tries the next. A source that answers — including "player not found" — is used as-is and never triggers failover.
+
+Point the CLI at a specific instance when you want to:
+
+```bash
+# One-off override (wins over everything; no failover):
+soccer-goat-pp-cli player "Jhon Duran" --base-url https://your-instance.example
+
+# Or via environment:
+export SOCCER_GOAT_BASE_URL=https://your-instance.example        # single source
+export SOCCER_GOAT_BASE_URLS=https://a.example,https://b.example  # ordered failover list
+```
+
+Resolution precedence (highest first): `--base-url` → `SOCCER_GOAT_BASE_URL` → `base_url` config key → `SOCCER_GOAT_BASE_URLS` → `base_urls` config key → the built-in default list. A single-value override collapses to exactly that one source. Config-file form:
+
+```toml
+# config.toml
+base_urls = ["https://your-instance.example", "https://transfermarkt-api.fly.dev"]
+```
+
+Run `soccer-goat-pp-cli doctor` to see every configured source and which are reachable right now.
+
+**The public instances are a best-effort convenience, not an availability guarantee** — they have had multi-day outages. For reliable use, **self-host** the open-source API and point `--base-url`/`SOCCER_GOAT_BASE_URL` at it:
+
+```bash
+# felipeall/transfermarkt-api ships a Docker image:
+docker run -p 8000:8000 felipeall/transfermarkt-api:latest
+soccer-goat-pp-cli player "Jhon Duran" --base-url http://localhost:8000
+```
+
+When every source is down, commands exit with code 5 and a hint pointing you at these options (or `--data-source local` if you have synced an offline dataset).
+
 ## Paths & environment variables
 
 This CLI separates local files into four path kinds:
@@ -349,7 +383,7 @@ This CLI resolves endpoint placeholders at runtime, so one installed binary can 
 Endpoint environment variables:
 - `SOCCER_GOAT_PLAYER_ID` resolves `{player_id}`
 
-Base URL: `https://transfermarkt-api.fly.dev`
+Base URL: an ordered, overridable list of Transfermarkt API instances (default leads with `https://transfermarkt-api.fly.dev`, with community-mirror failover). See [Data source](#data-source-transfermarkt) to override or self-host.
 
 ## Health Check
 

--- a/library/media-and-entertainment/soccer-goat/SKILL.md
+++ b/library/media-and-entertainment/soccer-goat/SKILL.md
@@ -168,6 +168,29 @@ No authentication required.
 
 Run `soccer-goat-pp-cli doctor` to verify setup.
 
+## Data source (Transfermarkt) and outages
+
+Market value / squad / identity data comes from a [Transfermarkt API](https://github.com/felipeall/transfermarkt-api) instance. The CLI ships an ordered default list and **fails over automatically** on 5xx/unreachable; a source that answers (including "not found") is used as-is.
+
+If `player`/`team`/`compare` exit with code 5 and a "data source is unavailable" hint, every configured Transfermarkt source is down. Recovery, in order of preference:
+
+```bash
+# See which sources are up:
+soccer-goat-pp-cli doctor --agent          # inspect the "sources" array
+
+# Point at a known-working instance for this run (wins over everything, no failover):
+soccer-goat-pp-cli player "<name>" --base-url https://your-instance.example --agent
+
+# Or set an ordered failover list for the session:
+export SOCCER_GOAT_BASE_URLS=https://a.example,https://b.example
+
+# Most reliable: self-host felipeall/transfermarkt-api (Docker) and point at it:
+docker run -p 8000:8000 felipeall/transfermarkt-api:latest
+soccer-goat-pp-cli player "<name>" --base-url http://localhost:8000 --agent
+```
+
+Resolution precedence: `--base-url` > `SOCCER_GOAT_BASE_URL` > `base_url` config > `SOCCER_GOAT_BASE_URLS` > `base_urls` config > default list. The public instances are best-effort, not guaranteed; self-hosting is the durable path.
+
 ## Agent Mode
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.

--- a/library/media-and-entertainment/soccer-goat/internal/cli/compare.go
+++ b/library/media-and-entertainment/soccer-goat/internal/cli/compare.go
@@ -49,11 +49,11 @@ func newNovelCompareCmd(flags *rootFlags) *cobra.Command {
 			ctx := cmd.Context()
 			a, err := agg.ResolvePlayer(ctx, args[0])
 			if err != nil {
-				return err
+				return classifyAPIError(err, flags)
 			}
 			b, err := agg.ResolvePlayer(ctx, args[1])
 			if err != nil {
-				return err
+				return classifyAPIError(err, flags)
 			}
 			comparison := playerComparison{A: a, B: b}
 			if novelMachineOutput(cmd.OutOrStdout(), flags) {

--- a/library/media-and-entertainment/soccer-goat/internal/cli/doctor.go
+++ b/library/media-and-entertainment/soccer-goat/internal/cli/doctor.go
@@ -210,6 +210,13 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				report["config"] = fmt.Sprintf("error: %s", err)
 			} else {
+				// Mirror newClient()'s --base-url override so the whole report —
+				// the base_url line, the API reachability check, and the
+				// per-source probe below — reflects the source the command
+				// actually uses, not the default list.
+				if strings.TrimSpace(flags.baseURL) != "" {
+					cfg.SetBaseURLOverride(flags.baseURL)
+				}
 				report["config"] = "ok"
 				report["config_path"] = cfg.Path
 				report["base_url"] = cfg.BaseURL

--- a/library/media-and-entertainment/soccer-goat/internal/cli/doctor.go
+++ b/library/media-and-entertainment/soccer-goat/internal/cli/doctor.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -19,6 +20,56 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/soccer-goat/internal/store"
 	"github.com/spf13/cobra"
 )
+
+// sourceProbePath is the cheap search the doctor issues against each candidate
+// source. "/" is a poor health signal — the reference deployment answers it
+// with a 307 to /docs even while its scraper backend 5xxes on real searches —
+// so probe the actual search endpoint to tell "this instance works" from "the
+// host is up but broken".
+const sourceProbePath = "/players/search/haaland?page_number=1"
+
+// collectSourcesReport probes each configured Transfermarkt source in order and
+// reports per-source reachability, so `doctor` answers "which source am I using
+// and is it up?" without the user reverse-engineering it from a failed command.
+func collectSourcesReport(ctx context.Context, cfg *config.Config, timeout time.Duration) []map[string]any {
+	if cfg == nil || len(cfg.BaseURLs) == 0 {
+		return nil
+	}
+	if timeout <= 0 || timeout > 10*time.Second {
+		timeout = 10 * time.Second
+	}
+	httpClient := &http.Client{Timeout: timeout}
+	out := make([]map[string]any, 0, len(cfg.BaseURLs))
+	for i, base := range cfg.BaseURLs {
+		entry := map[string]any{"url": base, "primary": i == 0}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(base, "/")+sourceProbePath, nil)
+		if err != nil {
+			entry["status"] = fmt.Sprintf("error: %s", err)
+			out = append(out, entry)
+			continue
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "soccer-goat-pp-cli/0.1.0")
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			entry["status"] = fmt.Sprintf("unreachable: %s", err)
+			out = append(out, entry)
+			continue
+		}
+		resp.Body.Close()
+		entry["http_status"] = resp.StatusCode
+		switch {
+		case resp.StatusCode < 400:
+			entry["status"] = "reachable"
+		case resp.StatusCode >= 500:
+			entry["status"] = fmt.Sprintf("unavailable (HTTP %d)", resp.StatusCode)
+		default:
+			entry["status"] = fmt.Sprintf("reachable (HTTP %d)", resp.StatusCode)
+		}
+		out = append(out, entry)
+	}
+	return out
+}
 
 // looksLikeDoctorInterstitial reports whether the response body matches a known
 // bot-detection challenge page (Cloudflare, Akamai, Vercel, AWS WAF, DataDome,
@@ -233,6 +284,17 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			} else if cfg != nil && cfg.BaseURL == "" {
 				report["api"] = "not configured (set base_url in config file)"
 			}
+
+			// Per-source health: probe every configured Transfermarkt candidate
+			// (the failover list) so the user sees which source is up. The "api"
+			// line above uses the failover client and can read "reachable" off a
+			// mirror even when the primary is down; this block shows each.
+			if cfg != nil {
+				if sources := collectSourcesReport(cmd.Context(), cfg, flags.timeout); len(sources) > 0 {
+					report["sources"] = sources
+				}
+			}
+
 			// Cache health: only reported when this CLI has generated sync.
 			// Surfaces rows + last_synced_at per resource, schema version,
 			// and a fresh/stale/unknown verdict so agents can introspect
@@ -317,6 +379,27 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			for _, key := range []string{"config_path", "base_url", "auth_source", "credentials_location", "version"} {
 				if v, ok := report[key]; ok {
 					fmt.Fprintf(w, "  %s: %v\n", key, v)
+				}
+			}
+			// Per-source health block (the failover list, in order).
+			if sourcesAny, ok := report["sources"]; ok {
+				if sources, ok := sourcesAny.([]map[string]any); ok && len(sources) > 0 {
+					fmt.Fprintf(w, "  Sources:\n")
+					for _, s := range sources {
+						statusStr, _ := s["status"].(string)
+						indicator := green("OK")
+						switch {
+						case strings.Contains(statusStr, "unavailable") || strings.Contains(statusStr, "unreachable") || strings.HasPrefix(statusStr, "error"):
+							indicator = red("FAIL")
+						case strings.Contains(statusStr, "HTTP 4"):
+							indicator = yellow("WARN")
+						}
+						tag := ""
+						if primary, _ := s["primary"].(bool); primary {
+							tag = " (primary)"
+						}
+						fmt.Fprintf(w, "    %s %v%s: %s\n", indicator, s["url"], tag, statusStr)
+					}
 				}
 			}
 			// Print auth setup hints (indented under Auth line)

--- a/library/media-and-entertainment/soccer-goat/internal/cli/helpers.go
+++ b/library/media-and-entertainment/soccer-goat/internal/cli/helpers.go
@@ -394,6 +394,28 @@ func classifyAPIError(err error, flags *rootFlags) error {
 		return err
 	}
 
+	// A 5xx that survived retries (and, when a source list is configured,
+	// failover across every candidate) means the Transfermarkt data source is
+	// down. Name the source and route the user to a working one instead of
+	// surfacing a raw "returned HTTP 500" string.
+	var apiE *client.APIError
+	isAPIErr := errors.As(err, &apiE)
+	if isAPIErr && apiE.StatusCode >= 500 {
+		classified := apiErr(fmt.Errorf("%w\nhint: the Transfermarkt data source is unavailable (HTTP %d) — it may be down."+
+			"\n      Point at a working instance with --base-url <url> or SOCCER_GOAT_BASE_URL,"+
+			"\n      self-host felipeall/transfermarkt-api, or use --data-source local if you have synced."+
+			"\n      Run 'soccer-goat-pp-cli doctor' to see which sources are reachable.", err, apiE.StatusCode))
+		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
+		return classified
+	}
+
+	// App-level "player/club not found" (a working source returned zero
+	// results) is a genuine 404-class outcome, not an upstream failure. Map it
+	// to exit 3 so it is never misread as a 5xx source outage.
+	if !isAPIErr && strings.Contains(err.Error(), "not found:") {
+		return notFoundErr(err)
+	}
+
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):

--- a/library/media-and-entertainment/soccer-goat/internal/cli/helpers.go
+++ b/library/media-and-entertainment/soccer-goat/internal/cli/helpers.go
@@ -394,25 +394,28 @@ func classifyAPIError(err error, flags *rootFlags) error {
 		return err
 	}
 
-	// A 5xx that survived retries (and, when a source list is configured,
-	// failover across every candidate) means the Transfermarkt data source is
-	// down. Name the source and route the user to a working one instead of
-	// surfacing a raw "returned HTTP 500" string.
+	// The Transfermarkt data source is unreachable when either every source
+	// 5xxed (an *APIError carrying a >=500 status) or every source failed at the
+	// transport level (a *client.SourceUnavailableError — DNS, refused,
+	// timeout). Both get the same actionable guidance instead of a raw
+	// "returned HTTP 500" or bare Go dial error.
 	var apiE *client.APIError
 	isAPIErr := errors.As(err, &apiE)
-	if isAPIErr && apiE.StatusCode >= 500 {
-		classified := apiErr(fmt.Errorf("%w\nhint: the Transfermarkt data source is unavailable (HTTP %d) — it may be down."+
+	var srcErr *client.SourceUnavailableError
+	isSourceDown := errors.As(err, &srcErr)
+	if (isAPIErr && apiE.StatusCode >= 500) || isSourceDown {
+		classified := apiErr(fmt.Errorf("%w\nhint: the Transfermarkt data source is unavailable — it may be down or unreachable."+
 			"\n      Point at a working instance with --base-url <url> or SOCCER_GOAT_BASE_URL,"+
 			"\n      self-host felipeall/transfermarkt-api, or use --data-source local if you have synced."+
-			"\n      Run 'soccer-goat-pp-cli doctor' to see which sources are reachable.", err, apiE.StatusCode))
+			"\n      Run 'soccer-goat-pp-cli doctor' to see which sources are reachable.", err))
 		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
 		return classified
 	}
 
 	// App-level "player/club not found" (a working source returned zero
 	// results) is a genuine 404-class outcome, not an upstream failure. Map it
-	// to exit 3 so it is never misread as a 5xx source outage.
-	if !isAPIErr && strings.Contains(err.Error(), "not found:") {
+	// to exit 3 so it is never misread as a source outage.
+	if !isAPIErr && !isSourceDown && strings.Contains(err.Error(), "not found:") {
 		return notFoundErr(err)
 	}
 

--- a/library/media-and-entertainment/soccer-goat/internal/cli/player.go
+++ b/library/media-and-entertainment/soccer-goat/internal/cli/player.go
@@ -46,7 +46,7 @@ func newNovelPlayerCmd(flags *rootFlags) *cobra.Command {
 			ctx := cmd.Context()
 			player, err := agg.ResolvePlayer(ctx, name)
 			if err != nil {
-				return err
+				return classifyAPIError(err, flags)
 			}
 			if novelMachineOutput(cmd.OutOrStdout(), flags) {
 				return printJSONFiltered(cmd.OutOrStdout(), player, flags)

--- a/library/media-and-entertainment/soccer-goat/internal/cli/root.go
+++ b/library/media-and-entertainment/soccer-goat/internal/cli/root.go
@@ -38,6 +38,7 @@ type rootFlags struct {
 	noLearn       bool
 	selectFields  string
 	configPath    string
+	baseURL       string
 	homePath      string
 	profileName   string
 	deliverSpec   string
@@ -190,6 +191,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.PersistentFlags().BoolVar(&flags.plain, "plain", false, "Output as plain tab-separated text")
 	rootCmd.PersistentFlags().BoolVar(&flags.quiet, "quiet", false, "Bare output, one value per line")
 	rootCmd.PersistentFlags().StringVar(&flags.configPath, "config", "", "Config file path")
+	rootCmd.PersistentFlags().StringVar(&flags.baseURL, "base-url", "", "Override the Transfermarkt data source for this run (e.g. a self-hosted or mirror instance); also SOCCER_GOAT_BASE_URL / base_url config. Wins over env, config, and the default source list.")
 	rootCmd.PersistentFlags().StringVar(&flags.homePath, "home", "", "Root directory for config, data, state, and cache files")
 	rootCmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 60*time.Second, "Request timeout")
 	rootCmd.PersistentFlags().BoolVar(&flags.dryRun, "dry-run", false, "Show request without sending")
@@ -535,6 +537,11 @@ func (f *rootFlags) newClient() (*client.Client, error) {
 	cfg, err := config.Load(f.configPath)
 	if err != nil {
 		return nil, configErr(err)
+	}
+	// --base-url wins over env, config, and the default list, collapsing
+	// resolution to that single source (no failover).
+	if strings.TrimSpace(f.baseURL) != "" {
+		cfg.SetBaseURLOverride(f.baseURL)
 	}
 	c := client.New(cfg, f.timeout, f.rateLimit)
 	c.DryRun = f.dryRun

--- a/library/media-and-entertainment/soccer-goat/internal/cli/source_resilience_test.go
+++ b/library/media-and-entertainment/soccer-goat/internal/cli/source_resilience_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/soccer-goat/internal/client"
+)
+
+// wrapAPIError mimics how the report layer surfaces a transport-level HTTP
+// failure: a *client.APIError wrapped with contextual prose.
+func wrapAPIError(status int) error {
+	return fmt.Errorf("transfermarkt player search %q: %w", "someone",
+		&client.APIError{Method: "GET", Path: "/players/search/someone", StatusCode: status, Body: "boom"})
+}
+
+func TestClassifyAPIError_5xxIsFriendlyUpstream(t *testing.T) {
+	for _, status := range []int{500, 502, 503} {
+		got := classifyAPIError(wrapAPIError(status), &rootFlags{})
+		if code := ExitCode(got); code != 5 {
+			t.Fatalf("status %d: exit code = %d, want 5", status, code)
+		}
+		msg := got.Error()
+		if !strings.Contains(msg, "unavailable") || !strings.Contains(msg, "--base-url") {
+			t.Fatalf("status %d: hint missing --base-url/unavailable guidance: %q", status, msg)
+		}
+	}
+}
+
+func TestClassifyAPIError_AppNotFoundIsExit3(t *testing.T) {
+	// The report layer emits a plain (non-APIError) "player not found: X" when a
+	// working source returns zero results. It must map to exit 3, not the 5xx path.
+	got := classifyAPIError(fmt.Errorf("player not found: %s", "nobody"), &rootFlags{})
+	if code := ExitCode(got); code != 3 {
+		t.Fatalf("exit code = %d, want 3", code)
+	}
+	if strings.Contains(got.Error(), "--base-url") {
+		t.Fatalf("not-found must not carry the upstream-down hint: %q", got.Error())
+	}
+}
+
+func TestClassifyAPIError_HTTP404IsExit3(t *testing.T) {
+	got := classifyAPIError(wrapAPIError(404), &rootFlags{})
+	if code := ExitCode(got); code != 3 {
+		t.Fatalf("exit code = %d, want 3", code)
+	}
+}
+
+func TestClassifyAPIError_HTTP429IsExit7(t *testing.T) {
+	got := classifyAPIError(wrapAPIError(429), &rootFlags{})
+	if code := ExitCode(got); code != 7 {
+		t.Fatalf("exit code = %d, want 7", code)
+	}
+}
+
+func TestBaseURLFlagRegistered(t *testing.T) {
+	root := newRootCmd(&rootFlags{})
+	if root.PersistentFlags().Lookup("base-url") == nil {
+		t.Fatal("--base-url persistent flag is not registered")
+	}
+}

--- a/library/media-and-entertainment/soccer-goat/internal/cli/source_resilience_test.go
+++ b/library/media-and-entertainment/soccer-goat/internal/cli/source_resilience_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -27,6 +28,20 @@ func TestClassifyAPIError_5xxIsFriendlyUpstream(t *testing.T) {
 		if !strings.Contains(msg, "unavailable") || !strings.Contains(msg, "--base-url") {
 			t.Fatalf("status %d: hint missing --base-url/unavailable guidance: %q", status, msg)
 		}
+	}
+}
+
+func TestClassifyAPIError_TransportExhaustionIsFriendly(t *testing.T) {
+	// All-sources transport failure surfaces as *client.SourceUnavailableError,
+	// which must get the same exit-5 outage hint as an all-5xx exhaustion.
+	base := fmt.Errorf("transfermarkt player search %q: %w", "someone",
+		&client.SourceUnavailableError{Err: errors.New("dial tcp: connection refused")})
+	got := classifyAPIError(base, &rootFlags{})
+	if code := ExitCode(got); code != 5 {
+		t.Fatalf("exit code = %d, want 5", code)
+	}
+	if msg := got.Error(); !strings.Contains(msg, "unavailable") || !strings.Contains(msg, "--base-url") {
+		t.Fatalf("transport-down hint missing --base-url/unavailable guidance: %q", msg)
 	}
 }
 

--- a/library/media-and-entertainment/soccer-goat/internal/cli/team.go
+++ b/library/media-and-entertainment/soccer-goat/internal/cli/team.go
@@ -47,7 +47,7 @@ func newNovelTeamCmd(flags *rootFlags) *cobra.Command {
 			ctx := cmd.Context()
 			team, err := agg.ResolveTeam(ctx, club)
 			if err != nil {
-				return err
+				return classifyAPIError(err, flags)
 			}
 			if novelMachineOutput(cmd.OutOrStdout(), flags) {
 				return printJSONFiltered(cmd.OutOrStdout(), team, flags)

--- a/library/media-and-entertainment/soccer-goat/internal/client/client.go
+++ b/library/media-and-entertainment/soccer-goat/internal/client/client.go
@@ -70,6 +70,19 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
+// SourceUnavailableError reports that every configured source failed to respond
+// at the transport level (DNS failure, connection refused, timeout) — the
+// all-sources-unreachable case, distinct from an HTTP error (which carries an
+// *APIError). The CLI maps both to the same "data source unavailable" guidance,
+// so failover exhaustion on transport errors is not silently downgraded to a
+// bare Go dial error.
+type SourceUnavailableError struct {
+	Err error
+}
+
+func (e *SourceUnavailableError) Error() string { return e.Err.Error() }
+func (e *SourceUnavailableError) Unwrap() error { return e.Err }
+
 func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {
 	for {
 		start := strings.IndexByte(path, '{')
@@ -596,6 +609,16 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		lastErr, lastStatus = aerr, status
 		if i < len(bases)-1 {
 			fmt.Fprintf(os.Stderr, "source %s unavailable, trying next source (%d/%d)\n", displayBaseHost(base), i+2, len(bases))
+		}
+	}
+	// Every source failed. A 5xx already carries an *APIError (classified
+	// upstream); a transport failure (DNS, refused, timeout) does not, so wrap
+	// it as SourceUnavailableError. Without this the all-sources-unreachable
+	// case would surface as a bare Go dial error instead of the outage hint.
+	if lastErr != nil {
+		var apiE *APIError
+		if !errors.As(lastErr, &apiE) {
+			lastErr = &SourceUnavailableError{Err: lastErr}
 		}
 	}
 	return nil, lastStatus, lastErr

--- a/library/media-and-entertainment/soccer-goat/internal/client/client.go
+++ b/library/media-and-entertainment/soccer-goat/internal/client/client.go
@@ -28,7 +28,15 @@ import (
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
 
 type Client struct {
-	BaseURL    string
+	// BaseURL is the primary (first) candidate source. Kept as the cache-key
+	// and display identity; failover responses are cached under it so a later
+	// identical request served from a mirror still hits the warm cache.
+	BaseURL string
+	// BaseURLs is the ordered candidate list the request path tries in turn,
+	// advancing only when a source fails (5xx after retries, or transport
+	// error) — never on a 4xx/empty answer. A single-value override yields a
+	// one-element list, so failover is a no-op for override users.
+	BaseURLs   []string
 	Config     *config.Config
 	HTTPClient *http.Client
 	DryRun     bool
@@ -36,6 +44,12 @@ type Client struct {
 	cacheDir   string
 	limiter    *cliutil.AdaptiveLimiter
 }
+
+// failoverRetriesPerSource caps per-source retries while candidates remain, so
+// a dead primary fails over quickly instead of exhausting the full exponential
+// backoff before trying the next mirror. The final candidate still gets the
+// full clientMaxRetries() budget.
+const failoverRetriesPerSource = 1
 
 // RequestBaseURL returns the base URL used for requests.
 // Novel commands that build request URLs by hand should use this instead of
@@ -102,8 +116,26 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		cacheDir = filepath.Join(dir, "http")
 	}
 	httpClient := newHTTPClient(timeout, nil)
+	// Resolve the ordered candidate sources. Prefer cfg.BaseURLs (the resolved
+	// list); fall back to the single cfg.BaseURL for older/hand-built configs.
+	// Trailing slashes are trimmed so path concatenation stays clean.
+	candidates := cfg.BaseURLs
+	if len(candidates) == 0 {
+		candidates = []string{cfg.BaseURL}
+	}
+	bases := make([]string, 0, len(candidates))
+	for _, b := range candidates {
+		if b = strings.TrimRight(strings.TrimSpace(b), "/"); b != "" {
+			bases = append(bases, b)
+		}
+	}
+	primary := ""
+	if len(bases) > 0 {
+		primary = bases[0]
+	}
 	c := &Client{
-		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+		BaseURL:    primary,
+		BaseURLs:   bases,
 		Config:     cfg,
 		HTTPClient: httpClient,
 		cacheDir:   cacheDir,
@@ -515,11 +547,6 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if c.Config != nil {
 		endpointVars = c.Config.TemplateVars
 	}
-	targetURL, urlErr := buildURL(c.BaseURL, path, endpointVars)
-	if urlErr != nil {
-		return nil, 0, urlErr
-	}
-
 	var bodyBytes []byte
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -538,12 +565,66 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		return nil, 0, err
 	}
 
-	// Build the request for dry-run display or actual execution
-	if c.DryRun {
-		return c.dryRun(method, targetURL, path, params, bodyBytes, headerOverrides, authHeader)
+	// Failover across candidate sources. Each candidate runs the full
+	// send/retry cycle; a source failure (5xx after retries, or a transport
+	// error) advances to the next, while any definitive answer (2xx, or a
+	// 4xx/429 the server actually returned) returns immediately — a working
+	// source that says "not found" must never trigger failover onto a mirror.
+	bases := c.requestBaseURLs()
+	var lastErr error
+	var lastStatus int
+	for i, base := range bases {
+		targetURL, urlErr := buildURL(base, path, endpointVars)
+		if urlErr != nil {
+			return nil, 0, urlErr
+		}
+		if c.DryRun {
+			// Dry-run previews the primary candidate only; it never dials, so
+			// there is nothing to fail over.
+			return c.dryRun(method, targetURL, path, params, bodyBytes, headerOverrides, authHeader)
+		}
+		maxRetries := clientMaxRetries()
+		if i < len(bases)-1 && maxRetries > failoverRetriesPerSource {
+			// Candidates remain: fail over fast instead of burning the full
+			// exponential backoff on a source that is already down.
+			maxRetries = failoverRetriesPerSource
+		}
+		result, status, aerr, sourceFailed := c.attempt(ctx, method, targetURL, path, params, bodyBytes, headerOverrides, authHeader, maxRetries)
+		if !sourceFailed {
+			return result, status, aerr
+		}
+		lastErr, lastStatus = aerr, status
+		if i < len(bases)-1 {
+			fmt.Fprintf(os.Stderr, "source %s unavailable, trying next source (%d/%d)\n", displayBaseHost(base), i+2, len(bases))
+		}
 	}
+	return nil, lastStatus, lastErr
+}
 
-	maxRetries := clientMaxRetries()
+// requestBaseURLs returns the ordered candidate sources, falling back to the
+// single BaseURL when no list was configured.
+func (c *Client) requestBaseURLs() []string {
+	if len(c.BaseURLs) > 0 {
+		return c.BaseURLs
+	}
+	return []string{c.BaseURL}
+}
+
+// displayBaseHost renders a base URL's host for a stderr failover notice
+// without leaking any path/query. Falls back to the raw value if unparseable.
+func displayBaseHost(base string) string {
+	if u, err := url.Parse(base); err == nil && u.Host != "" {
+		return u.Host
+	}
+	return base
+}
+
+// attempt runs one candidate source through the send/retry cycle. It returns
+// sourceFailed=true only for outcomes that justify trying the next candidate: a
+// transport error after retries, or a 5xx after retries. A success, a 4xx, a
+// retry-exhausted 429, a context cancellation, or a local build error all
+// return sourceFailed=false so the caller stops.
+func (c *Client) attempt(ctx context.Context, method, targetURL, path string, params map[string]string, bodyBytes []byte, headerOverrides map[string]string, authHeader string, maxRetries int) (json.RawMessage, int, error, bool) {
 	var lastErr error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -556,7 +637,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 
 		req, err := http.NewRequestWithContext(ctx, method, targetURL, bodyReader)
 		if err != nil {
-			return nil, 0, fmt.Errorf("creating request: %w", err)
+			return nil, 0, fmt.Errorf("creating request: %w", err), false
 		}
 		if bodyBytes != nil {
 			req.Header.Set("Content-Type", "application/json")
@@ -613,7 +694,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		resp, err := c.HTTPClient.Do(req)
 		if err != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
-				return nil, 0, ctxErr
+				return nil, 0, ctxErr, false
 			}
 			lastErr = fmt.Errorf("%s %s: %w", method, c.displayURL(path, authHeader), c.maskError(err, authHeader))
 			continue
@@ -622,7 +703,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		respBody, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
-			return nil, 0, fmt.Errorf("reading response: %w", err)
+			return nil, 0, fmt.Errorf("reading response: %w", err), false
 		}
 
 		// Success
@@ -638,11 +719,11 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			if isBinaryResponseContentType(resp.Header.Get("Content-Type")) {
 				env, encErr := wrapBinaryResponse(resp.Header.Get("Content-Type"), respBody)
 				if encErr != nil {
-					return nil, 0, encErr
+					return nil, 0, encErr, false
 				}
-				return env, resp.StatusCode, nil
+				return env, resp.StatusCode, nil, false
 			}
-			return json.RawMessage(sanitizeJSONResponse(respBody)), resp.StatusCode, nil
+			return json.RawMessage(sanitizeJSONResponse(respBody)), resp.StatusCode, nil, false
 		}
 
 		if !binaryResponse {
@@ -662,7 +743,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			wait := cliutil.RetryAfter(resp)
 			fmt.Fprintf(os.Stderr, "rate limited, waiting %s (attempt %d/%d, rate adjusted to %.1f req/s)\n", wait, attempt+1, maxRetries, c.limiter.Rate())
 			if err := sleepContext(ctx, wait); err != nil {
-				return nil, 0, err
+				return nil, 0, err, false
 			}
 			lastErr = apiErr
 			continue
@@ -673,17 +754,23 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
 			if err := sleepContext(ctx, wait); err != nil {
-				return nil, 0, err
+				return nil, 0, err, false
 			}
 			lastErr = apiErr
 			continue
 		}
 
-		// Client error or retries exhausted - return the error
-		return nil, resp.StatusCode, apiErr
+		// Terminal outcome for this candidate. A 5xx that survived its retries
+		// is a source failure -> fail over; any 4xx (including a retry-exhausted
+		// 429) is the source answering -> return it, no failover.
+		if resp.StatusCode >= 500 {
+			return nil, resp.StatusCode, apiErr, true
+		}
+		return nil, resp.StatusCode, apiErr, false
 	}
 
-	return nil, 0, lastErr
+	// Retries exhausted on transport errors -> source failure, fail over.
+	return nil, 0, lastErr, true
 }
 
 // dryRun prints the outgoing request exactly as the live path would send it,

--- a/library/media-and-entertainment/soccer-goat/internal/client/client_failover_test.go
+++ b/library/media-and-entertainment/soccer-goat/internal/client/client_failover_test.go
@@ -167,6 +167,26 @@ func TestFailover_AllSourcesDown(t *testing.T) {
 	}
 }
 
+// TestFailover_AllTransportDown: when every candidate refuses connections, the
+// exhausted error is a *SourceUnavailableError (not a bare dial error), so the
+// CLI layer can surface the same outage hint it gives for all-5xx.
+func TestFailover_AllTransportDown(t *testing.T) {
+	t.Setenv(cliutil.DogfoodEnvVar, "1")
+
+	mkDead := func() string {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		u := s.URL
+		s.Close() // refuses connections
+		return u
+	}
+	c := newFailoverClient(mkDead(), mkDead())
+	_, err := c.Get(context.Background(), "/x", nil)
+	var srcErr *SourceUnavailableError
+	if !errors.As(err, &srcErr) {
+		t.Fatalf("want *SourceUnavailableError after all transport failures, got %T: %v", err, err)
+	}
+}
+
 // TestFailover_SingleSource: a one-element list is a plain single-source client
 // (an override); it is hit exactly once under dogfood and never fans out.
 func TestFailover_SingleSource(t *testing.T) {

--- a/library/media-and-entertainment/soccer-goat/internal/client/client_failover_test.go
+++ b/library/media-and-entertainment/soccer-goat/internal/client/client_failover_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/soccer-goat/internal/cliutil"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/soccer-goat/internal/config"
+)
+
+// newFailoverClient builds a client over an ordered candidate list with the
+// response cache disabled, so tests exercise the wire path deterministically
+// and never touch the real user cache dir.
+func newFailoverClient(bases ...string) *Client {
+	c := New(&config.Config{BaseURLs: bases}, 2*time.Second, 0)
+	c.NoCache = true
+	return c
+}
+
+// TestFailover_5xxThenSuccess: a primary that 5xxes after retries hands off to
+// the next candidate, whose 200 body is returned.
+func TestFailover_5xxThenSuccess(t *testing.T) {
+	t.Setenv(cliutil.DogfoodEnvVar, "1") // 0 retries -> fast, deterministic failover
+
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer down.Close()
+
+	var upHits int32
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&upHits, 1)
+		_, _ = w.Write([]byte(`{"results":[{"id":"1"}]}`))
+	}))
+	defer up.Close()
+
+	c := newFailoverClient(down.URL, up.URL)
+	body, err := c.Get(context.Background(), "/players/search/x", nil)
+	if err != nil {
+		t.Fatalf("expected failover success, got error: %v", err)
+	}
+	var parsed struct {
+		Results []struct {
+			ID string `json:"id"`
+		} `json:"results"`
+	}
+	if jErr := json.Unmarshal(body, &parsed); jErr != nil || len(parsed.Results) != 1 {
+		t.Fatalf("unexpected body %s (err %v)", body, jErr)
+	}
+	if got := atomic.LoadInt32(&upHits); got != 1 {
+		t.Fatalf("secondary hits = %d, want 1", got)
+	}
+}
+
+// TestFailover_4xxDoesNotFailOver: a 4xx is the source answering, not a source
+// failure. It must return immediately without probing the next candidate — a
+// "player not found" must never trigger a mirror sweep.
+func TestFailover_4xxDoesNotFailOver(t *testing.T) {
+	t.Setenv(cliutil.DogfoodEnvVar, "1")
+
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer first.Close()
+
+	var secondHits int32
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&secondHits, 1)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer second.Close()
+
+	c := newFailoverClient(first.URL, second.URL)
+	_, err := c.Get(context.Background(), "/players/search/x", nil)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusNotFound {
+		t.Fatalf("want APIError 404, got %v", err)
+	}
+	if got := atomic.LoadInt32(&secondHits); got != 0 {
+		t.Fatalf("secondary must not be hit on 4xx, hits = %d", got)
+	}
+}
+
+// TestFailover_200EmptyDoesNotFailOver: a 200 with an empty result set is a
+// working source answering, not a failure — return it, do not fail over.
+func TestFailover_200EmptyDoesNotFailOver(t *testing.T) {
+	t.Setenv(cliutil.DogfoodEnvVar, "1")
+
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer first.Close()
+
+	var secondHits int32
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&secondHits, 1)
+		_, _ = w.Write([]byte(`{"results":[{"id":"9"}]}`))
+	}))
+	defer second.Close()
+
+	c := newFailoverClient(first.URL, second.URL)
+	body, err := c.Get(context.Background(), "/players/search/x", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != `{"results":[]}` {
+		t.Fatalf("want primary empty body, got %s", body)
+	}
+	if got := atomic.LoadInt32(&secondHits); got != 0 {
+		t.Fatalf("secondary must not be hit on empty 200, hits = %d", got)
+	}
+}
+
+// TestFailover_TransportErrorThenSuccess: a candidate that refuses connections
+// is a source failure — fail over to the next candidate.
+func TestFailover_TransportErrorThenSuccess(t *testing.T) {
+	t.Setenv(cliutil.DogfoodEnvVar, "1")
+
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close() // now refuses connections -> transport error
+
+	var upHits int32
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&upHits, 1)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer up.Close()
+
+	c := newFailoverClient(deadURL, up.URL)
+	if _, err := c.Get(context.Background(), "/x", nil); err != nil {
+		t.Fatalf("expected failover past transport error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&upHits); got != 1 {
+		t.Fatalf("secondary hits = %d, want 1", got)
+	}
+}
+
+// TestFailover_AllSourcesDown: when every candidate 5xxes, the last error is
+// returned as a >=500 APIError (which the CLI layer maps to the friendly hint).
+func TestFailover_AllSourcesDown(t *testing.T) {
+	t.Setenv(cliutil.DogfoodEnvVar, "1")
+
+	mk := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}))
+	}
+	s1, s2 := mk(), mk()
+	defer s1.Close()
+	defer s2.Close()
+
+	c := newFailoverClient(s1.URL, s2.URL)
+	_, err := c.Get(context.Background(), "/x", nil)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode < 500 {
+		t.Fatalf("want >=500 APIError after exhausting sources, got %v", err)
+	}
+}
+
+// TestFailover_SingleSource: a one-element list is a plain single-source client
+// (an override); it is hit exactly once under dogfood and never fans out.
+func TestFailover_SingleSource(t *testing.T) {
+	t.Setenv(cliutil.DogfoodEnvVar, "1")
+
+	var hits int32
+	only := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer only.Close()
+
+	c := newFailoverClient(only.URL)
+	_, err := c.Get(context.Background(), "/x", nil)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("single source hit count = %d, want 1 (0 retries under dogfood)", got)
+	}
+}

--- a/library/media-and-entertainment/soccer-goat/internal/config/config.go
+++ b/library/media-and-entertainment/soccer-goat/internal/config/config.go
@@ -13,8 +13,22 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
+// defaultBaseURLs is the compiled fallback list of Transfermarkt data sources,
+// tried in order. The upstream reference deployment leads; the community
+// mirrors are failover targets for when it 5xxes (its scraper backend has had
+// multi-day outages). All three run the same felipeall/transfermarkt-api code,
+// so the response shape is identical. This list is a best-effort convenience,
+// not an availability guarantee — the durable path is self-hosting and pointing
+// --base-url / SOCCER_GOAT_BASE_URL at your own instance.
+var defaultBaseURLs = []string{
+	"https://transfermarkt-api.fly.dev",        // upstream reference deployment
+	"https://transfermarkt-api.up.railway.app", // community mirror (failover)
+	"https://transfermarkt-api.onrender.com",   // community mirror (failover)
+}
+
 type Config struct {
 	BaseURL       string            `toml:"base_url"`
+	BaseURLs      []string          `toml:"base_urls,omitempty"`
 	AuthHeaderVal string            `toml:"auth_header"`
 	Headers       map[string]string `toml:"headers,omitempty"`
 	AuthSource    string            `toml:"-"`
@@ -29,9 +43,9 @@ type Config struct {
 }
 
 func Load(configPath string) (*Config, error) {
-	cfg := &Config{
-		BaseURL: "https://transfermarkt-api.fly.dev",
-	}
+	// BaseURL/BaseURLs start empty so resolveBaseURLs() can tell an explicit
+	// file/env override apart from the compiled default (which it applies last).
+	cfg := &Config{}
 
 	// Resolve config path
 	path, explicitConfigFile, err := resolveConfigPath(configPath)
@@ -77,10 +91,14 @@ func Load(configPath string) (*Config, error) {
 
 	// Env var overrides
 
-	// Base URL override (used by printing-press verify to point at mock/test servers)
-	if v := os.Getenv("SOCCER_GOAT_BASE_URL"); v != "" {
-		cfg.BaseURL = v
-	}
+	// Resolve the ordered Transfermarkt base-URL candidates. Honors the
+	// SOCCER_GOAT_BASE_URL / base_url single-source overrides (also the
+	// printing-press verify hook that points at a mock server) and the
+	// SOCCER_GOAT_BASE_URLS / base_urls list forms, falling back to the
+	// compiled default list. The --base-url flag is layered on later, in the
+	// CLI's newClient(). Runs after snapshotFileConfig so a later save() would
+	// persist the file's original values, not these resolved defaults.
+	cfg.resolveBaseURLs()
 
 	// Endpoint template vars: resolve each {placeholder} in BaseURL or the
 	// GraphQL path against the matching env var. Populated even when values
@@ -140,6 +158,64 @@ func parseConfigData(data []byte, cfg *Config, path string, owner string) error 
 		return fmt.Errorf("parsing %s %s: %w", owner, path, err)
 	}
 	return nil
+}
+
+// resolveBaseURLs computes the ordered list of Transfermarkt base URLs the
+// client will try, honoring this precedence:
+//
+//  1. SOCCER_GOAT_BASE_URL env  -> single source (no failover)
+//  2. base_url config key       -> single source (no failover)
+//  3. SOCCER_GOAT_BASE_URLS env -> ordered list (comma-separated)
+//  4. base_urls config key      -> ordered list
+//  5. compiled defaultBaseURLs  -> ordered list
+//
+// A single-value override collapses resolution to exactly that one source, so
+// "point at my instance" never silently falls back to a public mirror. The
+// list forms enable lazy failover in the client. c.BaseURL is always set to the
+// primary (first) candidate so existing readers keep working unchanged.
+func (c *Config) resolveBaseURLs() {
+	if env := strings.TrimSpace(os.Getenv("SOCCER_GOAT_BASE_URL")); env != "" {
+		c.BaseURL = env
+		c.BaseURLs = []string{env}
+		return
+	}
+	if single := strings.TrimSpace(c.BaseURL); single != "" {
+		c.BaseURL = single
+		c.BaseURLs = []string{single}
+		return
+	}
+	if env := strings.TrimSpace(os.Getenv("SOCCER_GOAT_BASE_URLS")); env != "" {
+		c.BaseURLs = splitBaseURLs(env)
+	} else if len(c.BaseURLs) == 0 {
+		c.BaseURLs = append([]string(nil), defaultBaseURLs...)
+	}
+	if len(c.BaseURLs) > 0 {
+		c.BaseURL = c.BaseURLs[0]
+	}
+}
+
+// SetBaseURLOverride collapses resolution to a single source. The CLI calls it
+// from newClient() when --base-url is passed, so the flag wins over env, config,
+// and the default list.
+func (c *Config) SetBaseURLOverride(url string) {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return
+	}
+	c.BaseURL = url
+	c.BaseURLs = []string{url}
+}
+
+// splitBaseURLs parses a comma-separated base-URL list, trimming blanks.
+func splitBaseURLs(csv string) []string {
+	parts := strings.Split(csv, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func (c *Config) AuthHeader() string {

--- a/library/media-and-entertainment/soccer-goat/internal/config/config_test.go
+++ b/library/media-and-entertainment/soccer-goat/internal/config/config_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// clearBaseURLEnv wipes both base-URL env vars for a hermetic resolution test.
+func clearBaseURLEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("SOCCER_GOAT_BASE_URL", "")
+	t.Setenv("SOCCER_GOAT_BASE_URLS", "")
+}
+
+func TestResolveBaseURLs_DefaultList(t *testing.T) {
+	clearBaseURLEnv(t)
+	c := &Config{}
+	c.resolveBaseURLs()
+	if !reflect.DeepEqual(c.BaseURLs, defaultBaseURLs) {
+		t.Fatalf("BaseURLs = %v, want default %v", c.BaseURLs, defaultBaseURLs)
+	}
+	if c.BaseURL != defaultBaseURLs[0] {
+		t.Fatalf("primary BaseURL = %q, want %q", c.BaseURL, defaultBaseURLs[0])
+	}
+}
+
+func TestResolveBaseURLs_EnvSingleBeatsEnvList(t *testing.T) {
+	t.Setenv("SOCCER_GOAT_BASE_URL", "https://single.example")
+	t.Setenv("SOCCER_GOAT_BASE_URLS", "https://a.example,https://b.example")
+	c := &Config{}
+	c.resolveBaseURLs()
+	if want := []string{"https://single.example"}; !reflect.DeepEqual(c.BaseURLs, want) {
+		t.Fatalf("BaseURLs = %v, want %v (single env override collapses to one source)", c.BaseURLs, want)
+	}
+}
+
+func TestResolveBaseURLs_FileSingle(t *testing.T) {
+	clearBaseURLEnv(t)
+	c := &Config{BaseURL: "https://file.example"}
+	c.resolveBaseURLs()
+	if want := []string{"https://file.example"}; !reflect.DeepEqual(c.BaseURLs, want) {
+		t.Fatalf("BaseURLs = %v, want %v", c.BaseURLs, want)
+	}
+}
+
+func TestResolveBaseURLs_EnvList(t *testing.T) {
+	t.Setenv("SOCCER_GOAT_BASE_URL", "")
+	t.Setenv("SOCCER_GOAT_BASE_URLS", "https://a.example, https://b.example ,https://c.example")
+	c := &Config{}
+	c.resolveBaseURLs()
+	want := []string{"https://a.example", "https://b.example", "https://c.example"}
+	if !reflect.DeepEqual(c.BaseURLs, want) {
+		t.Fatalf("BaseURLs = %v, want %v", c.BaseURLs, want)
+	}
+	if c.BaseURL != "https://a.example" {
+		t.Fatalf("primary = %q, want first list entry", c.BaseURL)
+	}
+}
+
+func TestResolveBaseURLs_FileList(t *testing.T) {
+	clearBaseURLEnv(t)
+	c := &Config{BaseURLs: []string{"https://a.example", "https://b.example"}}
+	c.resolveBaseURLs()
+	want := []string{"https://a.example", "https://b.example"}
+	if !reflect.DeepEqual(c.BaseURLs, want) {
+		t.Fatalf("BaseURLs = %v, want %v", c.BaseURLs, want)
+	}
+	if c.BaseURL != "https://a.example" {
+		t.Fatalf("primary = %q, want first file-list entry", c.BaseURL)
+	}
+}
+
+func TestSetBaseURLOverride_WinsOverList(t *testing.T) {
+	c := &Config{BaseURLs: append([]string(nil), defaultBaseURLs...)}
+	c.SetBaseURLOverride("  https://flag.example  ")
+	if want := []string{"https://flag.example"}; !reflect.DeepEqual(c.BaseURLs, want) {
+		t.Fatalf("BaseURLs = %v, want %v", c.BaseURLs, want)
+	}
+	if c.BaseURL != "https://flag.example" {
+		t.Fatalf("primary = %q, want the override", c.BaseURL)
+	}
+}
+
+func TestSetBaseURLOverride_EmptyIsNoop(t *testing.T) {
+	c := &Config{BaseURLs: []string{"https://keep.example"}, BaseURL: "https://keep.example"}
+	c.SetBaseURLOverride("   ")
+	if c.BaseURL != "https://keep.example" {
+		t.Fatalf("empty override should be a no-op, got %q", c.BaseURL)
+	}
+}
+
+func TestSplitBaseURLs(t *testing.T) {
+	got := splitBaseURLs("https://a.example, ,https://b.example,")
+	want := []string{"https://a.example", "https://b.example"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("splitBaseURLs = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## soccer-goat: source resilience

`soccer-goat-pp-cli` was pinned to one hardcoded Transfermarkt data source (`https://transfermarkt-api.fly.dev`). When that instance's scraper backend 5xxes — as it has for multi-day stretches — every command whose spine is Transfermarkt (`player`, `team`, `compare`) dies with a raw `HTTP 500` and no recovery path. This PR makes the data source swappable and resilient.

**API:** Transfermarkt (`felipeall/transfermarkt-api`) | **Category:** media-and-entertainment

### What changed
- **`--base-url` flag** (plus `SOCCER_GOAT_BASE_URL` env and the existing `base_url` config key, now documented) to point at any instance. Precedence: `--base-url` > `SOCCER_GOAT_BASE_URL` > `base_url` > `SOCCER_GOAT_BASE_URLS` > `base_urls` > compiled default list. A single-value override collapses to exactly one source (no failover).
- **Ordered fallback list with lazy failover** (`base_urls` / `SOCCER_GOAT_BASE_URLS`, plus a refreshed compiled default). The client advances to the next candidate only on a 5xx-after-retries or a transport error — never on a 4xx or an empty answer, so a "player not found" is returned as-is and never triggers a mirror sweep. Failover is fast: per-source retries are reduced while candidates remain, and the final candidate keeps the full retry budget.
- **`doctor` per-source health** — a `Sources` block probes every configured instance (`/players/search/...`, a real signal, since the reference deployment 307s on `/` even while search 5xxes) and reports which are reachable.
- **Friendly exhaustion error** — when every source is down, `player`/`team`/`compare` exit `5` with an actionable hint (`--base-url`, self-hosting, `--data-source local`, `doctor`) via a new 5xx case in `classifyAPIError`. App-level "not found" stays exit `3`.
- **Docs + reprint-guard** — README/SKILL document the override and self-hosting `felipeall/transfermarkt-api`; a `.printing-press-patches/` entry records the durable contract and flags the single-hardcoded-base-URL pattern as generator-shaped (worth a parallel `cli-printing-press` template fix).

Graceful partial degradation (returning EA/ESPN when the value source is down) is intentionally **out of scope** — a working market-value source is the goal, not a valueless partial report.

### Validation
| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS (+19 new tests: failover matrix, base-URL precedence, error classification) |
| `govulncheck ./...` | PASS (no vulnerabilities) |
| `verify_skill.py --dir library/media-and-entertainment/soccer-goat/` | PASS |
| Live: default-list failover while `fly.dev` is 500ing | `player "Jhon Duran"` → €15.00m via a mirror |
| Live: single dead `--base-url` | exit 5 + actionable hint, no fan-out |
| Live: `doctor` | primary FAIL (HTTP 500), mirrors OK |
