### PR TITLE
fix(amazon-orders): reject malformed cookie imports

### DIFF
--- a/library/commerce/amazon-orders/.printing-press-patches/reject-malformed-cookie-imports.json
+++ b/library/commerce/amazon-orders/.printing-press-patches/reject-malformed-cookie-imports.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "reject-malformed-cookie-imports",
+  "applied_at": "2026-07-22",
+  "base_run_id": "20260510-105710",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Browser-cookie login must reject malformed extractor output before persisting credentials.",
+  "reason": "Chrome cookie database schema 24 prepends a binary SHA-256 host hash to encrypted values. Stale extractors can leave that prefix attached, producing an invalid Cookie header and invalid UTF-8 that makes the saved TOML unreadable on the next invocation.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/cli/auth_count_cookies_test.go"
+  ],
+  "validated_outcome": "Focused tests cover valid headers, binary schema metadata, malformed pairs, and newlines; live Chrome login succeeds with pycookiecheat 0.8.0.",
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/3706"
+}

--- a/library/commerce/amazon-orders/internal/cli/auth.go
+++ b/library/commerce/amazon-orders/internal/cli/auth.go
@@ -263,6 +263,9 @@ profile by name when the installed backend supports it.`,
 			if cookies == "" {
 				return authErr(fmt.Errorf("cookie tool returned no cookies for %s", domain))
 			}
+			if err := validateExtractedCookieHeader(cookies); err != nil {
+				return authErr(err)
+			}
 			// Step 4: Save to config
 			if err := cfg.SaveTokens("", "", cookies, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving cookies: %w", err))
@@ -520,6 +523,9 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 	}
 	if cookies == "" {
 		return fmt.Errorf("no cookies found for %s", domain)
+	}
+	if err := validateExtractedCookieHeader(cookies); err != nil {
+		return err
 	}
 	if err := cfg.SaveTokens("", "", cookies, "", time.Time{}); err != nil {
 		return configErr(fmt.Errorf("saving cookies: %w", err))
@@ -985,6 +991,18 @@ func resolveProfileByName(name string) (string, error) {
 // --- Cookie extraction tools ---
 
 var detectedPycookiecheatCLIPath string
+
+// validateExtractedCookieHeader rejects malformed browser-extractor output
+// before it can be persisted or passed to net/http. In Chrome cookie database
+// schema 24+, stale extractors may leave the binary SHA-256(host_key) prefix
+// attached to each decrypted value. net/http rejects those bytes, and writing
+// invalid UTF-8 into TOML can make the CLI's config unreadable on its next run.
+func validateExtractedCookieHeader(header string) error {
+	if _, err := http.ParseCookie(header); err != nil {
+		return fmt.Errorf("cookie importer returned malformed Cookie header: %w; update the browser extractor (pycookiecheat 0.8.0 or newer); refusing to save credentials", err)
+	}
+	return nil
+}
 
 func runCookieToolProbe(name string, args ...string) error {
 	cmd := exec.Command(name, args...)

--- a/library/commerce/amazon-orders/internal/cli/auth_count_cookies_test.go
+++ b/library/commerce/amazon-orders/internal/cli/auth_count_cookies_test.go
@@ -134,6 +134,31 @@ func TestCookieDomainFromConfig_InvalidBaseURLSurfacesError(t *testing.T) {
 	}
 }
 
+func TestValidateExtractedCookieHeader(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		wantErr bool
+	}{
+		{name: "valid", header: "session-id=abc; ubid-main=def"},
+		{name: "empty", header: "", wantErr: true},
+		{name: "missing equals", header: "session-id", wantErr: true},
+		{name: "chrome schema metadata bytes", header: "session-id=\x01\xffbinary", wantErr: true},
+		{name: "newline", header: "session-id=abc\ndef", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExtractedCookieHeader(tt.header)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateExtractedCookieHeader() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.header != "" && strings.Contains(err.Error(), tt.header) {
+				t.Fatal("validation error leaked raw cookie material")
+			}
+		})
+	}
+}
+
 func TestValidateBrowserSessionOrWarnClearsProofAndReturnsFalse(t *testing.T) {
 	cfg := &config.Config{Path: filepath.Join(t.TempDir(), "config.toml")}
 	if err := writeBrowserSessionProof(cfg, []byte("{}\n")); err != nil {


### PR DESCRIPTION
## Summary

- Reject malformed Chrome cookie extractor output before it reaches TOML or `net/http`.
- Apply the guard to both first-run login and unattended cookie refresh.
- Record the customization as a durable `.printing-press-patches/` reprint guard.
- Backport the systemic fix tracked by mvanhorn/cli-printing-press#3706; this also closes the unresolved serialization failure described in #492 for Amazon Orders.

## Published CLI Metadata

**API:** `amazon-orders` | **Category:** `commerce` | **Press version:** `4.2.2`  
**Spec:** `library/commerce/amazon-orders/spec.yaml`  
**Required env:** `AMAZON_COOKIES` (optional non-browser injection path)

## What Changed

Chrome cookie database schema 24 prepends a binary `SHA256(host_key)` value before the decrypted cookie payload. Homebrew `cookies` 0.5.1 leaves that prefix attached; the CLI previously persisted it, reported success despite failed validation, and then could not parse its own TOML config.

The CLI now validates the complete Cookie header before saving. Invalid input exits with an auth error, prints a safe `pycookiecheat` upgrade hint, does not expose cookie bytes, and leaves the target config untouched.

## CLI Shape

```bash
$ amazon-orders-pp-cli auth login --help
Authenticate using your browser session.

Usage:
  amazon-orders-pp-cli auth login [flags]

Flags:
      --browser          Alias for --chrome
      --chrome           Read cookies from Chrome
      --domain string    Amazon marketplace domain to read cookies for
      --profile string   Chrome profile name
```

## What This CLI Does

Amazon Orders imports a read-only Amazon buyer session, syncs order history into local SQLite, and supports offline order, shipment, spending, and purchase-history analysis. This patch changes only the credential-import trust boundary; no command or MCP surface changes.

## Manuscripts

- [Research Brief](./library/commerce/amazon-orders/.manuscripts/20260510-105710/research/)
- [Shipcheck Results](./library/commerce/amazon-orders/.manuscripts/20260510-105710/proofs/)

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/commerce/amazon-orders/`
- [x] `go build ./...` from the touched CLI root
- [x] `go vet ./...` from the touched CLI root
- [x] `go test ./...` from the touched CLI root
- [x] `govulncheck ./...` from the touched CLI root
- [ ] `go run ./tools/generate-skills/main.go` when `library/**/SKILL.md` changed — not applicable; SKILL.md is unchanged
- [x] `git diff --check`
- [x] Live Chrome 150 / schema 24 login with `pycookiecheat` 0.8.0: browser-session proof valid, doctor credentials valid, live orders request succeeded
- [x] Forced stale `cookies` 0.5.1 path: exit 4 and target config not created

## Gaps / Follow-Up

- The backport prevents corruption but intentionally does not repair third-party `cookies` 0.5.1 output. The actionable recovery path is `pycookiecheat` 0.8.0+; the generator-level guard is tracked in mvanhorn/cli-printing-press#3706.
