### PR TITLE
fix(edgar): map efts --date-range to startdt/enddt so the filter applies

### DIFF
--- a/library/other/edgar/.printing-press-patches/amend-efts-date-range.json
+++ b/library/other/edgar/.printing-press-patches/amend-efts-date-range.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 2,
+  "id": "amend-efts-date-range",
+  "applied_at": "2026-07-21",
+  "base_run_id": "20260513-115144",
+  "base_printing_press_version": "4.3.0",
+  "summary": "fix(edgar): map efts --date-range \"A,B\" to startdt/enddt query params so the date filter actually applies (CLI + MCP efts_query).",
+  "reason": "The generated efts surface sent the combined \"A,B\" value as a single dateRange query param. efts.sec.gov's full-text search endpoint filters by two separate params (startdt, enddt) and silently ignores an unknown dateRange param, so --date-range was a no-op: `efts \"artificial intelligence\" --forms S-1 --date-range \"2026-07-20,2026-07-21\"` returned the full unfiltered corpus (total 7361, 2024-dated hits) instead of the 10 in-range hits the API returns for startdt=2026-07-20&enddt=2026-07-21. A shared cliutil.SplitDateRange helper splits the value; both the `efts` command and the MCP efts_query tool now emit startdt/enddt. Note: efts applies the filter only when BOTH bounds are present (a lone startdt or enddt is ignored by the API itself); the fix passes bounds through faithfully. The identical dateRange mapping in internal/cli/sync.go (determineDateRangeParam, a shared multi-resource sync path with a distinct --dates flag) is intentionally out of scope for this focused fix.",
+  "files": [
+    "internal/cliutil/daterange.go",
+    "internal/cli/promoted_efts.go",
+    "internal/mcp/tools.go"
+  ],
+  "validated_outcome": "go build, go vet, and package tests (cli, mcp, cliutil incl. new TestSplitDateRange) pass. Live repro: patched `efts ... --date-range \"2026-07-20,2026-07-21\"` returns total 10 (== raw efts.sec.gov startdt/enddt count), all returned file_dates within range; no-date-range invocation unchanged (large total). `cli-printing-press publish validate` code checks pass (phase5, go mod tidy, govulncheck, go vet, go build, --help, --version); the two failing checks (manifest schema_version==1, SKILL.md canonical-sections drift) are pre-existing baseline drift untouched by this patch.",
+  "findings_addressed": ["F1"],
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator param mapping for combined date-range flags whose target API expects two separate bound params (start/end).",
+      "reason": "The Printing Press emitted a naive single-param camelCase mapping (date-range -> dateRange) for an endpoint (efts.sec.gov) that filters via two params (startdt/enddt). This is an exotic single-CLI parameter shape rather than a multi-CLI template defect, so it is patched here in the published library; a generator that learns start/end range decomposition would supersede this local patch."
+    }
+  ]
+}

--- a/library/other/edgar/internal/cli/promoted_efts.go
+++ b/library/other/edgar/internal/cli/promoted_efts.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mvanhorn/printing-press-library/library/other/edgar/internal/cliutil"
 	"github.com/spf13/cobra"
 )
 
@@ -47,8 +48,21 @@ func newEftsPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flagForms != "" {
 				params["forms"] = fmt.Sprintf("%v", flagForms)
 			}
+			// PATCH(amend-efts-date-range): efts.sec.gov filters by separate
+			// startdt/enddt query params, not a single combined "dateRange"
+			// value. The generator emitted params["dateRange"]="A,B", which the
+			// API silently ignores — the filter never applied and every query
+			// returned unfiltered totals. Split into startdt/enddt so the range
+			// actually takes effect.
 			if flagDateRange != "" {
-				params["dateRange"] = fmt.Sprintf("%v", flagDateRange)
+				if start, end := cliutil.SplitDateRange(flagDateRange); start != "" || end != "" {
+					if start != "" {
+						params["startdt"] = start
+					}
+					if end != "" {
+						params["enddt"] = end
+					}
+				}
 			}
 			if flagCiks != "" {
 				params["ciks"] = fmt.Sprintf("%v", flagCiks)

--- a/library/other/edgar/internal/cliutil/daterange.go
+++ b/library/other/edgar/internal/cliutil/daterange.go
@@ -1,0 +1,28 @@
+// Copyright 2026 magoo242 and contributors. Licensed under Apache-2.0. See LICENSE.
+// PATCH(amend-efts-date-range): hand-added helper — see .printing-press-patches/.
+
+package cliutil
+
+import "strings"
+
+// SplitDateRange splits a combined "start,end" date-range flag value into its
+// two bounds, trimming surrounding whitespace on each side. Either bound may be
+// empty to express an open-ended range:
+//
+//	"2024-01-01,2026-05-13" -> ("2024-01-01", "2026-05-13")
+//	"2024-01-01,"           -> ("2024-01-01", "")
+//	",2026-05-13"           -> ("",           "2026-05-13")
+//	"2024-01-01"            -> ("2024-01-01", "")   // no comma: start-only
+//
+// It exists because efts.sec.gov's full-text search endpoint filters by two
+// separate query params (startdt, enddt) rather than a single combined range
+// value; callers map the two returned bounds onto those params. Sending the
+// combined "start,end" string as one param is silently ignored by the API.
+func SplitDateRange(s string) (start, end string) {
+	parts := strings.SplitN(s, ",", 2)
+	start = strings.TrimSpace(parts[0])
+	if len(parts) == 2 {
+		end = strings.TrimSpace(parts[1])
+	}
+	return start, end
+}

--- a/library/other/edgar/internal/cliutil/daterange_test.go
+++ b/library/other/edgar/internal/cliutil/daterange_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 magoo242 and contributors. Licensed under Apache-2.0. See LICENSE.
+// PATCH(amend-efts-date-range): hand-added test — see .printing-press-patches/.
+
+package cliutil
+
+import "testing"
+
+func TestSplitDateRange(t *testing.T) {
+	cases := []struct {
+		in, wantStart, wantEnd string
+	}{
+		{"2024-01-01,2026-05-13", "2024-01-01", "2026-05-13"},
+		{"2026-07-20,2026-07-21", "2026-07-20", "2026-07-21"},
+		{" 2024-01-01 , 2026-05-13 ", "2024-01-01", "2026-05-13"}, // whitespace trimmed
+		{"2024-01-01,", "2024-01-01", ""},                         // open-ended end
+		{",2026-05-13", "", "2026-05-13"},                         // open-ended start
+		{"2024-01-01", "2024-01-01", ""},                          // no comma: start-only
+		{"", "", ""},                                              // empty
+		{"   ", "", ""},                                           // whitespace-only
+	}
+	for _, c := range cases {
+		start, end := SplitDateRange(c.in)
+		if start != c.wantStart || end != c.wantEnd {
+			t.Errorf("SplitDateRange(%q) = (%q, %q), want (%q, %q)", c.in, start, end, c.wantStart, c.wantEnd)
+		}
+	}
+}

--- a/library/other/edgar/internal/mcp/tools.go
+++ b/library/other/edgar/internal/mcp/tools.go
@@ -66,7 +66,10 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "https://efts.sec.gov/LATEST/search-index", []mcpParamBinding{{PublicName: "query", WireName: "q", Location: "query"}, {PublicName: "forms", WireName: "forms", Location: "query"}, {PublicName: "date-range", WireName: "dateRange", Location: "query"}, {PublicName: "ciks", WireName: "ciks", Location: "query"}}, []string{"q"}),
+		// PATCH(amend-efts-date-range): date-range maps to efts.sec.gov's two
+		// startdt/enddt query params (comma-listed composite wire name), not a
+		// single "dateRange" value the API silently ignores. See makeAPIHandler.
+		makeAPIHandler("GET", "https://efts.sec.gov/LATEST/search-index", []mcpParamBinding{{PublicName: "query", WireName: "q", Location: "query"}, {PublicName: "forms", WireName: "forms", Location: "query"}, {PublicName: "date-range", WireName: "startdt,enddt", Location: "query"}, {PublicName: "ciks", WireName: "ciks", Location: "query"}}, []string{"q"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("filings_browse",
@@ -163,6 +166,23 @@ func makeAPIHandler(method, pathTemplate string, bindings []mcpParamBinding, pos
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:
+				// PATCH(amend-efts-date-range): a comma-listed WireName (e.g.
+				// "startdt,enddt") is a composite range binding — the single
+				// "start,end" input is split across the listed query params.
+				// efts.sec.gov ignores a single combined date-range value, so
+				// the filter only applies when the two bounds are sent
+				// separately. cliutil.SplitDateRange is the same splitter the
+				// `efts` CLI command uses, keeping both surfaces in lockstep.
+				if wires := strings.Split(binding.WireName, ","); len(wires) == 2 {
+					start, end := cliutil.SplitDateRange(fmt.Sprintf("%v", v))
+					if start != "" {
+						params[strings.TrimSpace(wires[0])] = start
+					}
+					if end != "" {
+						params[strings.TrimSpace(wires[1])] = end
+					}
+					continue
+				}
 				params[binding.WireName] = fmt.Sprintf("%v", v)
 			}
 		}


### PR DESCRIPTION
## Summary

The `efts` full-text-search surface silently ignored `--date-range`. The generated code sent the combined `"A,B"` value as a single `dateRange` query param, but efts.sec.gov filters by two separate params (`startdt`, `enddt`) and ignores an unknown `dateRange` — so the date filter never applied. This maps the flag to `startdt`/`enddt` on both the `efts` CLI command and the MCP `efts_query` tool, via a shared `cliutil.SplitDateRange` helper.

## Findings

| ID | Category | Type | Rationale |
|---|---|---|---|
| F1 | efts date filtering | bug | `--date-range "A,B"` was sent as `dateRange=A,B` (unknown to efts, silently dropped); must be `startdt=A&enddt=B`. |

## Root cause

`library/other/edgar/internal/cli/promoted_efts.go` set `params["dateRange"] = flagDateRange`. The MCP tool (`internal/mcp/tools.go`) bound `date-range → dateRange` the same way. efts.sec.gov applies the filter only when both `startdt` and `enddt` are present.

## Changes

```
 .../amend-efts-date-range.json                     | 22 +++++++++++++++++
 library/other/edgar/internal/cli/promoted_efts.go  | 16 ++++++++++++-
 library/other/edgar/internal/cliutil/daterange.go  | 28 ++++++++++++++++++++++
 .../other/edgar/internal/cliutil/daterange_test.go | 27 +++++++++++++++++++++
 library/other/edgar/internal/mcp/tools.go          | 22 ++++++++++++++++-
 5 files changed, 113 insertions(+), 2 deletions(-)
```

- **New** `internal/cliutil/daterange.go` — `SplitDateRange("start,end")` splitter (single source of truth), plus `daterange_test.go`.
- `internal/cli/promoted_efts.go` — split `--date-range` into `startdt`/`enddt`.
- `internal/mcp/tools.go` — the `efts_query` binding uses a composite wire name `startdt,enddt`; `makeAPIHandler` splits a comma-listed query binding across the two params using the same helper.
- `.printing-press-patches/amend-efts-date-range.json` — patch record.

## Verification

Live, against efts.sec.gov (query `"artificial intelligence"`, `--forms S-1`, range `2026-07-20,2026-07-21`):

| | total | dates |
|---|---|---|
| Raw API (`startdt`/`enddt`) — ground truth | **10** | all 2026-07-20/21 |
| Patched CLI **with** `--date-range` | **10** | all 2026-07-20/21 |
| Patched CLI **without** `--date-range` (unchanged) | 7361 | unfiltered (2024+) |
| Before fix (`dateRange=A,B`) | 7361 | unfiltered — bug |

- `go build ./...`, `go vet`: pass
- Package tests (`internal/cli`, `internal/mcp`, `internal/cliutil` incl. new `TestSplitDateRange`): pass
- `cli-printing-press publish validate` code checks pass: phase5, go mod tidy, govulncheck, go vet, go build, --help, --version. Two checks fail on the **pre-existing baseline** (untouched by this PR): `manifest` (`schema_version` must be 2, published manifest is 1) and `verify-skill` (SKILL.md canonical-install-section drift). Neither `.printing-press.json` nor `SKILL.md` is in this diff.

Documentation checkpoint: no user-facing doc change — `--date-range` and its documented semantics are unchanged; this makes the implementation honor the existing flag help. `sync.go`'s separate `dateRange` mapping (distinct `--dates` flag, shared multi-resource path) is intentionally out of scope.

## Notes

- Generator dimension: recorded as `deferred_to_upstream` in the patch record — the Printing Press emitted a naive `date-range → dateRange` camelCase mapping for an endpoint that decomposes a range into two bound params. Exotic single-CLI param shape, so patched in the library per AGENTS.md; a generator that learns start/end decomposition would supersede this patch.
- This amend was run on documented pre-approval for both checkpoints (scope: fix the efts date-range mapping bug; PR open pre-approved), so the two interactive checkpoints were satisfied ahead of the run rather than in-session.

## Evidence

- Patch record: https://github.com/chrisabra-co/printing-press-library/blob/a1e3d194755816b623989384942172456fa5acec/library/other/edgar/.printing-press-patches/amend-efts-date-range.json
