### PR TITLE
fix(slack): assemble POST bodies from flags; unwrap live search envelope; surface ok:false

### DIFF
--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -1170,6 +1170,27 @@ def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, rep
         for raw_cmd_path, _positional, flags, _surface in extract_cli_invocations(src, cli_binary, cli_dir):
             cmd_path = list(raw_cmd_path)
             path_str = " ".join(cmd_path)
+            # The extractor under-resolves subcommands whose names contain an
+            # underscore — `messages post_message --text` yields cmd_path
+            # ["messages"] with "post_message" left among the positionals — so
+            # flags belonging to the subcommand were attributed to its parent and
+            # reported as "declared elsewhere but not on <parent>".
+            #
+            # check_positional_args already treats this shape as a false positive
+            # (see the snake_case note there), but that only downgraded its own
+            # finding; this check still emitted hard errors.
+            #
+            # Resolve it instead of suppressing it, but only as a fallback once the
+            # parent has been ruled out. Trying the child first would misread
+            # commands that take a resource name positionally — `export messages
+            # --format` and `tail messages --interval` both resolve
+            # ["export", "messages"] to a messages source file, which does not
+            # declare --format or --interval, turning working docs into errors.
+            fallback_path: list[str] | None = None
+            if len(cmd_path) == 1 and _positional and re.match(r"^[a-z][a-z0-9_-]+$", _positional[0]):
+                candidate = cmd_path + [_positional[0]]
+                if find_command_source(cli_dir, candidate)[0]:
+                    fallback_path = candidate
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
                 key = (path_str, flag)
@@ -1182,6 +1203,15 @@ def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, rep
                     continue
                 if cmd_files and flag_declared_via_helper(cli_dir, cmd_files, flag):
                     continue
+                # Parent ruled out — the flag may belong to an under-resolved
+                # subcommand left in the positionals (see fallback_path above).
+                if fallback_path:
+                    sub_files, _, _ = find_command_source(cli_dir, fallback_path)
+                    if sub_files and (
+                        flag_declared_in(sub_files, flag)
+                        or flag_declared_via_helper(cli_dir, sub_files, flag)
+                    ):
+                        continue
                 seen.add(key)
                 if flag_declared_in(all_files, flag):
                     report.findings.append(

--- a/library/productivity/slack/.printing-press-patches/slack-ok-false-on-writes-and-search.json
+++ b/library/productivity/slack/.printing-press-patches/slack-ok-false-on-writes-and-search.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 2,
+  "applied_at": "2026-07-25",
+  "base_run_id": "20260409-073625",
+  "base_printing_press_version": "1.2.1",
+  "id": "slack-ok-false-on-writes-and-search",
+  "summary": "Surface Slack ok:false application errors on writes, imports, and live search.",
+  "reason": "Slack answers application errors with HTTP 200 and {\"ok\":false,\"error\":\"...\"}, and internal/client/client.go has no ok handling on any verb, so the client reports these as success. The CLI layer compensates via checkSlackAPIError, but only on paths that route through resolveRead or the DM helpers. Every POST command called c.Post directly and never checked, so the JSON envelope reported success:true and exit 0 for a write Slack had rejected \u2014 the failure mode in cli-printing-press#790's own reproduction. search's live path likewise called c.Get directly, bypassing resolveRead, which is why a failed search coerced to an empty result set rather than an error. import discarded the response entirely and counted rejected records as imported. All now reuse the existing checkSlackAPIError helper rather than adding a second detector; the prior fix-ok-false-detection patch covered internal/cli/sync.go only and is unchanged by this patch.",
+  "files": [
+    "internal/cli/auth_test.go",
+    "internal/cli/conversations_archive.go",
+    "internal/cli/conversations_create.go",
+    "internal/cli/conversations_invite.go",
+    "internal/cli/conversations_mark.go",
+    "internal/cli/conversations_set_purpose.go",
+    "internal/cli/conversations_set_topic.go",
+    "internal/cli/conversations_unarchive.go",
+    "internal/cli/dnd_end_dnd.go",
+    "internal/cli/dnd_end_snooze.go",
+    "internal/cli/dnd_set_snooze.go",
+    "internal/cli/dnd_team_info.go",
+    "internal/cli/files_delete.go",
+    "internal/cli/files_upload.go",
+    "internal/cli/messages_delete_message.go",
+    "internal/cli/messages_list_scheduled.go",
+    "internal/cli/messages_post_message.go",
+    "internal/cli/messages_schedule_message.go",
+    "internal/cli/messages_update_message.go",
+    "internal/cli/pins_add.go",
+    "internal/cli/pins_remove.go",
+    "internal/cli/reactions_add.go",
+    "internal/cli/reactions_remove.go",
+    "internal/cli/reminders_add.go",
+    "internal/cli/reminders_complete.go",
+    "internal/cli/reminders_delete.go",
+    "internal/cli/stars_add.go",
+    "internal/cli/stars_remove.go",
+    "internal/cli/usergroups_create.go",
+    "internal/cli/usergroups_update.go",
+    "internal/cli/usergroups_users_update.go",
+    "internal/cli/users_profile_set.go",
+    "internal/cli/users_set_presence.go",
+    "internal/cli/import.go",
+    "internal/cli/search.go"
+  ],
+  "validated_outcome": "Table-driven tests cover ok:false plain errors, missing_scope (asserting the needed scope is named in the message), ok:true success, and non-Slack payloads. go vet and go build clean. --dry-run is unaffected because the dry-run payload carries no ok field.",
+  "findings_addressed": [
+    "F4"
+  ],
+  "deferred_to_upstream": [
+    {
+      "feature": "An additive error-classifier seam so 200-with-error-envelope APIs are handled in the client",
+      "reason": "Slack is one of many APIs that signal failure inside a 200 body. Without a generator-level seam, each printed CLI must hand-patch detection at every call site \u2014 this patch touches 35 files to do what one client-level hook would. Tracked upstream as the additive error-classifier seam request."
+    }
+  ],
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/3740"
+}

--- a/library/productivity/slack/.printing-press-patches/slack-ok-false-on-writes-and-search.json
+++ b/library/productivity/slack/.printing-press-patches/slack-ok-false-on-writes-and-search.json
@@ -5,7 +5,7 @@
   "base_printing_press_version": "1.2.1",
   "id": "slack-ok-false-on-writes-and-search",
   "summary": "Surface Slack ok:false application errors on writes, imports, and live search.",
-  "reason": "Slack answers application errors with HTTP 200 and {\"ok\":false,\"error\":\"...\"}, and internal/client/client.go has no ok handling on any verb, so the client reports these as success. The CLI layer compensates via checkSlackAPIError, but only on paths that route through resolveRead or the DM helpers. Every POST command called c.Post directly and never checked, so the JSON envelope reported success:true and exit 0 for a write Slack had rejected \u2014 the failure mode in cli-printing-press#790's own reproduction. search's live path likewise called c.Get directly, bypassing resolveRead, which is why a failed search coerced to an empty result set rather than an error. import discarded the response entirely and counted rejected records as imported. All now reuse the existing checkSlackAPIError helper rather than adding a second detector; the prior fix-ok-false-detection patch covered internal/cli/sync.go only and is unchanged by this patch.",
+  "reason": "Slack answers application errors with HTTP 200 and {\"ok\":false,\"error\":\"...\"}, and internal/client/client.go has no ok handling on any verb, so the client reports these as success. The CLI layer compensates via checkSlackAPIError, but only on paths that route through resolveRead or the DM helpers. Every POST command called c.Post directly and never checked, so the JSON envelope reported success:true and exit 0 for a write Slack had rejected — the failure mode in cli-printing-press#790's own reproduction. search's live path likewise called c.Get directly, bypassing resolveRead, which is why a failed search coerced to an empty result set rather than an error. import discarded the response entirely and counted rejected records as imported. All now reuse the existing checkSlackAPIError helper rather than adding a second detector; the prior fix-ok-false-detection patch covered internal/cli/sync.go only and is unchanged by this patch. Follow-up within the same change: checkSlackAPIError returned bare fmt.Errorf values, so ExitCode found no *cliError and fell through to its generic 1. Read paths happened to exit 5 regardless, because they hand the error back to classifyAPIError whose default branch wraps with apiErr; the write and upload paths return it directly and exited 1. That made a rejected write indistinguishable from a usage error for any caller branching on exit codes, against a README that documents 5 as the API-error code. Wrapping both returns in apiErr inside checkSlackAPIError corrects every caller at once rather than editing 35 call sites, and leaves read-path behaviour unchanged since classifyAPIError's re-wrap resolves to the same code.",
   "files": [
     "internal/cli/auth_test.go",
     "internal/cli/conversations_archive.go",
@@ -41,16 +41,17 @@
     "internal/cli/users_profile_set.go",
     "internal/cli/users_set_presence.go",
     "internal/cli/import.go",
-    "internal/cli/search.go"
+    "internal/cli/search.go",
+    "internal/cli/helpers.go"
   ],
-  "validated_outcome": "Table-driven tests cover ok:false plain errors, missing_scope (asserting the needed scope is named in the message), ok:true success, and non-Slack payloads. go vet and go build clean. --dry-run is unaffected because the dry-run payload carries no ok field.",
+  "validated_outcome": "Table-driven tests cover ok:false plain errors, missing_scope (asserting the needed scope is named in the message), ok:true success, and non-Slack payloads. go vet and go build clean. --dry-run is unaffected because the dry-run payload carries no ok field. Exit codes verified against a nonexistent channel after the fix: messages post_message, conversations history, and files upload all exit 5 (previously 1, 5, and 1 respectively); search --data-source live and a valid conversations history still exit 0; the rendered error text is byte-identical.",
   "findings_addressed": [
     "F4"
   ],
   "deferred_to_upstream": [
     {
       "feature": "An additive error-classifier seam so 200-with-error-envelope APIs are handled in the client",
-      "reason": "Slack is one of many APIs that signal failure inside a 200 body. Without a generator-level seam, each printed CLI must hand-patch detection at every call site \u2014 this patch touches 35 files to do what one client-level hook would. Tracked upstream as the additive error-classifier seam request."
+      "reason": "Slack is one of many APIs that signal failure inside a 200 body. Without a generator-level seam, each printed CLI must hand-patch detection at every call site — this patch touches 35 files to do what one client-level hook would. Tracked upstream as the additive error-classifier seam request."
     }
   ],
   "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/3740"

--- a/library/productivity/slack/.printing-press-patches/slack-post-body-from-flags.json
+++ b/library/productivity/slack/.printing-press-patches/slack-post-body-from-flags.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 2,
+  "applied_at": "2026-07-25",
+  "base_run_id": "20260409-073625",
+  "base_printing_press_version": "1.2.1",
+  "id": "slack-post-body-from-flags",
+  "summary": "Assemble POST request bodies from flag values; every write shipped an empty {}.",
+  "reason": "Slack's internal-YAML spec declares write fields under `params:` rather than `body:`. The generator's bodyMap iterated only Endpoint.Body, so the non-stdin branch of every POST command assigned a literal empty map and the flag values were never read. Flags were registered and validated, then discarded \u2014 no write operation in the CLI could succeed. Required-flag validation also ran unconditionally, so --stdin alone failed validation and the only working invocation duplicated every value in both flags and stdin. Validation now runs only on the non-stdin path, making flags and --stdin independent routes with stdin winning when both are given. unfurl_links and is_private are booleans and post_at and num_minutes are integers in the Slack API, so those four are coerced from their string flags and reject non-parsing input with a named error instead of sending a JSON string the API rejects.",
+  "files": [
+    "internal/cli/conversations_archive.go",
+    "internal/cli/conversations_create.go",
+    "internal/cli/conversations_invite.go",
+    "internal/cli/conversations_mark.go",
+    "internal/cli/conversations_set_purpose.go",
+    "internal/cli/conversations_set_topic.go",
+    "internal/cli/conversations_unarchive.go",
+    "internal/cli/dnd_set_snooze.go",
+    "internal/cli/dnd_team_info.go",
+    "internal/cli/files_delete.go",
+    "internal/cli/files_upload.go",
+    "internal/cli/messages_delete_message.go",
+    "internal/cli/messages_list_scheduled.go",
+    "internal/cli/messages_post_message.go",
+    "internal/cli/messages_schedule_message.go",
+    "internal/cli/messages_update_message.go",
+    "internal/cli/pins_add.go",
+    "internal/cli/pins_remove.go",
+    "internal/cli/reactions_add.go",
+    "internal/cli/reactions_remove.go",
+    "internal/cli/reminders_add.go",
+    "internal/cli/reminders_complete.go",
+    "internal/cli/reminders_delete.go",
+    "internal/cli/stars_add.go",
+    "internal/cli/stars_remove.go",
+    "internal/cli/usergroups_create.go",
+    "internal/cli/usergroups_update.go",
+    "internal/cli/usergroups_users_update.go",
+    "internal/cli/users_profile_set.go",
+    "internal/cli/users_set_presence.go"
+  ],
+  "validated_outcome": "go build, go vet, and gofmt clean. Dry-run with flags only now emits {\"channel\":...,\"text\":...,\"thread_ts\":...} where it previously emitted {}; --stdin alone no longer fails required-flag validation; is_private serializes as a JSON boolean and post_at as a JSON integer; --is-private maybe errors with a named message. publish validate output is byte-identical to the pre-change baseline (4 pre-existing failures unchanged, no new ones).",
+  "findings_addressed": [
+    "F1"
+  ],
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator promotion of write-endpoint `params:` into the request body",
+      "reason": "Fixed upstream in cli-printing-press PR #791 (promoteParamsToBodyForWriteEndpoints, press ~4.2.0). Verified by generating this spec under press 4.29.0: the emitted else-branch populates bodyMap correctly. This patch is a backport for a CLI still printed under 1.2.1 and is superseded the moment slack is reprinted."
+    }
+  ],
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/790"
+}

--- a/library/productivity/slack/.printing-press-patches/slack-search-messages-matches.json
+++ b/library/productivity/slack/.printing-press-patches/slack-search-messages-matches.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 2,
+  "applied_at": "2026-07-25",
+  "base_run_id": "20260409-073625",
+  "base_printing_press_version": "1.2.1",
+  "id": "slack-search-messages-matches",
+  "summary": "Unwrap Slack's messages.matches search envelope and stop discarding the hits.",
+  "reason": "Two stacked defects made live search a silent wrong answer. extractSearchResults probes the wrapper keys data/results/items/records/entries, but search.messages nests hits at messages.matches, so no probe matched and the whole envelope fell through to the single-item return. outputSearchResults then ran that envelope through isNilOrEmpty, which looks for a top-level title/name/identifier/id, a nested document, or a score \u2014 a Slack envelope has none \u2014 so it was dropped, the slice emptied, and the command printed 'No results' and exited 0 for a query with thousands of matches. A Slack match object is identified by text/ts/permalink, none of which isNilOrEmpty recognized, so unwrapping alone would still have discarded every hit.",
+  "files": [
+    "internal/cli/search.go",
+    "internal/cli/search_amend_test.go"
+  ],
+  "validated_outcome": "Six new unit tests in internal/cli/search_amend_test.go pass: matches unwrap from messages.matches, each survives the isNilOrEmpty filter, the two fixes compose end-to-end, a genuinely empty result set still reads as empty (no false positives), and ok:false envelopes surface as errors.",
+  "findings_addressed": [
+    "F2"
+  ],
+  "deferred_to_upstream": [
+    {
+      "feature": "Per-API search-envelope knowledge in the generated search template",
+      "reason": "The generated extractSearchResults hardcodes a generic wrapper-key list and isNilOrEmpty hardcodes a generic identity-field list; neither can express 'this API nests hits at messages.matches and identifies them by text/ts/permalink'. Any API whose search envelope or result shape falls outside those two lists reproduces this silent-empty failure. Tracked upstream as cli-printing-press#3795, which proposes a spec-declared search response_path plus identity_fields; that declaration would supersede this patch."
+    }
+  ],
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/3795"
+}

--- a/library/productivity/slack/README.md
+++ b/library/productivity/slack/README.md
@@ -343,8 +343,15 @@ slack-pp-cli messages post_message --channel C0123456789 --text "Hello from the 
 # Reply in a thread
 slack-pp-cli messages post_message --channel C0123456789 --text "Thread reply" --thread-ts 1234567890.123456
 
-# Search for messages mentioning a keyword
+# Search the workspace for messages mentioning a keyword (live search)
 slack-pp-cli search "deploy failed"
+
+# Preview the exact request body before sending a write
+slack-pp-cli messages post_message --channel C0123456789 --text "Hello" --dry-run
+
+# Supply a whole request body as JSON instead of flags (stdin replaces the flags)
+echo '{"channel":"C0123456789","text":"Hello"}' \
+  | slack-pp-cli messages post_message --stdin --agent
 
 # Get channel health report after syncing
 slack-pp-cli sync && slack-pp-cli health
@@ -379,6 +386,33 @@ slack-pp-cli conversations create --name "secret-project" --is-private true
 # Look up a user by email
 slack-pp-cli users lookup_by_email --email alice@example.com --json
 ```
+
+## Writing to Slack
+
+Write commands take their fields as flags, and the flags alone are sufficient. `--stdin` is an
+alternative to the flags rather than a supplement — pass the whole body as JSON and omit them:
+
+```bash
+echo '{"channel":"C0123456789","text":"Hello"}' \
+  | slack-pp-cli messages post_message --stdin --agent
+```
+
+When both are supplied, stdin wins and the flags are ignored. Use `--dry-run` on any write to
+inspect the exact request body before it is sent.
+
+Slack reports application errors as HTTP 200 with `{"ok":false,"error":"..."}`. Writes and live
+search now exit non-zero and name the Slack error (including the needed scope for
+`missing_scope`) instead of reporting success.
+
+## Known Limitations
+
+- `search --data-source local` does not return messages. `sync` populates the local
+  `messages`/`messages_fts` tables, but the local search path never queries them, so it reports
+  no results even when the index holds matches. Use the default (live) mode for message search.
+- `files upload` targets Slack's retired `files.upload` endpoint and fails with
+  `method_deprecated`. There is no file-attachment path yet.
+- `auth test` is not registered on the command tree.
+- `sync --resources channels` fails with `unknown_method`; use `conversations` instead.
 
 ## Health Check
 

--- a/library/productivity/slack/SKILL.md
+++ b/library/productivity/slack/SKILL.md
@@ -100,7 +100,7 @@ Source routing (local vs live) is controlled by `--data-source`: `auto` (default
 |---------|--------------|
 | `conversations` | List channels and DMs in the workspace |
 | `users` | List all users in the workspace |
-| `search <query>` | Full-text search across synced messages (or live API with `--data-source live`) |
+| `search <query>` | Live workspace search via `search.messages`. Local mode (`--data-source local`) does not reach synced messages yet — see Known Limitations |
 | `digest` | Daily/weekly activity digest from locally synced data |
 | `health` | Channel health report (activity, engagement, stagnation) |
 | `quiet` | Find dead or low-activity channels |
@@ -113,6 +113,41 @@ Source routing (local vs live) is controlled by `--data-source`: `auto` (default
 | `team` | Access logs (requires admin token) |
 
 Run any command with `--help` for full flag documentation.
+
+## Writing to Slack
+
+Write commands take their fields as flags, and the flags alone are sufficient:
+
+```bash
+slack-pp-cli reactions add --channel C0123456789 --name thumbsup --timestamp 1234567890.123456 --agent
+slack-pp-cli pins add --channel C0123456789 --timestamp 1234567890.123456 --agent
+```
+
+`--stdin` is an alternative to the flags, not a supplement to them — pass the whole body as
+JSON and omit the flags:
+
+```bash
+echo '{"channel":"C0123456789","text":"Hello"}' \
+  | slack-pp-cli messages post_message --stdin --agent
+```
+
+When both are supplied, stdin wins and the flags are ignored. Preview any write with
+`--dry-run` to see the exact body before it is sent.
+
+Slack reports application errors as HTTP 200 with `{"ok":false,"error":"..."}`. These now
+exit non-zero with the Slack error name (and the needed scope for `missing_scope`) instead of
+reporting success.
+
+## Known Limitations
+
+- `search --data-source local` does not return messages. `sync` writes them to the local
+  `messages`/`messages_fts` tables, but the local search path never queries those tables, so
+  it reports no results even when the index holds matches. Use the default (live) mode for
+  message search.
+- `files upload` targets Slack's retired `files.upload` endpoint and fails with
+  `method_deprecated`. There is no file-attachment path yet.
+- `auth test` is not registered on the command tree.
+- `sync --resources channels` fails with `unknown_method`; use `conversations`.
 
 ## Agent Mode
 

--- a/library/productivity/slack/internal/cli/auth_test.go
+++ b/library/productivity/slack/internal/cli/auth_test.go
@@ -46,6 +46,13 @@ func newAuthTestCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err)
 			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
+			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")
 				var items []map[string]any

--- a/library/productivity/slack/internal/cli/conversations_archive.go
+++ b/library/productivity/slack/internal/cli/conversations_archive.go
@@ -21,10 +21,10 @@ func newConversationsArchiveCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Archive a channel",
 		Example: "  slack-pp-cli conversations archive",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -44,11 +44,24 @@ func newConversationsArchiveCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/conversations_create.go
+++ b/library/productivity/slack/internal/cli/conversations_create.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -22,10 +23,10 @@ func newConversationsCreateCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Create a new channel",
 		Example: "  slack-pp-cli conversations create",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("name") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "name")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("name") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "name")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -45,11 +46,32 @@ func newConversationsCreateCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagName != "" {
+					bodyMap["name"] = flagName
+				}
+				if flagIsPrivate != "" {
+					// is_private is a boolean in the Slack API; a JSON string is rejected.
+					parsed, parseErr := strconv.ParseBool(flagIsPrivate)
+					if parseErr != nil {
+						return fmt.Errorf("--is-private expects true or false, got %q", flagIsPrivate)
+					}
+					bodyMap["is_private"] = parsed
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/conversations_invite.go
+++ b/library/productivity/slack/internal/cli/conversations_invite.go
@@ -22,13 +22,13 @@ func newConversationsInviteCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Invite users to a channel",
 		Example: "  slack-pp-cli conversations invite",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("users") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "users")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("users") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "users")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -48,11 +48,27 @@ func newConversationsInviteCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagUsers != "" {
+					bodyMap["users"] = flagUsers
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/conversations_mark.go
+++ b/library/productivity/slack/internal/cli/conversations_mark.go
@@ -22,13 +22,13 @@ func newConversationsMarkCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Mark a channel as read up to a specific message",
 		Example: "  slack-pp-cli conversations mark",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("ts") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "ts")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("ts") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "ts")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -48,11 +48,27 @@ func newConversationsMarkCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagTs != "" {
+					bodyMap["ts"] = flagTs
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/conversations_set_purpose.go
+++ b/library/productivity/slack/internal/cli/conversations_set_purpose.go
@@ -22,13 +22,13 @@ func newConversationsSetPurposeCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Set the purpose for a channel",
 		Example: "  slack-pp-cli conversations set_purpose",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("purpose") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "purpose")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("purpose") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "purpose")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -48,11 +48,27 @@ func newConversationsSetPurposeCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagPurpose != "" {
+					bodyMap["purpose"] = flagPurpose
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/conversations_set_topic.go
+++ b/library/productivity/slack/internal/cli/conversations_set_topic.go
@@ -22,13 +22,13 @@ func newConversationsSetTopicCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Set the topic for a channel",
 		Example: "  slack-pp-cli conversations set_topic",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("topic") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "topic")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("topic") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "topic")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -48,11 +48,27 @@ func newConversationsSetTopicCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagTopic != "" {
+					bodyMap["topic"] = flagTopic
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/conversations_unarchive.go
+++ b/library/productivity/slack/internal/cli/conversations_unarchive.go
@@ -21,10 +21,10 @@ func newConversationsUnarchiveCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Unarchive a channel",
 		Example: "  slack-pp-cli conversations unarchive",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -44,11 +44,24 @@ func newConversationsUnarchiveCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/dnd_end_dnd.go
+++ b/library/productivity/slack/internal/cli/dnd_end_dnd.go
@@ -46,6 +46,13 @@ func newDndEndDndCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err)
 			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
+			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")
 				var items []map[string]any

--- a/library/productivity/slack/internal/cli/dnd_end_snooze.go
+++ b/library/productivity/slack/internal/cli/dnd_end_snooze.go
@@ -46,6 +46,13 @@ func newDndEndSnoozeCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err)
 			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
+			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")
 				var items []map[string]any

--- a/library/productivity/slack/internal/cli/dnd_set_snooze.go
+++ b/library/productivity/slack/internal/cli/dnd_set_snooze.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -21,10 +22,10 @@ func newDndSetSnoozeCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Turn on Do Not Disturb for a specified number of minutes",
 		Example: "  slack-pp-cli dnd set_snooze",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("num-minutes") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "num-minutes")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("num-minutes") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "num-minutes")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -44,11 +45,29 @@ func newDndSetSnoozeCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagNumMinutes != "" {
+					// num_minutes is an integer in the Slack API; a JSON string is rejected.
+					parsed, parseErr := strconv.ParseInt(flagNumMinutes, 10, 64)
+					if parseErr != nil {
+						return fmt.Errorf("--num-minutes expects an integer, got %q", flagNumMinutes)
+					}
+					bodyMap["num_minutes"] = parsed
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/dnd_team_info.go
+++ b/library/productivity/slack/internal/cli/dnd_team_info.go
@@ -21,10 +21,10 @@ func newDndTeamInfoCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Get DND status for multiple users",
 		Example: "  slack-pp-cli dnd team_info",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("users") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "users")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("users") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "users")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -44,11 +44,24 @@ func newDndTeamInfoCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagUsers != "" {
+					bodyMap["users"] = flagUsers
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/files_delete.go
+++ b/library/productivity/slack/internal/cli/files_delete.go
@@ -21,10 +21,10 @@ func newFilesDeleteCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Delete a file",
 		Example: "  slack-pp-cli files delete",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("file") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "file")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("file") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "file")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -44,11 +44,24 @@ func newFilesDeleteCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagFile != "" {
+					bodyMap["file"] = flagFile
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/files_upload.go
+++ b/library/productivity/slack/internal/cli/files_upload.go
@@ -45,11 +45,36 @@ func newFilesUploadCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannels != "" {
+					bodyMap["channels"] = flagChannels
+				}
+				if flagContent != "" {
+					bodyMap["content"] = flagContent
+				}
+				if flagFilename != "" {
+					bodyMap["filename"] = flagFilename
+				}
+				if flagTitle != "" {
+					bodyMap["title"] = flagTitle
+				}
+				if flagInitialComment != "" {
+					bodyMap["initial_comment"] = flagInitialComment
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/helpers.go
+++ b/library/productivity/slack/internal/cli/helpers.go
@@ -407,10 +407,16 @@ func checkSlackAPIError(data json.RawMessage) error {
 	if resp.OK || resp.Error == "" {
 		return nil
 	}
+	// PATCH(amend-2026-07-25: give ok:false errors the documented exit code) —
+	// these were returned unwrapped, so ExitCode fell through to its generic 1.
+	// Read paths happened to get 5 anyway because they funnel the error back
+	// through classifyAPIError, whose default branch wraps with apiErr; write
+	// paths return it directly and exited 1. Wrapping here makes every caller
+	// agree with the documented table (5 = API error) without touching call sites.
 	if resp.Error == "missing_scope" && resp.Needed != "" {
-		return fmt.Errorf("missing Slack scope: %s\nAdd it in your app's OAuth & Permissions settings at https://api.slack.com/apps and reinstall", resp.Needed)
+		return apiErr(fmt.Errorf("missing Slack scope: %s\nAdd it in your app's OAuth & Permissions settings at https://api.slack.com/apps and reinstall", resp.Needed))
 	}
-	return fmt.Errorf("Slack API error: %s", resp.Error)
+	return apiErr(fmt.Errorf("Slack API error: %s", resp.Error))
 }
 
 func extractResponseData(data json.RawMessage) json.RawMessage {

--- a/library/productivity/slack/internal/cli/import.go
+++ b/library/productivity/slack/internal/cli/import.go
@@ -74,9 +74,17 @@ but do not stop the import.`,
 					continue
 				}
 
-				_, _, err := c.Post(path, body)
+				data, _, err := c.Post(path, body)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)
+					failed++
+					continue
+				}
+				// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — the response
+				// was discarded entirely, so a record Slack rejected with HTTP 200 and
+				// {"ok":false,...} was still counted as an import success.
+				if slackErr := checkSlackAPIError(data); slackErr != nil {
+					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", slackErr)
 					failed++
 					continue
 				}

--- a/library/productivity/slack/internal/cli/import.go
+++ b/library/productivity/slack/internal/cli/import.go
@@ -96,6 +96,14 @@ but do not stop the import.`,
 			}
 
 			fmt.Fprintf(os.Stderr, "Import complete: %d succeeded, %d failed, %d skipped\n", success, failed, skipped)
+			// PATCH(amend-2026-07-25: fail the command when records were rejected) —
+			// detecting per-record failures above only mattered if the exit code moved
+			// with them. Returning nil meant a partial or total import failure exited 0,
+			// so a caller could not distinguish it from a clean run without parsing
+			// stderr. Same silent-success class this patch set exists to remove.
+			if failed > 0 {
+				return apiErr(fmt.Errorf("import completed with %d failed record(s) of %d attempted", failed, success+failed))
+			}
 			return nil
 		},
 	}

--- a/library/productivity/slack/internal/cli/messages_delete_message.go
+++ b/library/productivity/slack/internal/cli/messages_delete_message.go
@@ -22,13 +22,13 @@ func newMessagesDeleteMessageCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Delete a message",
 		Example: "  slack-pp-cli messages delete_message",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("ts") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "ts")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("ts") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "ts")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -48,11 +48,27 @@ func newMessagesDeleteMessageCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagTs != "" {
+					bodyMap["ts"] = flagTs
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/messages_list_scheduled.go
+++ b/library/productivity/slack/internal/cli/messages_list_scheduled.go
@@ -41,11 +41,24 @@ func newMessagesListScheduledCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/messages_post_message.go
+++ b/library/productivity/slack/internal/cli/messages_post_message.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -24,13 +25,13 @@ func newMessagesPostMessageCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Send a message to a channel, DM, or thread",
 		Example: "  slack-pp-cli messages post_message",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("text") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "text")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("text") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "text")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -50,11 +51,38 @@ func newMessagesPostMessageCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagText != "" {
+					bodyMap["text"] = flagText
+				}
+				if flagThreadTs != "" {
+					bodyMap["thread_ts"] = flagThreadTs
+				}
+				if flagUnfurlLinks != "" {
+					// unfurl_links is a boolean in the Slack API; a JSON string is rejected.
+					parsed, parseErr := strconv.ParseBool(flagUnfurlLinks)
+					if parseErr != nil {
+						return fmt.Errorf("--unfurl-links expects true or false, got %q", flagUnfurlLinks)
+					}
+					bodyMap["unfurl_links"] = parsed
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/messages_schedule_message.go
+++ b/library/productivity/slack/internal/cli/messages_schedule_message.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -23,16 +24,16 @@ func newMessagesScheduleMessageCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Schedule a message for later delivery",
 		Example: "  slack-pp-cli messages schedule_message",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("text") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "text")
-			}
-			if !cmd.Flags().Changed("post-at") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "post-at")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("text") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "text")
+				}
+				if !cmd.Flags().Changed("post-at") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "post-at")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -52,11 +53,35 @@ func newMessagesScheduleMessageCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagText != "" {
+					bodyMap["text"] = flagText
+				}
+				if flagPostAt != "" {
+					// post_at is an integer in the Slack API; a JSON string is rejected.
+					parsed, parseErr := strconv.ParseInt(flagPostAt, 10, 64)
+					if parseErr != nil {
+						return fmt.Errorf("--post-at expects an integer, got %q", flagPostAt)
+					}
+					bodyMap["post_at"] = parsed
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/messages_update_message.go
+++ b/library/productivity/slack/internal/cli/messages_update_message.go
@@ -23,16 +23,16 @@ func newMessagesUpdateMessageCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Update an existing message",
 		Example: "  slack-pp-cli messages update_message",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("ts") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "ts")
-			}
-			if !cmd.Flags().Changed("text") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "text")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("ts") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "ts")
+				}
+				if !cmd.Flags().Changed("text") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "text")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -52,11 +52,30 @@ func newMessagesUpdateMessageCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagTs != "" {
+					bodyMap["ts"] = flagTs
+				}
+				if flagText != "" {
+					bodyMap["text"] = flagText
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/pins_add.go
+++ b/library/productivity/slack/internal/cli/pins_add.go
@@ -22,13 +22,13 @@ func newPinsAddCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Pin a message to a channel",
 		Example: "  slack-pp-cli pins add",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("timestamp") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "timestamp")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("timestamp") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "timestamp")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -48,11 +48,27 @@ func newPinsAddCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagTimestamp != "" {
+					bodyMap["timestamp"] = flagTimestamp
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/pins_remove.go
+++ b/library/productivity/slack/internal/cli/pins_remove.go
@@ -22,13 +22,13 @@ func newPinsRemoveCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Unpin a message from a channel",
 		Example: "  slack-pp-cli pins remove",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("timestamp") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "timestamp")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("timestamp") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "timestamp")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -48,11 +48,27 @@ func newPinsRemoveCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagTimestamp != "" {
+					bodyMap["timestamp"] = flagTimestamp
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/reactions_add.go
+++ b/library/productivity/slack/internal/cli/reactions_add.go
@@ -23,16 +23,16 @@ func newReactionsAddCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Add an emoji reaction to a message",
 		Example: "  slack-pp-cli reactions add",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("name") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "name")
-			}
-			if !cmd.Flags().Changed("timestamp") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "timestamp")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("name") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "name")
+				}
+				if !cmd.Flags().Changed("timestamp") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "timestamp")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -52,11 +52,30 @@ func newReactionsAddCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagName != "" {
+					bodyMap["name"] = flagName
+				}
+				if flagTimestamp != "" {
+					bodyMap["timestamp"] = flagTimestamp
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/reactions_remove.go
+++ b/library/productivity/slack/internal/cli/reactions_remove.go
@@ -23,16 +23,16 @@ func newReactionsRemoveCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Remove an emoji reaction from a message",
 		Example: "  slack-pp-cli reactions remove",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("channel") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "channel")
-			}
-			if !cmd.Flags().Changed("name") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "name")
-			}
-			if !cmd.Flags().Changed("timestamp") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "timestamp")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("channel") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "channel")
+				}
+				if !cmd.Flags().Changed("name") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "name")
+				}
+				if !cmd.Flags().Changed("timestamp") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "timestamp")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -52,11 +52,30 @@ func newReactionsRemoveCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagName != "" {
+					bodyMap["name"] = flagName
+				}
+				if flagTimestamp != "" {
+					bodyMap["timestamp"] = flagTimestamp
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/reminders_add.go
+++ b/library/productivity/slack/internal/cli/reminders_add.go
@@ -23,13 +23,13 @@ func newRemindersAddCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Create a new reminder",
 		Example: "  slack-pp-cli reminders add",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("text") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "text")
-			}
-			if !cmd.Flags().Changed("time") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "time")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("text") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "text")
+				}
+				if !cmd.Flags().Changed("time") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "time")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -49,11 +49,30 @@ func newRemindersAddCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagText != "" {
+					bodyMap["text"] = flagText
+				}
+				if flagTime != "" {
+					bodyMap["time"] = flagTime
+				}
+				if flagUser != "" {
+					bodyMap["user"] = flagUser
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/reminders_complete.go
+++ b/library/productivity/slack/internal/cli/reminders_complete.go
@@ -21,10 +21,10 @@ func newRemindersCompleteCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Mark a reminder as complete",
 		Example: "  slack-pp-cli reminders complete",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("reminder") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "reminder")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("reminder") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "reminder")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -44,11 +44,24 @@ func newRemindersCompleteCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagReminder != "" {
+					bodyMap["reminder"] = flagReminder
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/reminders_delete.go
+++ b/library/productivity/slack/internal/cli/reminders_delete.go
@@ -21,10 +21,10 @@ func newRemindersDeleteCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Delete a reminder",
 		Example: "  slack-pp-cli reminders delete",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("reminder") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "reminder")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("reminder") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "reminder")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -44,11 +44,24 @@ func newRemindersDeleteCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagReminder != "" {
+					bodyMap["reminder"] = flagReminder
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/search.go
+++ b/library/productivity/slack/internal/cli/search.go
@@ -54,6 +54,20 @@ func isNilOrEmpty(raw json.RawMessage) bool {
 	if _, ok := obj["score"]; ok {
 		return false
 	}
+	// PATCH(amend-2026-07-25: recognize Slack message matches) — a search.messages
+	// match carries no title/name/identifier/id at the top level (its channel is a
+	// nested object), so every check above missed and each hit was discarded as
+	// empty. Slack identifies a match by its text/ts/permalink fields.
+	for _, key := range []string{"text", "ts", "permalink"} {
+		if v, ok := obj[key]; ok && v != nil {
+			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+				return false
+			}
+			if _, ok := v.(string); !ok {
+				return false
+			}
+		}
+	}
 	return true
 }
 
@@ -63,6 +77,20 @@ func extractSearchResults(data json.RawMessage) []json.RawMessage {
 	var items []json.RawMessage
 	if json.Unmarshal(data, &items) == nil {
 		return items
+	}
+	// PATCH(amend-2026-07-25: Slack nests search hits under messages.matches) — none
+	// of the generic wrapper keys below match search.messages, whose shape is
+	// {"ok":true,"messages":{"total":N,"matches":[...],"paging":{...}}}. Without this
+	// the whole envelope fell through to the single-item return at the bottom and was
+	// then dropped by isNilOrEmpty, so a query with thousands of hits printed
+	// "No results" and exited 0.
+	var slackSearch struct {
+		Messages struct {
+			Matches []json.RawMessage `json:"matches"`
+		} `json:"messages"`
+	}
+	if json.Unmarshal(data, &slackSearch) == nil && len(slackSearch.Messages.Matches) > 0 {
+		return slackSearch.Messages.Matches
 	}
 	// Try common wrapper paths: data, results, items
 	var wrapped map[string]json.RawMessage
@@ -120,6 +148,15 @@ In local mode: searches locally synced data only.`,
 					"query": query,
 				})
 				if getErr == nil {
+					// PATCH(amend-2026-07-25: surface Slack ok:false in live search) — Slack
+					// answers application errors with HTTP 200 and {"ok":false,"error":...},
+					// which the client reports as success. This path called c.Get directly
+					// instead of resolveRead, so it skipped the checkSlackAPIError that
+					// other read paths already perform, and a failed search rendered as an
+					// empty result set with exit 0.
+					if slackErr := checkSlackAPIError(data); slackErr != nil {
+						return slackErr
+					}
 					// Live search succeeded
 					results := extractSearchResults(data)
 					prov := DataProvenance{Source: "live"}

--- a/library/productivity/slack/internal/cli/search_amend_test.go
+++ b/library/productivity/slack/internal/cli/search_amend_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// All fixtures below use placeholder ids and invented message text.
+
+// slackSearchEnvelope mirrors the real shape of a Slack search.messages response:
+// hits are nested under messages.matches, which none of the generic wrapper keys
+// in extractSearchResults reach.
+const slackSearchEnvelope = `{
+  "ok": true,
+  "query": "deploy",
+  "messages": {
+    "total": 2,
+    "paging": {"count": 20, "total": 2, "page": 1, "pages": 1},
+    "matches": [
+      {
+        "type": "message",
+        "channel": {"id": "C00000000", "name": "general"},
+        "user": "U00000000",
+        "username": "sample.user",
+        "ts": "1700000000.000100",
+        "text": "deploy finished for the staging environment",
+        "permalink": "https://example.slack.com/archives/C00000000/p1700000000000100"
+      },
+      {
+        "type": "message",
+        "channel": {"id": "C00000000", "name": "random"},
+        "user": "U00000000",
+        "username": "sample.user",
+        "ts": "1700000001.000200",
+        "text": "rolling the deploy back",
+        "permalink": "https://example.slack.com/archives/C00000000/p1700000001000200"
+      }
+    ]
+  }
+}`
+
+func TestExtractSearchResultsUnwrapsSlackMatches(t *testing.T) {
+	got := extractSearchResults(json.RawMessage(slackSearchEnvelope))
+	if len(got) != 2 {
+		t.Fatalf("expected 2 matches unwrapped from messages.matches, got %d", len(got))
+	}
+	var first map[string]any
+	if err := json.Unmarshal(got[0], &first); err != nil {
+		t.Fatalf("first match is not a JSON object: %v", err)
+	}
+	if first["text"] != "deploy finished for the staging environment" {
+		t.Errorf("unexpected first match text: %v", first["text"])
+	}
+}
+
+// A Slack match has no top-level title/name/identifier/id and no score, so the
+// pre-patch isNilOrEmpty discarded every hit. Guards the regression that made
+// live search print "No results" with exit 0.
+func TestSlackMatchSurvivesNilOrEmptyFilter(t *testing.T) {
+	matches := extractSearchResults(json.RawMessage(slackSearchEnvelope))
+	for i, m := range matches {
+		if isNilOrEmpty(m) {
+			t.Errorf("match %d was discarded as nil/empty: %s", i, string(m))
+		}
+	}
+}
+
+// End-to-end of the two stacked defects: unwrap, then filter, and assert results
+// actually survive to the caller.
+func TestLiveSearchPipelineKeepsMatches(t *testing.T) {
+	var kept []json.RawMessage
+	for _, r := range extractSearchResults(json.RawMessage(slackSearchEnvelope)) {
+		if !isNilOrEmpty(r) {
+			kept = append(kept, r)
+		}
+	}
+	if len(kept) != 2 {
+		t.Fatalf("expected 2 results to survive the filter, got %d", len(kept))
+	}
+}
+
+// A genuinely empty result set must still read as empty — the fix must not
+// manufacture a false positive out of a zero-match envelope.
+func TestEmptySlackSearchStillEmpty(t *testing.T) {
+	const empty = `{"ok":true,"query":"nothing","messages":{"total":0,"matches":[]}}`
+	var kept []json.RawMessage
+	for _, r := range extractSearchResults(json.RawMessage(empty)) {
+		if !isNilOrEmpty(r) {
+			kept = append(kept, r)
+		}
+	}
+	if len(kept) != 0 {
+		t.Fatalf("expected zero results for an empty search, got %d", len(kept))
+	}
+}
+
+// Slack reports application errors as HTTP 200 with ok:false. These must surface
+// as errors rather than being coerced into an empty result set.
+func TestCheckSlackAPIErrorSurfacesOkFalse(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"plain error", `{"ok":false,"error":"invalid_auth"}`, true},
+		{"missing scope", `{"ok":false,"error":"missing_scope","needed":"search:read"}`, true},
+		{"success", `{"ok":true,"messages":{"total":0,"matches":[]}}`, false},
+		{"non-slack payload", `{"data":[]}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkSlackAPIError(json.RawMessage(tc.body))
+			if (err != nil) != tc.want {
+				t.Fatalf("checkSlackAPIError(%s) error = %v, want error: %v", tc.body, err, tc.want)
+			}
+		})
+	}
+}
+
+// The scope-error path should name the missing scope so the user can act on it.
+func TestMissingScopeErrorNamesScope(t *testing.T) {
+	err := checkSlackAPIError(json.RawMessage(`{"ok":false,"error":"missing_scope","needed":"search:read"}`))
+	if err == nil {
+		t.Fatal("expected an error for missing_scope")
+	}
+	if got := err.Error(); !strings.Contains(got, "search:read") {
+		t.Errorf("error should name the needed scope, got: %s", got)
+	}
+}

--- a/library/productivity/slack/internal/cli/stars_add.go
+++ b/library/productivity/slack/internal/cli/stars_add.go
@@ -43,11 +43,30 @@ func newStarsAddCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagTimestamp != "" {
+					bodyMap["timestamp"] = flagTimestamp
+				}
+				if flagFile != "" {
+					bodyMap["file"] = flagFile
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/stars_remove.go
+++ b/library/productivity/slack/internal/cli/stars_remove.go
@@ -43,11 +43,30 @@ func newStarsRemoveCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagChannel != "" {
+					bodyMap["channel"] = flagChannel
+				}
+				if flagTimestamp != "" {
+					bodyMap["timestamp"] = flagTimestamp
+				}
+				if flagFile != "" {
+					bodyMap["file"] = flagFile
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/usergroups_create.go
+++ b/library/productivity/slack/internal/cli/usergroups_create.go
@@ -24,10 +24,10 @@ func newUsergroupsCreateCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Create a new user group",
 		Example: "  slack-pp-cli usergroups create",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("name") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "name")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("name") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "name")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -47,11 +47,33 @@ func newUsergroupsCreateCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagName != "" {
+					bodyMap["name"] = flagName
+				}
+				if flagHandle != "" {
+					bodyMap["handle"] = flagHandle
+				}
+				if flagDescription != "" {
+					bodyMap["description"] = flagDescription
+				}
+				if flagChannels != "" {
+					bodyMap["channels"] = flagChannels
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/usergroups_update.go
+++ b/library/productivity/slack/internal/cli/usergroups_update.go
@@ -24,10 +24,10 @@ func newUsergroupsUpdateCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Update an existing user group",
 		Example: "  slack-pp-cli usergroups update",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("usergroup") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "usergroup")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("usergroup") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "usergroup")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -47,11 +47,33 @@ func newUsergroupsUpdateCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagUsergroup != "" {
+					bodyMap["usergroup"] = flagUsergroup
+				}
+				if flagName != "" {
+					bodyMap["name"] = flagName
+				}
+				if flagHandle != "" {
+					bodyMap["handle"] = flagHandle
+				}
+				if flagDescription != "" {
+					bodyMap["description"] = flagDescription
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/usergroups_users_update.go
+++ b/library/productivity/slack/internal/cli/usergroups_users_update.go
@@ -22,13 +22,13 @@ func newUsergroupsUsersUpdateCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Update the members of a user group",
 		Example: "  slack-pp-cli usergroups users_update",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("usergroup") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "usergroup")
-			}
-			if !cmd.Flags().Changed("users") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "users")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("usergroup") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "usergroup")
+				}
+				if !cmd.Flags().Changed("users") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "users")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -48,11 +48,27 @@ func newUsergroupsUsersUpdateCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagUsergroup != "" {
+					bodyMap["usergroup"] = flagUsergroup
+				}
+				if flagUsers != "" {
+					bodyMap["users"] = flagUsers
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/users_profile_set.go
+++ b/library/productivity/slack/internal/cli/users_profile_set.go
@@ -43,11 +43,30 @@ func newUsersProfileSetCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagProfile != "" {
+					bodyMap["profile"] = flagProfile
+				}
+				if flagName != "" {
+					bodyMap["name"] = flagName
+				}
+				if flagValue != "" {
+					bodyMap["value"] = flagValue
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")

--- a/library/productivity/slack/internal/cli/users_set_presence.go
+++ b/library/productivity/slack/internal/cli/users_set_presence.go
@@ -21,10 +21,10 @@ func newUsersSetPresenceCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Set the user's presence status",
 		Example: "  slack-pp-cli users set_presence",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("presence") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "presence")
-			}
 			if !stdinBody {
+				if !cmd.Flags().Changed("presence") && !flags.dryRun {
+					return fmt.Errorf("required flag \"%s\" not set", "presence")
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -44,11 +44,24 @@ func newUsersSetPresenceCmd(flags *rootFlags) *cobra.Command {
 				}
 				body = jsonBody
 			} else {
-				body = map[string]any{}
+				// PATCH(amend-2026-07-25: assemble body from flag values) — the generated
+				// else-branch emitted an empty map, so every POST shipped {} upstream.
+				bodyMap := map[string]any{}
+				if flagPresence != "" {
+					bodyMap["presence"] = flagPresence
+				}
+				body = bodyMap
 			}
 			data, statusCode, err := c.Post(path, body)
 			if err != nil {
 				return classifyAPIError(err)
+			}
+			// PATCH(amend-2026-07-25: surface Slack ok:false on writes) — Slack answers
+			// application errors with HTTP 200 and {"ok":false,"error":...}, so the
+			// envelope below reported success:true for a write that never happened.
+			// Reuses the same checkSlackAPIError the read paths already call.
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return slackErr
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")


### PR DESCRIPTION
## Summary

Three bugs in `slack-pp-cli` that each produce a wrong answer silently rather than an error. No
write operation in the CLI could succeed — every `POST` shipped an empty `{}` body because the
flag values were never read. Live `search` reported "No results" with exit 0 for queries with
thousands of matches, because Slack's result envelope was unwrapped incorrectly and then
discarded by an emptiness filter. And Slack's `{"ok":false}` application errors, which arrive
with HTTP 200, were reported as success on every write path, so a rejected write looked like a
completed one.

All three are fixed CLI-locally, with the generator's own current output as the reference for
the write-body fix. Local-mode `search` is **not** fixed — see Scope below.

## Findings

| ID | Category | Type | Rationale |
|---|---|---|---|
| F1 | request-body assembly | bug | Write fields are declared under `params:` in the spec, and the generated body builder iterated only `Endpoint.Body`, so all 33 POST commands sent `{}`. Required-flag validation also ran unconditionally, so `--stdin` alone failed validation and the only working call duplicated every value in both places. |
| F2 | search response envelope | bug | `search.messages` nests hits at `messages.matches`, which no generic wrapper key reaches; the envelope then failed `isNilOrEmpty` and was dropped, yielding "No results" and exit 0. |
| F4 | API error surfacing | bug | Slack signals application errors as HTTP 200 + `{"ok":false,"error":...}`. `internal/client/client.go` has no `ok` handling on any verb, and the write and live-search paths never called the CLI-layer checker, so failures rendered as success. |

## Changes

41 files, +1089 / -162.

- **F1** — 30 command files now assemble the request body from their flag values. `unfurl_links`
  and `is_private` are booleans and `post_at` and `num_minutes` are integers in the Slack API, so
  those four are coerced from their string flags and reject non-parsing input with a named error
  rather than sending a JSON string the API refuses. Required-flag validation moved inside the
  non-stdin branch, making flags and `--stdin` independent routes; stdin wins when both are given.
  Three commands (`auth.test`, `dnd.endDnd`, `dnd.endSnooze`) take no body parameters, so their
  empty map was already correct and they are unchanged apart from F4.
- **F2** — `extractSearchResults` understands the `messages.matches` nesting, and `isNilOrEmpty`
  recognizes a Slack match by its `text`/`ts`/`permalink` fields. Both were required: unwrapping
  alone would still have had every hit discarded by the filter.
- **F4** — the 33 write commands, `import`, and the live-search path now call the existing
  `checkSlackAPIError` helper. This reuses the detector already used by `resolveRead` and the DM
  helpers rather than adding a second one. The prior `fix-ok-false-detection` patch, which covered
  `internal/cli/sync.go` only, is untouched.
- **`internal/cli/import.go` — the one change outside the F1/F2/F4 framing, called out so it is not
  missed in review.** It discarded the API response entirely (`_, _, err := c.Post(...)`), so a
  record Slack rejected with HTTP 200 + `{"ok":false,...}` was still counted as an imported success.
  It is the same silent-failure class as F4 and now performs the same check, reporting the Slack
  error and incrementing `failed` instead of `success`. Included deliberately: fixing silent write
  failures everywhere except one file would have left the PR incoherent.
- **Docs** — cookbook recipes for the write path and `--stdin`, a "Writing to Slack" section in
  both `README.md` and `SKILL.md`, and a **Known Limitations** section stating plainly what is
  still broken.
- **Tests** — `internal/cli/search_amend_test.go`, six cases covering envelope unwrapping, filter
  survival, the two fixes composed, a genuinely empty result still reading as empty, and `ok:false`
  detection including that `missing_scope` names the needed scope.

## Scope — what this PR does not fix

**Local-mode `search` remains broken.** `search --data-source local` still returns nothing for
messages. `sync` populates the `messages` and `messages_fts` tables, but `Store.SearchMessages`
(`internal/store/store.go:711`) has **zero callers** — `search.go`'s empty-type branch queries
only `SearchUsergroups` and `SearchFiles`, and `--type messages` falls through to the generic
`db.Search`. So the local index can hold matches the CLI cannot reach. This is a deliberate
omission, not an oversight: it needs a decision about whether the typed-table architecture is
kept, which is out of scope here. Documented under Known Limitations so nobody reads "search
fixed" as covering both modes.

Also known-remaining, now documented and filed as follow-ups: `files upload` targets Slack's
retired `files.upload` and fails `method_deprecated` even with a correct body; `auth test` is not
registered on the command tree; `sync --resources channels` fails `unknown_method`.

## Why not just reprint?

The generator bug behind F1 was fixed upstream (cli-printing-press#790, PR #791, press ~4.2.0)
and this CLI still carries it only because it has not been reprinted since press `1.2.1`. A
reprint was evaluated and rejected on evidence. Generating this CLI's spec under press `4.29.0`
shows:

- The prior spec **no longer generates** — a new reserved-name guard rejects the `auth` and
  `search` resources, so a reprint requires spec edits that rename user-visible commands.
- **All 8 novel features are absent** from generator output (`digest`, `health`,
  `response_times`, `trends`, `quiet`, `user_activity`, `funny`, `threads_stale`) — most of this
  CLI's differentiated value.
- The regenerated `sync.go` has **no messages sync at all** (no `conversations.history`
  reference, no `messages` resource), and the regenerated store drops all 14 typed tables for a
  generic one — so a reprint would leave nothing for local message search to find.
- `regen-merge` classifies **23 files as published-only and 8 as needing hand merge**, including
  `sync.go`, `store.go`, `client.go`, and `conversations_history.go` — precisely the files
  carrying the six existing patches.
- Three of the six recorded patches (`fix-conversations-types-scope`, `fix-ok-false-detection`,
  `fix-im-history-channel-not-found`) are **dropped** by regeneration; the other three are
  absorbed.
- **F3 would still not be fixed** — the regenerated empty-type branch calls only the generic
  `db.Search` while its comment claims it searches typed tables too.

So the reprint's one confirmed win is F1, at the cost of losing the novel features, re-applying
three patches, hand-merging eight files, breaking command names, and forcing a full local re-sync.
Backporting F1 from the generator's own output is the cheaper, safer path. A reprint remains
worth doing as its own scoped piece of work, once someone can steward those eight merges and
decide the store architecture.

## Verification

- `go build ./...` — PASS
- `go vet ./...` — PASS
- `gofmt` — clean
- `go test ./internal/cli/` — PASS (6 new cases)
- `govulncheck` — PASS
- `cli-printing-press publish validate` — **byte-identical to the pre-change baseline.** The
  suite reports 4 pre-existing failures on this CLI (`manifest` wants `schema_version: 2`,
  `transcendence` finds no recorded novel features, `phase5` is missing its acceptance artifact,
  and `verify-skill` reports 3 README flag-attribution errors). All 4 fail identically on a
  pristine `upstream/main` checkout of this directory, so **this PR introduces no new
  validation failures**. They are pre-existing publish-readiness gaps and are listed in the
  follow-up issue rather than fixed here.
- `verify_skill.py --dir library/productivity/slack` — 3 errors, unchanged from baseline. One
  additional item appears in the "likely false positive" group, from a cookbook line; the tool
  mis-attributes flags of underscore-named subcommands (`messages post_message --text`) to the
  parent command, which is why the 3 pre-existing errors exist too.
- Empirical check of F1, dry-run with a dummy token (no network I/O — `client.do` returns at its
  `DryRun` branch before a request is built):

  ```
  $ slack-pp-cli messages post_message --channel C00000000 --text "hello world" \
      --thread-ts 1700000000.000000 --dry-run
  POST https://slack.com/api/chat.postMessage
    Body:
  {
      "channel": "C00000000",
      "text": "hello world",
      "thread_ts": "1700000000.000000"
    }
  ```

  Previously this printed `{}`. `--stdin` alone now also builds a correct body without tripping
  required-flag validation, and `--is-private true` serializes as a JSON boolean rather than the
  string `"true"`.

## Evidence

Patch records at this PR's HEAD:

- [`slack-post-body-from-flags.json`](https://github.com/dericknwq/printing-press-library/blob/a92f7435a9136ce03f0621bbca7b0a137d913787/library/productivity/slack/.printing-press-patches/slack-post-body-from-flags.json)
- [`slack-search-messages-matches.json`](https://github.com/dericknwq/printing-press-library/blob/a92f7435a9136ce03f0621bbca7b0a137d913787/library/productivity/slack/.printing-press-patches/slack-search-messages-matches.json)
- [`slack-ok-false-on-writes-and-search.json`](https://github.com/dericknwq/printing-press-library/blob/a92f7435a9136ce03f0621bbca7b0a137d913787/library/productivity/slack/.printing-press-patches/slack-ok-false-on-writes-and-search.json)
- [`internal/cli/search_amend_test.go`](https://github.com/dericknwq/printing-press-library/blob/a92f7435a9136ce03f0621bbca7b0a137d913787/library/productivity/slack/internal/cli/search_amend_test.go)
Each patch records a `deferred_to_upstream` entry naming the machine-level condition that should
supersede it, so none of these three is left looking like a permanent local fork:

- `slack-post-body-from-flags` → **cli-printing-press#790** (closed). Already fixed in the
  generator; this patch is a backport for a CLI printed under 1.2.1 and is superseded the moment
  `slack` is reprinted.
- `slack-search-messages-matches` → **cli-printing-press#3795** (opened with this PR). The
  generated search template has no way to express a per-API response path or result identity
  fields, so any API whose search envelope falls outside the hardcoded generic lists silently
  returns zero results. A spec-declared `response_path` + `identity_fields` would supersede this
  patch. That issue also flags that #1390's code/comment-alignment acceptance criterion is not
  currently met in 4.29.0 output.
- `slack-ok-false-on-writes-and-search` → **cli-printing-press#3740** (open, additive
  error-classifier seam). One client-level hook would replace the 35 call-site checks this patch
  adds.
