### PR TITLE
fix(amazon-orders): reject HTML sync payloads

### DIFF
--- a/library/commerce/amazon-orders/internal/cli/sync.go
+++ b/library/commerce/amazon-orders/internal/cli/sync.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
@@ -26,6 +27,19 @@ type syncResult struct {
 	Err      error
 	Warn     error
 	Duration time.Duration
+}
+
+// rejectHTMLSyncPayload prevents an HTML page from being persisted as JSON.
+// Browser-oriented services can reply with a 200 HTML shell even when a session
+// is valid; storing that shell makes a sync look successful and corrupts local
+// reads later.
+func rejectHTMLSyncPayload(data json.RawMessage) error {
+	trimmed := bytes.TrimSpace(data)
+	lower := strings.ToLower(string(trimmed))
+	if strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") {
+		return fmt.Errorf("received HTML instead of JSON; this endpoint requires an HTML parser or browser-rendered response")
+	}
+	return nil
 }
 
 func newSyncCmd(flags *rootFlags) *cobra.Command {
@@ -343,6 +357,9 @@ func syncResource(c interface {
 			return returnFetchError(err)
 		}
 		if err := parser.AuthInterstitialError(data); err != nil {
+			return returnFetchError(err)
+		}
+		if err := rejectHTMLSyncPayload(data); err != nil {
 			return returnFetchError(err)
 		}
 

--- a/library/commerce/amazon-orders/internal/cli/sync_html_test.go
+++ b/library/commerce/amazon-orders/internal/cli/sync_html_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRejectHTMLSyncPayload(t *testing.T) {
+	err := rejectHTMLSyncPayload(json.RawMessage(" \n<!DOCTYPE html><html><head><title>Your Orders</title></head></html>"))
+	if err == nil {
+		t.Fatal("expected an HTML response to be rejected before it reaches the JSON store")
+	}
+}
+
+func TestRejectHTMLSyncPayloadAllowsJSON(t *testing.T) {
+	if err := rejectHTMLSyncPayload(json.RawMessage(`[{"orderId":"111-2222222-3333333"}]`)); err != nil {
+		t.Fatalf("expected JSON payload to be accepted: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- reject HTML responses before generic sync stores them in the JSON resource table
- return a clear sync error instead of emitting a false `sync_complete` and poisoning local reads
- add regression coverage for HTML rejection and normal JSON acceptance

## Why

Amazon can serve an HTTP 200 HTML shell/interstitial to the HTTP client. The generic sync path previously persisted that document as JSON; later local reads failed on raw `<html>`.

Closes #1568.

## Verification

- `go test ./...`
- `go vet ./...`
- live authenticated Amazon sync: observed the existing interstitial guard fail closed (exit 1, no `sync_complete`) rather than write a local record