### PR TITLE
feat(facebook-marketplace): add direct buyer thread reader

### DIFF
--- a/library/commerce/facebook-marketplace/README.md
+++ b/library/commerce/facebook-marketplace/README.md
@@ -206,6 +206,7 @@ Sell-side composer helper operations.
 Marketplace inbox and messaging operations.
 
 - **`facebook-marketplace-pp-cli inbox list`** - Fetch Marketplace inbox overview.
+- **`facebook-marketplace-pp-cli inbox thread`** - Fetch a direct Marketplace/Messenger thread by thread id.
 - **`facebook-marketplace-pp-cli inbox message_seller`** - Send a Marketplace seller message.
 - **`facebook-marketplace-pp-cli inbox seller_threads`** - Fetch Marketplace seller inbox threads.
 - **`facebook-marketplace-pp-cli inbox seller_threads_page`** - Fetch a page of Marketplace seller inbox threads.

--- a/library/commerce/facebook-marketplace/SKILL.md
+++ b/library/commerce/facebook-marketplace/SKILL.md
@@ -101,6 +101,7 @@ This CLI uses Chrome-compatible HTTP transport over HTTP/3 for browser-facing en
 **inbox** — Marketplace inbox and messaging operations.
 
 - `facebook-marketplace-pp-cli inbox list` — Fetch Marketplace inbox overview.
+- `facebook-marketplace-pp-cli inbox thread` — Fetch a direct Marketplace/Messenger thread by thread id.
 - `facebook-marketplace-pp-cli inbox message_seller` — Send a Marketplace seller message.
 - `facebook-marketplace-pp-cli inbox seller_threads` — Fetch Marketplace seller inbox threads.
 - `facebook-marketplace-pp-cli inbox seller_threads_page` — Fetch a page of Marketplace seller inbox threads.
@@ -154,6 +155,14 @@ facebook-marketplace-pp-cli watch add --name "eames" --query "eames lounge" --ma
 ```
 
 Stores deterministic filter criteria locally so future runs can compare new listings.
+
+### Read a direct Marketplace buyer thread
+
+```bash
+facebook-marketplace-pp-cli inbox thread --thread 27799138726406206 --agent
+```
+
+Reads the real Messenger thread route for a known Marketplace thread id and returns parsed summary plus message text, sender ids, and timestamps.
 
 ### Draft a seller listing
 

--- a/library/commerce/facebook-marketplace/internal/cli/inbox.go
+++ b/library/commerce/facebook-marketplace/internal/cli/inbox.go
@@ -15,6 +15,7 @@ func newInboxCmd(flags *rootFlags) *cobra.Command {
 	}
 
 	cmd.AddCommand(newInboxListCmd(flags))
+	cmd.AddCommand(newInboxThreadCmd(flags))
 	cmd.AddCommand(newInboxMessageSellerCmd(flags))
 	cmd.AddCommand(newInboxSellerThreadsCmd(flags))
 	cmd.AddCommand(newInboxSellerThreadsPageCmd(flags))

--- a/library/commerce/facebook-marketplace/internal/cli/inbox_thread.go
+++ b/library/commerce/facebook-marketplace/internal/cli/inbox_thread.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newInboxThreadCmd(flags *rootFlags) *cobra.Command {
+	var threadID string
+
+	cmd := &cobra.Command{
+		Use:   "thread",
+		Short: "Fetch a direct Marketplace/Messenger thread by thread id.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if threadID == "" {
+				return fmt.Errorf("--thread is required")
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			data, statusCode, err := c.MarketplaceThreadSnapshot(threadID)
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
+				if flags.quiet {
+					return nil
+				}
+				filtered := data
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				} else if flags.compact {
+					filtered = compactFields(filtered)
+				}
+				envelope := map[string]any{
+					"action":   "get",
+					"resource": "inbox_thread",
+					"path":     "/messages/t/" + threadID + "/",
+					"status":   statusCode,
+					"success":  statusCode >= 200 && statusCode < 300,
+				}
+				if len(filtered) > 0 {
+					var parsed any
+					if err := json.Unmarshal(filtered, &parsed); err == nil {
+						envelope["data"] = parsed
+					}
+				}
+				envelopeJSON, err := json.Marshal(envelope)
+				if err != nil {
+					return err
+				}
+				return printOutput(cmd.OutOrStdout(), json.RawMessage(envelopeJSON), true)
+			}
+
+			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&threadID, "thread", "", "Marketplace/Messenger thread id")
+	return cmd
+}

--- a/library/commerce/facebook-marketplace/internal/cli/which.go
+++ b/library/commerce/facebook-marketplace/internal/cli/which.go
@@ -30,6 +30,7 @@ var whichIndex = []whichEntry{
 	{Command: "draft", Description: "Draft a Marketplace title, description, and price suggestion from photos and notes.", Group: "Seller workflow", WhyItMatters: "Use this when preparing a seller listing before opening a write-gated post flow."},
 	{Command: "watch add", Description: "Persist a Marketplace search watch with deterministic keyword, price, and distance filters.", Group: "Buy-side workflow", WhyItMatters: "Use this when the agent needs to monitor Marketplace without deciding relevance on every raw result."},
 	{Command: "matches", Description: "Show new watch matches after deterministic filtering.", Group: "Buy-side workflow", WhyItMatters: "Use this when an agent needs the shortlist worth showing a human buyer."},
+	{Command: "inbox thread", Description: "Fetch a direct Marketplace buyer conversation by thread id, including parsed message text.", Group: "Buy-side workflow", WhyItMatters: "Use this when listing detail or a sent opener gives you a thread id and you need the real seller reply instead of the generic inbox stub."},
 	{Command: "stale", Description: "Find local seller listings older than seven days with no engagement.", Group: "Local mirror", WhyItMatters: "Use this when deciding which seller listings need price changes or renewal."},
 	{Command: "reply", Description: "Prepare and send a seller inbox reply only when `--write` and doctor gating both pass.", Group: "Seller workflow", WhyItMatters: "Use this only for human-approved sell-side messaging."},
 }

--- a/library/commerce/facebook-marketplace/internal/client/marketplace_thread.go
+++ b/library/commerce/facebook-marketplace/internal/client/marketplace_thread.go
@@ -1,0 +1,183 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+)
+
+var (
+	marketplaceThreadTitleRe   = regexp.MustCompile(`<title>([^<]+)</title>`)
+	marketplaceThreadSummaryRe = regexp.MustCompile(`deleteThenInsertThread",\[19,"(\d+)"\],\[19,"(\d+)"\],"((?:\\.|[^"])*)","((?:\\.|[^"])*)","((?:\\.|[^"])*)",false,\[19,"80"\],\[19,"([^"]+)".*?\[19,"(-?\d+)"\]`)
+	marketplaceThreadMessageRe = regexp.MustCompile(`upsertMessage","((?:\\.|[^"])*)",\[9\],\[19,"80"\],\[19,"([^"]+)"\],\[19,"0"\],\[19,"(\d+)"\],\[19,"(\d+)"\],\[9\],"([^"]+)","([^"]+)",\[19,"([^"]+)"\]`)
+	marketplaceThreadContactRe = regexp.MustCompile(`verifyContactRowExists",\[19,"([^"]+)"\],\[19,"([^"]+)"\],"((?:\\.|[^"])*)","((?:\\.|[^"])*)",\[19,"(\d+)"\]`)
+)
+
+type marketplaceThreadSummary struct {
+	UpdatedAt         int64  `json:"updated_at"`
+	PreviousUpdatedAt int64  `json:"previous_updated_at"`
+	Snippet           string `json:"snippet"`
+	Title             string `json:"title"`
+	ImageURL          string `json:"image_url,omitempty"`
+	FolderCode        int    `json:"folder_code"`
+}
+
+type marketplaceThreadMessage struct {
+	Text               string `json:"text"`
+	TimestampMS        int64  `json:"timestamp_ms"`
+	SortKeyMS          int64  `json:"sort_key_ms"`
+	MessageID          string `json:"message_id"`
+	OfflineThreadingID string `json:"offline_threading_id"`
+	SenderID           string `json:"sender_id"`
+	SenderName         string `json:"sender_name,omitempty"`
+}
+
+type marketplaceThreadContact struct {
+	ContactID   string
+	ContactType int
+	Name        string
+	ImageURL    string
+}
+
+type marketplaceThreadSnapshot struct {
+	Mode          string                     `json:"mode"`
+	Route         string                     `json:"route"`
+	RouteTitle    string                     `json:"route_title,omitempty"`
+	ThreadID      string                     `json:"thread_id"`
+	Summary       *marketplaceThreadSummary  `json:"summary,omitempty"`
+	MessageCount  int                        `json:"message_count"`
+	Messages      []marketplaceThreadMessage `json:"messages"`
+	LatestMessage *marketplaceThreadMessage  `json:"latest_message,omitempty"`
+}
+
+// MarketplaceThreadSnapshot reads the direct Messenger thread route for a
+// known Marketplace thread id. This route exposes the actual buyer-side thread
+// payload even when /marketplace/inbox resolves to an unrelated top-level inbox store.
+func (c *Client) MarketplaceThreadSnapshot(threadID string) (json.RawMessage, int, error) {
+	noCacheBefore := c.NoCache
+	c.NoCache = true
+	defer func() { c.NoCache = noCacheBefore }()
+
+	route := "/messages/t/" + threadID + "/"
+	shell, statusCode, err := c.do("GET", route, nil, nil, nil)
+	if err != nil {
+		return nil, statusCode, err
+	}
+
+	contacts := parseMarketplaceThreadContacts(string(shell))
+	messages := parseMarketplaceThreadMessages(string(shell), threadID, contacts)
+	var latestMessage *marketplaceThreadMessage
+	if len(messages) > 0 {
+		last := messages[len(messages)-1]
+		latestMessage = &last
+	}
+
+	snapshot := marketplaceThreadSnapshot{
+		Mode:          "messenger_thread_route",
+		Route:         route,
+		RouteTitle:    parseMarketplaceThreadTitle(string(shell)),
+		ThreadID:      threadID,
+		Summary:       parseMarketplaceThreadSummary(string(shell), threadID),
+		MessageCount:  len(messages),
+		Messages:      messages,
+		LatestMessage: latestMessage,
+	}
+
+	out, err := json.Marshal(snapshot)
+	if err != nil {
+		return nil, statusCode, err
+	}
+	return out, statusCode, nil
+}
+
+func parseMarketplaceThreadTitle(shell string) string {
+	match := marketplaceThreadTitleRe.FindStringSubmatch(shell)
+	if len(match) != 2 {
+		return ""
+	}
+	return match[1]
+}
+
+func parseMarketplaceThreadSummary(shell string, threadID string) *marketplaceThreadSummary {
+	for _, match := range marketplaceThreadSummaryRe.FindAllStringSubmatch(shell, -1) {
+		if len(match) != 8 || match[6] != threadID {
+			continue
+		}
+		return &marketplaceThreadSummary{
+			UpdatedAt:         mustParseInt64(match[1]),
+			PreviousUpdatedAt: mustParseInt64(match[2]),
+			Snippet:           unquoteJSONString(match[3]),
+			Title:             unquoteJSONString(match[4]),
+			ImageURL:          unquoteJSONString(match[5]),
+			FolderCode:        mustParseInt(match[7]),
+		}
+	}
+	return nil
+}
+
+func parseMarketplaceThreadMessages(shell string, threadID string, contacts map[string]marketplaceThreadContact) []marketplaceThreadMessage {
+	out := make([]marketplaceThreadMessage, 0)
+	seen := map[string]struct{}{}
+	for _, match := range marketplaceThreadMessageRe.FindAllStringSubmatch(shell, -1) {
+		if len(match) != 8 || match[2] != threadID {
+			continue
+		}
+		message := marketplaceThreadMessage{
+			Text:               unquoteJSONString(match[1]),
+			TimestampMS:        mustParseInt64(match[3]),
+			SortKeyMS:          mustParseInt64(match[4]),
+			MessageID:          match[5],
+			OfflineThreadingID: match[6],
+			SenderID:           match[7],
+			SenderName:         contacts[match[7]].Name,
+		}
+		key := fmt.Sprintf("%s:%d", message.MessageID, message.TimestampMS)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, message)
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].TimestampMS != out[j].TimestampMS {
+			return out[i].TimestampMS < out[j].TimestampMS
+		}
+		return out[i].MessageID < out[j].MessageID
+	})
+	return out
+}
+
+func parseMarketplaceThreadContacts(shell string) map[string]marketplaceThreadContact {
+	out := map[string]marketplaceThreadContact{}
+	for _, match := range marketplaceThreadContactRe.FindAllStringSubmatch(shell, -1) {
+		if len(match) != 6 {
+			continue
+		}
+		out[match[1]] = marketplaceThreadContact{
+			ContactID:   match[1],
+			ContactType: mustParseInt(match[2]),
+			Name:        unquoteJSONString(match[4]),
+			ImageURL:    unquoteJSONString(match[3]),
+		}
+	}
+	return out
+}
+
+func mustParseInt(raw string) int {
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func mustParseInt64(raw string) int64 {
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/library/commerce/facebook-marketplace/internal/client/marketplace_thread_test.go
+++ b/library/commerce/facebook-marketplace/internal/client/marketplace_thread_test.go
@@ -1,0 +1,56 @@
+package client
+
+import "testing"
+
+func TestParseMarketplaceThreadSummary(t *testing.T) {
+	t.Parallel()
+
+	shell := `
+<title>Messenger</title>
+deleteThenInsertThread",[19,"1784924049824"],[19,"1784916026901"],"Meghana Reddy is waiting for your response about Technivorm Moccamaster KBGV Select \u2013 Yellow Pepper.","Meghana Reddy \u00b7 Technivorm Moccamaster KBGV Select \u2013 Yellow Pepper","https:\/\/img.example\/listing.jpg",false,[19,"80"],[19,"27799138726406206"],[19,"0"],[19,"5"],"inbox","\/messaging\/lightspeed\/media_fallback\/?entity_id=27799138726406206",[19,"1787522555"],[19,"0"],[19,"0"],[19,"0"],[19,"0"],true,[19,"100017629485378"],[9],[9],[9],[9],[9],[9],[9],[9],[9],[19,"0"],[19,"0"],[9],[9],[9],[9],[9],[19,"-12"],[9],[9],[9],[9],[9],[9],false,false,false,[19,"5"],[9],[9],[9],[19,"0"],[9],[19,"0"],false,[9],"michael \u00b7 technivorm moccamaster kbgv select \u2013 yellow pepper",[9],[9],false,[9],[19,"0"],[9],[19,"0"],[9],[19,"27799138726406206"],[9],[19,"-1"],[19,"1"],[19,"0"],"",[19,"0"],[9],[19,"0"],[9],[9],[9],[9],[9],[19,"2"],[9],[9],[9],[19,"8102337"],[19,"4747"],[19,"0"],[9],[19,"3"],[9],"{\"eb_message_timestamp_type\":[{\"timestamp_status\":0}]",[19,"0"],[19,"2"]]
+`
+
+	summary := parseMarketplaceThreadSummary(shell, "27799138726406206")
+	if summary == nil {
+		t.Fatal("expected summary")
+	}
+	if summary.Snippet != "Meghana Reddy is waiting for your response about Technivorm Moccamaster KBGV Select – Yellow Pepper." {
+		t.Fatalf("unexpected snippet: %q", summary.Snippet)
+	}
+	if summary.Title != "Meghana Reddy · Technivorm Moccamaster KBGV Select – Yellow Pepper" {
+		t.Fatalf("unexpected title: %q", summary.Title)
+	}
+	if summary.FolderCode != 0 {
+		t.Fatalf("unexpected folder code: %d", summary.FolderCode)
+	}
+}
+
+func TestParseMarketplaceThreadMessages(t *testing.T) {
+	t.Parallel()
+
+	shell := `
+verifyContactRowExists",[19,"8102337"],[19,"1"],"https:\/\/img.example\/me.jpg","Michael Galpert",[19,"1"]
+verifyContactRowExists",[19,"100017629485378"],[19,"1"],"https:\/\/img.example\/seller.jpg","Meghana Reddy Bobbili",[19,"1"]
+upsertMessage","You started this chat.",[9],[19,"80"],[19,"27799138726406206"],[19,"0"],[19,"1784916026554"],[19,"1784916026554"],[9],"mid.start","7486480428977688798",[19,"8102337"],[9],true
+upsertMessage","Hi, I am Michaels AI Chief of Staff helping him buy this. He can do $155 cash and pick up quickly if that works for you.",[9],[19,"80"],[19,"27799138726406206"],[19,"0"],[19,"1784916026901"],[19,"1784916026901"],[9],"mid.offer","7486480430059965337",[19,"8102337"],[9],false
+upsertMessage","Hi \u0040Michael Galpert \nLast we can do for 300",[9],[19,"80"],[19,"27799138726406206"],[19,"0"],[19,"1784916092783"],[19,"1784916092783"],[9],"mid.counter","7486480705939133371",[19,"100017629485378"],[9],false
+upsertMessage","Hi \u0040Michael Galpert \nLast we can do for 300",[9],[19,"80"],[19,"27799138726406206"],[19,"0"],[19,"1784916092783"],[19,"1784916092783"],[9],"mid.counter","7486480705939133371",[19,"100017629485378"],[9],false
+upsertMessage","Meghana Reddy is waiting for your response about Technivorm Moccamaster KBGV Select \u2013 Yellow Pepper.",[9],[19,"80"],[19,"27799138726406206"],[19,"0"],[19,"1784924049824"],[19,"1784924049824"],[9],"mid.reminder","7486514080953655043",[19,"100017629485378"],[9],true
+upsertMessage","ignore this other thread",[9],[19,"80"],[19,"999"],[19,"0"],[19,"1"],[19,"1"],[9],"mid.other","1",[19,"100017629485378"],[9],false
+`
+
+	contacts := parseMarketplaceThreadContacts(shell)
+	messages := parseMarketplaceThreadMessages(shell, "27799138726406206", contacts)
+	if len(messages) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(messages))
+	}
+	if messages[2].Text != "Hi @Michael Galpert \nLast we can do for 300" {
+		t.Fatalf("unexpected counter text: %q", messages[2].Text)
+	}
+	if messages[2].SenderName != "Meghana Reddy Bobbili" {
+		t.Fatalf("unexpected sender name: %q", messages[2].SenderName)
+	}
+	if messages[3].MessageID != "mid.reminder" {
+		t.Fatalf("unexpected latest message id: %q", messages[3].MessageID)
+	}
+}


### PR DESCRIPTION
## Summary
- add a new `inbox thread` command that reads a known Marketplace Messenger thread route directly by thread id
- parse thread summary, contact rows, and message rows from the direct `/messages/t/<thread>/` shell instead of relying on the generic inbox feed
- document the new command and cover the parser with targeted client tests

## Validation
- env GOCACHE=/private/tmp/go-build-cache /Users/pal/.homebrew/bin/go test ./internal/client ./internal/cli
- env GOCACHE=/private/tmp/go-build-cache /Users/pal/.homebrew/bin/go run ./cmd/facebook-marketplace-pp-cli inbox thread --thread 27799138726406206 --agent