### PR TITLE
fix(fireflies): use input-object shape for updateMeetingTitle/updateMeetingPrivacy

### DIFF
--- a/library/productivity/fireflies/internal/cli/transcripts_ff.go
+++ b/library/productivity/fireflies/internal/cli/transcripts_ff.go
@@ -855,16 +855,16 @@ func newTranscriptsUpdateCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if title != "" {
-				const q = `mutation UpdateMeetingTitle($id: String!, $title: String!) { updateMeetingTitle(id: $id, title: $title) { success message } }`
-				data, err := client.Query(cmd.Context(), q, map[string]any{"id": args[0], "title": title}, "updateMeetingTitle")
+				const q = `mutation UpdateMeetingTitle($input: UpdateMeetingTitleInput!) { updateMeetingTitle(input: $input) { title } }`
+				data, err := client.Query(cmd.Context(), q, map[string]any{"input": map[string]any{"id": args[0], "title": title}}, "updateMeetingTitle")
 				if err != nil {
 					return fmt.Errorf("updating title: %w", err)
 				}
 				return printJSONFiltered(cmd.OutOrStdout(), data, flags)
 			}
 			if privacy != "" {
-				const q = `mutation UpdateMeetingPrivacy($id: String!, $privacy: String!) { updateMeetingPrivacy(id: $id, privacy: $privacy) { success message } }`
-				data, err := client.Query(cmd.Context(), q, map[string]any{"id": args[0], "privacy": privacy}, "updateMeetingPrivacy")
+				const q = `mutation UpdateMeetingPrivacy($input: UpdateMeetingPrivacyInput!) { updateMeetingPrivacy(input: $input) { id title privacy } }`
+				data, err := client.Query(cmd.Context(), q, map[string]any{"input": map[string]any{"id": args[0], "privacy": privacy}}, "updateMeetingPrivacy")
 				if err != nil {
 					return fmt.Errorf("updating privacy: %w", err)
 				}

--- a/library/productivity/fireflies/spec.yaml
+++ b/library/productivity/fireflies/spec.yaml
@@ -61,10 +61,10 @@ type Query {
 
 type Mutation {
   """Update a meeting title"""
-  updateMeetingTitle(id: String!, title: String!): MutationResult
+  updateMeetingTitle(input: UpdateMeetingTitleInput!): Transcript
 
   """Update meeting privacy"""
-  updateMeetingPrivacy(id: String!, privacy: String!): MutationResult
+  updateMeetingPrivacy(input: UpdateMeetingPrivacyInput!): Transcript
 
   """Update meeting channel/folder"""
   updateMeetingChannel(id: String!, channel_id: String!): MutationResult
@@ -378,6 +378,16 @@ input AttendeeInput {
   displayName: String
   email: String
   phoneNumber: String
+}
+
+input UpdateMeetingTitleInput {
+  id: String!
+  title: String!
+}
+
+input UpdateMeetingPrivacyInput {
+  id: String!
+  privacy: String!
 }
 
 scalar DateTime


### PR DESCRIPTION
## Problem

`fireflies-pp-cli transcripts update <id> --title "..."` fails on every call against the live Fireflies API. The CLI sends the mutations with flat arguments and a `{ success message }` selection set:

```graphql
mutation UpdateMeetingTitle($id: String!, $title: String!) { updateMeetingTitle(id: $id, title: $title) { success message } }
```

but the Fireflies GraphQL API defines them as single input-object mutations returning the updated meeting fields ([updateMeetingTitle docs](https://docs.fireflies.ai/graphql-api/mutation/update-meeting-title), [updateMeetingPrivacy docs](https://docs.fireflies.ai/graphql-api/mutation/update-meeting-privacy)):

```graphql
mutation($input: UpdateMeetingTitleInput!) { updateMeetingTitle(input: $input) { title } }
mutation($input: UpdateMeetingPrivacyInput!) { updateMeetingPrivacy(input: $input) { id title privacy } }
```

## Fix

- `internal/cli/transcripts_ff.go`: both mutation branches of `transcripts update` now use the input-object shape and select the fields the API actually returns.
- `spec.yaml`: corrected the two mutation signatures and added the `UpdateMeetingTitleInput` / `UpdateMeetingPrivacyInput` input types.

## Verification

- `go build ./...` and `go vet` pass.
- `go test ./...` — one pre-existing failure (`internal/store TestMigrate_ConcurrentFreshDB`, SQLITE_BUSY on Windows) that fails identically on a clean checkout of main; all other packages pass.
- Live test: rebuilt the CLI and ran `transcripts update <real-id> --title "..."` against the live API — returns `{"title": "..."}` where it previously errored.

The privacy branch was not live-tested (did not want to mutate a real meeting''s privacy), but it is the identical shape fix verified against the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GawAkbKBhmazTsdK2h3xy4