### PR TITLE
fix(table-reservation-goat): fetch OpenTable availability bodies after loadingFinished with bounded retry

### DIFF
--- a/library/food-and-dining/table-reservation-goat/.printing-press-patches/opentable-chrome-avail-body-capture.json
+++ b/library/food-and-dining/table-reservation-goat/.printing-press-patches/opentable-chrome-avail-body-capture.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "opentable-chrome-avail-body-capture",
+  "applied_at": "2026-07-20",
+  "base_run_id": "20260712-223206",
+  "base_printing_press_version": "4.28.0",
+  "summary": "OpenTable browser availability capture must bind the requested restaurant and wait for both the response metadata and loading completion before reading a response body, while allowing any successful matching request to win.",
+  "reason": "CDP does not guarantee Network.getResponseBody can read a resource at responseReceived time, and a restaurant page can issue multiple availability requests. A reprint must preserve loading-finished coordination, exact transient retry handling, target-restaurant arbitration, independent persisted-hash harvesting, and the distinct diagnostic for a successful response containing no availability data for the requested restaurant.",
+  "files": [
+    "internal/source/opentable/chrome_avail.go",
+    "internal/source/opentable/chrome_avail_capture.go",
+    "internal/source/opentable/chrome_avail_capture_test.go",
+    "internal/cli/earliest.go",
+    "internal/cli/earliest_test.go"
+  ],
+  "validated_outcome": "Synthetic coordinator and injected-fetch tests cover response/loading event order, unresolved request binding, failure and duplicate handling, multi-request arbitration, body-read retry eligibility and cancellation, empty bodies, hash-only request tolerance, and both OpenTable no-availability reason paths."
+}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -846,12 +846,11 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 			anchorHH := 19
 			anchorMM := 0
 			var bookable []string
-			matchingAvailabilityChunks := 0
+			matchingAvailabilityChunks := countInformativeAvailabilityChunks(avail, restID)
 			for _, ra := range avail {
 				if ra.RestaurantID != restID {
 					continue
 				}
-				matchingAvailabilityChunks++
 				for _, d := range ra.AvailabilityDays {
 					dayDate := d.Date
 					if dayDate == "" {
@@ -924,6 +923,22 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 		}
 	}
 	return row
+}
+
+// countInformativeAvailabilityChunks counts availability wrappers for the
+// requested restaurant that actually carry day data. A matching wrapper with
+// an empty AvailabilityDays array holds no slot information, so it must not
+// flip the no-availability diagnostic to the "slots present but none
+// available/matching" phrasing.
+func countInformativeAvailabilityChunks(avail []opentable.RestaurantAvailability, restID int) int {
+	count := 0
+	for _, ra := range avail {
+		if ra.RestaurantID != restID || len(ra.AvailabilityDays) == 0 {
+			continue
+		}
+		count++
+	}
+	return count
 }
 
 func openTableNoAvailabilityReason(venueLabel string, restID, within, party, matchingAvailabilityChunks int, cacheNote string) string {

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -846,10 +846,12 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 			anchorHH := 19
 			anchorMM := 0
 			var bookable []string
+			matchingAvailabilityChunks := 0
 			for _, ra := range avail {
 				if ra.RestaurantID != restID {
 					continue
 				}
+				matchingAvailabilityChunks++
 				for _, d := range ra.AvailabilityDays {
 					dayDate := d.Date
 					if dayDate == "" {
@@ -910,7 +912,7 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 				row.Reason = fmt.Sprintf("opentable %s: earliest slot at %s%s", venueLabel, earliestSlotAt, cacheNote)
 			} else {
 				row.Available = false
-				row.Reason = fmt.Sprintf("opentable %s: no open slots in %d-day window for party=%d%s", venueLabel, within, party, cacheNote)
+				row.Reason = openTableNoAvailabilityReason(venueLabel, restID, within, party, matchingAvailabilityChunks, cacheNote)
 			}
 			return row
 		}
@@ -922,6 +924,13 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 		}
 	}
 	return row
+}
+
+func openTableNoAvailabilityReason(venueLabel string, restID, within, party, matchingAvailabilityChunks int, cacheNote string) string {
+	if matchingAvailabilityChunks == 0 {
+		return fmt.Sprintf("opentable %s: response contained no availability data for restaurant %d%s", venueLabel, restID, cacheNote)
+	}
+	return fmt.Sprintf("opentable %s: no open slots in %d-day window for party=%d (availability data matched; slots present but none available/matching)%s", venueLabel, within, party, cacheNote)
 }
 
 // resolveEarliestForResy fans out one Availability call per day across the

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
@@ -240,6 +240,31 @@ func TestResolveEarliestForVenue_BareNumericIsAmbiguous(t *testing.T) {
 	}
 }
 
+func TestOpenTableNoAvailabilityReason_DistinguishesMissingDataFromFullness(t *testing.T) {
+	t.Run("no matching availability chunks", func(t *testing.T) {
+		reason := openTableNoAvailabilityReason("restaurant #1080775", 1080775, 3, 2, 0, "")
+		if !strings.Contains(reason, "response contained no availability data for restaurant 1080775") {
+			t.Fatalf("reason = %q; want missing restaurant data diagnostic", reason)
+		}
+		if strings.Contains(reason, "no open slots") {
+			t.Fatalf("reason = %q; missing data must not be reported as genuine fullness", reason)
+		}
+	})
+
+	t.Run("matching chunks with no bookable slots", func(t *testing.T) {
+		reason := openTableNoAvailabilityReason("Perry's", 1080775, 3, 2, 1, "")
+		if !strings.Contains(reason, "no open slots in 3-day window for party=2") {
+			t.Fatalf("reason = %q; want genuine fullness diagnostic", reason)
+		}
+		if !strings.Contains(reason, "slots present but none available/matching") {
+			t.Fatalf("reason = %q; want matching-data distinction", reason)
+		}
+		if strings.Contains(reason, "response contained no availability data") {
+			t.Fatalf("reason = %q; matched chunks must not use missing-data diagnostic", reason)
+		}
+	})
+}
+
 // TestSummarizeEarliest covers issue #406 failure 4: zero-resolution
 // requests previously rendered as `{}` (via the --select path), making
 // "couldn't resolve any input" look identical to "checked, no slots."

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/source/opentable"
 )
 
 // runEarliest drives the earliest cobra command through a string-args
@@ -263,6 +265,26 @@ func TestOpenTableNoAvailabilityReason_DistinguishesMissingDataFromFullness(t *t
 			t.Fatalf("reason = %q; matched chunks must not use missing-data diagnostic", reason)
 		}
 	})
+}
+
+func TestCountInformativeAvailabilityChunks_IgnoresEmptyDayWrappers(t *testing.T) {
+	avail := []opentable.RestaurantAvailability{
+		{RestaurantID: 1080775},                                   // matching, no day data
+		{RestaurantID: 999, AvailabilityDays: dayFixtures(1)},     // day data, wrong restaurant
+		{RestaurantID: 1080775, AvailabilityDays: dayFixtures(0)}, // matching, empty days slice
+		{RestaurantID: 1080775, AvailabilityDays: dayFixtures(2)}, // informative
+	}
+	if got := countInformativeAvailabilityChunks(avail, 1080775); got != 1 {
+		t.Fatalf("countInformativeAvailabilityChunks = %d; want 1 (empty-day wrappers carry no slot data)", got)
+	}
+	if got := countInformativeAvailabilityChunks(avail[:3], 1080775); got != 0 {
+		t.Fatalf("countInformativeAvailabilityChunks = %d; want 0 when every matching wrapper is day-free", got)
+	}
+}
+
+func dayFixtures(n int) []opentable.AvailabilityDay {
+	days := make([]opentable.AvailabilityDay, n)
+	return days
 }
 
 // TestSummarizeEarliest covers issue #406 failure 4: zero-resolution

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail.go
@@ -419,6 +419,13 @@ func (c *Client) ChromeAvailability(
 		chromedp.Navigate("https://www.opentable.com/restaurant/profile/100"),
 		chromedp.Sleep(2 * time.Second),
 		chromedp.ActionFunc(func(actCtx context.Context) error {
+			// Arm before navigating: the page can fire its availability
+			// request while Navigate is still in flight, and an unarmed
+			// coordinator drops that request's events. Warm-up traffic
+			// stays excluded by the restaurant-ID binding.
+			coordinatorMu.Lock()
+			coordinator.Arm()
+			coordinatorMu.Unlock()
 			_, _, errorText, _, err := page.Navigate(pageURL).Do(actCtx)
 			if err != nil {
 				return err
@@ -426,9 +433,6 @@ func (c *Client) ChromeAvailability(
 			if errorText != "" {
 				return fmt.Errorf("page load error %s", errorText)
 			}
-			coordinatorMu.Lock()
-			coordinator.Arm()
-			coordinatorMu.Unlock()
 			return nil
 		}),
 		// Wait until either the listener captures the response or the

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail.go
@@ -32,6 +32,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -190,7 +191,7 @@ func (c *Client) ChromeAvailability(
 		cookies = c.session.HTTPCookies(auth.NetworkOpenTable)
 	}
 
-	// Capture state for the response listener
+	// Capture state shared by the event listener and the body-fetch worker.
 	type slotCapture struct {
 		mu       sync.Mutex
 		body     []byte
@@ -202,15 +203,86 @@ func (c *Client) ChromeAvailability(
 		done     chan struct{}
 	}
 	cap := &slotCapture{hashDone: make(chan struct{}), done: make(chan struct{})}
-	closed := false
-	closeOnce := func() {
-		cap.mu.Lock()
-		if !closed {
-			closed = true
-			close(cap.done)
+	coordinator := newAvailabilityCaptureCoordinator()
+	var coordinatorMu sync.Mutex
+	var callbackMu sync.Mutex
+	workerCtx, cancelWorker := context.WithCancel(timed)
+	var postDataWorkers sync.WaitGroup
+	var actionMu sync.Mutex
+	var fetchActions []availabilityCaptureAction
+	actionReady := make(chan struct{}, 1)
+	var resultOnce sync.Once
+	publishResult := func(result *availabilityCaptureResult) {
+		if result == nil {
+			return
 		}
-		cap.mu.Unlock()
+		resultOnce.Do(func() {
+			cap.mu.Lock()
+			cap.body = result.body
+			cap.status = result.status
+			cap.err = result.err
+			cap.mu.Unlock()
+			close(cap.done)
+		})
 	}
+	queueAction := func(action *availabilityCaptureAction) {
+		if action == nil {
+			return
+		}
+		select {
+		case <-workerCtx.Done():
+			return
+		default:
+		}
+		actionMu.Lock()
+		fetchActions = append(fetchActions, *action)
+		actionMu.Unlock()
+		select {
+		case actionReady <- struct{}{}:
+		default:
+		}
+	}
+	dequeueAction := func() (availabilityCaptureAction, bool) {
+		actionMu.Lock()
+		defer actionMu.Unlock()
+		if len(fetchActions) == 0 {
+			return availabilityCaptureAction{}, false
+		}
+		action := fetchActions[0]
+		fetchActions = fetchActions[1:]
+		return action, true
+	}
+	workerDone := make(chan struct{})
+	go func() {
+		defer close(workerDone)
+		for {
+			select {
+			case <-workerCtx.Done():
+				return
+			case <-actionReady:
+				for {
+					action, ok := dequeueAction()
+					if !ok {
+						break
+					}
+					// Listener callbacks are synchronous in chromedp. Waiting on
+					// this barrier keeps CDP body reads out of the callback path.
+					callbackMu.Lock()
+					callbackMu.Unlock()
+					select {
+					case <-workerCtx.Done():
+						return
+					default:
+					}
+					body, err := fetchResponseBodyWithRetry(workerCtx, action.requestID, fetchResponseBody, 25*time.Millisecond)
+					coordinatorMu.Lock()
+					result := coordinator.FetchCompleted(action.requestID, body, err)
+					coordinatorMu.Unlock()
+					publishResult(result)
+				}
+			}
+		}
+	}()
 	hashClosed := false
 	closeHashOnce := func() {
 		cap.mu.Lock()
@@ -222,6 +294,8 @@ func (c *Client) ChromeAvailability(
 	}
 
 	chromedp.ListenTarget(timed, func(ev any) {
+		callbackMu.Lock()
+		defer callbackMu.Unlock()
 		switch e := ev.(type) {
 		case *network.EventRequestWillBeSent:
 			// Harvest the persisted-query hash the page's own JS uses. The
@@ -230,6 +304,31 @@ func (c *Client) ChromeAvailability(
 			// direct path after an OpenTable bundle rotation.
 			if e.Request == nil || !strings.Contains(e.Request.URL, "opname=RestaurantsAvailability") {
 				return
+			}
+			coordinatorMu.Lock()
+			coordinator.RequestWillBeSent(e.RequestID)
+			coordinatorMu.Unlock()
+			if ids, ok := restaurantIDsFromRequest(e.Request); ok {
+				coordinatorMu.Lock()
+				action, result := coordinator.BindRequest(e.RequestID, containsRestaurantID(ids, restID))
+				coordinatorMu.Unlock()
+				queueAction(action)
+				publishResult(result)
+			} else {
+				reqID := e.RequestID
+				postDataWorkers.Add(1)
+				go func() {
+					defer postDataWorkers.Done()
+					callbackMu.Lock()
+					callbackMu.Unlock()
+					postData, err := network.GetRequestPostData(reqID).Do(timed)
+					ids, ok := restaurantIDsFromPostData(string(postData))
+					coordinatorMu.Lock()
+					action, result := coordinator.BindRequest(reqID, err == nil && ok && containsRestaurantID(ids, restID))
+					coordinatorMu.Unlock()
+					queueAction(action)
+					publishResult(result)
+				}()
 			}
 			if h := hashFromRequest(e.Request); h != "" {
 				cap.mu.Lock()
@@ -243,7 +342,11 @@ func (c *Client) ChromeAvailability(
 			cap.hashSeen = true
 			cap.mu.Unlock()
 			reqID := e.RequestID
+			postDataWorkers.Add(1)
 			go func() {
+				defer postDataWorkers.Done()
+				callbackMu.Lock()
+				callbackMu.Unlock()
 				body, err := network.GetRequestPostData(reqID).Do(timed)
 				if err == nil {
 					if h := hashFromPostData(body); h != "" {
@@ -264,19 +367,20 @@ func (c *Client) ChromeAvailability(
 			if !strings.Contains(e.Response.URL, "opname=RestaurantsAvailability") {
 				return
 			}
-			// Defer the body fetch — chromedp wants us to call from the
-			// run context, not the listener thread.
-			reqID := e.RequestID
-			status := int(e.Response.Status)
-			go func() {
-				body, err := fetchResponseBody(timed, reqID)
-				cap.mu.Lock()
-				cap.body = body
-				cap.status = status
-				cap.err = err
-				cap.mu.Unlock()
-				closeOnce()
-			}()
+			coordinatorMu.Lock()
+			action := coordinator.ResponseReceived(e.RequestID, int(e.Response.Status))
+			coordinatorMu.Unlock()
+			queueAction(action)
+		case *network.EventLoadingFinished:
+			coordinatorMu.Lock()
+			action := coordinator.LoadingFinished(e.RequestID)
+			coordinatorMu.Unlock()
+			queueAction(action)
+		case *network.EventLoadingFailed:
+			coordinatorMu.Lock()
+			result := coordinator.LoadingFailed(e.RequestID, e.ErrorText)
+			coordinatorMu.Unlock()
+			publishResult(result)
 		}
 	})
 
@@ -314,7 +418,19 @@ func (c *Client) ChromeAvailability(
 		// touch the rate-limited GraphQL endpoint.
 		chromedp.Navigate("https://www.opentable.com/restaurant/profile/100"),
 		chromedp.Sleep(2 * time.Second),
-		chromedp.Navigate(pageURL),
+		chromedp.ActionFunc(func(actCtx context.Context) error {
+			_, _, errorText, _, err := page.Navigate(pageURL).Do(actCtx)
+			if err != nil {
+				return err
+			}
+			if errorText != "" {
+				return fmt.Errorf("page load error %s", errorText)
+			}
+			coordinatorMu.Lock()
+			coordinator.Arm()
+			coordinatorMu.Unlock()
+			return nil
+		}),
 		// Wait until either the listener captures the response or the
 		// timeout fires. `chromedp.ActionFunc` lets us yield to the event
 		// loop without spinning.
@@ -328,6 +444,7 @@ func (c *Client) ChromeAvailability(
 		}),
 	}
 	runErr := chromedp.Run(timed, tasks)
+	cancelWorker()
 
 	// Harvest the persisted-query hash from the page's own outgoing request,
 	// regardless of whether the availability call returned slots — the hash
@@ -342,6 +459,14 @@ func (c *Client) ChromeAvailability(
 		case <-time.After(500 * time.Millisecond):
 		}
 	}
+	// Stop listener-owned post-data work and wait for every worker before
+	// reading capture state or returning. This prevents late writes after a
+	// successful body capture ends chromedp.Run.
+	cancelTimed()
+	callbackMu.Lock()
+	callbackMu.Unlock()
+	postDataWorkers.Wait()
+	<-workerDone
 	cap.mu.Lock()
 	harvested := cap.reqHash
 	cap.mu.Unlock()
@@ -381,6 +506,64 @@ func (c *Client) ChromeAvailability(
 			mode, status, hint)
 	}
 	return parseAvailabilityResponse(body)
+}
+
+func restaurantIDsFromRequest(req *network.Request) ([]int, bool) {
+	if req == nil {
+		return nil, false
+	}
+	var postData strings.Builder
+	for _, entry := range req.PostDataEntries {
+		if entry == nil || entry.Bytes == "" {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(entry.Bytes)
+		if err != nil {
+			return nil, false
+		}
+		postData.Write(decoded)
+	}
+	if postData.Len() == 0 {
+		return nil, false
+	}
+	return restaurantIDsFromPostData(postData.String())
+}
+
+func restaurantIDsFromPostData(postData string) ([]int, bool) {
+	var envelope struct {
+		Variables struct {
+			RestaurantIDs []json.RawMessage `json:"restaurantIds"`
+		} `json:"variables"`
+	}
+	if err := json.Unmarshal([]byte(postData), &envelope); err != nil || len(envelope.Variables.RestaurantIDs) == 0 {
+		return nil, false
+	}
+	ids := make([]int, 0, len(envelope.Variables.RestaurantIDs))
+	for _, raw := range envelope.Variables.RestaurantIDs {
+		var id int
+		if err := json.Unmarshal(raw, &id); err != nil {
+			var text string
+			if json.Unmarshal(raw, &text) != nil {
+				return nil, false
+			}
+			parsed, err := strconv.Atoi(text)
+			if err != nil {
+				return nil, false
+			}
+			id = parsed
+		}
+		ids = append(ids, id)
+	}
+	return ids, true
+}
+
+func containsRestaurantID(ids []int, want int) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
 }
 
 // hashFromRequest reconstructs a GraphQL request's POST body from the CDP

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail_capture.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail_capture.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Pejman Pour-Moezzi and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package opentable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/chromedp/cdproto"
+	"github.com/chromedp/cdproto/network"
+)
+
+type availabilityCaptureAction struct {
+	requestID network.RequestID
+}
+
+type availabilityCaptureResult struct {
+	body   []byte
+	status int
+	err    error
+}
+
+type availabilityCaptureRequest struct {
+	bound         bool
+	boundKnown    bool
+	responseKnown bool
+	status        int
+	loadingDone   bool
+	fetchIssued   bool
+	terminal      bool
+	err           error
+}
+
+// availabilityCaptureCoordinator is the I/O-free state machine for one
+// Chrome availability run. Callers execute emitted actions separately and
+// publish their result back through FetchCompleted.
+type availabilityCaptureCoordinator struct {
+	armed       bool
+	terminal    bool
+	lastFailure error
+	requests    map[network.RequestID]*availabilityCaptureRequest
+}
+
+func newAvailabilityCaptureCoordinator() *availabilityCaptureCoordinator {
+	return &availabilityCaptureCoordinator{requests: make(map[network.RequestID]*availabilityCaptureRequest)}
+}
+
+func (c *availabilityCaptureCoordinator) Arm() {
+	if !c.terminal {
+		c.armed = true
+	}
+}
+
+func (c *availabilityCaptureCoordinator) RequestWillBeSent(id network.RequestID) {
+	if !c.armed || c.terminal {
+		return
+	}
+	if _, ok := c.requests[id]; !ok {
+		c.requests[id] = &availabilityCaptureRequest{}
+	}
+}
+
+func (c *availabilityCaptureCoordinator) BindRequest(id network.RequestID, matches bool) (*availabilityCaptureAction, *availabilityCaptureResult) {
+	r := c.requests[id]
+	if r == nil || r.boundKnown || c.terminal {
+		return nil, nil
+	}
+	r.boundKnown = true
+	r.bound = matches
+	if !matches {
+		return nil, c.finishFailureIfSettled()
+	}
+	if r.terminal {
+		c.lastFailure = r.err
+		return nil, c.finishFailureIfSettled()
+	}
+	return c.fetchIfReady(id, r), nil
+}
+
+func (c *availabilityCaptureCoordinator) ResponseReceived(id network.RequestID, status int) *availabilityCaptureAction {
+	r := c.requests[id]
+	if r == nil || r.responseKnown || r.terminal || c.terminal {
+		return nil
+	}
+	r.responseKnown = true
+	r.status = status
+	return c.fetchIfReady(id, r)
+}
+
+func (c *availabilityCaptureCoordinator) LoadingFinished(id network.RequestID) *availabilityCaptureAction {
+	r := c.requests[id]
+	if r == nil || r.loadingDone || r.terminal || c.terminal {
+		return nil
+	}
+	r.loadingDone = true
+	return c.fetchIfReady(id, r)
+}
+
+func (c *availabilityCaptureCoordinator) LoadingFailed(id network.RequestID, reason string) *availabilityCaptureResult {
+	r := c.requests[id]
+	if r == nil || r.loadingDone || r.terminal || c.terminal {
+		return nil
+	}
+	r.loadingDone = true
+	r.terminal = true
+	r.err = fmt.Errorf("request %s loading failed: %s", id, reason)
+	if !r.boundKnown || !r.bound {
+		return nil
+	}
+	c.lastFailure = r.err
+	return c.finishFailureIfSettled()
+}
+
+func (c *availabilityCaptureCoordinator) FetchCompleted(id network.RequestID, body []byte, err error) *availabilityCaptureResult {
+	r := c.requests[id]
+	if r == nil || !r.fetchIssued || r.terminal || c.terminal {
+		return nil
+	}
+	r.terminal = true
+	if err == nil && len(body) == 0 {
+		err = errors.New("response body was empty")
+	}
+	if err != nil {
+		r.err = err
+		c.lastFailure = err
+		return c.finishFailureIfSettled()
+	}
+	c.terminal = true
+	return &availabilityCaptureResult{body: body, status: r.status}
+}
+
+func (c *availabilityCaptureCoordinator) fetchIfReady(id network.RequestID, r *availabilityCaptureRequest) *availabilityCaptureAction {
+	if !r.boundKnown || !r.bound || !r.responseKnown || !r.loadingDone || r.fetchIssued || r.terminal || c.terminal {
+		return nil
+	}
+	r.fetchIssued = true
+	return &availabilityCaptureAction{requestID: id}
+}
+
+func (c *availabilityCaptureCoordinator) finishFailureIfSettled() *availabilityCaptureResult {
+	boundCount := 0
+	for _, r := range c.requests {
+		if !r.boundKnown {
+			return nil
+		}
+		if !r.bound {
+			continue
+		}
+		boundCount++
+		if !r.terminal {
+			return nil
+		}
+	}
+	if boundCount == 0 || c.lastFailure == nil {
+		return nil
+	}
+	c.terminal = true
+	return &availabilityCaptureResult{err: c.lastFailure}
+}
+
+type responseBodyFetcher func(context.Context, network.RequestID) ([]byte, error)
+
+func fetchResponseBodyWithRetry(ctx context.Context, reqID network.RequestID, fetch responseBodyFetcher, backoff time.Duration) ([]byte, error) {
+	const attempts = 3
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		var body []byte
+		body, err = fetch(ctx, reqID)
+		if err == nil {
+			return body, nil
+		}
+		if !isResponseBodyNotReady(err) || attempt == attempts {
+			return nil, fmt.Errorf("fetch response body for request %s after %d attempt(s): %w", reqID, attempt, err)
+		}
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return nil, fmt.Errorf("fetch response body for request %s retry backoff: %w", reqID, ctx.Err())
+		case <-timer.C:
+		}
+	}
+	return nil, fmt.Errorf("fetch response body for request %s: %w", reqID, err)
+}
+
+func isResponseBodyNotReady(err error) bool {
+	var cdpErr *cdproto.Error
+	return errors.As(err, &cdpErr) && cdpErr.Code == -32000 && cdpErr.Message == "No resource with given identifier found"
+}

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail_capture_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail_capture_test.go
@@ -1,0 +1,314 @@
+// Copyright 2026 Pejman Pour-Moezzi and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package opentable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto"
+	"github.com/chromedp/cdproto/network"
+)
+
+func boundCapture(t *testing.T, ids ...network.RequestID) *availabilityCaptureCoordinator {
+	t.Helper()
+	c := newAvailabilityCaptureCoordinator()
+	c.Arm()
+	for _, id := range ids {
+		c.RequestWillBeSent(id)
+		if action, result := c.BindRequest(id, true); action != nil || result != nil {
+			t.Fatalf("BindRequest(%s) emitted action=%v result=%v before response/loading completion", id, action, result)
+		}
+	}
+	return c
+}
+
+func TestAvailabilityCaptureCoordinator_EventOrdering(t *testing.T) {
+	t.Run("response alone does not fetch", func(t *testing.T) {
+		c := boundCapture(t, "one")
+		if action := c.ResponseReceived("one", 200); action != nil {
+			t.Fatalf("ResponseReceived emitted early fetch: %+v", action)
+		}
+	})
+
+	t.Run("response then loading finished", func(t *testing.T) {
+		c := boundCapture(t, "one")
+		if action := c.ResponseReceived("one", 200); action != nil {
+			t.Fatalf("ResponseReceived emitted early fetch: %+v", action)
+		}
+		action := c.LoadingFinished("one")
+		if action == nil || action.requestID != "one" {
+			t.Fatalf("LoadingFinished action = %+v; want fetch for one", action)
+		}
+		result := c.FetchCompleted("one", []byte(`{"ok":true}`), nil)
+		if result == nil || result.err != nil || result.status != 200 {
+			t.Fatalf("FetchCompleted result = %+v; want HTTP 200 success", result)
+		}
+	})
+
+	t.Run("loading finished before response", func(t *testing.T) {
+		c := boundCapture(t, "one")
+		if action := c.LoadingFinished("one"); action != nil {
+			t.Fatalf("LoadingFinished emitted early fetch: %+v", action)
+		}
+		action := c.ResponseReceived("one", 204)
+		if action == nil || action.requestID != "one" {
+			t.Fatalf("ResponseReceived action = %+v; want fetch for one", action)
+		}
+	})
+
+	t.Run("loading failed before response", func(t *testing.T) {
+		c := boundCapture(t, "one")
+		result := c.LoadingFailed("one", "net::ERR_FAILED")
+		if result == nil || result.err == nil || !strings.Contains(result.err.Error(), "net::ERR_FAILED") {
+			t.Fatalf("LoadingFailed result = %+v; want terminal reason", result)
+		}
+		if action := c.ResponseReceived("one", 200); action != nil {
+			t.Fatalf("late response emitted fetch: %+v", action)
+		}
+	})
+
+	t.Run("response then loading failed", func(t *testing.T) {
+		c := boundCapture(t, "one")
+		c.ResponseReceived("one", 502)
+		result := c.LoadingFailed("one", "connection reset")
+		if result == nil || result.err == nil || !strings.Contains(result.err.Error(), "connection reset") {
+			t.Fatalf("LoadingFailed result = %+v; want terminal reason", result)
+		}
+	})
+
+	t.Run("cache response with empty body is an error", func(t *testing.T) {
+		c := boundCapture(t, "cached")
+		c.ResponseReceived("cached", 200)
+		action := c.LoadingFinished("cached")
+		if action == nil {
+			t.Fatal("cache-served request did not emit fetch after loading completion")
+		}
+		result := c.FetchCompleted("cached", nil, nil)
+		if result == nil || result.err == nil || !strings.Contains(result.err.Error(), "empty") {
+			t.Fatalf("empty body result = %+v; want error", result)
+		}
+	})
+
+	t.Run("duplicate and late events are ignored", func(t *testing.T) {
+		c := boundCapture(t, "one")
+		c.ResponseReceived("one", 200)
+		if action := c.ResponseReceived("one", 500); action != nil {
+			t.Fatalf("duplicate response emitted action: %+v", action)
+		}
+		action := c.LoadingFinished("one")
+		if action == nil {
+			t.Fatal("first completion did not emit fetch")
+		}
+		if duplicate := c.LoadingFinished("one"); duplicate != nil {
+			t.Fatalf("duplicate completion emitted action: %+v", duplicate)
+		}
+		result := c.FetchCompleted("one", []byte("body"), nil)
+		if result == nil || result.status != 200 {
+			t.Fatalf("result = %+v; duplicate response overwrote status", result)
+		}
+		if late := c.LoadingFailed("one", "late"); late != nil {
+			t.Fatalf("late failure emitted result: %+v", late)
+		}
+	})
+}
+
+func TestAvailabilityCaptureCoordinator_ArmingAndBinding(t *testing.T) {
+	c := newAvailabilityCaptureCoordinator()
+	c.RequestWillBeSent("warmup")
+	c.Arm()
+	if action, result := c.BindRequest("warmup", true); action != nil || result != nil {
+		t.Fatalf("warm-up request was captured: action=%v result=%v", action, result)
+	}
+	c.RequestWillBeSent("other-restaurant")
+	c.BindRequest("other-restaurant", false)
+	c.ResponseReceived("other-restaurant", 200)
+	if action := c.LoadingFinished("other-restaurant"); action != nil {
+		t.Fatalf("non-target restaurant emitted fetch: %+v", action)
+	}
+}
+
+func TestRestaurantIDsFromPostData(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want []int
+		ok   bool
+	}{
+		{name: "numeric ids", body: `{"variables":{"restaurantIds":[1080775,42]}}`, want: []int{1080775, 42}, ok: true},
+		{name: "string id", body: `{"variables":{"restaurantIds":["1080775"]}}`, want: []int{1080775}, ok: true},
+		{name: "missing ids", body: `{"variables":{}}`},
+		{name: "hash-only persisted query", body: `{"extensions":{"persistedQuery":{"sha256Hash":"0123456789abcdef"}}}`},
+		{name: "malformed", body: `{`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := restaurantIDsFromPostData(tc.body)
+			if ok != tc.ok || fmt.Sprint(got) != fmt.Sprint(tc.want) {
+				t.Fatalf("restaurantIDsFromPostData() = (%v, %v); want (%v, %v)", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestAvailabilityCaptureCoordinator_MultipleCandidates(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		successFirst bool
+	}{
+		{name: "failed candidate completes first"},
+		{name: "successful candidate completes first", successFirst: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := boundCapture(t, "failed", "successful")
+			c.ResponseReceived("failed", 500)
+			failedAction := c.LoadingFinished("failed")
+			c.ResponseReceived("successful", 200)
+			successAction := c.LoadingFinished("successful")
+			if failedAction == nil || successAction == nil {
+				t.Fatalf("actions = failed:%+v successful:%+v; want both", failedAction, successAction)
+			}
+			if tc.successFirst {
+				result := c.FetchCompleted("successful", []byte("winner"), nil)
+				if result == nil || string(result.body) != "winner" {
+					t.Fatalf("successful result = %+v", result)
+				}
+				if late := c.FetchCompleted("failed", nil, errors.New("failed")); late != nil {
+					t.Fatalf("late failure preempted winner: %+v", late)
+				}
+				return
+			}
+			if early := c.FetchCompleted("failed", nil, errors.New("failed")); early != nil {
+				t.Fatalf("failed candidate preempted pending success: %+v", early)
+			}
+			result := c.FetchCompleted("successful", []byte("winner"), nil)
+			if result == nil || string(result.body) != "winner" {
+				t.Fatalf("successful result = %+v", result)
+			}
+		})
+	}
+}
+
+func TestAvailabilityCaptureCoordinator_UnresolvedBindingStaysPending(t *testing.T) {
+	c := newAvailabilityCaptureCoordinator()
+	c.Arm()
+	c.RequestWillBeSent("failed")
+	c.RequestWillBeSent("pending")
+	c.BindRequest("failed", true)
+	c.ResponseReceived("failed", 500)
+	failedAction := c.LoadingFinished("failed")
+	if failedAction == nil {
+		t.Fatal("failed candidate did not emit fetch action")
+	}
+	c.ResponseReceived("pending", 200)
+	if action := c.LoadingFinished("pending"); action != nil {
+		t.Fatalf("unbound pending request emitted action: %+v", action)
+	}
+	if result := c.FetchCompleted(failedAction.requestID, nil, errors.New("failed candidate")); result != nil {
+		t.Fatalf("failed candidate preempted unresolved binding: %+v", result)
+	}
+	action, result := c.BindRequest("pending", true)
+	if result != nil || action == nil || action.requestID != "pending" {
+		t.Fatalf("pending BindRequest = action:%+v result:%+v; want fetch action", action, result)
+	}
+	result = c.FetchCompleted("pending", []byte("winner"), nil)
+	if result == nil || result.err != nil || string(result.body) != "winner" {
+		t.Fatalf("pending candidate result = %+v; want success", result)
+	}
+}
+
+func TestAvailabilityCaptureCoordinator_NonTargetFailureDoesNotReplaceBoundFailure(t *testing.T) {
+	c := newAvailabilityCaptureCoordinator()
+	c.Arm()
+	c.RequestWillBeSent("target")
+	c.RequestWillBeSent("non-target")
+	c.BindRequest("target", true)
+	c.ResponseReceived("target", 500)
+	targetAction := c.LoadingFinished("target")
+	if targetAction == nil {
+		t.Fatal("target candidate did not emit fetch action")
+	}
+	if result := c.FetchCompleted(targetAction.requestID, nil, errors.New("target fetch failed")); result != nil {
+		t.Fatalf("target failure preempted unresolved binding: %+v", result)
+	}
+	if result := c.LoadingFailed("non-target", "non-target load failed"); result != nil {
+		t.Fatalf("unbound non-target failure emitted result: %+v", result)
+	}
+	action, result := c.BindRequest("non-target", false)
+	if action != nil || result == nil || result.err == nil {
+		t.Fatalf("non-target BindRequest = action:%+v result:%+v; want settled target failure", action, result)
+	}
+	if !strings.Contains(result.err.Error(), "target fetch failed") || strings.Contains(result.err.Error(), "non-target load failed") {
+		t.Fatalf("settled error = %v; want bound target failure only", result.err)
+	}
+}
+
+func TestFetchResponseBodyWithRetry(t *testing.T) {
+	notReady := func() error {
+		return fmt.Errorf("wrapped: %w", &cdproto.Error{Code: -32000, Message: "No resource with given identifier found"})
+	}
+
+	t.Run("exact transient then success", func(t *testing.T) {
+		calls := 0
+		body, err := fetchResponseBodyWithRetry(context.Background(), "one", func(context.Context, network.RequestID) ([]byte, error) {
+			calls++
+			if calls == 1 {
+				return nil, notReady()
+			}
+			return []byte("body"), nil
+		}, time.Millisecond)
+		if err != nil || string(body) != "body" || calls != 2 {
+			t.Fatalf("body=%q err=%v calls=%d; want success on call 2", body, err, calls)
+		}
+	})
+
+	t.Run("persistent transient is wrapped", func(t *testing.T) {
+		calls := 0
+		_, err := fetchResponseBodyWithRetry(context.Background(), "one", func(context.Context, network.RequestID) ([]byte, error) {
+			calls++
+			return nil, notReady()
+		}, time.Millisecond)
+		if err == nil || calls != 3 || !strings.Contains(err.Error(), "after 3 attempt") {
+			t.Fatalf("err=%v calls=%d; want wrapped persistent failure", err, calls)
+		}
+		var cdpErr *cdproto.Error
+		if !errors.As(err, &cdpErr) {
+			t.Fatalf("wrapped error lost *cdproto.Error: %v", err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "same code different message", err: &cdproto.Error{Code: -32000, Message: "Another failure"}},
+		{name: "different code same message", err: &cdproto.Error{Code: -32001, Message: "No resource with given identifier found"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			_, err := fetchResponseBodyWithRetry(context.Background(), "one", func(context.Context, network.RequestID) ([]byte, error) {
+				calls++
+				return nil, tc.err
+			}, time.Millisecond)
+			if err == nil || calls != 1 {
+				t.Fatalf("err=%v calls=%d; want one fetch and no retry", err, calls)
+			}
+		})
+	}
+
+	t.Run("context canceled during retry backoff", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		_, err := fetchResponseBodyWithRetry(ctx, "one", func(context.Context, network.RequestID) ([]byte, error) {
+			calls++
+			cancel()
+			return nil, notReady()
+		}, time.Hour)
+		if !errors.Is(err, context.Canceled) || calls != 1 {
+			t.Fatalf("err=%v calls=%d; want cancellation during backoff", err, calls)
+		}
+	})
+}


### PR DESCRIPTION
## What

OpenTable's `RestaurantsAvailability` GraphQL operation recently started returning 403 on the direct path (operation-specific, sibling ops unaffected), which routes availability through the Chrome fallback in `chrome_avail.go`. That fallback then failed intermittently with `read response body: No resource with given identifier found (-32000)`: the `EventResponseReceived` handler fetches the body immediately, but CDP only guarantees a readable body after `Network.loadingFinished`. The race usually wins against fast pages and loses against a real attached Chrome — and the resulting failure can surface downstream as a plain "no open slots," which is indistinguishable from genuine fullness.

## Changes

- **Capture coordinator** (`chrome_avail_capture.go`): a small pure state machine, keyed per request from `RequestWillBeSent`, that emits an exactly-once fetch action only when both the response metadata and `loadingFinished` are known — in either event order. `loadingFailed` is terminal with its reason. Duplicate/late events are ignored. The coordinator performs no I/O; a worker executes the fetch after the listener callback returns (chromedp listeners are synchronous — CDP calls inside the callback path can deadlock the event loop), behind an explicit callback barrier, with joined lifecycles so no worker outlives the run.
- **Candidate arbitration**: body capture arms only for the target page navigation (warm-up traffic excluded) and binds candidates to the requested restaurant ID parsed from POST variables (hash-only persisted-query bodies bind as unknown without mis-binding). The first successfully completing bound candidate wins; a failed candidate never preempts a pending or still-binding one.
- **Bounded retry**: `Network.getResponseBody` is retried at most twice more only for the exact transient condition (code `-32000` with message "No resource with given identifier found", matched via `errors.As` so wrapping preserves eligibility). Same code with a different message, or a different code, fails immediately.
- **Hash-harvest invariant preserved**: persisted-query hash harvest and persistence still run even when loading or body capture fails — that self-heal path is what recovers the direct path after bundle rotations.
- **Diagnosable "no slots"** (`earliest.go`): a 200 response that parses to zero availability chunks for the requested restaurant now says "response contained no availability data for restaurant N" instead of the same "no open slots in N-day window" used for genuine fullness. Reason string only; row shape and `Available` semantics unchanged. (We hit exactly this in production: a clean "no open slots" while the live page showed five open times.)

## Testing

- Coordinator unit tests with synthetic events and scripted fetch results: no fetch on response alone; success after `loadingFinished` in both orders; completion-processed-before-response; `loadingFailed` before and after a response; cache/no-body; duplicate/late events; two matching request IDs with failure/success in both orders; unresolved-binding stays pending; non-target failure does not replace a bound failure; exact -32000 transient-then-success; persistent -32000; retry-exclusion pair (same code/different message and different code — one fetch, no retry); cancellation during backoff.
- Both reason phrasings in `earliest.go` covered by unit tests.
- `go test -race` clean on `internal/source/opentable` and `internal/cli`.

No changes to cookies, headers, request shaping, the availability cache, cooldown, or slot classification. One patch-registry entry added per repo convention (`opentable-chrome-avail-body-capture.json`).

https://claude.ai/code/session_017ZgvVfyPxcLHYy5DPoDf37
