### PR TITLE
fix(janeapp): reject anonymous sessions on browser cookie import

### DIFF
--- a/library/health/janeapp/.printing-press-patches/verify-authenticated-session-on-browser-import.json
+++ b/library/health/janeapp/.printing-press-patches/verify-authenticated-session-on-browser-import.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "verify-authenticated-session-on-browser-import",
+  "applied_at": "2026-07-22",
+  "base_run_id": "20260707-170547",
+  "base_printing_press_version": "4.27.1",
+  "summary": "The browser cookie-import login path (auth login --chrome / --cookies-file) must verify the imported session is actually authenticated before saving it, not merely that a cookie named _front_desk_session is present.",
+  "reason": "Jane sets _front_desk_session for logged-out visitors too, and Chrome's on-disk cookie DB lags the live in-memory session, so importing while signed out (or before Chrome flushes a fresh login) stored an anonymous session and printed 'Session saved'. Every later command then 401s with a hint to run the command that just 'succeeded'. A regen must keep janeVerifySession probing /api/v2/appointments (401 for absent/invalid/anonymous, 200 only when signed in) before setClinicSession, and must NOT switch the probe to the HTML /account page, which returns 200 for an invalid cookie by redirecting to /cookies_required. Server errors and transport failures are kept distinct from 'not authenticated' so a 500 or a network blip never tells the user to re-authenticate a working session. The verification honors the global --timeout, consistent with the two-step password path.",
+  "files": [
+    "internal/cli/jane_auth.go",
+    "internal/cli/auth.go",
+    "internal/cli/jane_auth_verify_test.go"
+  ],
+  "validated_outcome": "Against live clinics: importing a stale cookie for a signed-out clinic (leahkangas.janeapp.com) now exits 4 with actionable guidance instead of exiting 0 with 'Session saved'; a signed-in clinic (embophysio.janeapp.com) still imports cleanly and exits 0. Six httptest cases cover authenticated-accepted, anonymous-rejected, empty/whitespace-cookie-rejected, multi-cookie-string-parsed, and 500 / unreachable-host kept distinct from anonymous. go build, go vet, go test (full package suite), and gofmt all pass."
+}

--- a/library/health/janeapp/internal/cli/auth.go
+++ b/library/health/janeapp/internal/cli/auth.go
@@ -308,7 +308,7 @@ Alternatively, import an existing browser session:
 			// this path can capture a logged-out session and report success.
 			// Ask the server now, so the failure surfaces here with a fix
 			// instead of as a bare 401 on the user's next command.
-			if err := janeVerifySession(cmd.Context(), clinic.BaseURL, cookies, 30*time.Second); err != nil {
+			if err := janeVerifySession(cmd.Context(), clinic.BaseURL, cookies, flags.timeout); err != nil {
 				if errors.Is(err, errAnonymousSession) {
 					loginURL := strings.TrimSuffix(clinic.BaseURL, "/") + "/account"
 					fmt.Fprintf(w, "\n%s Imported a cookie for %s, but it is not a signed-in session.\n", red("ERROR"), domain)

--- a/library/health/janeapp/internal/cli/auth.go
+++ b/library/health/janeapp/internal/cli/auth.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/gorilla/websocket"
 	"github.com/mvanhorn/printing-press-library/library/health/janeapp/internal/cliutil"
@@ -300,6 +301,30 @@ Alternatively, import an existing browser session:
 			if err != nil {
 				return err
 			}
+
+			// The cookie exists — but existence is not authentication. Jane
+			// sets _front_desk_session for signed-out visitors too, and
+			// Chrome's on-disk cookie DB lags the live in-memory session, so
+			// this path can capture a logged-out session and report success.
+			// Ask the server now, so the failure surfaces here with a fix
+			// instead of as a bare 401 on the user's next command.
+			if err := janeVerifySession(cmd.Context(), clinic.BaseURL, cookies, 30*time.Second); err != nil {
+				if errors.Is(err, errAnonymousSession) {
+					loginURL := strings.TrimSuffix(clinic.BaseURL, "/") + "/account"
+					fmt.Fprintf(w, "\n%s Imported a cookie for %s, but it is not a signed-in session.\n", red("ERROR"), domain)
+					fmt.Fprintln(w, "")
+					fmt.Fprintln(w, "Jane sets this cookie for logged-out visitors too, and Chrome's")
+					fmt.Fprintln(w, "saved-to-disk copy can lag the session in the live browser window.")
+					fmt.Fprintln(w, "")
+					fmt.Fprintf(w, "Confirm you are signed in here (you should see your name):\n\n  %s\n\n", loginURL)
+					fmt.Fprintln(w, "Then re-run this command. If it still fails, the on-disk cookie is")
+					fmt.Fprintln(w, "stale — export from the live session and import the file instead:")
+					fmt.Fprintf(w, "\n  janeapp-pp-cli auth login --clinic %s --cookies-file <storage-state.json>\n", clinic.Name)
+					return authErr(fmt.Errorf("imported session for %s is not authenticated", domain))
+				}
+				return authErr(err)
+			}
+
 			if err := setClinicSession(clinic.Name, clinic.Username, cookies); err != nil {
 				return configErr(fmt.Errorf("saving session: %w", err))
 			}

--- a/library/health/janeapp/internal/cli/jane_auth.go
+++ b/library/health/janeapp/internal/cli/jane_auth.go
@@ -9,6 +9,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -222,6 +223,58 @@ func janeReq(ctx context.Context, hc *http.Client, method, u, referer string, fo
 		finalURL = resp.Request.URL.String()
 	}
 	return resp.StatusCode, string(b), finalURL, nil
+}
+
+// errAnonymousSession reports a cookie set that Jane accepted syntactically but
+// does not consider signed in.
+var errAnonymousSession = errors.New("session is not authenticated")
+
+// janeVerifySession reports whether cookies represents an AUTHENTICATED Jane
+// session for baseURL, rather than an anonymous one.
+//
+// Presence of _front_desk_session proves nothing. Jane sets that cookie for
+// logged-out visitors too, and Chrome's on-disk cookie DB lags the live
+// in-memory session, so a browser import routinely captures a signed-out
+// session and still looks like it worked. Only the server can settle it.
+//
+// /api/v2/appointments is the correct probe: it answers 401 for both an absent
+// and an invalid session and 200 only when signed in. The HTML /account page is
+// NOT usable here — it returns 200 for an invalid cookie, silently redirecting
+// to /cookies_required, so a status check against it passes when it shouldn't.
+func janeVerifySession(ctx context.Context, baseURL, cookies string, timeout time.Duration) error {
+	base := strings.TrimSuffix(baseURL, "/")
+	u, err := url.Parse(base)
+	if err != nil {
+		return fmt.Errorf("parsing base URL %q: %w", base, err)
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return fmt.Errorf("creating cookie jar: %w", err)
+	}
+	var cks []*http.Cookie
+	for _, part := range strings.Split(cookies, ";") {
+		name, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok {
+			continue
+		}
+		cks = append(cks, &http.Cookie{Name: strings.TrimSpace(name), Value: value})
+	}
+	if len(cks) == 0 {
+		return errAnonymousSession
+	}
+	jar.SetCookies(u, cks)
+
+	status, _, _, err := janeReqAccept(ctx, &http.Client{Jar: jar, Timeout: timeout}, base+"/api/v2/appointments")
+	if err != nil {
+		return fmt.Errorf("verifying session: %w", err)
+	}
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		return errAnonymousSession
+	}
+	if status >= 400 {
+		return fmt.Errorf("unexpected status %d verifying session against %s", status, base)
+	}
+	return nil
 }
 
 func janeReqAccept(ctx context.Context, hc *http.Client, u string) (int, string, string, error) {

--- a/library/health/janeapp/internal/cli/jane_auth_verify_test.go
+++ b/library/health/janeapp/internal/cli/jane_auth_verify_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Omar Shahine and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-written: covers janeVerifySession, the guard that stops a logged-out
+// browser cookie from being imported as a working session.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// janeVerifyServer stands in for a Jane instance: /api/v2/appointments answers
+// 200 only for the one session value it considers signed in, and 401 for
+// everything else — which is how the real API behaves for an absent, an
+// invalid, and a valid-but-anonymous session alike.
+func janeVerifyServer(t *testing.T, authedSession string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/appointments" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		ck, err := r.Cookie("_front_desk_session")
+		if err != nil || ck.Value != authedSession {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Sorry, looks like you don't have access to that area."}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"appointments":[]}`))
+	}))
+}
+
+func TestJaneVerifySessionAcceptsAuthenticated(t *testing.T) {
+	srv := janeVerifyServer(t, "good-session")
+	defer srv.Close()
+
+	if err := janeVerifySession(context.Background(), srv.URL, "_front_desk_session=good-session", 5*time.Second); err != nil {
+		t.Fatalf("expected authenticated session to verify, got %v", err)
+	}
+}
+
+// The regression this whole change exists for: Jane hands _front_desk_session
+// to logged-out visitors too, so a cookie import can succeed by name and still
+// carry an anonymous session. Presence must never be treated as proof.
+func TestJaneVerifySessionRejectsAnonymous(t *testing.T) {
+	srv := janeVerifyServer(t, "good-session")
+	defer srv.Close()
+
+	err := janeVerifySession(context.Background(), srv.URL, "_front_desk_session=anonymous-visitor", 5*time.Second)
+	if !errors.Is(err, errAnonymousSession) {
+		t.Fatalf("expected errAnonymousSession for a logged-out cookie, got %v", err)
+	}
+}
+
+func TestJaneVerifySessionRejectsEmptyCookies(t *testing.T) {
+	srv := janeVerifyServer(t, "good-session")
+	defer srv.Close()
+
+	for _, cookies := range []string{"", "   ", ";", "  ;  "} {
+		if err := janeVerifySession(context.Background(), srv.URL, cookies, 5*time.Second); !errors.Is(err, errAnonymousSession) {
+			t.Fatalf("cookies %q: expected errAnonymousSession, got %v", cookies, err)
+		}
+	}
+}
+
+// A trailing "; " and surrounding whitespace are normal in cookie strings
+// assembled from a jar; they must not be mistaken for an empty set.
+func TestJaneVerifySessionParsesMultiCookieString(t *testing.T) {
+	srv := janeVerifyServer(t, "good-session")
+	defer srv.Close()
+
+	if err := janeVerifySession(context.Background(), srv.URL, " jane_device=abc; _front_desk_session=good-session; ", 5*time.Second); err != nil {
+		t.Fatalf("expected multi-cookie string to verify, got %v", err)
+	}
+}
+
+// A server-side fault must not be reported as "you are logged out" — that
+// would send the user off to re-authenticate a session that is actually fine.
+func TestJaneVerifySessionDistinguishesServerErrorFromAnonymous(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	err := janeVerifySession(context.Background(), srv.URL, "_front_desk_session=whatever", 5*time.Second)
+	if err == nil {
+		t.Fatal("expected an error for a 500 response")
+	}
+	if errors.Is(err, errAnonymousSession) {
+		t.Fatalf("500 must not be reported as an anonymous session, got %v", err)
+	}
+}
+
+func TestJaneVerifySessionUnreachableHost(t *testing.T) {
+	srv := janeVerifyServer(t, "good-session")
+	url := srv.URL
+	srv.Close() // close immediately so the address refuses connections
+
+	err := janeVerifySession(context.Background(), url, "_front_desk_session=good-session", 2*time.Second)
+	if err == nil {
+		t.Fatal("expected an error for an unreachable host")
+	}
+	if errors.Is(err, errAnonymousSession) {
+		t.Fatalf("a transport failure must not be reported as anonymous, got %v", err)
+	}
+}


### PR DESCRIPTION
## The bug

`janeapp-pp-cli auth login --chrome` (and `--cookies-file`) checks only that a cookie **named** `_front_desk_session` exists, then saves it and prints `Session saved for clinic "..."`.

Jane sets that cookie for **logged-out visitors too**, and Chrome's on-disk cookie DB lags the live in-memory session. So importing while signed out — or while Chrome simply hasn't flushed a fresh login yet — stores an anonymous session and reports success.

Every command afterwards fails with a bare 401 whose hint is *"run `auth login --chrome`"* — the exact command that just reported success. That loop is genuinely hard to diagnose: a fresh `cookies.json` mtime and an `OK` message both say auth is fine, so the 401 reads like an account or permissions problem rather than a failed capture. I lost a while to it before finding the cause.

## The fix

The password path already handles this correctly — `janeLogin` probes `/api/v2/appointments` and fails on 401/403. This lifts that check into `janeVerifySession` and calls it from the browser-import path **before** saving.

`/api/v2/appointments` is the right probe: it returns 401 for absent, invalid, and valid-but-anonymous sessions alike, and 200 only when signed in. The HTML `/account` page is **not** usable — it returns 200 for an invalid cookie, silently redirecting to `/cookies_required`, so a status check against it passes when it shouldn't. (I made that mistake first; the comment records it so the next person doesn't.)

Server errors and transport failures are kept distinct from "not authenticated", so a 500 or a network blip never sends the user off to re-authenticate a session that's actually fine.

## Before / after

Against a live Jane instance with a stale cookie for a signed-out clinic:

```console
# before — silently stores an anonymous session
$ janeapp-pp-cli auth login --clinic leahkangas --chrome
OK Found 1 cookie(s) for leahkangas.janeapp.com
Session saved for clinic "leahkangas."
$ echo $?
0

# after
$ janeapp-pp-cli auth login --clinic leahkangas --chrome
ERROR Imported a cookie for leahkangas.janeapp.com, but it is not a signed-in session.

Jane sets this cookie for logged-out visitors too, and Chrome's
saved-to-disk copy can lag the session in the live browser window.

Confirm you are signed in here (you should see your name):

  https://leahkangas.janeapp.com/account

Then re-run this command. If it still fails, the on-disk cookie is
stale — export from the live session and import the file instead:

  janeapp-pp-cli auth login --clinic leahkangas --cookies-file <storage-state.json>
Error: imported session for leahkangas.janeapp.com is not authenticated
$ echo $?
4
```

A signed-in clinic still imports cleanly and exits 0 (verified separately).

## Tests

Six `httptest`-backed cases in `jane_auth_verify_test.go`: authenticated accepted, anonymous rejected, empty/whitespace cookie strings rejected, multi-cookie strings parsed, and 500 / unreachable-host both kept distinct from "anonymous".

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (full package suite, not just the new tests)
- `gofmt -l` clean

No changes to `registry.json` or `cli-skills/` per CONTRIBUTING.

## Note

This is a fix to an existing library CLI rather than a new submission, so it came in via a manual fork/PR rather than `/printing-press publish`. Happy to reshape it if you'd prefer this land differently.
