### PR TITLE
fix(judgeme): harden publication decoding

### DIFF
--- a/library/marketing/judgeme/.manuscripts/20260729-224012-eda553b7/proofs/2026-07-30-post-review-live-count.json
+++ b/library/marketing/judgeme/.manuscripts/20260729-224012-eda553b7/proofs/2026-07-30-post-review-live-count.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "verified_at": "2026-07-30T07:21:42Z",
+  "source": "live",
+  "decoder_contract": {
+    "sample_size": 100,
+    "published_field_present": 100,
+    "curated_field_present": 100,
+    "published_curated_disagreements": 0,
+    "missing_published_fallback": "curated == ok"
+  },
+  "corpus": {
+    "complete": true,
+    "count_matched": true,
+    "published_count_matched": true,
+    "expected_total": 12871,
+    "stored_rows": 12871,
+    "published_rows": 9638,
+    "hidden_rows": 3229,
+    "pending_rows": 4,
+    "unique_bodies": 8831,
+    "rating_partitions": {
+      "1": 1265,
+      "2": 495,
+      "3": 611,
+      "4": 1088,
+      "5": 9412
+    }
+  }
+}

--- a/library/marketing/judgeme/.printing-press-patches/judgeme-corpus-safety.json
+++ b/library/marketing/judgeme/.printing-press-patches/judgeme-corpus-safety.json
@@ -31,5 +31,5 @@
     "internal/mcp/tools_test.go",
     "tools-manifest.json"
   ],
-  "validated_outcome": "Unit tests prove repeated-page detection, count-mismatch refusal, normalized body hashing, atomic SQLite replacement, private-token header placement, CLI mutation gating, MCP mutation gating, and population filtering. Live count verification is recorded in the publication proof."
+  "validated_outcome": "Unit tests prove repeated-page detection, count-mismatch refusal, normalized body hashing, atomic SQLite replacement, private-token header placement, CLI mutation gating, MCP mutation gating, population filtering, and the curated publication fallback when published is absent. Live verification confirmed that published is present and agrees with curated on the sampled account response, then matched the full corpus and published counts after the fallback was added."
 }

--- a/library/marketing/judgeme/internal/cli/judgeme_reviews_store.go
+++ b/library/marketing/judgeme/internal/cli/judgeme_reviews_store.go
@@ -545,12 +545,16 @@ func decodeJudgeMeReview(raw json.RawMessage) (judgeMeReview, error) {
 		return judgeMeReview{}, errors.New("review has no id")
 	}
 	body := scalarString(obj["body"])
+	published := scalarBool(obj["published"])
+	if _, present := obj["published"]; !present {
+		published = scalarString(obj["curated"]) == "ok"
+	}
 	return judgeMeReview{
 		ID:                id,
 		Body:              body,
 		BodyHash:          normalizedBodyHash(body),
 		Rating:            scalarInt(obj["rating"]),
-		Published:         scalarBool(obj["published"]),
+		Published:         published,
 		Hidden:            scalarBool(obj["hidden"]),
 		ProductExternalID: scalarString(obj["product_external_id"]),
 		ProductHandle:     scalarString(obj["product_handle"]),

--- a/library/marketing/judgeme/internal/cli/judgeme_reviews_store_test.go
+++ b/library/marketing/judgeme/internal/cli/judgeme_reviews_store_test.go
@@ -83,6 +83,27 @@ func TestNormalizedBodyHashCollapsesSyndicatedFormatting(t *testing.T) {
 	}
 }
 
+func TestDecodeJudgeMeReviewPublicationFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		published bool
+	}{
+		{name: "explicit published field", raw: `{"id":1,"published":true}`, published: true},
+		{name: "explicit field remains authoritative", raw: `{"id":1,"published":false,"curated":"ok"}`, published: false},
+		{name: "curated ok fallback", raw: `{"id":1,"curated":"ok"}`, published: true},
+		{name: "curated spam fallback", raw: `{"id":1,"curated":"spam"}`, published: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			row := mustJudgeMeReview(t, tt.raw)
+			if row.Published != tt.published {
+				t.Fatalf("Published = %v, want %v", row.Published, tt.published)
+			}
+		})
+	}
+}
+
 func TestReplaceJudgeMeReviewCorpusAddsDocumentedColumnsAtomically(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "reviews.db")
 	db, err := store.OpenWithContext(context.Background(), path)


### PR DESCRIPTION
## Summary

Harden Judge.me publication decoding after the initial `judgeme` publication merged. Explicit `published` remains authoritative for the live API, while responses that omit it now fall back to `curated == "ok"`.

### Why

A fresh authenticated sample showed:

- `published` present on 100/100 reviews
- `curated` present on 100/100 reviews
- zero disagreements between `published == true` and `curated == "ok"`

The fallback still protects clients or response variants that follow the documented `curated` representation without returning `published`.

### Verification

- Four focused decoder cases pass: explicit true, explicit false with `curated: ok`, missing-field `curated: ok`, and missing-field `curated: spam`.
- `go test ./...`, `go vet ./...`, and `go build ./...` pass.
- A full live sync after the change matched 12,871 unique reviews and the 9,638-review published population.
- No review corpus or live SQLite database is committed; only aggregate proof metadata is included.

### Proof

- [Post-review live count](https://github.com/mvanhorn/printing-press-library/blob/bf09efee8005c86239bac50271936b29a93876ac/library/marketing/judgeme/.manuscripts/20260729-224012-eda553b7/proofs/2026-07-30-post-review-live-count.json)
