### PR TITLE
fix(table-reservation-goat): recover a lost Tock confirm click and report accurate checkout dialog state

### DIFF
--- a/library/food-and-dining/table-reservation-goat/.printing-press-patches/tock-confirm-click-recovery-and-interstitial-diagnostics.json
+++ b/library/food-and-dining/table-reservation-goat/.printing-press-patches/tock-confirm-click-recovery-and-interstitial-diagnostics.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "tock-confirm-click-recovery-and-interstitial-diagnostics",
+  "applied_at": "2026-07-20",
+  "base_run_id": "20260712-223206",
+  "base_printing_press_version": "4.28.0",
+  "summary": "Preserve Tock checkout confirmation delivery with one shared retry after a proven dialog-free idle interval, while retaining uncapped semantic interstitial and confirm-occlusion diagnostics.",
+  "reason": "Tock checkout can lose a trusted confirm click or interpose a text-alert dialog whose controls fall beyond the capped diagnostic label list. A reprint must retain fresh-coordinate retry delivery, the single retry ceiling shared with post-dismissal recovery, fail-closed opt-out handling, and semantic state probes that distinguish an idle checkout from a blocking dialog.",
+  "files": [
+    "internal/source/tock/chrome_book.go",
+    "internal/source/tock/chrome_book_test.go"
+  ],
+  "validated_outcome": "Fixture coverage guards semantic and legacy dialog detection, uncapped Skip diagnostics, delayed dialog dismissal, lost-click recovery, shared retry exclusivity, confirm occlusion, fail-closed modal selection, and receipt survey acceptance."
+}

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book.go
@@ -457,8 +457,16 @@ const tockCheckoutPageStateJS = `
 			const r = el.getBoundingClientRect();
 			return r.width > 0 && r.height > 0;
 		};
+		const labelledByText = (el) => {
+			const ids = (el.getAttribute('aria-labelledby') || '').split(/\s+/).filter(Boolean);
+			return ids
+				.map((id) => { const ref = document.getElementById(id); return ref ? ref.textContent : ''; })
+				.join(' ');
+		};
+		// Accessible-name precedence: aria-labelledby, aria-label, contents,
+		// title — mirroring how assistive tech names the control.
 		const accessibleName = (el) => clean(
-			el.getAttribute('aria-label') || el.textContent || el.getAttribute('title')
+			labelledByText(el) || el.getAttribute('aria-label') || el.textContent || el.getAttribute('title')
 		);
 		const allControls = Array.from(document.querySelectorAll('button, a, [role="button"]'));
 		const confirm = Array.from(document.querySelectorAll('button[type="submit"], button'))
@@ -1735,8 +1743,14 @@ func waitForReceiptThroughDialogsWithRetry(ctx context.Context, deadline time.Du
 	retryClick func(context.Context) error) (string, error) {
 	stop := time.Now().Add(deadline)
 	retryUsed := false
-	dialogDismissed := false
+	dismissals := 0
 	var idleSince time.Time
+	// Each confirm click can raise a fresh recognized dialog (the retry
+	// click re-opens the text-alert prompt), so dismissal stays armed for
+	// the whole wait instead of stopping after the first success. The cap
+	// keeps a dialog that survives its own dismissal from being clicked
+	// forever.
+	const maxDismissals = 3
 	for {
 		var loc string
 		if err := chromedp.Location(&loc).Do(ctx); err == nil {
@@ -1766,12 +1780,12 @@ func waitForReceiptThroughDialogsWithRetry(ctx context.Context, deadline time.Du
 			idleSince = time.Time{}
 		}
 
-		if !dialogDismissed {
+		if dismissals < maxDismissals {
 			clicked, err := dismiss(ctx)
 			switch {
 			case err == nil:
 				if clicked {
-					dialogDismissed = true
+					dismissals++
 					idleSince = time.Time{}
 				}
 			case isTransientNavigationError(err):
@@ -1793,7 +1807,13 @@ func waitForReceiptThroughDialogsWithRetry(ctx context.Context, deadline time.Du
 			checkoutState.ConfirmControlPresent && checkoutState.ConfirmControlEnabled &&
 			!checkoutState.ConfirmOccluded {
 			retryUsed = true
-			_ = retryClick(ctx)
+			// Bound the click by the receipt deadline: clickPlaceReservation
+			// polls a disabled control for up to 15s, and a click dispatched
+			// after the deadline would be reported as a timeout while the
+			// booking is still taking effect.
+			retryCtx, cancelRetry := context.WithDeadline(ctx, stop)
+			_ = retryClick(retryCtx)
+			cancelRetry()
 		}
 		select {
 		case <-ctx.Done():
@@ -1819,8 +1839,17 @@ func dismissPostConfirmDialog(ctx context.Context) (bool, error) {
 				const r = el.getBoundingClientRect();
 				return r.width > 0 && r.height > 0;
 			};
+			const labelledByText = (el) => {
+				const ids = (el.getAttribute('aria-labelledby') || '').split(/\s+/).filter(Boolean);
+				return ids
+					.map((id) => { const ref = document.getElementById(id); return ref ? ref.textContent : ''; })
+					.join(' ');
+			};
+			// Accessible-name precedence: aria-labelledby, aria-label,
+			// contents, title — a Skip named only through a referenced label
+			// must still be selectable.
 			const label = (el) => clean(
-				el.getAttribute('aria-label') || el.textContent || el.getAttribute('title')
+				labelledByText(el) || el.getAttribute('aria-label') || el.textContent || el.getAttribute('title')
 			);
 			const controls = (host) => Array.from(
 				host.querySelectorAll('button, a, [role="button"]')

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book.go
@@ -436,12 +436,63 @@ type tockCheckoutPageState struct {
 	Path                   string   `json:"path"`
 	ConfirmControlPresent  bool     `json:"confirm_control_present"`
 	ConfirmControlEnabled  bool     `json:"confirm_control_enabled"`
+	ConfirmOccluded        bool     `json:"confirm_occluded"`
+	DialogPresent          bool     `json:"dialog_present"`
+	SkipControlPresent     bool     `json:"skip_control_present"`
 	HasCVCField            bool     `json:"has_cvc_field"`
 	CheckboxCount          int      `json:"checkbox_count"`
 	RequiredUncheckedCount int      `json:"required_unchecked_count"`
 	SMSDialogPresent       bool     `json:"sms_dialog_present"`
 	VisibleControlLabels   []string `json:"visible_control_labels,omitempty"`
 }
+
+const tockCheckoutPageStateJS = `
+	(() => {
+		const dlgText = /stay in the know|text confirmation and updates|receive text|text alerts/i;
+		const clean = (s) => (s || '').replace(/\s+/g, ' ').trim();
+		const rendered = (el) => {
+			if (!el || !el.isConnected || el.closest('[aria-hidden="true"]')) return false;
+			const style = getComputedStyle(el);
+			if (style.display === 'none' || style.visibility === 'hidden') return false;
+			const r = el.getBoundingClientRect();
+			return r.width > 0 && r.height > 0;
+		};
+		const accessibleName = (el) => clean(
+			el.getAttribute('aria-label') || el.textContent || el.getAttribute('title')
+		);
+		const allControls = Array.from(document.querySelectorAll('button, a, [role="button"]'));
+		const confirm = Array.from(document.querySelectorAll('button[type="submit"], button'))
+			.find((el) => rendered(el) && /reservation|book|complete|confirm/i.test(accessibleName(el)));
+		const semanticDialogs = Array.from(document.querySelectorAll('dialog, [role="dialog"], [aria-modal]'))
+			.filter((host) => rendered(host) && dlgText.test(clean(host.textContent)));
+		const skipPresent = allControls.some((el) => rendered(el) && accessibleName(el) === 'Skip');
+		let confirmOccluded = false;
+		if (confirm) {
+			const r = confirm.getBoundingClientRect();
+			const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+			confirmOccluded = !hit || (hit !== confirm && !confirm.contains(hit));
+		}
+		const checkboxes = Array.from(document.querySelectorAll('input[type="checkbox"]'));
+		const legacySMS = Array.from(document.querySelectorAll(
+			'[data-testid="sms-confirmation-dialog-content"], #sms-confirmation-dialog-content'
+		)).some(rendered);
+		const controls = allControls.map(accessibleName).filter(Boolean).slice(0, 16);
+		return {
+			path: location.pathname,
+			confirm_control_present: Boolean(confirm),
+			confirm_control_enabled: Boolean(confirm && !confirm.disabled && confirm.getAttribute('aria-disabled') !== 'true'),
+			confirm_occluded: confirmOccluded,
+			dialog_present: semanticDialogs.length > 0,
+			skip_control_present: skipPresent,
+			has_cvc_field: Boolean(Array.from(document.querySelectorAll('input'))
+				.find((i) => /cvc|cvv|security/i.test((i.placeholder || '') + (i.name || '') + (i.id || '')))),
+			checkbox_count: checkboxes.length,
+			required_unchecked_count: checkboxes.filter((el) => el.required && !el.checked).length,
+			sms_dialog_present: legacySMS || semanticDialogs.length > 0,
+			visible_control_labels: controls
+		};
+	})()
+`
 
 func clickComboboxExperienceLayoutWithRetry(ctx context.Context, venueURL, displayTime, isoDate string, partySize, experienceID int) (context.Context, context.CancelFunc, error) {
 	if err := clickComboboxExperienceLayout(ctx, displayTime, isoDate, partySize, experienceID); err != nil {
@@ -1602,34 +1653,19 @@ func mustMarshalTockPageState(state any) string {
 // arrives: a query-free path, allowlisted controls, and boolean/count state for
 // confirmation, SMS, checkbox, and CVC inputs.
 func checkoutPageStateHint(ctx context.Context) string {
-	js := `
-		(() => {
-			const clean = (s) => (s || '').replace(/\s+/g, ' ').trim();
-			const controls = Array.from(document.querySelectorAll('button, a, [role="button"]'))
-				.map((el) => clean(el.textContent || el.getAttribute('aria-label'))).filter(Boolean).slice(0, 16);
-			const confirm = Array.from(document.querySelectorAll('button[type="submit"], button'))
-				.find((el) => /reservation|book|complete|confirm/i.test(clean(el.textContent || el.getAttribute('aria-label'))));
-			const checkboxes = Array.from(document.querySelectorAll('input[type="checkbox"]'));
-			return {
-				path: location.pathname,
-				confirm_control_present: Boolean(confirm),
-				confirm_control_enabled: Boolean(confirm && !confirm.disabled && confirm.getAttribute('aria-disabled') !== 'true'),
-				has_cvc_field: Boolean(Array.from(document.querySelectorAll('input'))
-					.find((i) => /cvc|cvv|security/i.test((i.placeholder || '') + (i.name || '') + (i.id || '')))),
-				checkbox_count: checkboxes.length,
-				required_unchecked_count: checkboxes.filter((el) => el.required && !el.checked).length,
-				sms_dialog_present: Boolean(document.querySelector('[data-testid="sms-confirmation-dialog-content"], #sms-confirmation-dialog-content')),
-				visible_control_labels: controls
-			};
-		})()
-	`
-	var state tockCheckoutPageState
-	if err := chromedp.Run(ctx, chromedp.Evaluate(js, &state)); err != nil {
+	state, err := readTockCheckoutPageState(ctx)
+	if err != nil {
 		return `{"path":"<unavailable>"}`
 	}
 	state.Path = sanitizeTockPath(state.Path)
 	state.VisibleControlLabels = normalizeTockControlLabels(state.VisibleControlLabels)
 	return mustMarshalTockPageState(state)
+}
+
+func readTockCheckoutPageState(ctx context.Context) (tockCheckoutPageState, error) {
+	var state tockCheckoutPageState
+	err := chromedp.Run(ctx, chromedp.Evaluate(tockCheckoutPageStateJS, &state))
+	return state, err
 }
 
 // waitForCheckoutPage polls for the URL containing /checkout/confirm-purchase.
@@ -1691,9 +1727,16 @@ func waitForReceiptThroughDialogs(ctx context.Context, deadline time.Duration) (
 
 func waitForReceiptThroughDialogsWith(ctx context.Context, deadline time.Duration,
 	dismiss func(context.Context) (bool, error)) (string, error) {
+	return waitForReceiptThroughDialogsWithRetry(ctx, deadline, dismiss, 5*time.Second, clickPlaceReservation)
+}
+
+func waitForReceiptThroughDialogsWithRetry(ctx context.Context, deadline time.Duration,
+	dismiss func(context.Context) (bool, error), retryDelay time.Duration,
+	retryClick func(context.Context) error) (string, error) {
 	stop := time.Now().Add(deadline)
-	reclicked := false
-	var dismissedAt time.Time
+	retryUsed := false
+	dialogDismissed := false
+	var idleSince time.Time
 	for {
 		var loc string
 		if err := chromedp.Location(&loc).Do(ctx); err == nil {
@@ -1701,12 +1744,35 @@ func waitForReceiptThroughDialogsWith(ctx context.Context, deadline time.Duratio
 				return loc, nil
 			}
 		}
-		if dismissedAt.IsZero() {
+		// Once the receipt deadline has elapsed, do not dispatch another
+		// booking-affecting click and then report a timeout while that click is
+		// still taking effect.
+		if time.Now().After(stop) {
+			return "", fmt.Errorf("receipt page never reached within %s", deadline)
+		}
+
+		var checkoutState tockCheckoutPageState
+		stateOK := false
+		if strings.Contains(loc, "/checkout/") {
+			var err error
+			checkoutState, err = readTockCheckoutPageState(ctx)
+			stateOK = err == nil
+			if !stateOK || checkoutState.DialogPresent {
+				idleSince = time.Time{}
+			} else if idleSince.IsZero() {
+				idleSince = time.Now()
+			}
+		} else {
+			idleSince = time.Time{}
+		}
+
+		if !dialogDismissed {
 			clicked, err := dismiss(ctx)
 			switch {
 			case err == nil:
 				if clicked {
-					dismissedAt = time.Now()
+					dialogDismissed = true
+					idleSince = time.Time{}
 				}
 			case isTransientNavigationError(err):
 				// The confirm click can win the race: the page navigates to
@@ -1719,18 +1785,15 @@ func waitForReceiptThroughDialogsWith(ctx context.Context, deadline time.Duratio
 				return "", fmt.Errorf("dismissing post-confirm dialog: %w", err)
 			}
 		}
-		// If the dialog intercepted the original submission, the checkout
-		// page sits idle after the dismissal — re-arm the confirm click
-		// once. clickPlaceReservation only clicks an enabled control, so a
-		// submission already in flight (button disabled/gone) is not
-		// double-fired.
-		if !dismissedAt.IsZero() && !reclicked && time.Since(dismissedAt) > 4*time.Second &&
-			strings.Contains(loc, "/checkout/") {
-			reclicked = true
-			_ = clickPlaceReservation(ctx)
-		}
-		if time.Now().After(stop) {
-			return "", fmt.Errorf("receipt page never reached within %s", deadline)
+		// A checkout that remains idle without a dialog may have lost the
+		// initial trusted click, or may be idle after a dismissed dialog.
+		// Both paths share this one retry token. The dialog-free interval is
+		// restarted whenever a dialog appears or is dismissed.
+		if !retryUsed && stateOK && !idleSince.IsZero() && time.Since(idleSince) >= retryDelay &&
+			checkoutState.ConfirmControlPresent && checkoutState.ConfirmControlEnabled &&
+			!checkoutState.ConfirmOccluded {
+			retryUsed = true
+			_ = retryClick(ctx)
 		}
 		select {
 		case <-ctx.Done():
@@ -1741,88 +1804,57 @@ func waitForReceiptThroughDialogsWith(ctx context.Context, deadline time.Duratio
 }
 
 // dismissPostConfirmDialog finds a blocking post-confirm dialog and clicks
-// its decline/close control with a trusted CDP click. Returns whether a
-// control was clicked. Only decline-flavored controls or an explicit close
-// are used — never an accept/opt-in or ambiguous lone control.
+// its decline control with a trusted CDP click. Returns whether a control was
+// clicked. Accept controls and ambiguous modal stacks are left untouched.
 func dismissPostConfirmDialog(ctx context.Context) (bool, error) {
 	js := `
 		(() => {
-			const dlgText = /stay in the know|text confirmation and updates|receive text/i;
+			const dlgText = /stay in the know|text confirmation and updates|receive text|text alerts/i;
 			const declRE = /no thanks|not now|skip|maybe later|decline|continue without/i;
 			const clean = (s) => (s || '').replace(/\s+/g, ' ').trim();
-			const visible = (el) => {
+			const rendered = (el) => {
+				if (!el || !el.isConnected || el.closest('[aria-hidden="true"]')) return false;
+				const style = getComputedStyle(el);
+				if (style.display === 'none' || style.visibility === 'hidden') return false;
 				const r = el.getBoundingClientRect();
 				return r.width > 0 && r.height > 0;
 			};
-			const label = (el) => clean([
-				el.textContent,
-				el.getAttribute('aria-label'),
-				el.getAttribute('title'),
-			].filter(Boolean).join(' '));
+			const label = (el) => clean(
+				el.getAttribute('aria-label') || el.textContent || el.getAttribute('title')
+			);
 			const controls = (host) => Array.from(
 				host.querySelectorAll('button, a, [role="button"]')
-			).filter(visible);
-			const declineIn = (host) => {
+			).filter(rendered);
+			const declineIn = (host, legacy) => {
 				const candidates = controls(host);
-				// Proven live Tock DOM (2026-07-09). Prefer the explicit opt-out
-				// control before applying the provider-agnostic fallback below.
-				const exact = candidates.find((el) => el.getAttribute('data-testid') === 'sms-skip-button');
-				if (exact) return exact;
-				const decline = candidates.find((el) => declRE.test(label(el)));
-				if (decline) return decline;
-				const close = candidates.find((el) => /close|dismiss/i.test(
-					clean(el.getAttribute('aria-label') || el.getAttribute('title'))
-				));
-				if (close) return close;
-				return null;
+				if (legacy) return candidates.find((el) => declRE.test(label(el))) || null;
+				return candidates.find((el) => label(el) === 'Skip') || null;
 			};
-			if (!dlgText.test((document.body && document.body.innerText) || '')) return '';
-
-			// Tock portals this Material UI dialog directly under <body>. The
-			// matching alert content and the action buttons are siblings inside
-			// role="dialog", so searching only the alert's nearby descendants
-			// cannot see the opt-out action.
-			const hosts = [];
-			const addHost = (host) => {
-				if (host && !hosts.includes(host)) hosts.push(host);
-			};
-			const smsContent = document.querySelector(
-				'[data-testid="sms-confirmation-dialog-content"], #sms-confirmation-dialog-content'
-			);
-			addHost(smsContent && smsContent.closest('dialog, [role="dialog"]'));
-			for (const dialog of document.querySelectorAll('dialog, [role="dialog"]')) {
-				if (dlgText.test(clean(dialog.textContent)) || /text alerts|sms/i.test(label(dialog))) {
-					addHost(dialog);
-				}
-			}
-
-			let best = null;
-			for (const el of Array.from(document.querySelectorAll('body *'))) {
-				if (el.children.length > 30) continue;
-				const t = clean(el.textContent);
-				if (!dlgText.test(t) || t.length > 1500) continue;
-				if (best === null || t.length < clean(best.textContent).length) best = el;
-			}
-			if (!best) return '';
-			addHost(best.closest('dialog, [role="dialog"]'));
-
-			// Generic fallback for providers/layouts without dialog semantics:
-			// walk all the way from the matching copy toward <body>, because
-			// actions may live in a sibling section under a higher ancestor.
-			for (let host = best; host && host !== document.body; host = host.parentElement) {
-				addHost(host);
-			}
-			for (const host of hosts) {
-				const decline = declineIn(host);
-				if (!decline) continue;
-				decline.scrollIntoView({ block: 'center' });
+			const hosts = Array.from(document.querySelectorAll('dialog, [role="dialog"], [aria-modal]'))
+				.filter((host) => rendered(host) && dlgText.test(clean(host.textContent)));
+			const candidates = hosts.map((host) => {
+				const legacy = Array.from(host.querySelectorAll(
+					'[data-testid="sms-confirmation-dialog-content"], #sms-confirmation-dialog-content'
+				)).some(rendered);
+				return { host, decline: declineIn(host, legacy) };
+			}).filter((candidate) => candidate.decline);
+			if (candidates.length === 0) return '';
+			const hitTestable = ({decline}, scroll) => {
+				if (scroll) decline.scrollIntoView({ block: 'center' });
 				const r = decline.getBoundingClientRect();
-				return JSON.stringify({
-					x: r.x + r.width / 2,
-					y: r.y + r.height / 2,
-				});
+				const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+				return Boolean(hit && (hit === decline || decline.contains(hit)));
+			};
+			let chosen = null;
+			if (candidates.length === 1) {
+				if (hitTestable(candidates[0], true)) chosen = candidates[0];
+			} else {
+				const active = candidates.filter((candidate) => hitTestable(candidate, false));
+				if (active.length === 1 && hitTestable(active[0], true)) chosen = active[0];
 			}
-			return '';
+			if (!chosen) return '';
+			const r = chosen.decline.getBoundingClientRect();
+			return JSON.stringify({ x: r.x + r.width / 2, y: r.y + r.height / 2 });
 		})()
 	`
 	var raw string
@@ -1967,19 +1999,28 @@ func clickPlaceReservation(ctx context.Context) error {
 				b.scrollIntoView({ block: 'center' });
 				b.setAttribute('data-trg-confirm', '1');
 			};
+			const rendered = (b) => {
+				if (!b || !b.isConnected || b.closest('[aria-hidden="true"]')) return false;
+				const style = getComputedStyle(b);
+				if (style.display === 'none' || style.visibility === 'hidden') return false;
+				const r = b.getBoundingClientRect();
+				return r.width > 0 && r.height > 0;
+			};
 			const btns = Array.from(document.querySelectorAll('button'));
+			for (const b of btns) b.removeAttribute('data-trg-confirm');
 			for (const b of btns) {
+				if (!rendered(b)) continue;
 				const t = (b.textContent || '').trim();
 				if (/place reservation|confirm reservation|book now|complete reservation|complete booking/i.test(t)) {
-					if (b.disabled) return 'disabled:' + t;
+					if (b.disabled || b.getAttribute('aria-disabled') === 'true') return 'disabled:' + t;
 					tag(b);
 					return t;
 				}
 			}
 			// Fallback: any visible blue/primary submit button at bottom of form
 			for (const b of btns) {
-				if (b.type === 'submit') {
-					if (b.disabled) return 'disabled:submit';
+				if (rendered(b) && b.type === 'submit') {
+					if (b.disabled || b.getAttribute('aria-disabled') === 'true') return 'disabled:submit';
 					tag(b);
 					return 'submit';
 				}

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book_test.go
@@ -200,6 +200,65 @@ func TestTockBookingPageStateHint_ReportsComboboxControls(t *testing.T) {
 	})
 }
 
+func TestCheckoutPageStateHint_ReportsLegacyAndSemanticDialogs(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+	}{
+		{
+			name: "legacy test id",
+			html: `<!doctype html><div role="dialog" style="padding:20px">
+				<div data-testid="sms-confirmation-dialog-content">Stay in the know about your table</div>
+				<button data-testid="sms-skip-button">Skip</button></div>`,
+		},
+		{
+			name: "semantic text alerts",
+			html: `<!doctype html><div role="dialog" aria-modal="true" style="padding:20px">
+				<h2>Enable text alerts from Tock</h2><button>Skip</button></div>`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withTockDOMFixture(t, tc.html, func(ctx context.Context) {
+				hint := checkoutPageStateHint(ctx)
+				for _, want := range []string{
+					`"dialog_present":true`,
+					`"skip_control_present":true`,
+					`"sms_dialog_present":true`,
+				} {
+					if !strings.Contains(hint, want) {
+						t.Fatalf("checkout hint missing %s: %s", want, hint)
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestCheckoutPageStateHint_UncappedDialogAndSkipBooleans(t *testing.T) {
+	var controls strings.Builder
+	for i := 0; i < 16; i++ {
+		fmt.Fprintf(&controls, `<button>Control %d</button>`, i)
+	}
+	html := `<!doctype html>` + controls.String() + `
+		<div role="dialog" aria-modal="true" style="padding:20px">
+			<h2>Enable text alerts from Tock</h2><button>Skip</button>
+		</div>`
+	withTockDOMFixture(t, html, func(ctx context.Context) {
+		state, err := readTockCheckoutPageState(ctx)
+		if err != nil {
+			t.Fatalf("read checkout state: %v", err)
+		}
+		if !state.DialogPresent || !state.SkipControlPresent || !state.SMSDialogPresent {
+			t.Fatalf("uncapped booleans = dialog:%v skip:%v sms:%v, want all true",
+				state.DialogPresent, state.SkipControlPresent, state.SMSDialogPresent)
+		}
+		if len(state.VisibleControlLabels) != 16 {
+			t.Fatalf("display labels = %d, want capped 16", len(state.VisibleControlLabels))
+		}
+	})
+}
+
 func TestClickRequestedTockBookingControl_TypedFallbackIsRedacted(t *testing.T) {
 	html := `
 		<!doctype html>
@@ -426,6 +485,431 @@ func TestWaitForReceiptThroughDialogs_NonTransientDismissErrorAborts(t *testing.
 		if !strings.Contains(err.Error(), "dismissing post-confirm dialog") {
 			t.Fatalf("error = %v, want dismissing post-confirm dialog wrap", err)
 		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_DelayedSemanticDialog(t *testing.T) {
+	html := `<!doctype html><p>checkout</p><script>
+		setTimeout(() => {
+			const dialog = document.createElement('div');
+			dialog.setAttribute('role', 'dialog');
+			dialog.setAttribute('aria-modal', 'true');
+			dialog.style.padding = '20px';
+			dialog.innerHTML = '<h2>Enable text alerts from Tock</h2><button id="skip">Skip</button>';
+			document.body.appendChild(dialog);
+			document.getElementById('skip').onclick = () => { location.href = '/receipt?purchaseId=2'; };
+		}, 900);
+	</script>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		var loc string
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			var waitErr error
+			loc, waitErr = waitForReceiptThroughDialogs(actCtx, 6*time.Second)
+			return waitErr
+		}))
+		if err != nil {
+			t.Fatalf("wait through delayed dialog: %v", err)
+		}
+		if !strings.Contains(loc, "/receipt") {
+			t.Fatalf("location = %q, want receipt", loc)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_LostClickRetriesOnce(t *testing.T) {
+	html := `<!doctype html><button id="confirm">Complete reservation</button><script>
+		window.confirmClicks = 0;
+		document.getElementById('confirm').onclick = () => {
+			window.confirmClicks++;
+			if (window.confirmClicks === 2) location.href = '/receipt?purchaseId=3';
+		};
+	</script>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		if err := clickPlaceReservation(ctx); err != nil {
+			t.Fatalf("initial confirm click: %v", err)
+		}
+		var loc string
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			var waitErr error
+			loc, waitErr = waitForReceiptThroughDialogsWithRetry(
+				actCtx, 5*time.Second, dismissPostConfirmDialog, 900*time.Millisecond, clickPlaceReservation,
+			)
+			return waitErr
+		}))
+		if err != nil {
+			t.Fatalf("wait after lost click: %v", err)
+		}
+		if !strings.Contains(loc, "/receipt") {
+			t.Fatalf("location = %q, want receipt", loc)
+		}
+	})
+}
+
+func TestClickPlaceReservation_AriaDisabledDoesNotClick(t *testing.T) {
+	html := `<!doctype html><button aria-disabled="true" onclick="window.clicked=true">Complete reservation</button>`
+	withTockDOMFixture(t, html, func(ctx context.Context) {
+		timed, cancel := context.WithTimeout(ctx, 800*time.Millisecond)
+		defer cancel()
+		if err := clickPlaceReservation(timed); err == nil {
+			t.Fatal("expected aria-disabled confirm to remain unavailable")
+		}
+		var clicked bool
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.clicked || false`, &clicked)); err != nil {
+			t.Fatalf("read click state: %v", err)
+		}
+		if clicked {
+			t.Fatal("aria-disabled confirm must not be clicked")
+		}
+	})
+}
+
+func TestClickPlaceReservation_RetargetsVisibleConfirmOnRetry(t *testing.T) {
+	html := `<!doctype html>
+		<button id="first" onclick="window.firstClicks=(window.firstClicks||0)+1; this.style.display='none'; document.getElementById('second').style.display='inline-block'">Complete reservation</button>
+		<button id="second" style="display:none" onclick="window.secondClicks=(window.secondClicks||0)+1">Complete reservation</button>`
+	withTockDOMFixture(t, html, func(ctx context.Context) {
+		if err := clickPlaceReservation(ctx); err != nil {
+			t.Fatalf("first confirm click: %v", err)
+		}
+		if err := clickPlaceReservation(ctx); err != nil {
+			t.Fatalf("retargeted confirm click: %v", err)
+		}
+		var firstClicks, secondClicks int
+		if err := chromedp.Run(ctx,
+			chromedp.Evaluate(`window.firstClicks || 0`, &firstClicks),
+			chromedp.Evaluate(`window.secondClicks || 0`, &secondClicks),
+		); err != nil {
+			t.Fatalf("read retargeted click state: %v", err)
+		}
+		if firstClicks != 1 || secondClicks != 1 {
+			t.Fatalf("first/second confirm clicks = %d/%d, want 1/1", firstClicks, secondClicks)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_RetryBudgetSharedAfterDismissal(t *testing.T) {
+	html := `<!doctype html><button id="confirm">Complete reservation</button><script>
+		window.confirmClicks = 0;
+		document.getElementById('confirm').onclick = () => {
+			window.confirmClicks++;
+			if (window.confirmClicks !== 1) return;
+			const dialog = document.createElement('div');
+			dialog.setAttribute('role', 'dialog');
+			dialog.setAttribute('aria-modal', 'true');
+			dialog.style.padding = '20px';
+			dialog.innerHTML = '<p>Enable text alerts from Tock</p><button id="skip">Skip</button>';
+			document.body.appendChild(dialog);
+			document.getElementById('skip').onclick = () => dialog.remove();
+		};
+	</script>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		if err := clickPlaceReservation(ctx); err != nil {
+			t.Fatalf("initial confirm click: %v", err)
+		}
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, 2500*time.Millisecond, dismissPostConfirmDialog, 500*time.Millisecond, clickPlaceReservation,
+			)
+			return waitErr
+		}))
+		if err == nil || !strings.Contains(err.Error(), "receipt page never reached") {
+			t.Fatalf("wait error = %v, want receipt timeout", err)
+		}
+		var clicks int
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.confirmClicks`, &clicks)); err != nil {
+			t.Fatalf("read confirm clicks: %v", err)
+		}
+		if clicks != 2 {
+			t.Fatalf("confirm clicks = %d, want initial click plus one shared retry", clicks)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_OccludedConfirmDoesNotRetry(t *testing.T) {
+	html := `<!doctype html>
+		<button id="confirm">Complete reservation</button>
+		<div role="dialog" aria-modal="true" style="position:fixed;inset:0;background:white;padding:20px;z-index:10">
+			<p>Enable text alerts from Tock</p><button>Agree and Continue</button>
+		</div>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		retryCalls := 0
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, 1500*time.Millisecond, dismissPostConfirmDialog, 400*time.Millisecond,
+				func(context.Context) error { retryCalls++; return nil },
+			)
+			return waitErr
+		}))
+		if err == nil {
+			t.Fatal("expected receipt timeout")
+		}
+		state, stateErr := readTockCheckoutPageState(ctx)
+		if stateErr != nil {
+			t.Fatalf("read checkout state: %v", stateErr)
+		}
+		if !state.DialogPresent || !state.ConfirmOccluded {
+			t.Fatalf("state = dialog:%v occluded:%v, want both true", state.DialogPresent, state.ConfirmOccluded)
+		}
+		if retryCalls != 0 {
+			t.Fatalf("retry calls = %d, want zero", retryCalls)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_NonDialogOccluderDoesNotRetry(t *testing.T) {
+	html := `<!doctype html>
+		<button id="confirm" style="position:absolute;left:20px;top:20px;width:200px;height:40px">Complete reservation</button>
+		<div id="overlay" style="position:absolute;left:20px;top:20px;width:200px;height:40px;background:white;z-index:10"></div>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		retryCalls := 0
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, 1100*time.Millisecond, func(context.Context) (bool, error) { return false, nil },
+				200*time.Millisecond, func(context.Context) error { retryCalls++; return nil },
+			)
+			return waitErr
+		}))
+		if err == nil {
+			t.Fatal("expected receipt timeout")
+		}
+		state, stateErr := readTockCheckoutPageState(ctx)
+		if stateErr != nil {
+			t.Fatalf("read checkout state: %v", stateErr)
+		}
+		if state.DialogPresent || !state.ConfirmOccluded {
+			t.Fatalf("state = dialog:%v occluded:%v, want false/true", state.DialogPresent, state.ConfirmOccluded)
+		}
+		if retryCalls != 0 {
+			t.Fatalf("retry calls = %d, want zero for independently occluded confirm", retryCalls)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_DialogBlocksRetryWhenConfirmIsUnoccluded(t *testing.T) {
+	html := `<!doctype html>
+		<button id="confirm" style="position:absolute;left:20px;top:20px;width:200px;height:40px">Complete reservation</button>
+		<div role="dialog" aria-modal="true" style="position:absolute;left:400px;top:20px;width:250px;height:120px;padding:20px">
+			<p>Enable text alerts from Tock</p><button>Agree and Continue</button>
+		</div>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		retryCalls := 0
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, 1100*time.Millisecond, dismissPostConfirmDialog, 200*time.Millisecond,
+				func(context.Context) error { retryCalls++; return nil },
+			)
+			return waitErr
+		}))
+		if err == nil {
+			t.Fatal("expected receipt timeout")
+		}
+		state, stateErr := readTockCheckoutPageState(ctx)
+		if stateErr != nil {
+			t.Fatalf("read checkout state: %v", stateErr)
+		}
+		if !state.DialogPresent || state.ConfirmOccluded {
+			t.Fatalf("state = dialog:%v occluded:%v, want true/false", state.DialogPresent, state.ConfirmOccluded)
+		}
+		if retryCalls != 0 {
+			t.Fatalf("retry calls = %d, want zero while a semantic dialog is present", retryCalls)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_AriaDisabledConfirmDoesNotRetry(t *testing.T) {
+	html := `<!doctype html><button aria-disabled="true">Complete reservation</button>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		retryCalls := 0
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, 1100*time.Millisecond, func(context.Context) (bool, error) { return false, nil },
+				200*time.Millisecond, func(context.Context) error { retryCalls++; return nil },
+			)
+			return waitErr
+		}))
+		if err == nil {
+			t.Fatal("expected receipt timeout")
+		}
+		state, stateErr := readTockCheckoutPageState(ctx)
+		if stateErr != nil {
+			t.Fatalf("read checkout state: %v", stateErr)
+		}
+		if !state.ConfirmControlPresent || state.ConfirmControlEnabled || state.ConfirmOccluded {
+			t.Fatalf("confirm state = present:%v enabled:%v occluded:%v, want true/false/false",
+				state.ConfirmControlPresent, state.ConfirmControlEnabled, state.ConfirmOccluded)
+		}
+		if retryCalls != 0 {
+			t.Fatalf("retry calls = %d, want zero for aria-disabled confirm", retryCalls)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_DialogAtRetryBoundaryResetsIdleTimer(t *testing.T) {
+	html := `<!doctype html>
+		<button id="confirm" style="position:absolute;left:20px;top:20px;width:200px;height:40px">Complete reservation</button>
+		<script>
+			setTimeout(() => {
+				const dialog = document.createElement('div');
+				dialog.id = 'boundary-dialog';
+				dialog.setAttribute('role', 'dialog');
+				dialog.setAttribute('aria-modal', 'true');
+				dialog.style.cssText = 'position:absolute;left:400px;top:20px;width:250px;height:120px;padding:20px';
+				dialog.innerHTML = '<p>Enable text alerts from Tock</p><button>Agree and Continue</button>';
+				document.body.appendChild(dialog);
+				// Insertion at 100ms beats the first ~700ms retry check even
+				// under heavy scheduler lag; removal at 1400ms restarts the
+				// idle timer too late for retryDelay (500ms) to elapse before
+				// the 1700ms receipt deadline. Both margins keep the
+				// zero-retry assertion deterministic.
+				setTimeout(() => dialog.remove(), 1300);
+			}, 100);
+		</script>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		retryCalls := 0
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, 1700*time.Millisecond, dismissPostConfirmDialog, 500*time.Millisecond,
+				func(context.Context) error { retryCalls++; return nil },
+			)
+			return waitErr
+		}))
+		if err == nil {
+			t.Fatal("expected receipt timeout")
+		}
+		if retryCalls != 0 {
+			t.Fatalf("retry calls = %d, want zero after dialog reset at retry boundary", retryCalls)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_DismissalResetsIdleTimer(t *testing.T) {
+	html := `<!doctype html><button>Complete reservation</button>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		dismissCalls := 0
+		retryCalls := 0
+		dismiss := func(context.Context) (bool, error) {
+			dismissCalls++
+			return dismissCalls == 2, nil
+		}
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, 1700*time.Millisecond, dismiss, 500*time.Millisecond,
+				func(context.Context) error { retryCalls++; return nil },
+			)
+			return waitErr
+		}))
+		if err == nil {
+			t.Fatal("expected receipt timeout")
+		}
+		if dismissCalls < 2 {
+			t.Fatalf("dismiss calls = %d, want at least two", dismissCalls)
+		}
+		if retryCalls != 0 {
+			t.Fatalf("retry calls = %d, want zero after dismissal resets the elapsed idle interval", retryCalls)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_SlowNavigationAfterRetryDoesNotDoubleFire(t *testing.T) {
+	html := `<!doctype html><button>Complete reservation</button>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		retryCalls := 0
+		retryClick := func(retryCtx context.Context) error {
+			retryCalls++
+			return chromedp.Evaluate(`setTimeout(() => { location.href = '/receipt?purchaseId=slow'; }, 900)`, nil).Do(retryCtx)
+		}
+		var loc string
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			var waitErr error
+			loc, waitErr = waitForReceiptThroughDialogsWithRetry(
+				actCtx, 3*time.Second, func(context.Context) (bool, error) { return false, nil },
+				200*time.Millisecond, retryClick,
+			)
+			return waitErr
+		}))
+		if err != nil {
+			t.Fatalf("wait for slow retry navigation: %v", err)
+		}
+		if !strings.Contains(loc, "/receipt") {
+			t.Fatalf("location = %q, want receipt", loc)
+		}
+		if retryCalls != 1 {
+			t.Fatalf("retry calls = %d, want exactly one while navigation is pending", retryCalls)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_DoesNotRetryAfterDeadline(t *testing.T) {
+	html := `<!doctype html><button>Complete reservation</button>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		dismissCalls := 0
+		retryCalls := 0
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, -time.Millisecond,
+				func(context.Context) (bool, error) { dismissCalls++; return false, nil },
+				0, func(context.Context) error { retryCalls++; return nil },
+			)
+			return waitErr
+		}))
+		if err == nil || !strings.Contains(err.Error(), "receipt page never reached") {
+			t.Fatalf("wait error = %v, want receipt timeout", err)
+		}
+		if dismissCalls != 0 || retryCalls != 0 {
+			t.Fatalf("dismiss/retry calls = %d/%d, want no booking-affecting work after deadline", dismissCalls, retryCalls)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_TimeoutHintHasUncappedDialogState(t *testing.T) {
+	html := `<!doctype html><button>Complete reservation</button>
+		<div role="dialog" aria-modal="true" style="position:fixed;inset:0;background:white;padding:20px;z-index:10">
+			<p>Enable text alerts from Tock</p><button>Agree and Continue</button>
+		</div>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		var hint string
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, 900*time.Millisecond, dismissPostConfirmDialog, 300*time.Millisecond, clickPlaceReservation,
+			)
+			hint = checkoutPageStateHint(actCtx)
+			return waitErr
+		}))
+		if err == nil {
+			t.Fatal("expected receipt timeout")
+		}
+		for _, want := range []string{`"dialog_present":true`, `"sms_dialog_present":true`, `"confirm_occluded":true`} {
+			if !strings.Contains(hint, want) {
+				t.Fatalf("timeout hint missing %s: %s", want, hint)
+			}
+		}
+	})
+}
+
+func TestReceiptWaitersAcceptSurveyPath(t *testing.T) {
+	withTockDOMFixtureAtPath(t, "/receipt/survey", `<!doctype html><p>survey</p>`, func(ctx context.Context) {
+		t.Run("plain waiter", func(t *testing.T) {
+			var loc string
+			err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+				var waitErr error
+				loc, waitErr = waitForReceiptPage(actCtx, time.Second)
+				return waitErr
+			}))
+			if err != nil || !strings.Contains(loc, "/receipt/survey") {
+				t.Fatalf("plain receipt waiter = %q, %v", loc, err)
+			}
+		})
+		t.Run("dialog waiter", func(t *testing.T) {
+			var loc string
+			err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+				var waitErr error
+				loc, waitErr = waitForReceiptThroughDialogs(actCtx, time.Second)
+				return waitErr
+			}))
+			if err != nil || !strings.Contains(loc, "/receipt/survey") {
+				t.Fatalf("dialog receipt waiter = %q, %v", loc, err)
+			}
+		})
 	})
 }
 
@@ -1690,13 +2174,13 @@ func TestDismissPostConfirmDialog_ClicksPortalSMSDialogSkip(t *testing.T) {
 	})
 }
 
-func TestDismissPostConfirmDialog_GenericFallbackSupportsRoleButton(t *testing.T) {
+func TestDismissPostConfirmDialog_SemanticDialogRequiresExactSkip(t *testing.T) {
 	html := `
 		<!doctype html>
-		<section class="custom-modal" style="padding:20px">
+		<section class="custom-modal" role="dialog" aria-modal="true" style="padding:20px">
 			<div><div><div><span>Receive text confirmation and updates for this and future bookings.</span></div></div></div>
 			<footer>
-				<div role="button" tabindex="0" style="display:inline-block;padding:10px" onclick="window.clickedControl = 'decline'">Not now</div>
+				<div role="button" tabindex="0" style="display:inline-block;padding:10px" onclick="window.clickedControl = 'decline'">Skip</div>
 				<button onclick="window.clickedControl = 'agree'">Agree and Continue</button>
 			</footer>
 		</section>`
@@ -1706,7 +2190,7 @@ func TestDismissPostConfirmDialog_GenericFallbackSupportsRoleButton(t *testing.T
 			t.Fatalf("dismissPostConfirmDialog: %v", err)
 		}
 		if !clicked {
-			t.Fatal("expected generic dialog fallback to find Not now")
+			t.Fatal("expected semantic dialog to find Skip")
 		}
 		var control string
 		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.clickedControl || ''`, &control)); err != nil {
@@ -1714,6 +2198,158 @@ func TestDismissPostConfirmDialog_GenericFallbackSupportsRoleButton(t *testing.T
 		}
 		if control != "decline" {
 			t.Fatalf("clicked control = %q, want decline", control)
+		}
+	})
+}
+
+func TestDismissPostConfirmDialog_SemanticDialogRejectsLegacyDeclinesAndClose(t *testing.T) {
+	tests := []struct {
+		name    string
+		control string
+	}{
+		{name: "legacy decline wording", control: `<button onclick="window.clickedControl='not-now'">Not now</button>`},
+		{name: "close control", control: `<button aria-label="Close" onclick="window.clickedControl='close'">×</button>`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			html := `<!doctype html><div role="dialog" aria-modal="true" style="padding:20px">
+				<h2>Enable text alerts from Tock</h2>` + tc.control + `
+				<button onclick="window.clickedControl='agree'">Agree and Continue</button>
+			</div>`
+			withTockDOMFixture(t, html, func(ctx context.Context) {
+				clicked, err := dismissPostConfirmDialog(ctx)
+				if err != nil {
+					t.Fatalf("dismiss semantic dialog: %v", err)
+				}
+				if clicked {
+					t.Fatal("semantic dialog without exact Skip must remain untouched")
+				}
+				var control string
+				if err := chromedp.Run(ctx, chromedp.Evaluate(`window.clickedControl || ''`, &control)); err != nil {
+					t.Fatalf("read clicked control: %v", err)
+				}
+				if control != "" {
+					t.Fatalf("unexpected clicked control %q", control)
+				}
+			})
+		})
+	}
+}
+
+func TestDismissPostConfirmDialog_NonSemanticAncestorFallbackStaysDisabled(t *testing.T) {
+	html := `<!doctype html><section style="padding:20px">
+		<p>Enable text alerts from Tock</p>
+		<button onclick="window.clickedControl='skip'">Skip</button>
+		<button onclick="window.clickedControl='agree'">Agree and Continue</button>
+	</section>`
+	withTockDOMFixture(t, html, func(ctx context.Context) {
+		clicked, err := dismissPostConfirmDialog(ctx)
+		if err != nil {
+			t.Fatalf("dismiss non-semantic copy: %v", err)
+		}
+		if clicked {
+			t.Fatal("non-semantic ancestor fallback must not click")
+		}
+		var control string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.clickedControl || ''`, &control)); err != nil {
+			t.Fatalf("read clicked control: %v", err)
+		}
+		if control != "" {
+			t.Fatalf("unexpected clicked control %q", control)
+		}
+	})
+}
+
+func TestDismissPostConfirmDialog_OccludedSkipFailsClosed(t *testing.T) {
+	html := `<!doctype html>
+		<div role="dialog" aria-modal="true" style="position:relative;width:260px;height:180px;padding:20px">
+			<p>Enable text alerts from Tock</p>
+			<button id="skip" style="position:absolute;left:20px;top:100px;width:200px;height:40px;z-index:1" onclick="window.clickedControl='skip'">Skip</button>
+			<button id="agree" style="position:absolute;left:20px;top:100px;width:200px;height:40px;z-index:2" onclick="window.clickedControl='agree'">Agree and Continue</button>
+		</div>`
+	withTockDOMFixture(t, html, func(ctx context.Context) {
+		clicked, err := dismissPostConfirmDialog(ctx)
+		if err != nil {
+			t.Fatalf("dismiss dialog with occluded Skip: %v", err)
+		}
+		if clicked {
+			t.Fatal("occluded Skip must fail closed")
+		}
+		var control string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.clickedControl || ''`, &control)); err != nil {
+			t.Fatalf("read clicked control: %v", err)
+		}
+		if control != "" {
+			t.Fatalf("occluded Skip coordinate landed on %q", control)
+		}
+	})
+}
+
+func TestDismissPostConfirmDialog_PrefersTopmostActiveHost(t *testing.T) {
+	html := `<!doctype html>
+		<div role="dialog" aria-modal="true" style="position:fixed;left:20px;top:20px;width:260px;height:180px;padding:20px;background:white;z-index:1">
+			<p>Enable text alerts from Tock</p>
+			<button style="position:absolute;left:20px;top:100px;width:200px;height:40px" onclick="window.clickedControl='lower'">Skip</button>
+		</div>
+		<div role="dialog" aria-modal="true" style="position:fixed;left:20px;top:20px;width:260px;height:180px;padding:20px;background:white;z-index:2">
+			<p>Enable text alerts from Tock</p>
+			<button style="position:absolute;left:20px;top:100px;width:200px;height:40px" onclick="window.clickedControl='upper'">Skip</button>
+		</div>`
+	withTockDOMFixture(t, html, func(ctx context.Context) {
+		clicked, err := dismissPostConfirmDialog(ctx)
+		if err != nil || !clicked {
+			t.Fatalf("dismiss topmost dialog = %v, %v", clicked, err)
+		}
+		var control string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.clickedControl || ''`, &control)); err != nil {
+			t.Fatalf("read clicked control: %v", err)
+		}
+		if control != "upper" {
+			t.Fatalf("clicked control = %q, want upper", control)
+		}
+	})
+}
+
+func TestDismissPostConfirmDialog_HiddenLegacyAndVisibleSemanticDialog(t *testing.T) {
+	html := `<!doctype html>
+		<div role="dialog" aria-hidden="true" style="display:none">
+			<div data-testid="sms-confirmation-dialog-content">Stay in the know</div>
+			<button data-testid="sms-skip-button" onclick="window.clickedControl='hidden'">Skip</button>
+		</div>
+		<div role="dialog" aria-modal="true" style="padding:20px">
+			<h2>Enable text alerts from Tock</h2>
+			<button onclick="window.clickedControl='visible'">Skip</button>
+		</div>`
+	withTockDOMFixture(t, html, func(ctx context.Context) {
+		clicked, err := dismissPostConfirmDialog(ctx)
+		if err != nil || !clicked {
+			t.Fatalf("dismiss visible semantic dialog = %v, %v", clicked, err)
+		}
+		var control string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.clickedControl || ''`, &control)); err != nil {
+			t.Fatalf("read clicked control: %v", err)
+		}
+		if control != "visible" {
+			t.Fatalf("clicked control = %q, want visible", control)
+		}
+	})
+}
+
+func TestDismissPostConfirmDialog_AmbiguousActiveHostsFailClosed(t *testing.T) {
+	html := `<!doctype html>
+		<div role="dialog" aria-modal="true" style="position:absolute;left:10px;top:10px;padding:20px">
+			<p>Enable text alerts from Tock</p><button onclick="window.clickedControl='one'">Skip</button>
+		</div>
+		<div role="dialog" aria-modal="true" style="position:absolute;left:300px;top:10px;padding:20px">
+			<p>Enable text alerts from Tock</p><button onclick="window.clickedControl='two'">Skip</button>
+		</div>`
+	withTockDOMFixture(t, html, func(ctx context.Context) {
+		clicked, err := dismissPostConfirmDialog(ctx)
+		if err != nil {
+			t.Fatalf("dismiss ambiguous dialogs: %v", err)
+		}
+		if clicked {
+			t.Fatal("ambiguous active dialogs must not be clicked")
 		}
 	})
 }

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book_test.go
@@ -810,6 +810,92 @@ func TestWaitForReceiptThroughDialogs_DismissalResetsIdleTimer(t *testing.T) {
 	})
 }
 
+func TestWaitForReceiptThroughDialogs_RedismissesDialogReopenedAfterFirstDismissal(t *testing.T) {
+	html := `<!doctype html><button>Complete reservation</button>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		dismissCalls := 0
+		// Every probe reports a clickable recognized dialog: the loop must
+		// keep dismissing (a retry click re-opens the prompt live), not stop
+		// after the first success.
+		dismiss := func(context.Context) (bool, error) {
+			dismissCalls++
+			return true, nil
+		}
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, 2500*time.Millisecond, dismiss, 500*time.Millisecond,
+				func(context.Context) error { return nil },
+			)
+			return waitErr
+		}))
+		if err == nil {
+			t.Fatal("expected receipt timeout")
+		}
+		if dismissCalls < 2 {
+			t.Fatalf("dismiss calls = %d, want at least two (dialog handling must stay armed)", dismissCalls)
+		}
+		if dismissCalls > 3 {
+			t.Fatalf("dismiss calls = %d, want at most three (dismissal cap)", dismissCalls)
+		}
+	})
+}
+
+func TestWaitForReceiptThroughDialogs_RetryClickContextCarriesReceiptDeadline(t *testing.T) {
+	html := `<!doctype html><button>Complete reservation</button>`
+	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {
+		waitDeadline := 3 * time.Second
+		start := time.Now()
+		var clickDeadline time.Time
+		var hadDeadline bool
+		err := chromedp.Run(ctx, chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, waitErr := waitForReceiptThroughDialogsWithRetry(
+				actCtx, waitDeadline, func(context.Context) (bool, error) { return false, nil },
+				500*time.Millisecond,
+				func(clickCtx context.Context) error {
+					clickDeadline, hadDeadline = clickCtx.Deadline()
+					return nil
+				},
+			)
+			return waitErr
+		}))
+		if err == nil {
+			t.Fatal("expected receipt timeout")
+		}
+		if !hadDeadline {
+			t.Fatal("retry click context carried no deadline; clickPlaceReservation could poll past the receipt deadline")
+		}
+		if latest := start.Add(waitDeadline + 250*time.Millisecond); clickDeadline.After(latest) {
+			t.Fatalf("retry click deadline %v exceeds receipt deadline bound %v", clickDeadline, latest)
+		}
+	})
+}
+
+func TestDismissPostConfirmDialog_SelectsSkipNamedByAriaLabelledBy(t *testing.T) {
+	html := `<!doctype html>
+		<div role="dialog" aria-modal="true" style="position:absolute;left:10px;top:10px;padding:20px">
+			<p>Enable text alerts from Tock</p>
+			<span id="skip-name" style="display:none">Skip</span>
+			<button aria-labelledby="skip-name" onclick="window.clickedControl='labelled-skip'" style="width:80px;height:32px"></button>
+			<button onclick="window.clickedControl='agree'">Agree and Continue</button>
+		</div>`
+	withTockDOMFixture(t, html, func(ctx context.Context) {
+		clicked, err := dismissPostConfirmDialog(ctx)
+		if err != nil {
+			t.Fatalf("dismiss labelledby dialog: %v", err)
+		}
+		if !clicked {
+			t.Fatal("expected the aria-labelledby Skip to be clicked")
+		}
+		var control string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.clickedControl || ''`, &control)); err != nil {
+			t.Fatalf("read clicked control: %v", err)
+		}
+		if control != "labelled-skip" {
+			t.Fatalf("clicked control = %q, want labelled-skip", control)
+		}
+	})
+}
+
 func TestWaitForReceiptThroughDialogs_SlowNavigationAfterRetryDoesNotDoubleFire(t *testing.T) {
 	html := `<!doctype html><button>Complete reservation</button>`
 	withTockDOMFixtureAtPath(t, "/checkout/confirm-purchase", html, func(ctx context.Context) {


### PR DESCRIPTION
## What

Tock's checkout flow recently began interposing an "Enable text alerts from Tock" dialog after the "Complete reservation" click, and our production bookings started timing out on the receipt wait with `confirm_control_present:true, confirm_control_enabled:true, sms_dialog_present:false` — a state that reads as "nothing happened." Investigating against the live site showed two distinct problems:

1. **A confirm click that doesn't take effect has no recovery.** `waitForReceiptThroughDialogs` only re-arms the click after a dialog dismissal, so a click lost to a layout shift (coordinates are captured once), a not-yet-hydrated handler, or a transient overlay leaves the checkout idle for the full 30s.
2. **The checkout-state diagnostics under-report dialogs.** `sms_dialog_present` keys only on the 2026-07-09 testids, and `visible_control_labels` truncates to the first 16 raw labels *before* redaction — so the hint can claim "no dialog" while one is on screen, which is exactly what sent our debugging down the wrong path.

## Changes

- **Single-retry click recovery**: one unified retry budget (initial click + at most one retry, shared between the idle-recovery and post-dismissal paths). The retry fires only after a ~5s dialog-free idle interval (the timer resets whenever a dialog appears or is dismissed) and only when the confirm is rendered, hit-testable at its center, and neither natively nor ARIA disabled. One retry is a deliberate ceiling: there is no provider idempotency guarantee for a slow in-flight submission.
- **Uncapped diagnostics**: the checkout-state probe now computes `dialog_present` (semantic modal-host detection), `skip_control_present` (exact accessible name), and `confirm_occluded` (hit-test) over the full DOM before the display list is truncated; `sms_dialog_present` recognizes both the legacy testids and the semantic dialog family (including the new "text alerts" heading).
- **Tightened semantic dismissal**: for non-testid dialogs, the decline control must be the exact accessible name "Skip", co-located in the same rendered modal host, and actually hit-testable at its center (an overlay covering Skip fails closed rather than clicking whatever is on top). Multiple candidate hosts select a single hit-testable/topmost one or fail closed. Accept controls are never clicked; legacy testid dialogs keep the existing decline-regex behavior.
- **Deadline ordering**: the receipt wait now enforces its deadline before dispatching any booking-affecting click, so a timeout report can no longer race a just-dispatched click.

## Testing

- New chromedp regression fixtures: legacy testid dialog, semantic no-testid dialog, >16-controls truncation, hidden-legacy + visible-semantic coexistence, agree-only and ambiguous-host fail-closed, occluded-Skip fail-closed, delayed dialog insertion through the polling loop, lost-click recovery, retry-budget exclusivity (both recovery paths cannot each fire), post-deadline no-click, and stale-hidden-confirm retargeting.
- Full `internal/source/tock` suite passes with real Chrome (fixtures run against a local httptest server; no live-site traffic in tests).
- Live validation: the failing checkout was reproduced manually on the live site; declining the new dialog via Skip completes the booking, and the flow changes here were derived from that session.

One patch-registry entry added per repo convention (`tock-confirm-click-recovery-and-interstitial-diagnostics.json`).

https://claude.ai/code/session_017ZgvVfyPxcLHYy5DPoDf37
