### PR TITLE
fix(yahoo-finance): let period1 override range

### DIFF
--- a/library/commerce/yahoo-finance/.printing-press-patches/yahoo-period1-overrides-range.json
+++ b/library/commerce/yahoo-finance/.printing-press-patches/yahoo-period1-overrides-range.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "yahoo-period1-overrides-range",
+  "applied_at": "2026-07-30",
+  "base_run_id": "20260524-221143",
+  "base_printing_press_version": "4.14.0",
+  "summary": "When chart period1 is non-zero, omit range so absolute historical intervals reach Yahoo unchanged.",
+  "reason": "The generated default range=1mo was serialized alongside period1 and period2, causing Yahoo to return only one month despite the documented period1 precedence. Tracked by printing-press-library issue #1632.",
+  "files": [
+    "internal/cli/promoted_chart.go",
+    "internal/cli/promoted_chart_test.go"
+  ],
+  "validated_outcome": "A pure request-construction regression test proves default range behavior is preserved while period1 and period1+period2 requests omit range."
+}

--- a/library/commerce/yahoo-finance/internal/cli/promoted_chart.go
+++ b/library/commerce/yahoo-finance/internal/cli/promoted_chart.go
@@ -46,25 +46,14 @@ func newChartPromotedCmd(flags *rootFlags) *cobra.Command {
 				return usageErr(fmt.Errorf("symbol is required\nUsage: %s <%s>", cmd.CommandPath(), "symbol"))
 			}
 			path = replacePathParam(path, "symbol", args[0])
-			params := map[string]string{}
-			if flagInterval != "" {
-				params["interval"] = fmt.Sprintf("%v", flagInterval)
-			}
-			if flagRange != "" {
-				params["range"] = fmt.Sprintf("%v", flagRange)
-			}
-			if flagPeriod1 != 0 {
-				params["period1"] = fmt.Sprintf("%v", flagPeriod1)
-			}
-			if flagPeriod2 != 0 {
-				params["period2"] = fmt.Sprintf("%v", flagPeriod2)
-			}
-			if flagEvents != "" {
-				params["events"] = fmt.Sprintf("%v", flagEvents)
-			}
-			if flagIncludePrePost != false {
-				params["includePrePost"] = fmt.Sprintf("%v", flagIncludePrePost)
-			}
+			params := chartQueryParams(
+				flagInterval,
+				flagRange,
+				flagPeriod1,
+				flagPeriod2,
+				flagEvents,
+				flagIncludePrePost,
+			)
 			data, prov, err := resolveRead(cmd.Context(), c, flags, "chart", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
@@ -129,4 +118,34 @@ func newChartPromotedCmd(flags *rootFlags) *cobra.Command {
 	// Wire sibling endpoints and sub-resources as subcommands
 
 	return cmd
+}
+
+func chartQueryParams(
+	interval string,
+	dateRange string,
+	period1 int,
+	period2 int,
+	events string,
+	includePrePost bool,
+) map[string]string {
+	params := map[string]string{}
+	if interval != "" {
+		params["interval"] = fmt.Sprintf("%v", interval)
+	}
+	if dateRange != "" && period1 == 0 {
+		params["range"] = fmt.Sprintf("%v", dateRange)
+	}
+	if period1 != 0 {
+		params["period1"] = fmt.Sprintf("%v", period1)
+	}
+	if period2 != 0 {
+		params["period2"] = fmt.Sprintf("%v", period2)
+	}
+	if events != "" {
+		params["events"] = fmt.Sprintf("%v", events)
+	}
+	if includePrePost {
+		params["includePrePost"] = fmt.Sprintf("%v", includePrePost)
+	}
+	return params
 }

--- a/library/commerce/yahoo-finance/internal/cli/promoted_chart_test.go
+++ b/library/commerce/yahoo-finance/internal/cli/promoted_chart_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Trevin Chow and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestChartQueryParamsPeriod1OverridesRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		dateRange string
+		period1   int
+		period2   int
+		want      map[string]string
+	}{
+		{
+			name:      "default range remains without absolute start",
+			dateRange: "1mo",
+			want: map[string]string{
+				"events":   "div|split|earn",
+				"interval": "1d",
+				"range":    "1mo",
+			},
+		},
+		{
+			name:      "period1 omits default range",
+			dateRange: "1mo",
+			period1:   631152000,
+			want: map[string]string{
+				"events":   "div|split|earn",
+				"interval": "1d",
+				"period1":  "631152000",
+			},
+		},
+		{
+			name:      "absolute interval preserves both periods and omits range",
+			dateRange: "1mo",
+			period1:   631152000,
+			period2:   1785369600,
+			want: map[string]string{
+				"events":   "div|split|earn",
+				"interval": "1d",
+				"period1":  "631152000",
+				"period2":  "1785369600",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := chartQueryParams(
+				"1d",
+				tt.dateRange,
+				tt.period1,
+				tt.period2,
+				"div|split|earn",
+				false,
+			)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("chartQueryParams() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Yahoo Finance absolute chart periods

Fixes #1632.

The generated `chart` command documented `--period1` as overriding `--range`, but request construction serialized the default `range=1mo` alongside absolute periods. Yahoo honored the range and silently returned only one month.

### Change

- Extract chart query construction into a pure helper.
- Omit `range` whenever `period1` is non-zero.
- Preserve default range behavior when no absolute start is supplied.
- Add a generated-tree patch record so reprints preserve the contract.

### Validation Results

| Gate | Result |
|---|---|
| Request-construction regression | PASS |
| `verify_skill.py` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS |
| `go build -trimpath -buildvcs=false` | PASS |
| `govulncheck ./...` | PASS: zero reachable vulnerabilities |

The regression is network-free and proves both `period1` and `period1+period2` omit `range`.
