### PR TITLE
feat(flight-goat): multi-city search for the soar (FlySoar) command

### DIFF
--- a/library/travel/flight-goat/.printing-press-patches/soar-multicity.json
+++ b/library/travel/flight-goat/.printing-press-patches/soar-multicity.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "soar-multicity",
+  "applied_at": "2026-07-24",
+  "base_run_id": "20260712-220852",
+  "base_printing_press_version": "4.28.0",
+  "summary": "The soar command prices multi-city itineraries natively: >= 2 repeatable --segment values (the flights command's ORIG>DEST@YYYY-MM-DD form) POST a bare slices array to FlySoar's stream endpoint, and the deep link uses the GUI's trip=multicity&slices=ORIG-DEST-YYMMDD-<cabin>;... shape.",
+  "reason": "FlySoar's anonymous stream endpoint accepts a slices array with no top-level origin/destination and echoes is_multi_city=true (verified live), but the soar backend only modeled one-way/round-trip, so multi-city trips had no Duffel price source and no bookable deep link. One-way/round-trip keeps its verified payload untouched (a separate multi payload struct, not omitempty on the shared one), the cabin applies trip-wide because the GUI repeats a single cabin into every slice token, and a return date is rejected alongside slices (the return is just another slice).",
+  "files": [
+    "internal/soar/soar.go",
+    "internal/soar/soar_test.go",
+    "internal/cli/soar.go",
+    "internal/cli/soar_test.go"
+  ],
+  "validated_outcome": "go build/vet and go test ./internal/soar/ ./internal/cli/ pass. Dry-run builds https://flysoar.ai/flights/iah/sea/260927/?cabin=first&slices=IAH-FCO-260927-first%3BCAI-SEA-261004-first&trip=multicity matching the live GUI URL. Live IAH->FCO 2026-09-27 + CAI->SEA 2026-10-04 in first returned 497 offers (cheapest $10,970.53, slice_count 2, legs IAH-MIA MIA-FCO CAI-LHR LHR-SEA) with trip_type multi_city, query.slices echoed, and the booking request reading 'multi-city: IAH -> FCO on 2026-09-27, then CAI -> SEA on 2026-10-04, first class'. Classic one-way SEA->DEN regression unchanged (92 offers, no slices field in the query echo).",
+  "upstream_issue": ""
+}

--- a/library/travel/flight-goat/internal/cli/soar.go
+++ b/library/travel/flight-goat/internal/cli/soar.go
@@ -28,7 +28,7 @@ import (
 func newSoarCmd(flags *rootFlags) *cobra.Command {
 	var returnDate, cabin string
 	var passengers int
-	var stopsTokens, airlines []string
+	var stopsTokens, airlines, segmentStrs []string
 
 	cmd := &cobra.Command{
 		Use:         "soar <origin> <destination> <date>",
@@ -39,7 +39,12 @@ date and returns real prices, durations, airlines, and leg details. Its fares
 come from Duffel's aggregated NDC + GDS content, which often differs from what
 Google Flights surfaces, so it's a useful second opinion on price. No API key,
 no auth, just results — plus a deep link to open and book the same search on
-flysoar.ai. Prices are always in USD (FlySoar's anonymous endpoint is USD-only).`,
+flysoar.ai. Prices are always in USD (FlySoar's anonymous endpoint is USD-only).
+
+Multi-city trips use >= 2 repeatable --segment values (the same
+'ORIG>DEST@YYYY-MM-DD' form as the flights command); the positional
+<origin> <destination> <date> become optional and ignored, and --return is
+replaced by adding the final leg as its own segment.`,
 		Example: `  # Cheapest SEA -> DEN on Sep 21
   flight-goat-pp-cli soar SEA DEN 2026-09-21
 
@@ -52,14 +57,21 @@ flysoar.ai. Prices are always in USD (FlySoar's anonymous endpoint is USD-only).
   # Nonstop or one-stop, on Delta or United only
   flight-goat-pp-cli soar DCA IAH 2026-09-23 --class first --stops 0,1 --airlines DL,UA
 
+  # Multi-city in first: IAH -> FCO, then CAI -> SEA a week later
+  flight-goat-pp-cli soar --segment "IAH>FCO@2026-09-27" --segment "CAI>SEA@2026-10-04" --class first
+
   # Two passengers
   flight-goat-pp-cli soar LHR DXB 2026-05-10 --passengers 2`,
-		Args: cobra.ExactArgs(3),
+		Args: func(cmd *cobra.Command, args []string) error {
+			// Multi-city mode (>=2 --segment values) makes the positional
+			// <origin> <destination> <date> optional and ignored, matching the
+			// flights command's contract.
+			if len(segmentStrs) >= 2 {
+				return nil
+			}
+			return cobra.ExactArgs(3)(cmd, args)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			origin := strings.ToUpper(args[0])
-			destination := strings.ToUpper(args[1])
-			departureDate := args[2]
-
 			stops, err := parseSoarStops(stopsTokens)
 			if err != nil {
 				return err
@@ -69,20 +81,41 @@ flysoar.ai. Prices are always in USD (FlySoar's anonymous endpoint is USD-only).
 			}
 
 			opts := soar.SearchOptions{
-				Origin:        origin,
-				Destination:   destination,
-				DepartureDate: departureDate,
-				ReturnDate:    returnDate,
-				CabinClass:    cabin,
-				Passengers:    passengers,
-				Stops:         stops,
-				Airlines:      airlines,
+				CabinClass: cabin,
+				Passengers: passengers,
+				Stops:      stops,
+				Airlines:   airlines,
+			}
+			if len(segmentStrs) >= 2 {
+				parsed, perr := parseMultiCitySegments(segmentStrs)
+				if perr != nil {
+					return perr
+				}
+				if returnDate != "" {
+					return fmt.Errorf("--return cannot be combined with --segment; add the return leg as its own --segment")
+				}
+				slices := make([]soar.Slice, len(parsed))
+				for i, s := range parsed {
+					slices[i] = soar.Slice{Origin: s.Origin, Destination: s.Destination, DepartureDate: s.DepartureDate}
+				}
+				opts.Slices = slices
+			} else if len(segmentStrs) == 1 {
+				return fmt.Errorf("--segment requires >= 2 values for multi-city; got 1. Use the positional <origin> <destination> <date> form for a one-way search")
+			} else {
+				opts.Origin = strings.ToUpper(args[0])
+				opts.Destination = strings.ToUpper(args[1])
+				opts.DepartureDate = args[2]
+				opts.ReturnDate = returnDate
 			}
 
 			if flags.dryRun {
-				fmt.Fprintf(cmd.OutOrStdout(), "soar.Search(%s -> %s on %s)", opts.Origin, opts.Destination, opts.DepartureDate)
-				if opts.ReturnDate != "" {
-					fmt.Fprintf(cmd.OutOrStdout(), " return=%s", opts.ReturnDate)
+				if len(opts.Slices) > 0 {
+					fmt.Fprintf(cmd.OutOrStdout(), "soar.Search(multi-city %s)", soarSlicesRoute(opts.Slices))
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "soar.Search(%s -> %s on %s)", opts.Origin, opts.Destination, opts.DepartureDate)
+					if opts.ReturnDate != "" {
+						fmt.Fprintf(cmd.OutOrStdout(), " return=%s", opts.ReturnDate)
+					}
 				}
 				if opts.CabinClass != "" {
 					fmt.Fprintf(cmd.OutOrStdout(), " class=%s", strings.ToLower(opts.CabinClass))
@@ -93,8 +126,11 @@ flysoar.ai. Prices are always in USD (FlySoar's anonymous endpoint is USD-only).
 				if len(opts.Airlines) > 0 {
 					fmt.Fprintf(cmd.OutOrStdout(), " airlines=%s", strings.Join(opts.Airlines, ","))
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "\nurl: %s\n(dry run - no request sent)\n",
-					soar.SearchURL(opts.Origin, opts.Destination, opts.DepartureDate, opts.ReturnDate, opts.CabinClass, opts.Stops, opts.Airlines))
+				dryURL := soar.SearchURL(opts.Origin, opts.Destination, opts.DepartureDate, opts.ReturnDate, opts.CabinClass, opts.Stops, opts.Airlines)
+				if len(opts.Slices) > 0 {
+					dryURL = soar.MultiCitySearchURL(opts.Slices, opts.CabinClass, opts.Stops, opts.Airlines)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "\nurl: %s\n(dry run - no request sent)\n", dryURL)
 				return nil
 			}
 
@@ -117,8 +153,12 @@ flysoar.ai. Prices are always in USD (FlySoar's anonymous endpoint is USD-only).
 				return nil
 			}
 
-			fmt.Fprintf(cmd.ErrOrStderr(), "%d flights found for %s -> %s on %s (source: %s)\n",
-				result.Count, opts.Origin, opts.Destination, opts.DepartureDate, result.Source)
+			route := fmt.Sprintf("%s -> %s on %s", result.Query.Origin, result.Query.Destination, result.Query.DepartureDate)
+			if len(result.Query.Slices) > 0 {
+				route = "multi-city " + soarSlicesRoute(result.Query.Slices)
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "%d flights found for %s (source: %s)\n",
+				result.Count, route, result.Source)
 			if result.Note != "" {
 				fmt.Fprintf(cmd.ErrOrStderr(), "note: %s\n", result.Note)
 			}
@@ -167,7 +207,18 @@ flysoar.ai. Prices are always in USD (FlySoar's anonymous endpoint is USD-only).
 	cmd.Flags().IntVarP(&passengers, "passengers", "p", 1, "Number of passengers")
 	cmd.Flags().StringSliceVar(&stopsTokens, "stops", nil, "Allowed stop counts (comma list): 0=nonstop, 1, 2. E.g. --stops 0,1")
 	cmd.Flags().StringSliceVarP(&airlines, "airlines", "a", nil, "Whitelist airlines by IATA code (comma list): e.g. --airlines DL,UA")
+	cmd.Flags().StringSliceVar(&segmentStrs, "segment", nil, "Multi-city: repeatable segment in 'ORIG>DEST@YYYY-MM-DD' form. Pass >=2 to trigger multi-city search; positional args become optional and ignored.")
 	return cmd
+}
+
+// soarSlicesRoute renders multi-city slices compactly for status lines and dry
+// runs, e.g. "IAH>FCO@2026-09-27 CAI>SEA@2026-10-04".
+func soarSlicesRoute(slices []soar.Slice) string {
+	parts := make([]string, len(slices))
+	for i, s := range slices {
+		parts[i] = fmt.Sprintf("%s>%s@%s", s.Origin, s.Destination, s.DepartureDate)
+	}
+	return strings.Join(parts, " ")
 }
 
 // parseSoarStops turns --stops tokens into a set of allowed stop counts,

--- a/library/travel/flight-goat/internal/cli/soar_test.go
+++ b/library/travel/flight-goat/internal/cli/soar_test.go
@@ -2,7 +2,11 @@
 
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
 
 func TestSoarPricePreservesCents(t *testing.T) {
 	cases := []struct {
@@ -19,5 +23,60 @@ func TestSoarPricePreservesCents(t *testing.T) {
 		if got := soarPrice(c.currency, c.price); got != c.want {
 			t.Errorf("soarPrice(%q, %v) = %q, want %q", c.currency, c.price, got, c.want)
 		}
+	}
+}
+
+// runSoar executes the soar command with args and returns combined output.
+func runSoar(t *testing.T, flags *rootFlags, args ...string) (string, error) {
+	t.Helper()
+	cmd := newSoarCmd(flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestSoarMultiCityDryRun(t *testing.T) {
+	out, err := runSoar(t, &rootFlags{dryRun: true},
+		"--segment", "IAH>FCO@2026-09-27", "--segment", "CAI>SEA@2026-10-04", "--class", "first")
+	if err != nil {
+		t.Fatalf("dry run: %v\n%s", err, out)
+	}
+	for _, want := range []string{
+		"multi-city IAH>FCO@2026-09-27 CAI>SEA@2026-10-04",
+		"trip=multicity",
+		"slices=IAH-FCO-260927-first%3BCAI-SEA-261004-first",
+		"/flights/iah/sea/260927/?",
+		"(dry run - no request sent)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSoarSingleSegmentRejected(t *testing.T) {
+	// One --segment plus positionals must not silently ignore the segment.
+	_, err := runSoar(t, &rootFlags{dryRun: true},
+		"SEA", "DEN", "2026-09-27", "--segment", "IAH>FCO@2026-09-27")
+	if err == nil || !strings.Contains(err.Error(), ">= 2") {
+		t.Fatalf("want single-segment error, got %v", err)
+	}
+}
+
+func TestSoarSegmentsRejectReturn(t *testing.T) {
+	_, err := runSoar(t, &rootFlags{dryRun: true},
+		"--segment", "IAH>FCO@2026-09-27", "--segment", "CAI>SEA@2026-10-04", "--return", "2026-10-10")
+	if err == nil || !strings.Contains(err.Error(), "--return") {
+		t.Fatalf("want --return conflict error, got %v", err)
+	}
+}
+
+func TestSoarPositionalsStillRequired(t *testing.T) {
+	// Without segments the classic 3-positional contract still applies.
+	if _, err := runSoar(t, &rootFlags{dryRun: true}, "SEA", "DEN"); err == nil {
+		t.Fatal("want arg-count error for 2 positionals without --segment")
 	}
 }

--- a/library/travel/flight-goat/internal/soar/soar.go
+++ b/library/travel/flight-goat/internal/soar/soar.go
@@ -96,18 +96,32 @@ type Flight struct {
 	Legs       []Leg  `json:"legs"`
 }
 
+// Slice is one flown leg of a multi-city trip: a route on a date. The cabin
+// applies trip-wide, mirroring FlySoar's GUI, which composes multicity
+// searches with a single cabin repeated into every slice.
+type Slice struct {
+	Origin        string `json:"origin"`
+	Destination   string `json:"destination"`
+	DepartureDate string `json:"departure_date"` // YYYY-MM-DD
+}
+
 // SearchQuery echoes the request back in the response envelope. Currency is
 // always USD — FlySoar's anonymous endpoint ignores any requested currency and
 // prices every offer in USD (verified live across US and intra-EU routes), so
 // the CLI deliberately does not expose a currency knob.
 type SearchQuery struct {
+	// For multi-city searches Origin/Destination/DepartureDate carry the trip's
+	// first origin, final destination, and first date (matching the endpoint's
+	// own created-event echo); Slices carries the full leg list.
 	Origin        string `json:"origin"`
 	Destination   string `json:"destination"`
 	DepartureDate string `json:"departure_date"`
 	ReturnDate    string `json:"return_date,omitempty"`
-	CabinClass    string `json:"cabin_class"`
-	Passengers    int    `json:"passengers"`
-	Currency      string `json:"currency"`
+	// Slices echoes the requested legs when the search was multi-city.
+	Slices     []Slice `json:"slices,omitempty"`
+	CabinClass string  `json:"cabin_class"`
+	Passengers int     `json:"passengers"`
+	Currency   string  `json:"currency"`
 	// Stops echoes the allowed stop counts (0 = nonstop, 1, 2, …); empty = any.
 	Stops []int `json:"stops,omitempty"`
 	// Airlines echoes the airline whitelist (IATA codes), empty when unset.
@@ -172,12 +186,17 @@ type SearchOptions struct {
 	// Airlines whitelists marketing carriers by IATA code (e.g. UA, DL).
 	// Empty means no airline filter. Matches FlySoar's ?airlines=DL,UA param.
 	Airlines []string
+	// Slices, when set (>= 2 entries), switches the search to multi-city mode.
+	// Origin/Destination/DepartureDate are ignored and ReturnDate must be empty
+	// (a return leg is just another slice). CabinClass applies to every slice.
+	Slices []Slice
 }
 
 // priceCurrency is the only currency FlySoar's anonymous endpoint returns.
 const priceCurrency = "USD"
 
-// searchPayload is the JSON body POSTed to the stream endpoint.
+// searchPayload is the JSON body POSTed to the stream endpoint for one-way and
+// round-trip searches.
 type searchPayload struct {
 	Origin      string `json:"origin"`
 	Destination string `json:"destination"`
@@ -186,6 +205,25 @@ type searchPayload struct {
 	Cabin       string `json:"cabin"`
 	Currency    string `json:"currency"`
 	Passengers  int    `json:"passengers"`
+}
+
+// multiSearchPayload is the JSON body for a multi-city search. Verified live:
+// the endpoint accepts a bare slices array with no top-level origin/destination
+// (it derives the trip's endpoints itself) and echoes is_multi_city=true in the
+// created event.
+type multiSearchPayload struct {
+	Slices     []payloadSlice `json:"slices"`
+	Cabin      string         `json:"cabin"`
+	Currency   string         `json:"currency"`
+	Passengers int            `json:"passengers"`
+}
+
+// payloadSlice is one requested multi-city leg. The endpoint accepts "date"
+// and echoes it back as departure_date.
+type payloadSlice struct {
+	Origin      string `json:"origin"`
+	Destination string `json:"destination"`
+	Date        string `json:"date"`
 }
 
 // --- raw Duffel-shaped offer decoding ---------------------------------------
@@ -263,11 +301,21 @@ type rawCarrier struct {
 
 // Search runs a FlySoar search and returns normalized, cheapest-first offers.
 func Search(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
-	if strings.TrimSpace(opts.Origin) == "" || strings.TrimSpace(opts.Destination) == "" {
-		return nil, fmt.Errorf("soar: origin and destination are required")
-	}
-	if strings.TrimSpace(opts.DepartureDate) == "" {
-		return nil, fmt.Errorf("soar: departure date is required")
+	multi := len(opts.Slices) > 0
+	if multi {
+		if len(opts.Slices) < 2 {
+			return nil, fmt.Errorf("soar: multi-city needs at least 2 slices; use origin/destination for a one-way")
+		}
+		if strings.TrimSpace(opts.ReturnDate) != "" {
+			return nil, fmt.Errorf("soar: return date cannot be combined with multi-city slices; add the return as its own slice")
+		}
+	} else {
+		if strings.TrimSpace(opts.Origin) == "" || strings.TrimSpace(opts.Destination) == "" {
+			return nil, fmt.Errorf("soar: origin and destination are required")
+		}
+		if strings.TrimSpace(opts.DepartureDate) == "" {
+			return nil, fmt.Errorf("soar: departure date is required")
+		}
 	}
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
@@ -281,24 +329,71 @@ func Search(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
 	// the "Airport alias maintenance" section in AGENTS.md.
 	origin := strings.ToUpper(strings.TrimSpace(opts.Origin))
 	dest := strings.ToUpper(strings.TrimSpace(opts.Destination))
+	depDate := strings.TrimSpace(opts.DepartureDate)
+	var slices []Slice
+	if multi {
+		slices = make([]Slice, len(opts.Slices))
+		for i, s := range opts.Slices {
+			slices[i] = Slice{
+				Origin:        strings.ToUpper(strings.TrimSpace(s.Origin)),
+				Destination:   strings.ToUpper(strings.TrimSpace(s.Destination)),
+				DepartureDate: strings.TrimSpace(s.DepartureDate),
+			}
+			if slices[i].Origin == "" || slices[i].Destination == "" || slices[i].DepartureDate == "" {
+				return nil, fmt.Errorf("soar: slice %d needs origin, destination, and date", i+1)
+			}
+		}
+		// The query echo mirrors the endpoint's created event: first origin,
+		// final destination, first date.
+		origin = slices[0].Origin
+		dest = slices[len(slices)-1].Destination
+		depDate = slices[0].DepartureDate
+	}
 	cabin := normalizeCabin(opts.CabinClass)
 	passengers := opts.Passengers
 	if passengers <= 0 {
 		passengers = 1
 	}
+	stops := normalizeStops(opts.Stops)
+	airlines := normalizeAirlines(opts.Airlines)
 
-	payload := searchPayload{
-		Origin:      origin,
-		Destination: dest,
-		Date:        opts.DepartureDate,
-		ReturnDate:  opts.ReturnDate,
-		Cabin:       cabin,
-		Currency:    priceCurrency,
-		Passengers:  passengers,
+	var body []byte
+	var err error
+	if multi {
+		ps := make([]payloadSlice, len(slices))
+		for i, s := range slices {
+			ps[i] = payloadSlice{Origin: s.Origin, Destination: s.Destination, Date: s.DepartureDate}
+		}
+		body, err = json.Marshal(multiSearchPayload{
+			Slices:     ps,
+			Cabin:      cabin,
+			Currency:   priceCurrency,
+			Passengers: passengers,
+		})
+	} else {
+		body, err = json.Marshal(searchPayload{
+			Origin:      origin,
+			Destination: dest,
+			Date:        opts.DepartureDate,
+			ReturnDate:  opts.ReturnDate,
+			Cabin:       cabin,
+			Currency:    priceCurrency,
+			Passengers:  passengers,
+		})
 	}
-	body, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("soar: encoding request: %w", err)
+	}
+
+	// The deep link doubles as the Referer: it reconstructs the site's own
+	// search URL, which FlySoar checks as part of its anonymous-request gating
+	// (both the path-only classic form and the multicity query form are
+	// verified live to pass the gate).
+	deepLink := SearchURL(origin, dest, depDate, opts.ReturnDate, cabin, stops, airlines)
+	referer := refererURL(origin, dest, depDate, opts.ReturnDate)
+	if multi {
+		deepLink = MultiCitySearchURL(slices, cabin, stops, airlines)
+		referer = deepLink
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, searchURL, bytes.NewReader(body))
@@ -308,7 +403,7 @@ func Search(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("Origin", baseURL)
-	req.Header.Set("Referer", refererURL(origin, dest, opts.DepartureDate, opts.ReturnDate))
+	req.Header.Set("Referer", referer)
 	req.Header.Set("User-Agent", browserUA)
 
 	resp, err := http.DefaultClient.Do(req)
@@ -329,8 +424,6 @@ func Search(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
 	// Apply the same stop/airline filters the deep link encodes, so the CLI's
 	// results match what opening search_url in the browser would show. FlySoar's
 	// stream endpoint returns the unfiltered set; these are GUI-side filters.
-	stops := normalizeStops(opts.Stops)
-	airlines := normalizeAirlines(opts.Airlines)
 	unfiltered := normalizeOffers(offers, priceCurrency, passengers)
 	flights := filterFlights(unfiltered, stops, airlines)
 	// Cheapest-first, matching the other price backends' default ordering.
@@ -339,7 +432,10 @@ func Search(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
 	})
 
 	tripType := "one_way"
-	if strings.TrimSpace(opts.ReturnDate) != "" {
+	switch {
+	case multi:
+		tripType = "multi_city"
+	case strings.TrimSpace(opts.ReturnDate) != "":
 		tripType = "round_trip"
 	}
 
@@ -351,8 +447,9 @@ func Search(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
 		Query: SearchQuery{
 			Origin:        origin,
 			Destination:   dest,
-			DepartureDate: opts.DepartureDate,
+			DepartureDate: depDate,
 			ReturnDate:    opts.ReturnDate,
+			Slices:        slices,
 			CabinClass:    cabin,
 			Passengers:    passengers,
 			Currency:      priceCurrency,
@@ -361,7 +458,7 @@ func Search(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
 		},
 		Count:     len(flights),
 		Flights:   flights,
-		SearchURL: SearchURL(origin, dest, opts.DepartureDate, opts.ReturnDate, cabin, stops, airlines),
+		SearchURL: deepLink,
 	}
 	res.Booking = buildBookingHandoff(res.Query, res.SearchURL)
 	if len(flights) == 0 {
@@ -413,11 +510,22 @@ func buildBookingHandoff(q SearchQuery, webURL string) BookingHandoff {
 
 // BookingRequest builds a natural-language booking seed the FlySoar agent
 // understands, mirroring how a user phrases it in chat, e.g.
-// "DEN -> SEA on 2026-09-28, first class, 2 passengers".
+// "DEN -> SEA on 2026-09-28, first class, 2 passengers". Multi-city queries
+// render every leg: "multi-city: IAH -> FCO on 2026-09-27, then CAI -> SEA on
+// 2026-10-04, first class".
 func BookingRequest(q SearchQuery) string {
-	b := fmt.Sprintf("%s -> %s on %s", q.Origin, q.Destination, q.DepartureDate)
-	if strings.TrimSpace(q.ReturnDate) != "" {
-		b += ", returning " + q.ReturnDate
+	var b string
+	if len(q.Slices) > 0 {
+		legs := make([]string, len(q.Slices))
+		for i, s := range q.Slices {
+			legs[i] = fmt.Sprintf("%s -> %s on %s", s.Origin, s.Destination, s.DepartureDate)
+		}
+		b = "multi-city: " + strings.Join(legs, ", then ")
+	} else {
+		b = fmt.Sprintf("%s -> %s on %s", q.Origin, q.Destination, q.DepartureDate)
+		if strings.TrimSpace(q.ReturnDate) != "" {
+			b += ", returning " + q.ReturnDate
+		}
 	}
 	if cabin := prettyCabin(q.CabinClass); cabin != "" {
 		b += ", " + cabin
@@ -492,6 +600,41 @@ func SearchURL(origin, dest, depDate, retDate, cabin string, stops []int, airlin
 		q.Set("cabin", c)
 	}
 	q.Set("trip", trip)
+	setFilterParams(q, stops, airlines)
+	return fmt.Sprintf("%s%s?%s", baseURL, flightPath(origin, dest, depDate, retDate), q.Encode())
+}
+
+// MultiCitySearchURL builds the browser deep link for a multi-city search,
+// mirroring FlySoar's GUI URL shape, e.g.
+// https://flysoar.ai/flights/iah/sea/260927/?cabin=first&slices=IAH-FCO-260927-first%3BCAI-SEA-261004-first&trip=multicity .
+// The path carries first origin / final destination / first date; the slices
+// param carries every leg as ORIG-DEST-YYMMDD-<cabin>, ';'-joined (the cabin
+// token repeats because the GUI applies one cabin trip-wide). stops/airlines
+// mirror SearchURL's GUI filter params.
+func MultiCitySearchURL(slices []Slice, cabin string, stops []int, airlines []string) string {
+	if len(slices) == 0 {
+		return baseURL
+	}
+	c := normalizeCabin(cabin)
+	parts := make([]string, len(slices))
+	for i, s := range slices {
+		parts[i] = fmt.Sprintf("%s-%s-%s-%s",
+			strings.ToUpper(strings.TrimSpace(s.Origin)),
+			strings.ToUpper(strings.TrimSpace(s.Destination)),
+			yymmdd(s.DepartureDate), c)
+	}
+	q := url.Values{}
+	q.Set("cabin", c)
+	q.Set("trip", "multicity")
+	q.Set("slices", strings.Join(parts, ";"))
+	setFilterParams(q, stops, airlines)
+	path := flightPath(slices[0].Origin, slices[len(slices)-1].Destination, slices[0].DepartureDate, "")
+	return fmt.Sprintf("%s%s?%s", baseURL, path, q.Encode())
+}
+
+// setFilterParams adds the stops/airlines GUI filter params shared by the
+// one-way/round-trip and multi-city deep links.
+func setFilterParams(q url.Values, stops []int, airlines []string) {
 	if len(stops) > 0 {
 		parts := make([]string, len(stops))
 		for i, s := range stops {
@@ -502,7 +645,6 @@ func SearchURL(origin, dest, depDate, retDate, cabin string, stops []int, airlin
 	if len(airlines) > 0 {
 		q.Set("airlines", strings.Join(airlines, ","))
 	}
-	return fmt.Sprintf("%s%s?%s", baseURL, flightPath(origin, dest, depDate, retDate), q.Encode())
 }
 
 // normalizeStops sorts and de-dupes the allowed stop counts, dropping negatives.

--- a/library/travel/flight-goat/internal/soar/soar_test.go
+++ b/library/travel/flight-goat/internal/soar/soar_test.go
@@ -3,6 +3,7 @@
 package soar
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -236,6 +237,70 @@ func TestSearchURLStopsAirlines(t *testing.T) {
 	}
 }
 
+func TestMultiCitySearchURL(t *testing.T) {
+	slices := []Slice{
+		{Origin: "IAH", Destination: "FCO", DepartureDate: "2026-09-27"},
+		{Origin: "CAI", Destination: "SEA", DepartureDate: "2026-10-04"},
+	}
+	// Mirrors the live GUI URL: path is first origin / final destination /
+	// first date; slices are ORIG-DEST-YYMMDD-<cabin> joined by ';' (%3B).
+	got := MultiCitySearchURL(slices, "first", nil, nil)
+	want := "https://flysoar.ai/flights/iah/sea/260927/?cabin=first&slices=IAH-FCO-260927-first%3BCAI-SEA-261004-first&trip=multicity"
+	if got != want {
+		t.Fatalf("MultiCitySearchURL:\n got %q\nwant %q", got, want)
+	}
+	// Empty cabin normalizes to economy (the slices token needs a cabin).
+	eco := MultiCitySearchURL(slices, "", nil, nil)
+	for _, want := range []string{"cabin=economy", "IAH-FCO-260927-economy"} {
+		if !strings.Contains(eco, want) {
+			t.Fatalf("MultiCitySearchURL default cabin missing %q in %q", want, eco)
+		}
+	}
+	// GUI filters carry over.
+	filtered := MultiCitySearchURL(slices, "business", []int{0, 1}, []string{"DL", "UA"})
+	for _, want := range []string{"stops=0%2C1", "airlines=DL%2CUA", "trip=multicity"} {
+		if !strings.Contains(filtered, want) {
+			t.Fatalf("MultiCitySearchURL filters missing %q in %q", want, filtered)
+		}
+	}
+	// Lowercase input codes normalize into the path and slice tokens.
+	lower := MultiCitySearchURL([]Slice{
+		{Origin: "sea", Destination: "den", DepartureDate: "2026-09-27"},
+		{Origin: "den", Destination: "sfo", DepartureDate: "2026-10-04"},
+	}, "economy", nil, nil)
+	if !strings.Contains(lower, "/flights/sea/sfo/260927/?") || !strings.Contains(lower, "SEA-DEN-260927-economy") {
+		t.Fatalf("MultiCitySearchURL case normalization wrong: %q", lower)
+	}
+}
+
+func TestSearchValidatesMultiCity(t *testing.T) {
+	ctx := context.Background()
+	// One slice is not a multi-city trip.
+	one := SearchOptions{Slices: []Slice{{Origin: "SEA", Destination: "DEN", DepartureDate: "2026-09-27"}}}
+	if _, err := Search(ctx, one); err == nil {
+		t.Fatal("expected error for a single slice")
+	}
+	// A return date cannot combine with slices.
+	rt := SearchOptions{
+		ReturnDate: "2026-10-10",
+		Slices: []Slice{
+			{Origin: "SEA", Destination: "DEN", DepartureDate: "2026-09-27"},
+			{Origin: "DEN", Destination: "SFO", DepartureDate: "2026-10-04"},
+		},
+	}
+	if _, err := Search(ctx, rt); err == nil {
+		t.Fatal("expected error for return date + slices")
+	}
+	// Every slice needs origin, destination, and date.
+	missing := SearchOptions{Slices: []Slice{
+		{Origin: "SEA", Destination: "DEN", DepartureDate: "2026-09-27"},
+		{Origin: "DEN", Destination: "SFO"},
+	}}
+	if _, err := Search(ctx, missing); err == nil {
+		t.Fatal("expected error for slice with missing date")
+	}
+}
+
 func TestNormalizeStops(t *testing.T) {
 	cases := []struct {
 		in   []int
@@ -351,6 +416,12 @@ func TestBookingRequest(t *testing.T) {
 			"DCA -> IAH on 2026-09-23, first class, nonstop, on UA"},
 		{SearchQuery{Origin: "DCA", Destination: "IAH", DepartureDate: "2026-09-23", CabinClass: "first", Passengers: 2, Stops: []int{0, 1}, Airlines: []string{"DL", "UA"}},
 			"DCA -> IAH on 2026-09-23, first class, nonstop or 1 stop, on DL/UA, 2 passengers"},
+		{SearchQuery{Origin: "IAH", Destination: "SEA", DepartureDate: "2026-09-27", CabinClass: "first", Passengers: 2,
+			Slices: []Slice{
+				{Origin: "IAH", Destination: "FCO", DepartureDate: "2026-09-27"},
+				{Origin: "CAI", Destination: "SEA", DepartureDate: "2026-10-04"},
+			}},
+			"multi-city: IAH -> FCO on 2026-09-27, then CAI -> SEA on 2026-10-04, first class, 2 passengers"},
 	}
 	for _, c := range cases {
 		if got := BookingRequest(c.q); got != c.want {


### PR DESCRIPTION
## What

Adds multi-city support to the `soar` (FlySoar.ai / Duffel) price source. Previously the command only modeled one-way and round-trip, so multi-city trips had no Duffel price source and no bookable deep link.

- `--segment` (repeatable, >= 2 values) triggers multi-city mode, reusing the `flights` command's `ORIG>DEST@YYYY-MM-DD` form so the two multi-city surfaces stay consistent. Positional args become optional and ignored, and `--return` is rejected (a return leg is just another segment).
- The request POSTs a bare `slices` array to `/api/search/stream` — verified live: the endpoint accepts it with no top-level origin/destination and echoes `is_multi_city: true`. One-way/round-trip keeps its verified payload untouched via a separate multi payload struct.
- `MultiCitySearchURL` emits the GUI's deep-link shape: `https://flysoar.ai/flights/<first-orig>/<final-dest>/<YYMMDD>/?cabin=<c>&slices=ORIG-DEST-YYMMDD-<cabin>%3B...&trip=multicity`, with the existing stops/airlines GUI filters carried over.
- The booking handoff renders every leg: `multi-city: IAH -> FCO on 2026-09-27, then CAI -> SEA on 2026-10-04, first class`.
- Recorded as `.printing-press-patches/soar-multicity.json` (reprint-guard for the slices payload shape and single-cabin-per-trip GUI contract).

## Validation

| Check | Result |
|---|---|
| `go build ./...` / `go vet ./...` | PASS |
| `go test ./...` | PASS (new: MultiCitySearchURL, multi-city BookingRequest, Search validation, CLI dry-run + arg-contract tests) |
| `verify_skill.py --dir library/travel/flight-goat/` | PASS |
| `govulncheck ./...` | 0 reachable vulnerabilities |
| Live multi-city search | IAH→FCO 2026-09-27 + CAI→SEA 2026-10-04 first class: 497 offers, cheapest $10,970.53 (slice_count 2, legs IAH-MIA MIA-FCO CAI-LHR LHR-SEA), `trip_type: multi_city`, `query.slices` echoed |
| Live one-way regression | SEA→DEN 2026-09-21 first: 92 offers, payload/deep link unchanged, no `slices` field in query echo |
| Dry-run deep link | `https://flysoar.ai/flights/iah/sea/260927/?cabin=first&slices=IAH-FCO-260927-first%3BCAI-SEA-261004-first&trip=multicity` matches the live GUI URL shape |

🤖 Generated with [Claude Code](https://claude.com/claude-code)