### PR TITLE
fix(granola): restore data access with a CLI-owned session, degraded-safe sync, and store-first reads

### DIFF
--- a/docs/plans/2026-08-03-001-fix-granola-cli-owned-auth-plan.md
+++ b/docs/plans/2026-08-03-001-fix-granola-cli-owned-auth-plan.md
@@ -1,0 +1,512 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+type: fix
+title: "fix(granola): restore data access with CLI-owned auth and an ungated API sync path"
+created: 2026-08-03
+plan_depth: deep
+target_cli: library/productivity/granola
+---
+
+# fix(granola): restore data access with CLI-owned auth and an ungated API sync path
+
+## Product Contract
+
+### Summary
+
+The Granola CLI has returned no meetings recorded after 2026-07-25 because the only data path that still works — Granola's internal `/v2/get-documents` API — is unreachable on a post-migration install: it sits behind a cache decrypt that can no longer succeed, and the WorkOS token it needs can no longer be obtained. This plan gives the CLI its own device-code login and lets the API document sync run without a readable cache.
+
+### Problem Frame
+
+PR #1598 (merged 2026-07-25) responded to Granola 7.447.1 moving the data encryption key (DEK) into an entitlement-gated macOS keychain access group. It established a dual path: decrypt the local desktop cache, or use the public REST API with a `GRANOLA_API_KEY`. On a workspace without a Business/Enterprise plan there is no API key, so the public path is unavailable, and the local path is permanently dead. The CLI therefore kept serving its last successful sync (2026-07-25) and silently returned nothing newer.
+
+Three separate Granola changes combine to produce the failure:
+
+1. **The DEK moved** (7.447.1, already documented). Local decrypt of `cache-v6.json.enc` is dead for third parties. `.printing-press-patches/dek-migration-classified-from-state-not-version.json` records this.
+
+2. **The local store moved to an encrypted database** (new, observed on 7.465.0). Granola now writes `~/Library/Application Support/Granola/granola.db`, a 50 MB SQLCipher database. Verified from the app bundle: it depends on `better-sqlite3-multiple-ciphers`, and opens the file with `pragma cipher='sqlcipher'`, `pragma legacy=4`, `pragma key="x'<hex>'"`. The key is the same DEK — the app logs `sqlite-encryption-key-dek-unavailable` when it cannot resolve it. The file has no SQLite magic bytes and high entropy throughout, while its `-wal` sidecar retains a plaintext SQLite WAL header, which is the standard SQLCipher signature. This closes the door on local reads permanently rather than opening a new one; the CLI must not chase it.
+
+3. **Granola stopped writing plaintext auth files.** `supabase.json` and `stored-accounts.json` were last written 2026-05-04 and 2026-05-19; only the `.enc` variants are current. The CLI's plaintext fallback therefore reads fossils whose access tokens expired in May.
+
+The resulting chain in the current code:
+
+- `runCacheSync` (`internal/cli/sync_cache.go`) returns fatally when `openGranolaCache()` fails, so the `HydrateDocumentsFromAPI` call on the next line never runs. That call is the only code path that *discovers* new meetings.
+- `loadTokensRaw` (`internal/granola/workos.go`) cannot read the live token from `supabase.json.enc` without the DEK, falls back to the May plaintext fossil, and gets an expired token.
+- `refreshRefusalFor` then refuses to refresh it, because desktop-owned token chains must not be rotated. That refusal is **correct and must be preserved**: WorkOS refresh tokens are single-use (verified — a second exchange returns `invalid_grant: "Refresh token already exchanged."`), so refreshing the desktop's token would sign the user out of the Granola desktop app.
+
+The remedy the code currently prints for this state — *"open Granola desktop briefly to refresh, then retry"* (`internal/granola/api_documents.go:64`) — no longer works, because the desktop refreshes only the encrypted file the CLI cannot read.
+
+### Evidence
+
+Gathered on this machine, 2026-08-03, against Granola desktop 7.465.0 and `granola-pp-cli 2026.7.2`:
+
+| Check | Result |
+|---|---|
+| `granola-pp-cli sync` (cache path) | Fails with `ErrSchemeMigrated`, as designed |
+| `granola-pp-cli sync-api` (public path) | HTTP 401 `MISSING_API_KEY` on `/v1/folders` and `/v1/notes` — no API key configured |
+| Local store freshness | Oldest resource age 210h (last sync 2026-07-25); newest meeting 2026-07-24 |
+| Refresh a fossil WorkOS token | Succeeds against `https://auth.granola.ai/user_management/authenticate` |
+| Re-use the same refresh token | HTTP 400 `invalid_grant` — single-use rotation confirmed |
+| `POST /v2/get-documents` with a fresh token | HTTP 200; returns 18 meetings dated 2026-07-27 to 2026-08-02, the exact window reported missing |
+| Client version header `7.299.0` vs `7.465.0` | Both HTTP 200 — the CLI's hardcoded version is **not** the cause |
+| WorkOS device authorization endpoint | HTTP 200 with `device_code`, `user_code`, `verification_uri: https://mcp-auth.granola.ai/device` |
+
+The last two rows are the load-bearing ones. The stale client identity is a red herring for this failure, and a CLI-owned login is available, so the fix does not depend on borrowing desktop credentials.
+
+### Requirements
+
+- **R1.** On an install where the desktop cache cannot be decrypted, and given a valid CLI-owned session (R2), the CLI must discover and sync meetings recorded after the last successful sync, without a `GRANOLA_API_KEY`. With no session and no API key, sync must fail with a message naming `auth login` — not silently return nothing.
+- **R2.** The CLI must be able to obtain and maintain a WorkOS session it owns, independently of the Granola desktop app's session.
+- **R3.** The CLI must never consume, rotate, or invalidate a refresh token belonging to the desktop app. The existing `refreshRefusalFor` guard stays intact for desktop-owned sources.
+- **R4.** A CLI-owned refresh token must be persisted on every rotation, so a single-use exchange never strands the session.
+- **R5.** Credentials the CLI owns must be stored with owner-only file permissions and must never appear in command output, logs, or error text.
+- **R6.** `doctor` and sync error messages must describe the actual state and a remedy that works. The current "open Granola desktop briefly" and "approve the Keychain prompt" hints are unreachable on a migrated install.
+- **R7.** Data already synced to the local store must remain readable throughout, and an install that still has a working cache must keep using it.
+
+### Key Decisions
+
+- **KD1: Add a CLI-owned device-code login rather than harvesting desktop credentials.** *(Governs R2, R3, R4.)* The device-code endpoint is available and returns a token chain the CLI can rotate freely. Every alternative fails: reading `supabase.json.enc` needs the inaccessible DEK; refreshing the desktop's chain signs the user out of the desktop app; scraping `granola.db` needs the same DEK. The smallest candidate — ungating the sync (U5) and having the user supply `GRANOLA_WORKOS_TOKEN` by hand — also fails, because a migrated install has no user-accessible way to obtain that token (both fossil chains on this machine were consumed during diagnosis), and a bare access token expires in hours with no rotatable chain behind it. U5 without a session restores nothing durable, which is why the auth work is not separable into a smaller first PR.
+- **KD2: Treat `granola.db` as permanently unreadable and do not implement SQLCipher support.** *(Governs R1.)* Its key is the same entitlement-gated DEK. Adding a SQLCipher dependency would buy nothing and would imply a capability the CLI cannot deliver.
+- **KD3: Leave the hardcoded client identity alone in this change.** Both `7.299.0` and `7.465.0` are accepted by the API today. `.printing-press-patches/granola-current-client-identity.json` already flags it as a moving target; bumping it here would add churn without fixing anything and would muddy the change's evidence story.
+
+### Scope Boundaries
+
+In scope: CLI-owned device-code auth, token persistence and rotation, ungating the API document sync from cache decrypt, and correcting the operator-facing messaging for the migrated state.
+
+Out of scope:
+
+- Reading or decrypting `granola.db` (KD2).
+- Changing the public REST API path (`public-api.granola.ai`) or `GRANOLA_API_KEY` behavior. It works as designed for workspaces that have a key.
+- Bumping the hardcoded client version (KD3).
+
+#### Deferred to Follow-Up Work
+
+- The ungated live fallbacks in `internal/cli/meetings.go:225-235` and `internal/cli/export.go:61,78` reach `NewInternalClient()` without the `hasCache()` guard used in `internal/cli/transcript.go:125-137`. After this change they will succeed when a CLI session exists, so they are no longer failure-producing; tightening them for consistency is a separate tidy-up.
+- The generic `resources`/`notes` tables written by the stage-1 public sync are read by nothing (`internal/cli/sync_api_hydrate.go:15-20`). Unrelated dead weight.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD1: Auth via OAuth 2.0 device authorization grant, polled at the server-specified interval.** Verified live: `POST https://auth.granola.ai/user_management/authorize/device` with `client_id=client_01JZJ0XBDAT8PHJWQY09Y0VD61` returns `device_code`, `user_code`, `verification_uri`, `expires_in: 300`, `interval: 5`. The CLI prints the user code and URI, then polls the token endpoint. This suits a terminal tool and needs no local callback listener or browser redirect handling.
+
+- **KTD2: CLI-owned credentials live in the CLI's own data directory, not in Granola's.** A new file beside the existing store at `~/.local/share/granola-pp-cli/` keeps the two sessions physically separate, which is what makes R3 enforceable by construction rather than by discipline. Written `0600` in a `0700` directory, via write-temp-then-rename so a crash mid-rotation cannot truncate the chain.
+
+- **KTD3: A new token source sits at the top of `loadTokensRaw`'s precedence, below only the env override.** Order becomes: `GRANOLA_WORKOS_TOKEN` env, **CLI-owned session**, `supabase.json.enc`, plaintext `supabase.json`, `stored-accounts.json`. The new source is exempt from `refreshRefusalFor` — it is the one chain the CLI may rotate. Every existing desktop-owned arm of that function is untouched (R3).
+
+- **KTD4: Rotation persists durably before the new access token is used.** Because a WorkOS exchange invalidates the presented refresh token immediately, the write must be durable before the CLI acts on the response. Losing the rotated token after a successful exchange strands the session with no recovery except signing in again — which is exactly what happened to the two fossil chains on this machine during diagnosis.
+
+  Temp-file-then-rename alone is not sufficient here. It guarantees the file is never *torn*, but not that the new record survives a crash between the remote exchange and the local commit — and that window is unrecoverable, because the old refresh token is already dead at the server. Durable commit means: write the temp file, `fsync` it, rename, then `fsync` the parent directory, and only then treat the refresh as successful. Because the exchange and the commit still cannot be made atomic with each other, an in-flight rotation marker written before the exchange lets startup detect an interrupted rotation and say so, instead of failing later with a misleading "invalid token" error.
+
+- **KTD5: When the cache cannot be decrypted, hydrate documents into an empty in-memory `Cache` rather than aborting.** `HydrateDocumentsFromAPI` (`internal/granola/api_documents.go:41`) uses its `cache` argument purely as a destination for `cache.Documents`; it reads nothing out of it. So the API document path has no real dependency on decrypted content — only an incidental structural one. This is the smallest change that satisfies R1.
+
+  **The upsert path is not reused unchanged — `SyncFromCache` must run in a degraded mode.** `SyncFromCache` treats an absent row as "deleted upstream" and performs owner-scoped retirement: the table-wide `DELETE FROM folder_memberships WHERE row_source='cache'` (`internal/granola/store_sync.go:441`) runs unconditionally, and `prepareSegmentRewrite`'s zero-incoming branch (`store_sync.go:596-603`) retires cache-owned transcript segments for every meeting the API hydrate returns. On a degraded run the cache is *unreadable*, not empty-because-deleted, so both clears would permanently destroy rows that can never be re-synced once the DEK path is closed — a direct R7 violation. The `row_source` scoping protects each path from the *other* path's deletes; it does not protect the cache path from its own. Degraded mode must therefore suppress both own-source retirement steps and upsert only.
+
+  **Restrict degraded continuation to classified migration states.** Only `ErrSchemeMigrated` (and an explicitly classified decrypt failure) degrades. A plain `ErrKeyUnavailable` on a non-migrated install still has a working remedy — signing into Granola desktop — and must stay fatal so that remedy is not hidden behind a silently thinner sync.
+
+  Surfaces not hydrated on this path: transcripts, folders, recipes, panels, and chat threads. Recipes and chat threads live only in the cache and are genuinely unreachable without the DEK. Transcripts, panels, and folder lists are **not** DEK-bound — the internal API this plan already authenticates exposes `GetDocumentTranscript`, `GetDocumentPanels`, and `GetDocumentLists` (`internal/granola/internalapi.go:247,277,371`) — they are simply out of scope for this change. The summary must state what was not hydrated rather than implying a complete sync, and must not claim the DEK is the reason for surfaces that a follow-up could restore.
+
+- **KTD6: The decrypt failure stops being fatal to the sync run, but stays visible.** It becomes a recorded, reported condition — consistent with the existing partial-failure posture in `.printing-press-patches/partial-failure-must-not-discard-the-run.json` — instead of a hard return that discards a run which could still fetch every meeting.
+
+### Assumptions
+
+- The device-code `client_id` observed in the desktop app's token payloads is valid for the device grant. The probe returning a well-formed device code supports this, but the full exchange has not been completed end-to-end; U1 must confirm the polling half before the rest of the auth work is built on it.
+- Granola's device-authorization verification page (`mcp-auth.granola.ai/device`) authorizes the same account scope the desktop app uses. If the granted scope turns out narrower than `/v2/get-documents` requires, U1 surfaces that before U2-U4 are written.
+
+---
+
+## High-Level Technical Design
+
+Current state on a post-migration install. Both paths terminate before reaching the API that works:
+
+```mermaid
+flowchart TD
+    A[command invoked] --> B{detectRefreshPlan}
+    B -->|cache: .enc file exists| C[runCacheSync]
+    B -->|api: GRANOLA_API_KEY set?| D[runApiSync]
+    C --> E[openGranolaCache]
+    E -->|ErrSchemeMigrated| F[return err - FATAL]
+    F -.->|never reached| G[HydrateDocumentsFromAPI]
+    G -.-> H[/v2/get-documents - WORKS/]
+    D -->|no API key| I[HTTP 401 MISSING_API_KEY]
+    style F fill:#c62828,color:#fff
+    style I fill:#c62828,color:#fff
+    style H fill:#2e7d32,color:#fff
+```
+
+After this change. The decrypt failure degrades the run instead of ending it, and the token comes from a chain the CLI owns:
+
+```mermaid
+flowchart TD
+    A[command invoked] --> B{detectRefreshPlan}
+    B --> C[runCacheSync]
+    C --> E[openGranolaCache]
+    E -->|ok| K[cache: transcripts, folders, recipes, panels, chat threads]
+    E -->|ErrSchemeMigrated| J[empty in-memory Cache + record degraded]
+    K --> G[HydrateDocumentsFromAPI]
+    J --> G
+    G --> L{token source}
+    L -->|GRANOLA_WORKOS_TOKEN env - unchanged| M
+    L -->|CLI-owned session| M[refresh allowed, persist rotation]
+    L -->|desktop-owned| N[refresh refused - unchanged]
+    B -->|api: GRANOLA_API_KEY set - unchanged| D[runApiSync]
+    M --> H[/v2/get-documents/]
+    H --> O[SyncFromCache upsert]
+    O --> P[meetings in local store]
+    style H fill:#2e7d32,color:#fff
+    style P fill:#2e7d32,color:#fff
+    style N fill:#ef6c00,color:#fff
+```
+
+Device-code login sequence for U1 and U2:
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as granola-pp-cli
+    participant W as auth.granola.ai
+    C->>W: POST /user_management/authorize/device (client_id)
+    W-->>C: device_code, user_code, verification_uri, interval
+    C->>U: display user_code + verification_uri
+    U->>W: authorize in browser
+    loop every `interval` seconds until expires_in
+        C->>W: POST token (device_code grant)
+        W-->>C: authorization_pending | slow_down | tokens
+    end
+    C->>C: persist access + refresh (0600, atomic) BEFORE use
+    C->>U: signed in
+```
+
+---
+
+## Implementation Units
+
+### U1. Confirm the device-code exchange end to end
+
+**Goal.** Establish that the device grant completes and yields a token accepted by `/v2/get-documents`, before any code is written against it.
+
+**Requirements.** R2. Validates the two entries under Assumptions.
+
+**Dependencies.** None.
+
+**Files.** No production files. Record findings in `library/productivity/granola/internal/granola/safestorage/testdata/scheme.md` under a new dated section.
+
+**Approach.**
+
+1. Request a device code; complete the browser authorization.
+2. Poll the token endpoint and capture the response envelope: exact field names, `expires_in`, whether a `refresh_token` is returned, and the error codes emitted while pending (`authorization_pending`, `slow_down`).
+3. Call `POST /v2/get-documents` with the resulting access token and confirm a document list comes back.
+4. **Capture the refresh contract for this chain.** The device grant is minted under a different WorkOS client than the desktop's hardcoded `WorkOSClientID` (`workos.go:26`), and `RefreshAccessToken` posts a bare refresh token to Granola's own proxy (`GranolaRefreshEndpoint`, `workos.go:32`) with no `client_id`. Determine which endpoint and request shape actually rotates a device-grant chain — test Granola's proxy explicitly, and the WorkOS token endpoint with `client_id` + `grant_type` — and record the working shape. U4 implements what this step records; it must not assume the desktop exchange transfers.
+5. Exchange the refresh token once and confirm rotation semantics match what the fossil chains showed.
+6. Record whether the session also authenticates the transcript-bearing internal endpoints (`/v1/get-document-transcript`, `/v1/get-document-panels`, `/v1/get-document-lists`). This does not gate this change, but it determines whether a follow-up can restore those surfaces and keeps KTD5's scope claim honest.
+7. Probe whether a session/token revocation endpoint is reachable for this grant. The answer decides whether `auth logout` can be more than a local file delete (see Open Questions).
+
+**Execution note.** This is a discovery unit against a live third-party service. Its output is written findings, not code. Two hard gates: if step 3 fails on scope, stop and reopen KD1; if step 4 finds no working refresh shape, stop — a session that cannot rotate is not a session, and U2-U4 must not be built on the assumption that it can.
+
+**Secret-handling rule.** `scheme.md` is tracked in git. Record request and response *shapes*, field names, and error codes only. Access tokens, refresh tokens, device codes, account identifiers, and meeting content must never be written to that file or to any test fixture.
+
+**Test scenarios.** `Test expectation: none -- discovery unit; its deliverable is the recorded scheme note that U2 is built against.`
+
+**Verification.** `scheme.md` carries a dated section stating the exact device-grant request and response shapes, the pending-state error codes, and confirmation that the resulting token is accepted by `/v2/get-documents`.
+
+---
+
+### U2. CLI-owned token store with atomic rotation
+
+**Goal.** A persistence layer for a WorkOS session the CLI owns, safe against the single-use rotation semantics.
+
+**Requirements.** R2, R4, R5.
+
+**Dependencies.** U1.
+
+**Files.**
+- `library/productivity/granola/internal/granola/clisession.go` (new)
+- `library/productivity/granola/internal/granola/clisession_test.go` (new)
+
+**Approach.**
+
+1. Define the on-disk record: access token, refresh token, expiry, obtained-at, and the account identifier the session belongs to.
+2. Resolve its path with the same XDG-aware resolution `SyncStatePath` uses (`internal/granola/syncstate.go:45-55`), which honors `XDG_DATA_HOME` and already ships an env override. Do **not** follow `defaultDBPath` (`internal/cli/helpers.go:1420-1423`): it hardcodes `~/.local/share`, and it lives in `internal/cli`, which this file cannot import — `internal/cli` imports `internal/granola`, not the reverse. Following `SyncStatePath` keeps the session file, sync state, and store co-located for XDG users.
+3. Write via temp-file-then-rename within the same directory, creating the temp file at `0600` (rename preserves its mode) and the directory at `0700`. `MkdirAll` is a no-op on an existing directory, and `~/.local/share/granola-pp-cli/` already exists at `0755` on every machine that has ever synced — so explicitly `chmod` the directory to `0700` when it exists with broader permissions, or the control silently never applies. Apply the same enforcement to the env-override path, and refuse to load a session file that is group- or world-readable or not owned by the current user. Never log or return token material; the record's string representation must redact both tokens.
+4. Implement durable commit per KTD4: `fsync` the temp file, rename, `fsync` the parent directory, and write an in-flight rotation marker before an exchange so an interrupted rotation is detectable at startup.
+5. Expose load, save, and clear. `clear` is what `auth logout` will call.
+
+**Patterns to follow.** Mirror the temp-file-then-rename atomic-write *shape* used for `sync_state.json` (`internal/granola/syncstate.go`) — but **not** its permissions: `WriteSyncState` creates its directory `0755` and writes the temp file `0644`, and `os.Rename` preserves the temp file's mode, so copying it verbatim would land the credential file world-readable. This file must be `0600` in a `0700` directory per KTD2. Match the `Err…` sentinel style of `internal/granola/safestorage/safestorage.go:35-65` for a missing or malformed session.
+
+**Test scenarios.**
+- Saving then loading a session round-trips every field intact.
+- Loading when no session file exists returns the "no session" sentinel, not a hard error.
+- The session file is created with mode `0600` and its parent directory with `0700`.
+- **When the parent directory already exists at `0755`** (pre-created in the test, as it is on every real install), saving tightens it to `0700`. This is the scenario that catches the `MkdirAll` no-op.
+- The env-override path gets the same permission enforcement as the default path.
+- Loading a session file that is group- or world-readable, or not owned by the current user, returns a typed error instead of a session.
+- A save that fails partway (simulated by making the target directory read-only) leaves any previously saved session readable and uncorrupted.
+- Loading a truncated or malformed session file returns a typed error rather than panicking.
+- The record's formatted output contains neither the access token nor the refresh token substring.
+- An in-flight rotation marker left behind by an interrupted rotation is detected on load and reported as such, not as a malformed session.
+- `clear` removes the file, and a subsequent load returns the "no session" sentinel.
+
+**Verification.** `go test ./internal/granola/ -run CLISession` passes, and the permission and redaction scenarios are asserted rather than assumed.
+
+---
+
+### U3. `auth login` device-code flow
+
+**Goal.** A command that signs the CLI in on its own account and persists the resulting session.
+
+**Requirements.** R2, R5.
+
+**Dependencies.** U1, U2.
+
+**Files.**
+- `library/productivity/granola/internal/cli/auth_login.go` (new)
+- `library/productivity/granola/internal/cli/auth_login_test.go` (new)
+- `library/productivity/granola/internal/cli/auth.go` (register `login` inside `newAuthCmd`, alongside the existing auth subcommands, and extend `status` / `logout`)
+- `library/productivity/granola/SKILL.md`, `library/productivity/granola/README.md`
+
+**Approach.**
+
+1. Add `auth login` beside the existing `logout`, `set-token`, `setup`, `status` subcommands.
+2. Request a device code, then display the user code and verification URI. Under `--no-input`/`--agent`, emit them as structured output and still poll — the flow needs no TTY interaction on this side.
+3. Poll at the server-supplied `interval`, backing off on `slow_down`, until authorization completes or `expires_in` elapses. Honor context cancellation so Ctrl-C exits cleanly.
+4. On success, persist through U2 **before** reporting success.
+5. Extend `auth status` to report which session is in use and its expiry, and `auth logout` to clear the CLI-owned session.
+
+**Execution note.** Drive the tests against an `httptest` server standing in for the WorkOS endpoints; the polling loop and its timing behavior are the parts worth proving, and they must not depend on the live service.
+
+**Test scenarios.**
+- A device-code response followed by a pending poll and then a success response results in a persisted session.
+- `authorization_pending` is treated as "keep waiting", not as a failure.
+- `slow_down` lengthens the poll interval rather than aborting.
+- The flow gives up once `expires_in` elapses, with an error naming expiry as the cause.
+- Context cancellation mid-poll returns promptly without writing a partial session.
+- A persistence failure after a successful token exchange surfaces as an error rather than reporting a successful login.
+- Neither the access nor the refresh token appears in command output on success or on any error path.
+- `auth status` with a CLI-owned session reports it as the active source; with none, it reports the desktop fallback state.
+- `auth logout` clears the session and `auth status` then reports none.
+
+**Verification.** `go test ./internal/cli/ -run AuthLogin` passes; running `auth login` against the live service produces a session that `auth status` reports and that U4 can refresh.
+
+---
+
+### U4. Wire the CLI-owned session into token resolution
+
+**Goal.** Make the new session the preferred token source and the only one the CLI is permitted to rotate.
+
+**Requirements.** R2, R3, R4.
+
+**Dependencies.** U2, U3.
+
+**Files.**
+- `library/productivity/granola/internal/granola/workos.go`
+- `library/productivity/granola/internal/granola/workos_test.go`
+- `library/productivity/granola/internal/cli/sync_cache.go` (the `tokenSourceLabel` change in step 5)
+- `library/productivity/granola/internal/cli/sync_cache_test.go`
+
+**Approach.**
+
+1. Add a `TokenSource` constant for the CLI-owned session.
+2. Insert it into `loadTokensRaw` (`workos.go:268-288`) directly after the `GRANOLA_WORKOS_TOKEN` env check and before the `supabase.json` probes. Leave every existing arm as-is.
+3. In `refreshRefusalFor` (`workos.go:215-225`), return no refusal for the new source. Do not touch the `TokenSourceEncryptedSupabase`, `TokenSourcePlaintextSupabaseDesktopFallback`, or `TokenSourceStoredAccounts` arms.
+4. In `RefreshAccessToken`, implement the refresh shape U1 recorded for the CLI-owned chain (it may differ from the desktop proxy exchange), then persist the rotated pair through U2 before returning. A persistence failure must fail the refresh loudly rather than returning a token whose refresh half has been lost (KTD4).
+
+   **Serialize the whole exchange, not just the write.** The current code releases `tokenMu` before the network call and reacquires it only for the in-process cache update, so two concurrent callers both perform an exchange today. Under single-use rotation the loser gets `invalid_grant` and the session is stranded. For the CLI-owned source, hold `tokenMu` (or a dedicated refresh lock / singleflight) across exchange **and** durable persist. This is a restructure of the existing locking, not a drop-in.
+5. Add the new source to `tokenSourceLabel` (`internal/cli/sync_cache.go:241-253`), and while there, add the missing `TokenSourcePlaintextSupabaseDesktopFallback` case that currently reports `"unknown"`.
+
+**Patterns to follow.** The existing `TokenSource` enum and `refreshRefusalFor` structure. `.printing-press-patches/d6-stored-accounts-is-desktop-owned.json` and `d6-read-only-applies-to-all-desktop-token-sources.json` record why the desktop arms exist — this unit must not weaken them.
+
+**Test scenarios.**
+- With a CLI-owned session present, `loadTokensRaw` returns it and reports the new source.
+- `GRANOLA_WORKOS_TOKEN` still wins over a CLI-owned session.
+- With no CLI-owned session, resolution falls through to the existing desktop probes in their current order and with their current sources.
+- `refreshRefusalFor` returns no refusal for the CLI-owned source.
+- `refreshRefusalFor` still returns `ErrRefreshRefused` for each desktop-owned source, including the `stored-accounts` case gated on `supabase.json.enc` being present.
+- A successful refresh of a CLI-owned session writes the rotated refresh token before returning, and a reload observes the new value.
+- A refresh whose persistence step fails returns an error and does not report success.
+- Concurrent refresh attempts serialize under `tokenMu` and produce exactly one exchange.
+- `tokenSourceLabel` returns a distinct non-`"unknown"` label for the new source and for `TokenSourcePlaintextSupabaseDesktopFallback`.
+
+**Verification.** `go test ./internal/granola/ -run 'Token|Refresh'` and `go test ./internal/cli/ -run TokenSourceLabel` pass. Every pre-existing refusal test still passes unmodified — if one needed editing, R3 has been violated.
+
+---
+
+### U5. Run the API document sync without a readable cache
+
+**Goal.** Let a decrypt failure degrade the sync run instead of ending it, so meetings are fetched on a migrated install.
+
+**Requirements.** R1, R7.
+
+**Dependencies.** U4.
+
+**Files.**
+- `library/productivity/granola/internal/cli/sync_cache.go`
+- `library/productivity/granola/internal/cli/sync_cache_test.go` (new)
+- `library/productivity/granola/internal/granola/store_sync.go`
+- `library/productivity/granola/internal/granola/store_sync_test.go`
+- `library/productivity/granola/internal/cli/autorefresh.go`
+
+**Approach.**
+
+1. Add a degraded mode to `SyncFromCache` (`internal/granola/store_sync.go`) that suppresses the cache path's **own-source retirement**: skip the cache-scoped `DELETE FROM folder_memberships` (`store_sync.go:441`) and skip `prepareSegmentRewrite`'s zero-incoming own-source segment retirement (`store_sync.go:596-603`). In degraded mode the function upserts only. This is the load-bearing step — without it the first degraded sync destroys every previously synced transcript and folder membership (see KTD5).
+2. In `runCacheSync` (`sync_cache.go:151-215`), replace the fatal return on `openGranolaCache()` failure with a degraded path, gated on classification:
+   - Keep `recordSyncDecryptStatus(err)` so `doctor` still sees the real classification.
+   - Degrade **only** when the error classifies as `ErrSchemeMigrated` or an explicitly classified decrypt failure. Any other cache-open error stays fatal, so the non-migrated remedy is not hidden.
+   - Construct an empty in-memory `Cache` and mark the result degraded, carrying the decrypt error.
+   - Continue into `HydrateDocumentsFromAPI`, then call `SyncFromCache` in degraded mode.
+   - Return an error only if the API hydrate *also* fails — that is the case where the run genuinely produced nothing.
+3. Extend `CacheSyncResult` with the degraded marker and the underlying decrypt error so callers can report accurately.
+4. Have the sync summary state plainly which surfaces were not hydrated and that only API-derived meetings were synced. Do not report a degraded run as a clean one.
+5. In `autorefresh.go:293-318`, render the degraded state distinctly from both success and failure in the provenance line.
+6. Add the missing `ErrSchemeMigrated` arm to the classification switch at `sync_cache.go:226-235` so the state is recorded as its own class rather than collapsing into `key_unavailable`.
+
+**Execution note.** Write the data-preservation test first, before the feature test: seed the store with cache-owned transcript segments and folder memberships, run a degraded sync, and assert every seeded row survives. That test is what stands between this unit and permanent data loss, and it fails against the naive implementation.
+
+**Test scenarios.**
+- **A degraded run preserves seeded cache-owned rows.** With transcript segments and folder memberships already in the store from a prior successful sync, a degraded run leaves every one of them intact — including for meetings the API hydrate returns with no transcript.
+- Cache decrypt fails with `ErrSchemeMigrated` and the API hydrate succeeds: meetings land in the store, the result is marked degraded, and no error is returned.
+- Cache decrypt fails and the API hydrate also fails: an error is returned and it names the hydrate failure, not only the decrypt failure.
+- A cache-open error that is **not** a classified migration or decrypt failure stays fatal and does not enter degraded mode.
+- Cache decrypts successfully: behavior is byte-for-byte what it is today, including all cache-derived surfaces and both retirement steps.
+- A degraded run records the decrypt classification for `doctor` exactly as the current fatal path does.
+- A degraded run's summary reports zero transcripts, folders, recipes, panels, and chat threads, and a non-zero document count.
+- The provenance line distinguishes degraded from clean success and from outright failure.
+- `ErrSchemeMigrated` is recorded as its own class, not as `key_unavailable`.
+
+**Verification.** `go test ./internal/cli/ -run 'CacheSync|Autorefresh'` passes. On this machine, after `auth login`, `granola-pp-cli sync` followed by `meetings list` shows meetings dated after 2026-07-25.
+
+---
+
+### U6. Correct the operator-facing messaging
+
+**Goal.** Stop printing remedies that cannot work on a migrated install.
+
+**Requirements.** R6.
+
+**Dependencies.** U3, U5.
+
+**Files.**
+- `library/productivity/granola/internal/granola/safestorage/safestorage.go` (the `migratedSchemeRemedy` constant)
+- `library/productivity/granola/internal/cli/doctor_encrypted_store.go`
+- `library/productivity/granola/internal/cli/doctor.go` (the `"not configured"` auth check)
+- `library/productivity/granola/internal/granola/workos.go` (no-token and `ErrRefreshRefused` messages)
+- `library/productivity/granola/internal/granola/api_documents.go`
+- `library/productivity/granola/internal/cli/doctor_encrypted_store_test.go`
+- `library/productivity/granola/SKILL.md`, `library/productivity/granola/README.md`
+
+**Approach.**
+
+1. Rewrite the remedy text at its source: the migrated-state message is the `migratedSchemeRemedy` constant baked in by `newMigratedSchemeError` (`safestorage.go:93-110`). `cache.go:474-482` deliberately passes that string through untouched, so editing `cache.go` cannot change the remedy — the rewrite must happen in `safestorage.go`. Lead with `auth login`; keep `GRANOLA_SAFESTORAGE_KEY_OVERRIDE` as the secondary route for anyone holding a pre-migration `storage.dek`; drop the claim that fetching new meetings requires a Business/Enterprise API key, which this change makes false.
+2. In `doctor_encrypted_store.go:85-86`, stop advising the user to approve a Keychain prompt when the state is `ErrSchemeMigrated` — no prompt will appear. Point at `auth login` instead.
+3. In `api_documents.go:64`, replace *"open Granola desktop briefly to refresh, then retry"* with `auth login`. The desktop no longer writes a file the CLI can read, so that remedy is dead. Do the same for the `ErrRefreshRefused` sentinel text and the no-token messages in `workos.go` — a fresh install with no fossil auth files hits those first, and they still name dead remedies.
+4. Have `doctor` report the CLI-owned session as its own check (the `"not configured"` string lives in `doctor.go`, not in `doctor_encrypted_store.go`), so "Auth: not configured" no longer appears when a valid session exists. That message currently refers only to `GRANOLA_API_KEY` and reads as a total auth failure.
+5. Have `auth status` and auth-failure messages detect an active `GRANOLA_WORKOS_TOKEN` override and say to unset it — it outranks the CLI-owned session in `loadTokensRaw`, so a stale value makes a successful `auth login` look like it did nothing.
+6. Update `SKILL.md` and `README.md`:
+   - Document `auth login`, and correct the standing claim that a current install is *"permanently unreadable by this CLI"* — the local files are, but the CLI is not without data.
+   - Explain **why** a second sign-in is needed while Granola desktop is already signed in: desktop refresh tokens are single-use, so rotating one would sign the desktop app out. State what credential the CLI stores, where, at what permissions, and that `auth logout` removes it. This has to live in the shipped docs, not only the PR body — catalog users never see the PR.
+   - Extend the SKILL.md **Capability split** with the CLI-owned-session tier: which surfaces it hydrates and which stay empty. Agents consult this section to decide whether an empty result means "no data" or "not synced on this tier"; without it, `talktime`, `memo run`, `attendee brief`, and `folder stream` return empty and read as authoritative answers.
+
+**Test scenarios.**
+- With `ErrSchemeMigrated` recorded, `doctor` names `auth login` and does not mention approving a Keychain prompt.
+- With a valid CLI-owned session, `doctor` reports auth as healthy rather than "not configured".
+- **Combined acceptance state:** with `ErrSchemeMigrated` recorded *and* a valid CLI-owned session, `doctor` simultaneously reports healthy auth, a migrated-but-degraded store, and no Keychain-prompt remedy. Testing these three separately can pass while the combined output still reads as a bare failure.
+- With no session and no API key, `doctor` still reports the actionable state and names `auth login`.
+- The `ErrRefreshRefused` message from the document hydrate names `auth login` and no longer instructs the user to open Granola desktop.
+- On a fresh install with no session, no API key, and no plaintext desktop fossils, the no-token message from `workos.go` names `auth login`.
+- With `GRANOLA_WORKOS_TOKEN` set and a CLI-owned session present, `auth status` reports that the env override is active and outranks the session.
+- The `ErrKeyUnavailable` (non-migrated) message is unchanged — that state's existing remedy is still correct.
+
+**Verification.** `go test ./internal/cli/ -run Doctor` passes, and `python3 .github/scripts/verify-skill/verify_skill.py --dir library/productivity/granola/` passes after the doc edits.
+
+---
+
+### U7. Record the patches and ship
+
+**Goal.** Land the change with the reprint-guard metadata this repo requires.
+
+**Requirements.** All.
+
+**Dependencies.** U1-U6.
+
+**Files.**
+- `library/productivity/granola/.printing-press-patches/cli-owned-workos-session.json` (new)
+- `library/productivity/granola/.printing-press-patches/api-sync-survives-unreadable-cache.json` (new)
+- `library/productivity/granola/.printing-press-patches/granola-local-store-is-sqlcipher.json` (new)
+- `library/productivity/granola/.printing-press-patches/device-grant-flow-is-a-moving-target.json` (new)
+- `library/productivity/granola/.printing-press.json` (contributors)
+- `library/productivity/granola/README.md`, `library/productivity/granola/NOTICE` (byline and contributor rows)
+
+**Approach.**
+
+1. Write one patch file per durable lesson, at reprint-guard altitude per this repo's conventions — the behavioral contract, not the diff:
+   - *CLI-owned session*: the CLI maintains its own WorkOS chain because desktop-owned refresh tokens are single-use and rotating one signs the user out of the desktop app.
+   - *Degraded sync*: an unreadable desktop cache must degrade the sync run rather than end it, because the API document path has no real dependency on decrypted cache content.
+   - *SQLCipher store*: `granola.db` is SQLCipher keyed with the entitlement-gated DEK; a regen must not attempt to read it.
+   - *Device-grant flow is a moving target*: the endpoint, `client_id`, and verification host are an unofficial dependency, minted through a Granola auth surface not issued to this CLI. Granola has closed three third-party access routes in roughly three months, so `auth login` failures should be triaged first as drift in that flow, not as a CLI regression. Same treatment `granola-current-client-identity.json` already gives the client version.
+2. Set `schema_version: 2`, and copy `base_run_id` and `base_printing_press_version` from `.printing-press.json`.
+3. Add the contributor entry across all three surfaces — manifest, README byline, and NOTICE. The manifest-only miss is this repo's documented recurring gap (it happened on granola #1022 and flight-goat #1008).
+4. Draft the PR body's security-posture statement (the Definition of Done requires it): what credential the CLI now stores, where, at what permissions, why the desktop's session is untouched, that the session is minted through a Granola auth surface not issued to this CLI and can be revoked upstream, and what `auth logout` does and does not invalidate.
+5. Do not touch `registry.json`, `cli-skills/pp-granola/SKILL.md`, `CHANGELOG.md`, or `.printing-press-release.json` — all are owned by post-merge automation and CI hard-fails on the first two.
+
+**Test scenarios.** `Test expectation: none -- metadata and attribution unit; correctness is enforced by the preflight checks below.`
+
+**Verification.** From `library/productivity/granola/`: `go build ./...`, `go vet ./...`, `go test ./...`, and `govulncheck ./...` all pass; `python3 .github/scripts/verify-skill/verify_skill.py --dir library/productivity/granola/` passes; `git diff --name-only origin/main` shows no generated artifacts.
+
+---
+
+## Verification Contract
+
+Before opening the PR, from `library/productivity/granola/`:
+
+```
+go build ./...
+go vet ./...
+go test ./...
+govulncheck ./...
+```
+
+From the repo root:
+
+```
+python3 .github/scripts/verify-skill/verify_skill.py --dir library/productivity/granola/
+```
+
+End-to-end on a migrated install, which is the acceptance case this plan exists for:
+
+1. `granola-pp-cli auth login` completes and persists a session.
+2. `granola-pp-cli doctor` reports auth healthy and the encrypted store as migrated-but-degraded, not as a bare failure. Assert this combined state in one test — classification, auth health, and remedy text are otherwise only checked separately, and the combination is what a real user sees.
+3. `granola-pp-cli sync` reports a degraded run with a non-zero document count.
+4. `granola-pp-cli meetings list` shows meetings recorded after 2026-07-25.
+5. Meetings and transcripts already in the local store before the run are all still there afterward. This is the R7 check and the P0 this plan's review caught.
+6. The Granola desktop app remains signed in throughout. This is the R3 check and it is not optional.
+
+Also verify the **fresh-install** path, which is the catalog's dominant audience and is not exercised by the upgraded machine above: with an empty local store and no plaintext desktop fossils, every message the CLI emits before `auth login` names `auth login` as the remedy — no "sign into the Granola desktop app", no "open Granola desktop briefly", no "needs a Business or Enterprise workspace".
+
+## Definition of Done
+
+- R1-R7 are satisfied, each traceable to at least one unit.
+- U1's two hard gates cleared: the session reaches `/v2/get-documents`, and a working refresh shape is recorded. Neither is assumed.
+- Every pre-existing test passes unmodified. An edited refusal test means R3 was violated.
+- The degraded-run data-preservation test passes. No previously synced row is lost on a degraded sync.
+- Four patch files are recorded and the contributor entry appears on all three surfaces.
+- No generated artifact appears in the PR diff.
+- The PR body states the security posture explicitly: what credential the CLI now stores, where, at what permissions, why the desktop's session is untouched, that the grant comes from a Granola auth surface not issued to this CLI and may be revoked or re-scoped upstream, and what `auth logout` does and does not invalidate.
+
+## Open Questions
+
+- **Blocking on U1:** whether the device grant returns a refresh token at all, and by what endpoint and request shape it rotates. If there is no refreshable chain, `auth login` cannot promise a maintained session and KD1 must be reopened before U2-U4 are built.
+- **Needs a decision before U3 ships:** whether `auth logout` revokes server-side. If U1 finds a reachable revocation endpoint, logout should call it — otherwise a leaked copy of the refresh token stays valid after the user believes they signed out. If revocation is unavailable, that residual has to be stated in the shipped docs rather than left implicit.
+- **Needs a decision before U3 ships:** whether to request a reduced scope for the CLI session. The device grant currently yields a desktop-equivalent chain; if the provider supports a narrower scope covering `/v2/get-documents`, taking it bounds the blast radius of a leaked credential.
+- **Deferred to implementation:** whether a CLI-owned session should be per-account when a user has several Granola accounts. Single-session is correct for this fix, but `auth login` and `auth status` should at minimum display the bound account identifier so a session pointed at a second account cannot silently look like missing data.
+- **Deferred to follow-up:** whether the CLI-owned session can hydrate transcripts, panels, and folder lists through the internal API's existing `GetDocumentTranscript` / `GetDocumentPanels` / `GetDocumentLists`. U1 step 6 records the answer. If yes, that restores most of the CLI's advertised value on migrated installs and is the natural next PR.
+
+## Sources & Research
+
+- PR #1598, `fix(granola): restore data access after Granola's DEK migration`, merged 2026-07-25 — establishes the dual-path design this plan extends.
+- `docs/plans/2026-07-25-001-fix-granola-dual-path-data-access-plan.md` — prior plan.
+- `library/productivity/granola/internal/granola/safestorage/testdata/scheme.md` — the empirical encryption note, including the 2026-07-25 tier-1 update. U1 extends it.
+- Granola desktop 7.465.0 bundle inspection: `better-sqlite3-multiple-ciphers` dependency; `pragma cipher='sqlcipher'` / `legacy=4` / `key="x'<hex>'"`; the `sqlite-encryption-key-dek-unavailable` log path establishing the SQLCipher key as the DEK.
+- Live API probes, 2026-08-03, recorded in the Evidence table above.

--- a/docs/plans/2026-08-03-002-fix-granola-cache-only-surfaces-plan.md
+++ b/docs/plans/2026-08-03-002-fix-granola-cache-only-surfaces-plan.md
@@ -1,0 +1,407 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+type: fix
+title: "fix(granola): serve recipes and chats from the store on a migrated install"
+created: 2026-08-03
+plan_depth: standard
+target_cli: library/productivity/granola
+---
+
+# fix(granola): serve recipes and chats from the store on a migrated install
+
+## Product Contract
+
+### Summary
+
+`recipes list`, `recipes describe`, `chat list` and `chat get` abort on a cache decrypt that can never succeed, even though the local store already holds 57 recipes and 225 chat threads. This plan routes them through the store-first read seam the working commands already use, builds the store readers those tables never got, and refreshes recipes, panel templates and folder metadata from the internal API so the data stays current.
+
+### Problem Frame
+
+The prior plan (`docs/plans/2026-08-03-001-fix-granola-cli-owned-auth-plan.md`) gave the CLI its own session and restored meetings, attendees and transcripts on installs where Granola's DEK moved out of reach. Four surfaces were left listed as "cache-only, therefore unavailable". Probing them showed that framing was wrong in three different ways, only one of which needs a fix here.
+
+**Recipes and chats fail on a decrypt that will never succeed.** `recipes.go:37`, `recipes.go:124`, `chat.go:34` and `chat.go:101` all call `openGranolaCache()`, which returns a hard error when the cache cannot be decrypted. Every other read command goes through `openGranolaRead()`, which serves the store first and treats an unreadable cache as the steady state rather than a failure. These four sites were simply never migrated. The store meanwhile holds 57 recipes and 225 chat threads from pre-migration syncs, so the data is present and the command refuses to show it.
+
+Fixing the routing alone is not enough: the `recipes` and `recipes_usage` tables have **no reader at all** (`grep "FROM recipes"` across `internal/` returns nothing). They have been written on every sync since the CLI shipped and read by nothing. Chat threads are in the same position. So the store-first path has to be built, not just called.
+
+**Panels already work, on one precondition.** `panel get` returns a full AI panel today. It never consulted the store — `panel.go:41-48` calls `GetDocumentPanels` live — so the session from the prior PR fixed it as a side effect. The precondition is that the session stays valid: `panel get` is the only read command with no store or cache fallback at all, so a lapsed session makes it fail hard where every other command degrades to stored data. This plan does not change that (KD2), but the tradeoff should be recorded rather than left implied by "nothing is required here".
+
+**Folders mostly work, with one gap.** `folder list` and `folder stream` are store-backed and functional. But the cache write path drops `description` and the favourite flag — there are no columns for them — so `folder list` reports those empty for every folder, which U3 repairs. The separate top-level `folders` command is generator-produced and calls the public REST `/v1/folders`, which 401s without a `GRANOLA_API_KEY`. That is a different command on a different API, and rerouting it changes behavior for key-holding users, so it is deferred rather than folded in.
+
+**Workspaces are already covered and were mis-listed.** `workspaces.go` falls back to the internal API's `GetWorkspaces()` when the cache is unreadable, the same live path that makes `panel get` work. The shipped capability docs list workspaces alongside chats as unavailable, which is wrong for the same reason the panels bullet is wrong. U5 corrects both rather than rewriting around them.
+
+**What is genuinely unreachable is chat content, not chat reads.** Seven endpoint namings were probed for chat threads on 2026-08-03 against Granola 7.465.0, all returning 404: `/v1/get-chat-threads`, `/v1/get-document-chats`, `/v1/get-chats`, `/v2/get-chat-threads`, `/v1/get-threads`, `/v1/get-document-thread`, `/v1/chat-threads`. Chats can be read from what the store already has, but cannot be refreshed. That distinction has to reach the docs, because "cache-only" currently implies a fix is coming.
+
+### Evidence
+
+Gathered 2026-08-03 against Granola 7.465.0 with a CLI-owned session.
+
+| Surface | Command today | Store rows | Internal API |
+|---|---|---|---|
+| Recipes | aborts on decrypt | 57 recipes, usage for 57 | `/v1/get-recipes` returns 200, full set in one call |
+| Chats | aborts on decrypt | 225 threads (newest 2026-06-22) | no endpoint found (7 namings, all 404 — listed in the Problem Frame) |
+| Panel templates | not read by any command | 31 templates | `/v1/get-panel-templates` returns 200, 31 items |
+| Panels | `panel get` works live | no table exists | `/v1/get-document-panels` returns 200 per document |
+| Folders | `folder list` works | 5 folders, 153 memberships | `/v2/get-document-lists` returns 200 with membership embedded |
+
+Two findings that change the work:
+
+- **`/v2/get-document-lists` carries membership.** Each list in the response has a `documents` array alongside `id`, `title`, `parent_document_list_id` and `preset`. The Go type `DocumentListMetadata` has no field for it, so `GetDocumentLists` currently discards the edges and the code comments assume membership must come from `APINote.FolderMembership`. Adding one field makes folders and memberships a single call.
+- **`RecipeUsage.TotalCount` is a string.** Both the store write (`store_sync.go:547`) and `recipes list --top-usage` (`recipes.go:67`) parse it with `Sscanf`. An API mapper that supplies a number will silently yield zero counts on both paths.
+
+### Requirements
+
+- **R1.** `recipes list`, `recipes describe`, `chat list` and `chat get` must return the store's data on an install where the cache cannot be decrypted, instead of erroring.
+- **R2.** Those commands must keep their current behavior on an install with a readable cache, including the cache-only fields the store does not carry.
+- **R3.** Recipes, recipe usage and panel templates must refresh from the internal API on a degraded sync, so the store does not stay frozen at whatever the last cache sync left.
+- **R4.** Rows written by the API must be distinguishable from cache-written rows, so a later change can retire stale rows of one origin without destroying the other's.
+- **R5.** Documentation must distinguish "not synced on this tier" from "unreachable". Chat content is unreachable; recipes and panel templates are not.
+- **R6.** A command serving store data on an install with an unreadable cache must surface how current that data is, at the point of use rather than only in the docs. Replacing a visible error with a silently frozen result is not an improvement. This binds hardest on chats, which can never be refreshed, but applies to recipes too on any install where U4 has not landed.
+- **R7.** Folder metadata (description, favourite flag) and folder membership must be complete in the store after a degraded sync, so `folder list` stops reporting empty fields for folders that have them.
+
+### Key Decisions
+
+- **KD1: Fix the read path before the write path.** *(Governs R1, R2.)* Routing four call sites through the existing seam makes three commands work against data already on disk. Hydration only keeps that data current, and is worthless until something reads it. This ordering also means U1 and U2 deliver user-visible value even if U3 slips.
+- **KD2: Do not persist panel content.** *(Governs the scope boundary.)* `panel get` already works live against the CLI session, so there is no broken behavior to repair — persisting panels would buy offline reads nobody has asked for, at the cost of a new table and a new per-document backfill with its own budget and fetch-state. Deferred, not rejected. Note the schema-version bump is *not* the differentiator: U3 needs one anyway (KTD6).
+- **KD3: Treat chats as read-only, and disclose the staleness boundary.** *(Governs R5, R6.)* No chat endpoint exists on the internal API as of Granola 7.465.0, probed 2026-08-03 across the seven namings listed in the Problem Frame. State it that way in the docs rather than as permanence: an absent endpoint today is a dated observation, and the plan is already correcting the opposite error of implying a fix is coming. Practically, the store's threads are frozen at whatever the last cache sync captured and will only age. On the probe machine that boundary is already six weeks behind the newest meeting. Serving that silently would trade a loud failure for a quiet wrong answer, so `chat list` must state how current its data is rather than presenting a frozen set as complete.
+
+### Scope Boundaries
+
+In scope: the four cache-only read sites, store readers for recipes and chat threads, API refresh for recipes and panel templates, folder metadata completeness, and `row_source` provenance on the four tables that lack it.
+
+Out of scope:
+
+- Persisting panel content or adding a panels table (KD2).
+- Any change to the public REST path or `GRANOLA_API_KEY` behavior.
+- Chat hydration (KD3 — no endpoint exists).
+
+#### Deferred to Follow-Up Work
+
+- The top-level `folders` command (`promoted_folders.go`) still calls public `/v1/folders` and 401s without a key. Rerouting it to the store would change what key-holding users get from it, so it needs its own decision.
+- `cache.ListRules` is parsed and written nowhere and read by nothing. Dead weight this plan does not touch.
+- `recipe_coverage.go:51` discards the error from `GetDocumentPanels`, so a client failure reports every meeting as missing its recipe. A real defect, but in the panel path this plan leaves alone.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD1: Extend the `granolaRead` view rather than adding a parallel accessor.** The seam at `internal/cli/granola_helpers.go` already merges store and cache for documents, folders and memberships, with the established precedent that store values overwrite only non-empty fields. Recipes and chat threads should join that same view so the merge semantics stay in one place.
+
+- **KTD2: Add `row_source` to `folders`, `panel_templates`, `recipes` and `recipes_usage` before any API writer touches them.** They currently have zero DELETEs — pure `INSERT OR REPLACE` — so the two paths would blend with no way to tell them apart, which is the situation that made the transcript retirement bug possible.
+
+  **`DEFAULT 'cache'` is accurate for only three of the four.** `folders` already has an API writer: `upsertAPIMemberships` (`store_sync.go:952`) creates stub folder rows during the API note-sync path. On any install that has run an API sync, the backfill will therefore stamp API-created folders as cache-owned. That mislabeling is unrecoverable — nothing distinguishes those stubs after the fact — so U3 must additionally stamp the `upsertAPIMemberships` insert with API ownership going forward, and no cache-scoped DELETE may ever target `folders` until the mislabeled generation has aged out. The default is genuinely historically accurate for `panel_templates`, `recipes` and `recipes_usage`, which have no API writer.
+
+  **Seven granola tables lack `row_source`, not four.** `chat_threads`, `chat_messages` and `workspaces` also lack it and are deliberately excluded: no API writer for them exists or is planned (KD3 forecloses chats entirely). Revisit if one is ever added — `workspaces` is the likeliest, since it already has an `INSERT OR REPLACE` writer.
+
+- **KTD3: Recipes and panel templates hydrate with no budget machinery.** Each is a single call returning the full set, unlike transcripts and panels which are per-document. Reusing the transcript hydrator's fetch-state and budget design here would add a table and a flag to protect against a cost that does not exist.
+
+- **KTD4: Add a `Documents` field to `DocumentListMetadata` and take membership from the same call.** The API already returns the edges; only the Go type omits them. This removes the need for a second membership source and closes the gap the existing comments call out.
+
+- **KTD5: Map `RecipeUsage.TotalCount` as a string.** The field is a string in the cache type and both existing consumers parse it with `Sscanf`. An API mapper must stringify the numeric count rather than change the type, or the two readers silently report zero.
+
+- **KTD7: Convert the four catalog writes from `INSERT OR REPLACE` to `ON CONFLICT DO UPDATE`, and thread the write origin through `SyncFromCache`.** These are one decision because they share a cause. SQLite's `REPLACE` deletes the row and inserts a new one, so every column the incoming payload omits is blanked and `row_source` is rewritten to whatever the current run stamps. On a degraded sync the API returns the full recipe set, which would flip every pre-existing cache row to API ownership and blank the cache-only fields — the exact opposite of what R4 and U4's own test scenarios require. The codebase already solved this for `meetings`: `ON CONFLICT(id) DO UPDATE` with `row_source` deliberately excluded from the SET list, so the creating path keeps ownership.
+
+  The origin itself needs a seam. U3 stamps cache ownership at the call sites and U4 needs those same loops to stamp API ownership, so a literal at each write leaves U4 nowhere to hook in. Add an origin field to `SyncOptions` defaulting to `RowSourceCache`, following the `TranscriptOwner` precedent the prior plan established, and have the degraded path set it.
+
+- **KTD6: U3 bumps `StoreSchemaVersion` from 3 to 4.** The constant's own contract requires it — "bump this whenever a migration changes table shape — adding columns" — and the precedent is exact: it went 2 to 3 for the previous round of `row_source` columns. The hazard is the same one that bump was for. These four tables are written with `INSERT OR REPLACE`, so a pre-bump binary opening a migrated database omits `row_source`, falls back to the column default, and silently reassigns every API-owned row to the cache path. Refusing to open is the only safe downgrade. Do not treat the absence of DELETEs on these tables as making the bump optional; ownership corruption does not need a DELETE.
+
+### Assumptions
+
+- The store's 225 chat threads and 57 recipes are representative enough to be worth reading. If a user's store predates chat threads entirely, these commands return empty rather than erroring, which is still the correct outcome.
+
+---
+
+## High-Level Technical Design
+
+Current state. Two read paths exist; four call sites are on the wrong one.
+
+```mermaid
+flowchart TD
+    A[read command] --> B{which helper?}
+    B -->|openGranolaRead| C[store first, cache fallback]
+    C --> D[works on migrated install]
+    B -->|openGranolaCache| E[cache only]
+    E --> F[hard error: decrypt failed]
+    F --> G[recipes list/describe<br/>chat list/get]
+    style F fill:#c62828,color:#fff
+    style D fill:#2e7d32,color:#fff
+```
+
+After. The four sites join the existing seam, and the seam gains readers for four tables that never had one.
+
+```mermaid
+flowchart TD
+    A[read command] --> C[openGranolaRead]
+    C --> S[(store)]
+    C --> K[cache, when readable]
+    S --> R1[meetings, transcripts,<br/>folders, memberships]
+    S --> R2[recipes, recipes_usage,<br/>chat_threads, chat_messages]
+    R2 -.new readers.-> C
+    C --> OUT[all read commands work]
+    style R2 fill:#1565c0,color:#fff
+    style OUT fill:#2e7d32,color:#fff
+```
+
+Refresh path on a degraded sync. Single-call surfaces, no budget.
+
+```mermaid
+sequenceDiagram
+    participant S as runCacheSync (degraded)
+    participant A as internal API
+    participant C as in-memory Cache
+    participant D as store
+    S->>A: /v1/get-recipes
+    A-->>C: fill PublicRecipes / UserRecipes / SharedRecipes / RecipesUsage
+    S->>A: /v1/get-panel-templates
+    A-->>C: fill PanelTemplates
+    S->>A: /v2/get-document-lists
+    A-->>C: fill DocumentListsMetadata + DocumentLists
+    S->>D: SyncFromCache writes all of it, row_source=api
+```
+
+---
+
+## Implementation Units
+
+### U1. Store readers for recipes and chat threads
+
+**Goal.** Give the read seam the ability to serve recipes, recipe usage, chat threads and chat messages from SQLite.
+
+**Requirements.** R1, R2.
+
+**Dependencies.** None.
+
+**Files.**
+- `library/productivity/granola/internal/cli/granola_helpers.go`
+- `library/productivity/granola/internal/cli/granola_read_test.go`
+
+**Approach.**
+
+1. Add store-backed accessors to the `granolaRead` view mirroring the existing `Folders()` / `FolderMeetings()` shape: recipes with their usage, and chat threads with their messages.
+2. Merge with the same precedence the folder accessors use — cache entries first, store rows overwriting only non-empty fields — so a readable-cache install keeps the richer cache values (notably `RecipeConfig.Instructions`, which the store does not carry).
+3. Preserve the derived fields `LoadCache` stamps: `Recipe.Source` (`public`/`user`/`shared`) and `Recipe.Name` defaulting to `Slug`. Store rows must arrive with these already populated or the readers must recompute them. Panel templates need no reader here — nothing reads them — so their slug derivation belongs to U4's write path, not this unit.
+4. Convert `recipes_usage.total_count` on read: the column is `INTEGER` while `RecipeUsage.TotalCount` is a string that both consumers parse with `Sscanf` (KTD5).
+
+**Patterns to follow.** `granola_helpers.go`, but note the two precedents differ and this unit needs both. `Folders()` does a field-level merge where store values overwrite only non-empty fields — use that for recipes, so cache-only fields like `Config.Instructions` survive. `FolderMeetings()` does an all-or-nothing fallback where an empty store result defers to the cache — use that for chat threads and messages, which have no field-level merge to do.
+
+**Test scenarios.**
+- With rows in the store and no readable cache, the recipes accessor returns them with `Source` and `Name` populated.
+- With both a readable cache and store rows, cache-only fields (`Config.Instructions`) survive the merge rather than being blanked by the store row.
+- A store row with an empty title does not overwrite a non-empty cache title.
+- With neither source, the accessors return empty slices, not nil-pointer panics.
+- Chat messages come back ordered by turn index for a given thread.
+- A chat thread whose messages are absent returns the thread with an empty message list rather than an error.
+
+**Verification.** `go test ./internal/cli/ -run 'GranolaRead|Recipes|Chat'` passes, and the accessors return data from a store-only fixture.
+
+---
+
+### U2. Route the four cache-only commands through the read seam
+
+**Goal.** Stop `recipes` and `chat` erroring on an unreadable cache.
+
+**Requirements.** R1, R2, R6.
+
+**Dependencies.** U1.
+
+**Files.**
+- `library/productivity/granola/internal/cli/recipes.go`
+- `library/productivity/granola/internal/cli/chat.go`
+- `library/productivity/granola/internal/cli/granola_read_test.go` (retire two allowlist entries)
+- `library/productivity/granola/internal/cli/recipes_test.go`
+- `library/productivity/granola/internal/cli/chat_test.go`
+
+**Approach.**
+
+1. Replace `openGranolaCache()` with `openGranolaRead(cmd.Context())` at `recipes.go:37`, `recipes.go:124`, `chat.go:34` and `chat.go:101`.
+2. Re-point the bodies at the U1 accessors instead of `c.RecipesAll()` and the cache's chat maps.
+3. Keep the existing not-found semantics: `recipes describe` on an unknown slug still returns `notFoundErr`, and must not degrade into an empty success.
+4. Preserve `--top-usage` ordering, which reads `RecipeUsage.TotalCount` through `Sscanf` (KTD5).
+5. Retire the `chat.go` and `recipes.go` entries from the `cacheOnlyCallSites` allowlist in `granola_read_test.go`. That test fails on a stale entry as well as a missing one, so leaving them makes `go test ./...` fail the moment this unit lands. The allowlist's own comment sets the bar — an entry means "the data simply is not in the store" — which stops being true once U1 builds the readers.
+6. Surface the store's last-sync timestamp on `recipes list`, `recipes describe` and `chat list` when serving from the store (R6). This ships in the same unit that removes the hard error, so no release ever trades a loud failure for an undated one.
+7. Disclose the chat staleness boundary per R6. On an install where the cache is unreadable, `chat list` reports the newest thread timestamp it holds and states that threads cannot be refreshed — chats have no API endpoint, so the set is frozen wherever the last cache sync left it. Carry the same field in the JSON envelope so an agent consuming the output can tell a frozen set from a current one.
+
+**Execution note.** Write the migrated-install test first: with a store fixture and a deliberately unreadable cache, `recipes list` should return rows. That assertion is the unit's whole point and fails against the current code.
+
+**Test scenarios.**
+- Cache unreadable, store populated: `recipes list` returns the store's recipes and exits zero.
+- Cache unreadable, store populated: `chat list` returns threads and exits zero.
+- Cache unreadable, store empty: both return an empty result and exit zero, not an error.
+- `recipes describe` with an unknown slug still returns not-found.
+- `recipes describe` with a known slug returns the recipe, including instructions when a cache is readable.
+- `recipes list --top-usage` orders by usage count, and a string count of `"12"` sorts above `"3"` rather than lexically.
+- `chat list` anchored to a meeting id filters to that meeting's threads.
+- Cache unreadable, store populated: `chat get` on a known thread id returns its messages and exits zero.
+- Cache unreadable: `recipes list`, `recipes describe` and `chat list` each report the store's last-sync timestamp.
+- Cache unreadable: `chat list` reports the newest thread timestamp it holds and states the set cannot be refreshed.
+- The `cacheOnlyCallSites` allowlist no longer names `chat.go` or `recipes.go`, and `TestOpenGranolaCacheCallSites_AllAccountedFor` passes.
+- With no database at all, the commands still return the existing no-local-data error rather than an empty success — the store-empty case above assumes a database that exists with zero rows.
+- The same staleness field appears in the JSON envelope, not only in human output.
+- Readable-cache install: output is unchanged from current behavior, including no staleness notice.
+
+**Verification.** All four commands succeed against a store-only fixture; `go test ./internal/cli/ -run 'Recipes|Chat'` passes.
+
+---
+
+### U3. Provenance columns on the four unmarked tables
+
+**Goal.** Let API-written and cache-written rows be told apart before any API writer exists.
+
+**Requirements.** R4, R7.
+
+**Dependencies.** None technically; land after U2 and before U4 per KD1.
+
+**Files.**
+- `library/productivity/granola/internal/granola/store_sync.go`
+- `library/productivity/granola/internal/granola/store_sync_test.go`
+- `library/productivity/granola/internal/store/store.go` (`StoreSchemaVersion` 3 to 4)
+- `library/productivity/granola/internal/store/schema_version_test.go`
+
+**Approach.**
+
+1. Add `row_source TEXT NOT NULL DEFAULT 'cache'` to `folders`, `panel_templates`, `recipes` and `recipes_usage` via `granolaAddedColumns`, alongside the existing four entries.
+2. Add the folder metadata columns the write path currently drops and `folder list` reports empty: description and favourite flag.
+3. Add an origin field to `SyncOptions` defaulting to `RowSourceCache` and thread it through the four catalog writes, rather than hard-coding a literal at each one (KTD7). U4 has no seam to hook into otherwise.
+4. Stamp the existing `upsertAPIMemberships` folder insert (`store_sync.go:952`) with API ownership. That path already creates folder rows today, so without this the very first backfill mislabels them (KTD2).
+5. Convert the four catalog writes from `INSERT OR REPLACE` to `ON CONFLICT(<pk>) DO UPDATE`, with `row_source` excluded from the SET list so the creating path keeps ownership (KTD7). Follow the `meetings` upsert, which solved this exact problem.
+6. Bump `StoreSchemaVersion` to 4 and extend its comment with this round's reason, following the existing entry's shape (KTD6). This is what stops an older binary from silently reassigning API-owned rows to the cache path through an `INSERT OR REPLACE` that omits the new column.
+
+**Approach note.** Do not add retirement DELETEs to these tables in this unit — an unscoped clear is precisely the failure the prior plan's P0 was about. Steps 3 through 5 are not additive and are the reason this unit must land before U4: without them U4's writes blank columns and rewrite ownership.
+
+**Patterns to follow.** `granolaAddedColumns` in `store_sync.go` and its comment explaining why `DEFAULT 'cache'` is historically correct rather than a guess.
+
+**Test scenarios.**
+- A database created by an older binary gains the columns on `EnsureSchema` without data loss.
+- Pre-existing rows read back as `row_source = 'cache'`.
+- `EnsureSchema` run twice is a no-op the second time.
+- A cache sync writes `folders` rows carrying description and favourite flag rather than empty strings.
+- No DELETE executes against these four tables on any sync path.
+- A database stamped at version 4 is refused by a binary compiled at version 3, with the existing upgrade-the-binary message.
+- A folder row created by the API membership path reads back as API-owned, not the cache default.
+- A catalog upsert of a row that already exists leaves its `row_source` unchanged and does not blank columns the incoming payload omits.
+- A fresh database is stamped 4, and a version-3 database migrates to 4 in place.
+
+**Verification.** `go test ./internal/granola/ -run 'Schema|Migrat'` passes; a v3 database opens and migrates cleanly.
+
+---
+
+### U4. Refresh recipes, panel templates and folders from the internal API
+
+**Goal.** Keep the store current on a degraded sync instead of frozen at the last cache sync.
+
+**Requirements.** R3, R4, R7.
+
+**Dependencies.** U3.
+
+**Files.**
+- `library/productivity/granola/internal/granola/api_catalog.go` (new)
+- `library/productivity/granola/internal/granola/api_catalog_test.go` (new)
+- `library/productivity/granola/internal/granola/internalapi.go`
+- `library/productivity/granola/internal/granola/store_sync.go`
+- `library/productivity/granola/internal/cli/sync_cache.go`
+
+**Approach.**
+
+1. Add internal-API methods for `/v1/get-recipes` and `/v1/get-panel-templates`, following `GetDocumentLists`'s shape-tolerant parsing.
+2. Add a `Documents` field to `DocumentListMetadata` so `/v2/get-document-lists` yields membership edges in the same call (KTD4), and populate `cache.DocumentLists` from it.
+3. Write a hydrator that fills `cache.PublicRecipes`, `cache.UserRecipes`, `cache.SharedRecipes`, `cache.RecipesUsage`, `cache.PanelTemplates`, `cache.DocumentListsMetadata` and `cache.DocumentLists`, then lets the existing `SyncFromCache` loops persist them — the same "hydrator writes nothing itself" rule the transcript hydrator follows.
+4. Replicate the cache-load derivations the API response lacks: `Recipe.Source` per bucket, `Recipe.Name` from `Slug`, `PanelTemplate.Slug` from `slugify(Title)`, and `RecipeUsage.TotalCount` as a string (KTD5).
+5. Call it from `runCacheSync` on the degraded path, alongside the transcript hydrate, setting the `SyncOptions` origin field U3 added to API ownership (KTD7).
+
+**Approach note.** No budget or fetch-state table (KTD3). Each surface is one call for the whole set.
+
+**Test scenarios.**
+- A recipes response fills all three recipe buckets and usage, with `Source` stamped per bucket.
+- `RecipeUsage.TotalCount` arrives as a string, and `recipes list --top-usage` orders correctly against it.
+- A panel-template response with a blank slug gets one derived from the title.
+- A document-lists response populates both folder metadata and membership edges from the single call.
+- A folder present in the API response but absent from the store is inserted; one present in both keeps its cache-supplied `parent_id` and `preset` rather than being blanked.
+- Rows written by this path carry API ownership, and pre-existing cache rows keep theirs.
+- A 401 from any of the three calls surfaces as a non-fatal warning and leaves the rest of the sync intact.
+- An unrecognized response shape returns a typed error naming the endpoint rather than panicking.
+- A healthy-cache sync does not invoke this hydrator.
+
+**Verification.** `go test ./internal/granola/ -run 'Catalog|Recipes|PanelTemplate'` passes. On a migrated install, `sync` followed by `recipes list` shows recipes with non-zero usage counts.
+
+---
+
+### U5. Correct the capability documentation and record the patches
+
+**Goal.** Stop the docs implying that chats are a pending fix and that recipes are unreachable.
+
+**Requirements.** R5.
+
+**Dependencies.** U2 for the read-path wording (step 3), U4 for the refresh-tier wording.
+
+**Files.**
+- `library/productivity/granola/SKILL.md`
+- `library/productivity/granola/README.md`
+- `library/productivity/granola/.printing-press-patches/read-path-store-first-for-recipes-and-chats.json` (new)
+- `library/productivity/granola/.printing-press-patches/catalog-surfaces-hydrate-without-budget.json` (new)
+- `library/productivity/granola/NOTICE`
+- `library/productivity/granola/.printing-press.json`
+
+**Approach.**
+
+1. Rewrite the capability split. The shipped list has four bullets under "unavailable on a migrated install": panels, recipes and panel templates, chats, and workspaces. Three of those four are wrong. Recipes, panel templates and folders are available and refreshable; panels and workspaces already work live; only chats are genuinely unrefreshable, and they are still readable from the store.
+2. State that `panel get` and `workspaces list` work against a live CLI session, and that `panel get` is the one read command with no local fallback — a lapsed session makes it fail hard rather than degrade.
+3. Land the read-path half of this rewrite with U2 rather than waiting on U4. U2 alone changes what these commands do, and KD1 explicitly sanctions shipping it without the refresh work; docs that still say "unavailable" while the command returns rows are worse than the original error.
+4. Record two reprint guards at reprint-guard altitude: that read commands must use the store-first seam rather than the cache-only loader, and that single-call catalog surfaces deliberately carry no budget machinery unlike the per-document ones.
+5. Confirm the contributor entry is present across manifest, README byline and NOTICE. This CLI has a recorded history of manifest-only contributor adds leaving the byline and NOTICE stale.
+
+**Test scenarios.** `Test expectation: none -- documentation and metadata; correctness is enforced by the verifier in the Verification Contract.`
+
+**Verification.** `verify_skill.py` passes; no generated artifact appears in the diff.
+
+---
+
+## Verification Contract
+
+From `library/productivity/granola/`:
+
+```
+go build ./...
+go vet ./...
+go test ./...
+govulncheck ./...
+```
+
+From the repo root:
+
+```
+python3 .github/scripts/verify-skill/verify_skill.py --dir library/productivity/granola/
+```
+
+End to end on a migrated install, which is the acceptance case:
+
+1. `recipes list` returns recipes instead of a decrypt error.
+2. `chat list` returns threads instead of a decrypt error.
+3. `recipes describe <slug>` returns a known recipe.
+4. `sync` refreshes recipes and panel templates, and `recipes list --top-usage` shows non-zero counts.
+5. `folder list` reports a non-empty description and favourite flag for a folder that has them (U3's columns), and a non-zero meeting count for a folder with members (U4's membership edges).
+6. `panel get` still works, unchanged.
+7. A database written by the previous binary opens and migrates without data loss.
+
+## Definition of Done
+
+- R1-R5 satisfied, each traceable to a unit.
+- The four `openGranolaCache()` call sites in `recipes.go` and `chat.go` are gone.
+- Every pre-existing test passes, apart from the two `cacheOnlyCallSites` allowlist entries U2 retires — that test fails on a stale entry by design, so retiring them is the intended outcome, not a weakened assertion.
+- No DELETE was added to `folders`, `panel_templates`, `recipes` or `recipes_usage`.
+- Two patch files recorded; no generated artifact in the diff.
+
+## Open Questions
+
+- **Confirm-or-override before U4 ships:** U4 already implements the conservative default — cache-supplied `parent_id` and `preset` are preserved, following `upsertAPIMemberships` — and asserts it in its test scenarios. The open decision is only whether to override that default, since the API response now carries those fields and preserving them discards real data. It does not block U4; it decides whether one test scenario inverts.
+- **Deferred:** whether the top-level `folders` command should reroute off the public REST API. It changes behavior for key-holding users, so it is not a silent fix.
+- **Deferred:** whether to persist panel content. Needs a new table and a per-document backfill with its own budget and fetch-state, for a command that already works live (KD2). U3 already carries the schema-version bump, so that is no longer a reason to defer.
+
+## Sources & Research
+
+- `docs/plans/2026-08-03-001-fix-granola-cli-owned-auth-plan.md` — the prior plan; this work is its deferred follow-up.
+- Live probes against Granola 7.465.0 with a CLI-owned session, 2026-08-03, recorded in the Evidence table.
+- `library/productivity/granola/internal/granola/api_transcripts.go` — the hydrator pattern U4 follows, and the budget machinery KTD3 deliberately omits.

--- a/library/productivity/granola/.printing-press-patches/api-catalog-refresh.json
+++ b/library/productivity/granola/.printing-press-patches/api-catalog-refresh.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "api-catalog-refresh",
+  "applied_at": "2026-08-03",
+  "base_run_id": "20260511-211333",
+  "base_printing_press_version": "4.4.0",
+  "summary": "Recipes, panel templates and folders are refreshed over the internal API on the degraded path, staged into the Cache so one write path persists them, and stamped as API-owned.",
+  "reason": "On an install whose desktop cache can never be decrypted again, every catalog surface was frozen at the last successful decrypt while still answering as though it were current -- a folder or recipe created since then simply did not exist. Each of these surfaces is a single call for the whole set, so unlike transcripts there is deliberately no budget, no fetch-state table and no resume; a regen must not add that machinery here. The API payload lacks derivations the cache reader applies, and a regen has to keep replaying them: the recipe's Source is the bucket it came out of, its Name falls back to the slug, a blank panel-template slug is derived from the title, and the usage counter must be stored as decimal digits because every consumer reads it with Sscanf. Folder membership arrives inline on each document list, which is why the folder metadata type carries it and why its unmarshaler is written to never fail -- a custom unmarshaler's error aborts the whole cache decode rather than being accumulated.",
+  "validated_outcome": "Mutation checks confirm the guards bite: dropping the source stamp, the slug fallback, the counter stringification, the document_id preference, the degraded guard on the hydrate call, the CatalogOwner assignment, or narrowing the document-list fallback back to any 4xx each turns a test red.",
+  "files": [
+    "internal/granola/api_catalog.go",
+    "internal/granola/internalapi.go",
+    "internal/granola/cache.go",
+    "internal/cli/sync_cache.go"
+  ]
+}

--- a/library/productivity/granola/.printing-press-patches/api-sync-survives-unreadable-cache.json
+++ b/library/productivity/granola/.printing-press-patches/api-sync-survives-unreadable-cache.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "api-sync-survives-unreadable-cache",
+  "applied_at": "2026-08-03",
+  "base_run_id": "20260511-211333",
+  "base_printing_press_version": "4.4.0",
+  "summary": "An unreadable desktop cache degrades the sync run instead of ending it, and a degraded run must never retire its own rows.",
+  "reason": "The document-fetch path uses the cache only as a destination for the documents it pulls from the API, so it has no real dependency on decrypted content. Aborting on cache-open therefore stranded the one path that still works on a migrated install. Degrading naively is worse than aborting, though: SyncFromCache reads an absent cache-derived row as deleted-upstream and retires it, so an empty cache would clear every cache-owned folder membership and every cache-owned transcript for each meeting the API returned -- rows that can never be re-synced once the key is out of reach. Degraded mode is upsert-only. Degradation is also gated on a classified migration, so a plain key-unavailable error keeps its working remedy instead of hiding behind a silently thinner sync.",
+  "validated_outcome": "Against a real 992-meeting store: a degraded run added 95 meetings while leaving 5385 cache-owned transcript segments and 153 cache-owned folder memberships untouched. The paired healthy-sync test asserts the retirement still happens when the cache is genuinely readable.",
+  "files": [
+    "internal/granola/store_sync.go",
+    "internal/cli/sync_cache.go",
+    "internal/cli/autorefresh.go"
+  ]
+}

--- a/library/productivity/granola/.printing-press-patches/api-transcript-hydrate.json
+++ b/library/productivity/granola/.printing-press-patches/api-transcript-hydrate.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "api-transcript-hydrate",
+  "applied_at": "2026-08-03",
+  "base_run_id": "20260511-211333",
+  "base_printing_press_version": "4.4.0",
+  "summary": "Transcripts are fetched per-document over the internal API on the degraded path, and the work must be bounded, resumable, and stamped as API-owned.",
+  "reason": "Documents alone leave every transcript-dependent command returning empty on a migrated install, which reads as 'you had no transcripts' rather than 'these were never synced'. The transcript endpoint accepts a CLI-owned session, but there is no bulk form: a backfill is one rate-limited call per meeting, so a regen must keep the per-run budget, the newest-first ordering, and the fetch-state table that stops the CLI re-asking about meetings which genuinely have no recording. These transcripts must be written with API row ownership, not cache ownership, or the cross-source retention check compares against a phantom cache copy and can block a later genuine refresh.",
+  "validated_outcome": "A 40-document budget pulled 39 transcripts and 15773 segments against a live account, reported 923 remaining, and resumed correctly on the next run.",
+  "files": [
+    "internal/granola/api_transcripts.go",
+    "internal/granola/store_sync.go",
+    "internal/cli/sync_cache.go"
+  ]
+}

--- a/library/productivity/granola/.printing-press-patches/catalog-provenance-and-merge.json
+++ b/library/productivity/granola/.printing-press-patches/catalog-provenance-and-merge.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "catalog-provenance-and-merge",
+  "applied_at": "2026-08-03",
+  "base_run_id": "20260511-211333",
+  "base_printing_press_version": "4.4.0",
+  "summary": "The catalog tables carry row ownership and merge on conflict; they must never be written with INSERT OR REPLACE.",
+  "reason": "folders, panel_templates, recipes and recipes_usage are written by both the cache path and the API path. SQLite's REPLACE deletes the row and reinserts it, so every column the incoming payload omits is blanked and the ownership marker is rewritten by whichever path wrote last -- on a degraded sync that silently reassigns every cache-owned row to the API. The writes therefore merge with ON CONFLICT DO UPDATE, coalescing each column against the stored value and deliberately leaving row_source out of the SET list so the creating path keeps ownership. A boolean cannot be coalesced that way, so the folder favourite flag is owner-scoped instead: the owning path may clear it, a foreign path may not. Adding an ownership column to these tables changes table shape and requires a StoreSchemaVersion bump, or a pre-bump binary's write reverts rows to the column default.",
+  "validated_outcome": "A no-DELETE guard using BEFORE DELETE triggers with recursive_triggers on proves REPLACE is gone: it fires on the pre-change code and stays silent across healthy, degraded and API syncs run twice each.",
+  "files": [
+    "internal/granola/store_sync.go",
+    "internal/cli/granola_helpers.go",
+    "internal/store/store.go"
+  ]
+}

--- a/library/productivity/granola/.printing-press-patches/cli-owned-workos-session.json
+++ b/library/productivity/granola/.printing-press-patches/cli-owned-workos-session.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "id": "cli-owned-workos-session",
+  "applied_at": "2026-08-03",
+  "base_run_id": "20260511-211333",
+  "base_printing_press_version": "4.4.0",
+  "summary": "The CLI holds its own Granola session obtained through the device authorization grant; it must never borrow another client's token chain.",
+  "reason": "Every credential on the machine belongs to someone else. Granola's data-encryption key moved into an entitlement-gated Keychain group, so the desktop's live token in supabase.json.enc is unreadable, and the plaintext files it used to leave behind stopped being written. What remains are the desktop app's and the browser's own chains, and the WorkOS refresh endpoint is single-use: refreshing one signs that client out mid-session. A regen must therefore keep a CLI-owned session as the primary auth path and keep the D6 refusal intact for every desktop-owned source.",
+  "validated_outcome": "Device grant verified live against Granola 7.465.0: it returns a refreshable session accepted by /v2/get-documents and by the transcript, panel and document-list endpoints. Granola's own proxy /v1/refresh-access-token renews it and was observed returning the same refresh token rather than a rotated one; the CLI persists whatever comes back regardless, because the WorkOS endpoint behind it is single-use.",
+  "files": [
+    "internal/granola/clisession.go",
+    "internal/granola/clisession_unix.go",
+    "internal/granola/clisession_windows.go",
+    "internal/granola/deviceauth.go",
+    "internal/granola/workos.go",
+    "internal/cli/auth_login.go",
+    "internal/cli/auth.go"
+  ]
+}

--- a/library/productivity/granola/.printing-press-patches/device-grant-flow-is-a-moving-target.json
+++ b/library/productivity/granola/.printing-press-patches/device-grant-flow-is-a-moving-target.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "device-grant-flow-is-a-moving-target",
+  "applied_at": "2026-08-03",
+  "base_run_id": "20260511-211333",
+  "base_printing_press_version": "4.4.0",
+  "summary": "The device-grant endpoints, client id and verification host are an unofficial dependency; triage auth login failures as upstream drift before treating them as a CLI regression.",
+  "reason": "Granola closed three separate third-party access routes in roughly three months -- the DEK moved behind an entitlement, the local store went SQLCipher, and the plaintext auth files stopped being written. The device grant the CLI now depends on is minted through a Granola auth surface not issued to this CLI, so it belongs in the same moving-target category as the client-version header. A regen must re-verify the endpoints and the grant's scope against the live service rather than trusting the recorded contract, and should expect revocation or re-scoping to be a live possibility rather than a bug.",
+  "upstream_issue": "",
+  "files": []
+}

--- a/library/productivity/granola/.printing-press-patches/dual-path-store-read.json
+++ b/library/productivity/granola/.printing-press-patches/dual-path-store-read.json
@@ -7,6 +7,8 @@
   "files": [
     "internal/cli/granola_helpers.go",
     "internal/cli/attendee.go",
+    "internal/cli/chat.go",
+    "internal/cli/recipes.go",
     "internal/cli/calendar.go",
     "internal/cli/collect.go",
     "internal/cli/duplicates.go",
@@ -25,9 +27,10 @@
     "internal/cli/transcript.go",
     "internal/cli/extract_test.go",
     "internal/cli/memo_test.go",
-    "internal/cli/granola_read_test.go"
+    "internal/cli/granola_read_test.go",
+    "internal/cli/recipes_chat_store_test.go"
   ],
-  "summary": "Read commands must not be wired to a single data path. They go through a read seam that serves the local store first and falls back to the desktop cache only when the store has no row and a cache is actually readable; documents merge field by field so a legacy install keeps the values only the cache carries. Neither step makes a network call or consults an API key, so whatever has already been synced stays readable offline and by either sync path. A command whose live fallback authenticates with the desktop credential must skip that fallback once the cache has proved unreadable, since the same credential is what the key migration invalidated and the call can only produce the refusal. State that genuinely exists nowhere but the cache — chat threads, recipes, workspaces, and AI panel content — stays on its own path and is honestly unavailable on a migrated install rather than faked.",
+  "summary": "Read commands must not be wired to a single data path. They go through a read seam that serves the local store first and falls back to the desktop cache only when the store has no row and a cache is actually readable; documents merge field by field so a legacy install keeps the values only the cache carries. Neither step makes a network call or consults an API key, so whatever has already been synced stays readable offline and by either sync path. A command whose live fallback authenticates with the desktop credential must skip that fallback once the cache has proved unreadable, since the same credential is what the key migration invalidated and the call can only produce the refusal. \"Cache-only\" is a claim about where the bytes are at read time, not about where they came from: state the cache sync already copied into the store — recipes, recipe usage, chat threads, chat messages — is store data and must be served, while state that exists nowhere but the cache (AI panel content, workspaces) stays on its own path and is honestly unavailable on a migrated install rather than faked. Data served from the store on an install whose cache is unreadable must disclose how current it is — the last-sync timestamp, and whether any code path can advance it at all — in the machine-readable envelope and not only in prose, because a consumer cannot otherwise tell a frozen set from a live one. That disclosure is absent when the cache is readable, since that path is not frozen.",
   "reason": "After the key migration the desktop cache is permanently undecryptable, so every command that opened it directly was unreachable even though sync-api had already written the same rows to disk. A test walks the AST for every direct cache call site and fails in both directions — an un-rerouted call site, or a stale allowlist entry — so the cache-only classification states a real data fact instead of recording a reroute that was skipped.",
   "validated_outcome": "transcript get returns all 564 segments of a post-migration meeting with byte-identical output with and without an API key set, and talktime reports non-zero microphone and system seconds from the same rows."
 }

--- a/library/productivity/granola/.printing-press-patches/granola-local-store-is-sqlcipher.json
+++ b/library/productivity/granola/.printing-press-patches/granola-local-store-is-sqlcipher.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 2,
+  "id": "granola-local-store-is-sqlcipher",
+  "applied_at": "2026-08-03",
+  "base_run_id": "20260511-211333",
+  "base_printing_press_version": "4.4.0",
+  "summary": "granola.db is a SQLCipher database keyed with the same entitlement-gated DEK; a regen must not attempt to read it.",
+  "reason": "Granola moved its local store out of cache-v6.json.enc and into granola.db. The bundle depends on better-sqlite3-multiple-ciphers and opens the file with cipher=sqlcipher, legacy=4 and a raw hex key, and the failure path logs that the key is the DEK. On disk the file carries no SQLite magic while its -wal sidecar keeps a plaintext WAL header, which is the SQLCipher signature. So this is a second door closed by the same lock, not a new opening: chasing it wastes a reprint's effort and adds a dependency that can never work for a third-party binary.",
+  "files": []
+}

--- a/library/productivity/granola/.printing-press-patches/logout-beats-a-concurrent-rotation.json
+++ b/library/productivity/granola/.printing-press-patches/logout-beats-a-concurrent-rotation.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "logout-beats-a-concurrent-rotation",
+  "applied_at": "2026-08-04",
+  "base_run_id": "granola-20260607-01",
+  "base_printing_press_version": "0.61.0",
+  "summary": "Every CLI invocation is its own process, so an in-process mutex cannot order logout against a token rotation. Deletion and publication must be ordered by durable on-disk state, not by a check performed before the write.",
+  "reason": "A logout landing between the rotation's existence check and its atomic rename let the rename recreate the credential after logout had already reported success. Ordering it lock-free requires the revocation be recorded before the session is removed, and re-read after the replacement is published, so either the rotation deletes what it wrote or the logout deletes the rotated file.",
+  "validated_outcome": "Mutation-verified: disabling the post-publish epoch check makes the raced-logout test report success with the session resurrected. The unraced and earlier-logout cases assert the check does not delete healthy rotations.",
+  "files": [
+    "internal/granola/clisession.go",
+    "internal/granola/workos.go"
+  ]
+}

--- a/library/productivity/granola/.printing-press-patches/logout-must-clear-every-credential-it-claims.json
+++ b/library/productivity/granola/.printing-press-patches/logout-must-clear-every-credential-it-claims.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "logout-must-clear-every-credential-it-claims",
+  "applied_at": "2026-08-04",
+  "base_run_id": "granola-20260607-01",
+  "base_printing_press_version": "0.61.0",
+  "summary": "When a CLI holds more than one kind of credential, logout must clear each one it reports clearing. The generated logout clears only the config token, so any hand-added credential store has to be wired in explicitly.",
+  "reason": "The CLI-owned WorkOS session was a second credential the generated logout never touched: it printed 'Credentials cleared' while a live access and refresh token stayed on disk, auth status still showed the account signed in, and background refresh kept renewing it. A regen restores the single-credential logout and silently reopens this.",
+  "validated_outcome": "TestAuthLogoutClearsCLISession asserts the session file is gone and HasCLISession is false after the command returns.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/cli/auth_logout_test.go"
+  ]
+}

--- a/library/productivity/granola/.printing-press-patches/read-path-store-first-for-recipes-and-chats.json
+++ b/library/productivity/granola/.printing-press-patches/read-path-store-first-for-recipes-and-chats.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "read-path-store-first-for-recipes-and-chats",
+  "applied_at": "2026-08-03",
+  "base_run_id": "20260511-211333",
+  "base_printing_press_version": "4.4.0",
+  "summary": "Every read command serves store-first; a command that abandons the store on an unreadable cache is a bug, and one that serves stale rows must date them by the clock that actually governs them.",
+  "reason": "Recipes and chats aborted on a cache decrypt that can never succeed post-migration while the store already held their rows, because those call sites were never moved onto the store-first seam. The allowlist guarding that seam fails on a stale entry as well as a missing one, so retiring a surface means retiring its entry too. Removing a loud error is only half the fix: the replacement must not be a silently frozen answer, so store-served reads carry a staleness block. Which clock dates it is load-bearing and easy to get wrong -- the general sync timestamp advances on every invocation because auto-refresh runs an API sync each time, so using it would stamp months-old rows as current. Refreshable surfaces are dated by the catalog refresh, frozen ones by the last successful cache decrypt, and a degraded run must not advance the cache clock.",
+  "validated_outcome": "On a migrated install recipes list returns 57 recipes dated by the API refresh, and chat list returns 225 threads reported as unrefreshable -- both previously hard errors.",
+  "files": [
+    "internal/cli/recipes.go",
+    "internal/cli/chat.go",
+    "internal/cli/granola_helpers.go",
+    "internal/granola/syncstate.go"
+  ]
+}

--- a/library/productivity/granola/.printing-press-patches/rotation-marker-means-started-not-broken.json
+++ b/library/productivity/granola/.printing-press-patches/rotation-marker-means-started-not-broken.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "rotation-marker-means-started-not-broken",
+  "applied_at": "2026-08-04",
+  "base_run_id": "granola-20260607-01",
+  "base_printing_press_version": "0.61.0",
+  "summary": "A single-use refresh chain needs an exclusion marker, and that marker records that a rotation started -- which is either one running now or one that died. Only the second is a fault, so liveness must be judged (staleness/ownership), never inferred from presence alone.",
+  "reason": "Treating any marker as breakage made every concurrent command fail with 'run auth login' while a healthy refresh was in flight, and pointed the user at the one command that then deleted the in-flight marker and allowed a double exchange. A regen that reintroduces presence-equals-broken, or an ownership-blind marker delete on save, recreates both.",
+  "validated_outcome": "Mutation-verified: the durability-refusal test fails against code with the refusal removed, and a concurrent save no longer clears a live rotation's marker. go test -race clean.",
+  "files": [
+    "internal/granola/clisession.go",
+    "internal/granola/workos.go",
+    "internal/cli/auth.go"
+  ]
+}

--- a/library/productivity/granola/README.md
+++ b/library/productivity/granola/README.md
@@ -138,7 +138,11 @@ Three paths fill the local SQLite store:
 
 ### Capability split
 
-With a CLI-owned session, hydrated by `sync`: meetings, titles, timestamps, attendees, calendar events. Transcripts, folders, panels, recipes and chats are not hydrated on this tier yet, so transcript-dependent commands (`talktime`, `memo run`, `attendee brief`, `collect`, `folder stream`) return empty until they are.
+With a CLI-owned session, hydrated by `sync`: meetings, titles, timestamps, attendees, calendar events, and transcripts.
+
+Transcripts backfill incrementally, because there is no bulk transcript endpoint — `sync` pulls them one meeting at a time, newest first, up to `--transcript-budget` (default 250) per run. It reports how many remain; re-run to continue, or use `--transcript-budget -1` for all of them. Meetings with no recording are asked about once and then skipped permanently. A non-zero `transcripts_remaining` means "not fetched yet", not "no transcript exists".
+
+Folders and folder membership, panels, recipes and chats are not hydrated on this tier.
 
 With a `GRANOLA_API_KEY`, hydrated by `sync-api`: all of the above plus transcripts, note summaries (`summary_markdown`), folders and folder membership.
 

--- a/library/productivity/granola/README.md
+++ b/library/productivity/granola/README.md
@@ -142,11 +142,13 @@ With a CLI-owned session, hydrated by `sync`: meetings, titles, timestamps, atte
 
 Transcripts backfill incrementally, because there is no bulk transcript endpoint — `sync` pulls them one meeting at a time, newest first, up to `--transcript-budget` (default 250) per run. It reports how many remain; re-run to continue, or use `--transcript-budget -1` for all of them. Meetings with no recording are asked about once and then skipped permanently. A non-zero `transcripts_remaining` means "not fetched yet", not "no transcript exists".
 
-Folders and folder membership, panels, recipes and chats are not hydrated on this tier.
+Recipes, panel templates, folders and folder membership hydrate on this tier too — each is a single API call, refreshed on every degraded `sync`.
 
-With a `GRANOLA_API_KEY`, hydrated by `sync-api`: all of the above plus transcripts, note summaries (`summary_markdown`), folders and folder membership.
+With a `GRANOLA_API_KEY`, hydrated by `sync-api`: all of the above plus note summaries (`summary_markdown`).
 
-Cache-only, and therefore unavailable on a migrated install regardless of credential: AI panels (`panel get`, and the `--panel` inlining in `attendee brief` and `folder stream`), recipes and panel templates, AI chat threads, and workspaces.
+Live on the same session, needing no sync: AI panels (`panel get`, and the `--panel` inlining in `attendee brief` and `folder stream`) and workspaces (`workspaces list`). Both read from the API on each call. Note `panel get` has no local fallback, so a lapsed session breaks it where other commands degrade to stored data.
+
+Frozen but readable: AI chat threads (`chat list`, `chat get`). Granola exposes no chat endpoint, so those threads are whatever the last desktop-cache sync captured and no re-sync adds more. Store-served reads carry a `staleness` block saying whether a surface can advance and when it was last refreshed.
 
 ## Authentication
 

--- a/library/productivity/granola/README.md
+++ b/library/productivity/granola/README.md
@@ -122,24 +122,41 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 ## Two Data Paths
 
-Granola desktop now keeps its data-encryption key in a macOS data-protection keychain group gated by an entitlement bound to Granola's own Apple Team ID. No third-party binary can read that key, so on a current install the encrypted desktop cache (`cache-v6.json.enc`) and `granola.db` are permanently unreadable by this CLI — and so is `supabase.json.enc`, which takes the internal-API token path down with it.
+Granola desktop keeps its data-encryption key in a macOS data-protection keychain group gated by an entitlement bound to Granola's own Apple Team ID. No third-party binary can read that key, so the encrypted desktop cache (`cache-v6.json.enc`), the SQLCipher store `granola.db`, and `supabase.json.enc` are all unreadable by this CLI on a current install.
 
-Two paths fill the local SQLite store, and the CLI ships both:
+That does not leave the CLI without data. Run `granola-pp-cli auth login` once and the CLI signs in with a session of its own — no API key, no paid workspace. You approve one browser page; the session then refreshes silently on every later command.
+
+Three paths fill the local SQLite store:
 
 | Path | Hydrate with | Works on a current install? |
 |---|---|---|
-| Granola public REST API (`https://public-api.granola.ai`) → local store | `sync-api` | **Yes**, with a `GRANOLA_API_KEY`. |
-| Desktop encrypted cache → local store | `sync` | **No.** Fails with a migrated-scheme error. Still works on pre-migration Granola builds, and on a machine holding a pre-migration `storage.dek`. |
+| CLI-owned session → local store | `auth login`, then `sync` | **Yes.** The default answer. |
+| Granola public REST API (`https://public-api.granola.ai`) → local store | `sync-api` | **Yes**, but needs a `GRANOLA_API_KEY` (Business/Enterprise only). |
+| Desktop encrypted cache → local store | `sync` | **Only on pre-migration builds**, or with a pre-migration `storage.dek` supplied via `GRANOLA_SAFESTORAGE_KEY_OVERRIDE`. Otherwise `sync` runs degraded and says so. |
 
-**Reading already-synced data needs no API key at all.** Every read command serves from the local store first and falls back to the desktop cache only when the store has no row and a cache is actually readable. Neither step makes a network call or consults a key. The key is only needed to fetch *new* data.
+**Reading already-synced data needs no credential at all.** Every read command serves from the local store first and falls back to the desktop cache only when the store has no row and a cache is actually readable. Neither step makes a network call or consults a key.
 
 ### Capability split
 
-Available from the public API and hydrated by `sync-api`: meetings, titles, timestamps, attendees, calendar events, transcripts, note summaries (`summary_markdown`), folders and folder membership.
+With a CLI-owned session, hydrated by `sync`: meetings, titles, timestamps, attendees, calendar events. Transcripts, folders, panels, recipes and chats are not hydrated on this tier yet, so transcript-dependent commands (`talktime`, `memo run`, `attendee brief`, `collect`, `folder stream`) return empty until they are.
 
-Cache-only, and therefore **unavailable on a migrated install**: AI panels (`panel get`, and the `--panel` inlining in `attendee brief` and `folder stream`), recipes and panel templates, AI chat threads, and workspaces.
+With a `GRANOLA_API_KEY`, hydrated by `sync-api`: all of the above plus transcripts, note summaries (`summary_markdown`), folders and folder membership.
+
+Cache-only, and therefore unavailable on a migrated install regardless of credential: AI panels (`panel get`, and the `--panel` inlining in `attendee brief` and `folder stream`), recipes and panel templates, AI chat threads, and workspaces.
 
 ## Authentication
+
+### `auth login` (recommended)
+
+```bash
+granola-pp-cli auth login
+```
+
+Runs Granola's device authorization grant. A browser opens to a short approval page; approve it and the CLI stores its own session at `~/.local/share/granola-pp-cli/session.json`, mode `0600` in a `0700` directory. `auth status` shows the signed-in account, `auth logout` removes the local copy.
+
+The CLI keeps its own session rather than borrowing the desktop app's because there is nothing safe to borrow: the desktop's token is behind the entitlement-gated key, and the refresh tokens the desktop and your browser hold are single-use, so refreshing one would sign that client out. Note that `auth logout` deletes the local session only; it does not revoke the token upstream.
+
+### `GRANOLA_API_KEY` (Business/Enterprise)
 
 API keys are created in **Granola desktop → Settings → Connectors → API keys**. Creating one **requires a Business or Enterprise Granola workspace**; personal and free workspaces cannot issue keys. Two scopes exist, `personal-notes` and `public-notes` — pick the narrowest that covers the notes you need.
 

--- a/library/productivity/granola/README.md
+++ b/library/productivity/granola/README.md
@@ -406,7 +406,8 @@ Prefer the environment variable for `GRANOLA_API_KEY` over writing it into `conf
 
 - **`sync` fails naming an entitlement-gated keychain group** — This is the upstream Granola key migration, not a misconfiguration. No Keychain approval, re-sign-in, or re-run can recover the key. Set `GRANOLA_API_KEY` and hydrate with `sync-api` instead. Data already in the local store stays readable.
 - **doctor reports cache file not found** — Make sure Granola is installed and you’ve opened it at least once. Override the path with GRANOLA_CACHE_PATH=/custom/path/cache-v6.json. Not needed at all if you use the API path.
-- **`panel get` / `chat list` / `recipes list` / `workspaces list` return nothing** — Those four are cache-only and have no public-API source. On a migrated install they are unavailable; see the capability split above.
+- **`panel get` / `workspaces list` return nothing** — Those two are cache-only and have no public-API source. On a migrated install they are unavailable; see the capability split above.
+- **`recipes list` / `chat list` look out of date** — They serve what the last desktop-cache `sync` wrote to the local store, which is the only readable copy once the cache stops decrypting. Both report that sync's timestamp alongside the data, and `chat list` also reports that the thread set can never be refreshed: Granola's internal API exposes no chat endpoint.
 - **WorkOS token expired warning** — Open the Granola desktop app once — it refreshes the token. On a migrated install this path is gone entirely; use `GRANOLA_API_KEY` with `sync-api`.
 - **memo run --since reports duplicate_of** — A file with the same title-date-attendees fingerprint already exists in --to. Pick a different `--to` directory, remove the existing file, or `mv` it out of the way.
 - **Transcript missing for a recent meeting** — Granola hasn’t flushed it yet. Run warm <id> <q> --launch to bring it forward in the GUI, wait 30 s, then re-run preflight.

--- a/library/productivity/granola/SKILL.md
+++ b/library/productivity/granola/SKILL.md
@@ -70,23 +70,23 @@ Transcripts backfill incrementally. There is no bulk transcript endpoint, so `sy
 
 **This matters when answering questions.** Before telling a user a meeting has no transcript, check whether the backfill has reached it. `sync` reports `transcripts_remaining` in its summary; a non-zero value means "not fetched yet", not "no transcript exists". Commands that depend on transcripts (`talktime`, `memo run`, `attendee brief`, `collect`) will be thin until the backfill completes.
 
-Not hydrated on this tier: folders and folder membership, panels, recipes, chats.
+- recipes and panel templates — `recipes list`, `recipes describe`
+- folders and folder membership — `folder list`, `folder stream`
 
-**With a `GRANOLA_API_KEY`, hydrated by `sync-api`:**
-
-- everything above, plus transcripts (full segment list), note summaries (`summary_markdown`), folders and folder membership
-
-**Cache-only, and therefore unavailable on a migrated install regardless of credential:**
+**Live on the same session, no sync needed:**
 
 - AI panels — `panel get`, and the `--panel` inlining in `attendee brief` and `folder stream`
 - workspaces — `workspaces list`
 
-**Frozen but still readable, served from whatever the last desktop-cache `sync` stored:**
+Both read straight from the API on each call, so they need no store rows. The tradeoff is that `panel get` is the one read command with no local fallback at all: if the session lapses it fails hard where everything else degrades to stored data.
 
-- recipes and panel templates — `recipes list`, `recipes describe`
-- AI chat threads — `chat list`, `chat get`
+**With a `GRANOLA_API_KEY`, hydrated by `sync-api`:** everything above plus note summaries (`summary_markdown`).
 
-The cache sync writes these four tables into the local store, so they keep answering after the desktop cache stops decrypting. What they cannot do is advance. `recipes list`, `recipes describe` and `chat list` therefore report the store's last-sync timestamp in both their human and JSON output (a `staleness` block carrying `last_sync_at` and `refreshable`), and `chat list` additionally states that the thread set can never be refreshed — Granola's internal API exposes no chat endpoint at all. Quote that timestamp when you use the data; a chat thread set can sit weeks behind the meetings it discusses.
+**Frozen but still readable — AI chat threads (`chat list`, `chat get`):**
+
+Chats are the one surface that cannot advance. Granola's internal API exposes no chat endpoint (seven namings probed on 7.465.0, 2026-08-03, all 404), so the threads in the store are whatever the last desktop-cache sync captured and no re-sync will add more. `chat list` says so in both its human and JSON output.
+
+**Read the `staleness` block before answering from any of this.** Store-served reads carry one when the desktop cache is unreadable: `refreshable` tells you whether the surface can advance, `last_catalog_sync_at` dates refreshable surfaces like recipes, and `last_cache_sync_at` dates frozen ones like chats. A chat set can sit weeks behind the meetings it discusses — quote the date rather than presenting it as current.
 
 When something in the first group is asked for on a migrated install, say the data is not reachable. Do not synthesize a panel, a recipe result, or a chat thread from transcript text.
 

--- a/library/productivity/granola/SKILL.md
+++ b/library/productivity/granola/SKILL.md
@@ -41,31 +41,37 @@ If `--version` reports "command not found" after install, the runtime cannot see
 
 ## Two Data Paths — Read This Before Running Anything
 
-Granola desktop now keeps its data-encryption key in a macOS data-protection keychain group gated by an entitlement bound to Granola's own Apple Team ID. No third-party binary can read that key. On a current install this means the encrypted desktop cache (`cache-v6.json.enc`) and `granola.db` are permanently unreadable by this CLI, and so is `supabase.json.enc` — which takes the internal-API token path down with it.
+Granola desktop keeps its data-encryption key in a macOS data-protection keychain group gated by an entitlement bound to Granola's own Apple Team ID. No third-party binary can read that key, so the encrypted desktop cache (`cache-v6.json.enc`), the SQLCipher store `granola.db`, and `supabase.json.enc` are all unreadable by this CLI on a current install.
 
-Two paths fill the local SQLite store. The CLI ships both:
+That does **not** leave the CLI without data. Run `granola-pp-cli auth login` once: the CLI signs in to Granola with its own session and syncs meetings over the API, no key and no paid workspace required. You approve one browser page; after that the session refreshes silently on every command. It never touches the Granola desktop app's session or your browser's.
+
+Three paths fill the local SQLite store:
 
 | Path | Hydrate with | Works on a current install? |
 |---|---|---|
-| Granola public REST API → local store | `sync-api` | **Yes**, with a `GRANOLA_API_KEY`. |
-| Desktop encrypted cache → local store | `sync` | **No.** Fails with a migrated-scheme error naming the entitlement-gated keychain group. Still works on pre-migration Granola builds, and on a machine holding a pre-migration `storage.dek`. |
+| CLI-owned session → local store | `auth login`, then `sync` | **Yes.** The default answer. Meetings, titles, timestamps, attendees. |
+| Granola public REST API → local store | `sync-api` | **Yes**, but only with a `GRANOLA_API_KEY`, which needs a Business or Enterprise workspace. |
+| Desktop encrypted cache → local store | `sync` | **Only on pre-migration builds**, or on a machine holding a pre-migration `storage.dek` supplied through `GRANOLA_SAFESTORAGE_KEY_OVERRIDE`. Otherwise `sync` runs degraded and reports so. |
 
-**Reading already-synced data needs no API key at all.** Every read command serves from the local store first and falls back to the desktop cache only when the store has no row and a cache is actually readable. Neither step makes a network call or consults a key. The key is only needed to fetch *new* data.
-
-So the normal flow on a current install is: set `GRANOLA_API_KEY`, run `granola-pp-cli sync-api` once, then read freely — offline and keyless from then on.
+**Reading already-synced data needs no credential at all.** Every read command serves from the local store first and falls back to the desktop cache only when the store has no row and a cache is actually readable. Neither step makes a network call or consults a key. Credentials are only needed to fetch *new* data.
 
 ### Capability split
 
-Available from the public API, hydrated by `sync-api`, readable from the store:
+Read this before telling a user their data is missing. An empty result on a migrated install usually means "not synced on this tier", not "you have none".
+
+**With a CLI-owned session (`auth login`), hydrated by `sync`:**
 
 - meetings, titles, timestamps
 - attendees
 - calendar events
-- transcripts (full segment list)
-- note summaries (`summary_markdown`)
-- folders and folder membership
 
-Cache-only, and therefore **unavailable on a migrated install**:
+Not hydrated on this tier yet: transcripts, folders, panels, recipes, chats. Transcript and folder endpoints do accept the CLI session, so this is a scope boundary of the current sync, not a hard limit. Commands that depend on transcripts (`talktime`, `memo run`, `attendee brief`, `collect`, `folder stream`) will return empty until those surfaces are hydrated. Say that plainly rather than presenting an empty result as an answer.
+
+**With a `GRANOLA_API_KEY`, hydrated by `sync-api`:**
+
+- everything above, plus transcripts (full segment list), note summaries (`summary_markdown`), folders and folder membership
+
+**Cache-only, and therefore unavailable on a migrated install regardless of credential:**
 
 - AI panels — `panel get`, and the `--panel` inlining in `attendee brief` and `folder stream`
 - recipes and panel templates — `recipes list`, `recipes describe`
@@ -73,6 +79,10 @@ Cache-only, and therefore **unavailable on a migrated install**:
 - workspaces — `workspaces list`
 
 When one of those is asked for on a migrated install, say the data is not reachable. Do not synthesize a panel, a recipe result, or a chat thread from transcript text.
+
+### Why `auth login` when Granola desktop is already signed in
+
+Because the desktop's session is not shareable. Its token lives behind the entitlement-gated key, and the refresh tokens the desktop and your browser hold are single-use — refreshing one signs *that* client out. So the CLI holds a chain of its own instead of borrowing. `auth login` stores it under the CLI's own data directory, readable only by you; `auth logout` removes it. Deleting it locally does not revoke it upstream.
 
 ## When to Use This CLI
 

--- a/library/productivity/granola/SKILL.md
+++ b/library/productivity/granola/SKILL.md
@@ -79,11 +79,16 @@ Not hydrated on this tier: folders and folder membership, panels, recipes, chats
 **Cache-only, and therefore unavailable on a migrated install regardless of credential:**
 
 - AI panels — `panel get`, and the `--panel` inlining in `attendee brief` and `folder stream`
-- recipes and panel templates — `recipes list`, `recipes describe`
-- AI chat threads — `chat list`, `chat get`
 - workspaces — `workspaces list`
 
-When one of those is asked for on a migrated install, say the data is not reachable. Do not synthesize a panel, a recipe result, or a chat thread from transcript text.
+**Frozen but still readable, served from whatever the last desktop-cache `sync` stored:**
+
+- recipes and panel templates — `recipes list`, `recipes describe`
+- AI chat threads — `chat list`, `chat get`
+
+The cache sync writes these four tables into the local store, so they keep answering after the desktop cache stops decrypting. What they cannot do is advance. `recipes list`, `recipes describe` and `chat list` therefore report the store's last-sync timestamp in both their human and JSON output (a `staleness` block carrying `last_sync_at` and `refreshable`), and `chat list` additionally states that the thread set can never be refreshed — Granola's internal API exposes no chat endpoint at all. Quote that timestamp when you use the data; a chat thread set can sit weeks behind the meetings it discusses.
+
+When something in the first group is asked for on a migrated install, say the data is not reachable. Do not synthesize a panel, a recipe result, or a chat thread from transcript text.
 
 ### Why `auth login` when Granola desktop is already signed in
 
@@ -171,7 +176,7 @@ These capabilities aren't available in any other tool for this API.
 
 ### Cache-native data
 
-These two read Granola desktop's own cache. `chat list` is cache-only and returns nothing on a migrated install; `calendar overlay` reads calendar events, which `sync-api` hydrates, so it keeps working.
+Both of these originate in Granola desktop's own cache. `chat list` reads the threads a cache `sync` already hydrated into the local store, so it keeps answering on a migrated install — but nothing can advance that set, and the output says so along with the last-sync timestamp. `calendar overlay` reads calendar events, which `sync-api` hydrates, so it keeps working.
 
 - **`chat list`** — List and dump Granola’s AI chat threads anchored to a meeting (entities.chat_thread + entities.chat_message in the cache).
 
@@ -329,7 +334,7 @@ Run `granola-pp-cli doctor` to see which paths resolve on this machine.
 | `OK ok` | Last successful cache sync recorded. Token source and document-fetch count are in the `--json` output. |
 | `ERROR last sync failed to decrypt (key_unavailable)` | Read the `encrypted_store_error` field in the `--json` output. If it names an entitlement-gated keychain group, this is the upstream key migration and **no Keychain approval or re-sync can fix it** — switch to `sync-api` with an API key. Only if the message does not mention the migration is signing back into Granola desktop the right move. |
 | `ERROR last sync failed to decrypt (decrypt_failed)` | Encryption scheme may have drifted with a Granola update. File an issue with the doctor output. |
-| Reads return empty after a successful `sync-api` | Check the capability split above — panels, recipes, chat, and workspaces are cache-only and have no API source. |
+| Reads return empty after a successful `sync-api` | Check the capability split above — panels and workspaces are cache-only and have no API source. Recipes and chat threads come from the last desktop-cache `sync`; if that never ran, there is nothing stored to serve. |
 
 ## Agent Mode
 

--- a/library/productivity/granola/SKILL.md
+++ b/library/productivity/granola/SKILL.md
@@ -64,8 +64,13 @@ Read this before telling a user their data is missing. An empty result on a migr
 - meetings, titles, timestamps
 - attendees
 - calendar events
+- **transcripts** (full segment list)
 
-Not hydrated on this tier yet: transcripts, folders, panels, recipes, chats. Transcript and folder endpoints do accept the CLI session, so this is a scope boundary of the current sync, not a hard limit. Commands that depend on transcripts (`talktime`, `memo run`, `attendee brief`, `collect`, `folder stream`) will return empty until those surfaces are hydrated. Say that plainly rather than presenting an empty result as an answer.
+Transcripts backfill incrementally. There is no bulk transcript endpoint, so `sync` fetches them one meeting at a time, newest first, up to `--transcript-budget` (default 250) per run. When work remains the command says so on stderr and records how many; re-run `sync` to continue, or pass `--transcript-budget -1` to fetch all remaining in one go. Meetings that genuinely have no recording are asked about once and then skipped forever.
+
+**This matters when answering questions.** Before telling a user a meeting has no transcript, check whether the backfill has reached it. `sync` reports `transcripts_remaining` in its summary; a non-zero value means "not fetched yet", not "no transcript exists". Commands that depend on transcripts (`talktime`, `memo run`, `attendee brief`, `collect`) will be thin until the backfill completes.
+
+Not hydrated on this tier: folders and folder membership, panels, recipes, chats.
 
 **With a `GRANOLA_API_KEY`, hydrated by `sync-api`:**
 

--- a/library/productivity/granola/internal/cli/auth.go
+++ b/library/productivity/granola/internal/cli/auth.go
@@ -4,10 +4,13 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
-	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/config"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/granola"
+	"github.com/spf13/cobra"
 )
 
 func newAuthCmd(flags *rootFlags) *cobra.Command {
@@ -65,7 +68,14 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 
 			w := cmd.OutOrStdout()
 			header := cfg.AuthHeader()
-			authed := header != ""
+			// PATCH(cli-owned-workos-session): a CLI-owned session counts as
+			// authenticated. It is reported separately from the public-API key
+			// because they authorize different surfaces, and because a user who
+			// just ran `auth login` should not be told they have no credentials.
+			session, sessionErr := granola.LoadCLISession()
+			hasSession := sessionErr == nil
+			authed := header != "" || hasSession
+			envOverride := os.Getenv("GRANOLA_WORKOS_TOKEN") != ""
 			// JSON envelope: {authenticated, verified, source, config}. When not
 			// authenticated, write the envelope first then return authErr
 			// so exit code carries the auth-failure signal.
@@ -75,6 +85,16 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 					"verified":      false,
 					"source":        cfg.AuthSource,
 					"config":        cfg.Path,
+					"cli_session":   hasSession,
+				}
+				if hasSession {
+					out["cli_session_account"] = session.AccountEmail
+					out["cli_session_path"] = granola.CLISessionPath()
+				} else if sessionErr != nil && !errors.Is(sessionErr, granola.ErrNoCLISession) {
+					out["cli_session_error"] = sessionErr.Error()
+				}
+				if envOverride {
+					out["env_override_active"] = true
 				}
 				if printErr := printJSONFiltered(w, out, flags); printErr != nil {
 					return printErr
@@ -87,10 +107,37 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			if !authed {
 				fmt.Fprintln(w, red("Not authenticated"))
 				fmt.Fprintln(w, "")
-				fmt.Fprintln(w, "Set your token:")
+				if sessionErr != nil && !errors.Is(sessionErr, granola.ErrNoCLISession) {
+					// A broken session is a different problem from an absent
+					// one, and "run auth login" is the wrong advice for, say, a
+					// permissions failure the user needs to see and fix.
+					fmt.Fprintf(w, "  CLI session unusable: %v\n\n", sessionErr)
+				}
+				fmt.Fprintln(w, "Sign this CLI in to Granola (recommended):")
+				fmt.Fprintln(w, "  granola-pp-cli auth login")
+				fmt.Fprintln(w, "")
+				fmt.Fprintln(w, "Or use a Business/Enterprise API key:")
 				fmt.Fprintln(w, "  export GRANOLA_API_KEY=\"your-token-here\"")
 				fmt.Fprintf(w, "  granola-pp-cli auth set-token <token>\n")
 				return authErr(fmt.Errorf("no credentials configured"))
+			}
+			if hasSession {
+				if session.AccountEmail != "" {
+					fmt.Fprintf(w, "CLI session: signed in as %s\n", session.AccountEmail)
+				} else {
+					fmt.Fprintln(w, "CLI session: signed in")
+				}
+				fmt.Fprintf(w, "  stored at %s\n", granola.CLISessionPath())
+				if envOverride {
+					fmt.Fprintln(w, red("  warning: GRANOLA_WORKOS_TOKEN is set and outranks this session; unset it to use the session"))
+				}
+			}
+			if header == "" {
+				// The session covers the internal API; the public REST surface
+				// still needs its own key. Saying so here avoids a confusing
+				// 401 later from sync-api.
+				fmt.Fprintln(w, "No GRANOLA_API_KEY set: public-API commands (sync-api, folders) remain unavailable.")
+				return nil
 			}
 
 			fmt.Fprintln(w, green("Credentials present (not verified)"))

--- a/library/productivity/granola/internal/cli/auth.go
+++ b/library/productivity/granola/internal/cli/auth.go
@@ -198,6 +198,14 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 			if err := cfg.ClearTokens(); err != nil {
 				return configErr(fmt.Errorf("clearing tokens: %w", err))
 			}
+			// PATCH(cli-owned-workos-session): the CLI-owned session is a
+			// separate credential from the config API key, and logout must
+			// remove both. Clearing only the key left a live access and refresh
+			// token on disk while reporting "credentials cleared".
+			if err := granola.ClearCLISession(); err != nil {
+				return fmt.Errorf("clearing CLI session: %w", err)
+			}
+			granola.ResetTokenCache()
 
 			// Identify which (if any) auth env var is still exported so the
 			// JSON envelope and the human prose can both surface it.

--- a/library/productivity/granola/internal/cli/auth.go
+++ b/library/productivity/granola/internal/cli/auth.go
@@ -16,6 +16,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 		Short: "Manage authentication for Granola",
 	}
 
+	cmd.AddCommand(newAuthLoginCmd(flags))
 	cmd.AddCommand(newAuthSetupCmd(flags))
 	cmd.AddCommand(newAuthStatusCmd(flags))
 	cmd.AddCommand(newAuthSetTokenCmd(flags))

--- a/library/productivity/granola/internal/cli/auth_login.go
+++ b/library/productivity/granola/internal/cli/auth_login.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"runtime"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/granola"
+	"github.com/spf13/cobra"
+)
+
+// PATCH(cli-owned-workos-session): `auth login` gives the CLI a session of its
+// own via Granola's device authorization grant.
+//
+// This exists because there is no longer any borrowable credential on the
+// machine. Granola moved the data encryption key into an entitlement-gated
+// Keychain group, so supabase.json.enc cannot be read; the plaintext files it
+// used to leave behind are months-stale; and the tokens the desktop app and the
+// browser still hold are theirs -- refreshing one against the WorkOS endpoint
+// consumes it and signs that client out. A CLI-owned chain is the only design
+// that is durable without breaking something else.
+func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
+	var noBrowser bool
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Sign this CLI in to Granola (one-time; refreshes automatically after)",
+		Long: "Signs this CLI in to Granola using the device authorization grant.\n\n" +
+			"Opens a browser to a short approval page. After you approve once, the CLI\n" +
+			"holds its own session and refreshes it silently on every later command --\n" +
+			"you will not be asked again unless you run `auth logout`.\n\n" +
+			"This does not touch the Granola desktop app's session or your browser's.",
+		Example: "  granola-pp-cli auth login\n  granola-pp-cli auth login --no-browser",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			w := cmd.OutOrStdout()
+
+			dc, err := granola.RequestDeviceCode(ctx)
+			if err != nil {
+				return err
+			}
+
+			target := dc.VerificationURIComplete
+			if target == "" {
+				target = dc.VerificationURI
+			}
+
+			if flags.asJSON || flags.agent {
+				// Agent callers get the code as data and poll alongside us.
+				b, _ := json.Marshal(map[string]any{
+					"event":            "device_authorization_pending",
+					"user_code":        dc.UserCode,
+					"verification_uri": target,
+					"expires_in":       dc.ExpiresIn,
+				})
+				fmt.Fprintln(w, string(b))
+			} else {
+				fmt.Fprintf(w, "\n  Approve this CLI at:  %s\n", target)
+				fmt.Fprintf(w, "  Code:                 %s\n", dc.UserCode)
+				fmt.Fprintf(w, "  (expires in %ds)\n\n", dc.ExpiresIn)
+			}
+
+			// Opening the browser is what makes this one click rather than a
+			// copy-paste. Suppressed for agents and non-interactive runs, and
+			// never fatal -- the URL is already printed above.
+			if !noBrowser && !flags.noInput && !flags.agent && !flags.asJSON {
+				if err := openBrowser(target); err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  (could not open a browser: %v -- open the URL above)\n", err)
+				}
+			}
+
+			session, err := granola.PollDeviceToken(ctx, dc)
+			if err != nil {
+				return err
+			}
+
+			// Persist before reporting success: a login we announce but did not
+			// store is worse than one that visibly failed.
+			if err := granola.SaveCLISession(session); err != nil {
+				return fmt.Errorf("signed in, but could not save the session: %w", err)
+			}
+			granola.ResetTokenCache()
+
+			if flags.asJSON || flags.agent {
+				b, _ := json.Marshal(map[string]any{
+					"event":   "device_authorization_complete",
+					"account": session.AccountEmail,
+					"stored":  granola.CLISessionPath(),
+				})
+				fmt.Fprintln(w, string(b))
+				return nil
+			}
+			if session.AccountEmail != "" {
+				fmt.Fprintf(w, "  Signed in as %s\n", session.AccountEmail)
+			} else {
+				fmt.Fprintln(w, "  Signed in.")
+			}
+			fmt.Fprintf(w, "  Session stored at %s (owner-only).\n", granola.CLISessionPath())
+			fmt.Fprintln(w, "  Run `granola-pp-cli sync` to pull your meetings.")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the approval URL without opening a browser")
+	return cmd
+}
+
+// openBrowser opens a URL with the platform's handler.
+func openBrowser(target string) error {
+	var cmd string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+	case "windows":
+		cmd, args = "rundll32", []string{"url.dll,FileProtocolHandler"}
+	default:
+		cmd = "xdg-open"
+	}
+	return exec.Command(cmd, append(args, target)...).Start()
+}

--- a/library/productivity/granola/internal/cli/auth_logout_test.go
+++ b/library/productivity/granola/internal/cli/auth_logout_test.go
@@ -36,6 +36,7 @@ func TestAuthLogoutClearsCLISession(t *testing.T) {
 		t.Fatal("precondition: session should exist before logout")
 	}
 
+	epochBefore := granola.RevocationEpoch()
 	flags := &rootFlags{configPath: filepath.Join(dir, "config.json")}
 	cmd := newAuthLogoutCmd(flags)
 	cmd.SetOut(&bytes.Buffer{})
@@ -49,5 +50,11 @@ func TestAuthLogoutClearsCLISession(t *testing.T) {
 	}
 	if granola.HasCLISession() {
 		t.Error("still signed in after logout")
+	}
+	// Logout must also record the revocation, which is how a token rotation
+	// running concurrently in another process learns not to republish the
+	// session it is midway through writing.
+	if after := granola.RevocationEpoch(); after == epochBefore {
+		t.Error("logout did not record a revocation; a concurrent refresh can restore the session after logout reports success")
 	}
 }

--- a/library/productivity/granola/internal/cli/auth_logout_test.go
+++ b/library/productivity/granola/internal/cli/auth_logout_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/granola"
+)
+
+// `auth logout` used to clear only the config API key, leaving the CLI-owned
+// session -- a live access and refresh token -- on disk while printing
+// "Credentials cleared". Every later command stayed authenticated and kept
+// refreshing, and `auth status` still reported the account as signed in. For a
+// command whose entire purpose is removing a credential, reporting success
+// while the credential survives is the worst available failure.
+func TestAuthLogoutClearsCLISession(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "granola-pp-cli", "session.json")
+	t.Setenv("GRANOLA_CLI_SESSION_PATH", sessionPath)
+	t.Setenv("GRANOLA_API_KEY", "")
+
+	if err := granola.SaveCLISession(granola.CLISession{
+		AccessToken:  "access-token-value-aaaaaaaaaaaa",
+		RefreshToken: "refresh-token-value-bbbb",
+		ExpiresAt:    time.Now().Add(time.Hour).UTC(),
+		AccountEmail: "someone@example.com",
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	if !granola.HasCLISession() {
+		t.Fatal("precondition: session should exist before logout")
+	}
+
+	flags := &rootFlags{configPath: filepath.Join(dir, "config.json")}
+	cmd := newAuthLogoutCmd(flags)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("auth logout: %v", err)
+	}
+
+	if _, err := os.Stat(sessionPath); !os.IsNotExist(err) {
+		t.Error("logout reported success but the session file is still on disk")
+	}
+	if granola.HasCLISession() {
+		t.Error("still signed in after logout")
+	}
+}

--- a/library/productivity/granola/internal/cli/autorefresh.go
+++ b/library/productivity/granola/internal/cli/autorefresh.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/granola"
 	"github.com/spf13/cobra"
 )
 
@@ -235,7 +236,7 @@ func encryptedCachePresent() bool {
 func (p refreshPlan) run(ctx context.Context, flags *rootFlags) []refreshResult {
 	var out []refreshResult
 	if p.cache {
-		res, err := runCacheSync(ctx)
+		res, err := runCacheSync(ctx, granola.AutoRefreshTranscriptBudget)
 		// Cache refresh is "ok" when the decrypt + SQLite upsert
 		// succeeded, even if document-API hydration was unable to
 		// reach /v2/get-documents (HydrateErr) or the sync_state

--- a/library/productivity/granola/internal/cli/autorefresh.go
+++ b/library/productivity/granola/internal/cli/autorefresh.go
@@ -81,6 +81,13 @@ type refreshResult struct {
 	rows     int
 	duration time.Duration
 	err      error
+
+	// PATCH(api-sync-survives-unreadable-cache): the run succeeded but the
+	// desktop cache was unreadable, so only API-derived documents were synced.
+	// Rendered as its own state because "ok" would hide that transcripts,
+	// folders, recipes, panels, and chats are all missing by circumstance
+	// rather than because the user has none.
+	degraded bool
 }
 
 // runAutoRefresh is the entry point the PersistentPreRunE hook calls.
@@ -243,6 +250,7 @@ func (p refreshPlan) run(ctx context.Context, flags *rootFlags) []refreshResult 
 			rows:     res.TotalRows(),
 			duration: res.Duration,
 			err:      err,
+			degraded: res.Degraded,
 		})
 	}
 	if p.api {
@@ -306,6 +314,12 @@ func emitProvenanceLine(w io.Writer, results []refreshResult) {
 // per-surface.
 func formatRefreshFragment(r refreshResult) string {
 	dur := formatRefreshDuration(r.duration)
+	if r.ok && r.degraded {
+		// PATCH(api-sync-survives-unreadable-cache): distinct from both ok and
+		// failed. Rows were written, so "failed" would be wrong; the cache was
+		// never read, so "ok" would imply transcripts and folders are current.
+		return fmt.Sprintf("%s=degraded, API only (%s, %d rows)", r.surface, dur, r.rows)
+	}
 	if r.ok {
 		return fmt.Sprintf("%s=ok (%s, %d rows)", r.surface, dur, r.rows)
 	}

--- a/library/productivity/granola/internal/cli/chat.go
+++ b/library/productivity/granola/internal/cli/chat.go
@@ -10,10 +10,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// chatFrozenReason is the second half of the staleness disclosure for chat.
+// Granola's internal API exposes no chat endpoint (seven namings probed, all
+// 404), so chat_threads/chat_messages only ever advance when a decryptable
+// desktop cache is synced. On a migrated install that never happens again:
+// the thread set is frozen wherever the last cache sync left it, however far
+// behind the meetings it discusses that now is.
+const chatFrozenReason = "These threads cannot be refreshed: Granola's internal API exposes no chat endpoint, so the set is frozen wherever the last desktop-cache sync left it."
+
 func newChatCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "chat",
-		Short: "Read Granola's AI chat threads from cache",
+		Short: "Read Granola's AI chat threads from the local store or cache",
 	}
 	cmd.AddCommand(newChatListCmd(flags))
 	cmd.AddCommand(newChatGetCmd(flags))
@@ -31,17 +39,22 @@ func newChatListCmd(flags *rootFlags) *cobra.Command {
 			if dryRunOK(flags) {
 				return nil
 			}
-			c, err := openGranolaCache()
+			// PATCH(dual-path-store-read): chat_threads/chat_messages are
+			// hydrated into the store by the cache sync, so the 225 threads on
+			// a migrated install remain readable long after the cache stops
+			// decrypting. The read seam is the only way to reach them.
+			v, err := openGranolaRead(cmd.Context())
 			if err != nil {
 				return err
 			}
+			defer v.Close()
 			meetingFilter := ""
 			if len(args) > 0 {
 				meetingFilter = args[0]
 			}
 			// Index messages per thread to extract a first-message preview.
 			byThread := map[string][]granola.ChatMessage{}
-			for _, m := range c.ChatMessages {
+			for _, m := range v.ChatMessages() {
 				byThread[m.Data.ThreadID] = append(byThread[m.Data.ThreadID], m)
 			}
 			for tid := range byThread {
@@ -50,7 +63,7 @@ func newChatListCmd(flags *rootFlags) *cobra.Command {
 				})
 			}
 			out := []map[string]any{}
-			for tid, t := range c.ChatThreads {
+			for tid, t := range v.ChatThreads() {
 				if meetingFilter != "" && t.Data.DocumentID != meetingFilter {
 					continue
 				}
@@ -72,7 +85,7 @@ func newChatListCmd(flags *rootFlags) *cobra.Command {
 			sort.Slice(out, func(i, j int) bool {
 				return fmt.Sprint(out[i]["created_at"]) > fmt.Sprint(out[j]["created_at"])
 			})
-			return emitJSON(cmd, flags, out)
+			return emitWithStaleness(cmd, flags, "threads", out, v.staleness(chatFrozenReason))
 		},
 	}
 	return cmd
@@ -98,23 +111,17 @@ func newChatGetCmd(flags *rootFlags) *cobra.Command {
 				return nil
 			}
 			tid := args[0]
-			c, err := openGranolaCache()
+			v, err := openGranolaRead(cmd.Context())
 			if err != nil {
 				return err
 			}
-			t, ok := c.ChatThreads[tid]
+			defer v.Close()
+			t, ok := v.ChatThreads()[tid]
 			if !ok {
 				return notFoundErr(fmt.Errorf("thread %s not found", tid))
 			}
-			var msgs []granola.ChatMessage
-			for _, m := range c.ChatMessages {
-				if m.Data.ThreadID == tid {
-					msgs = append(msgs, m)
-				}
-			}
-			sort.Slice(msgs, func(i, j int) bool {
-				return msgs[i].Data.TurnIndex < msgs[j].Data.TurnIndex
-			})
+			// ChatThreadMessages already returns turn order from either path.
+			msgs := v.ChatThreadMessages(tid)
 			out := map[string]any{
 				"id":         tid,
 				"title":      t.Data.Title,

--- a/library/productivity/granola/internal/cli/doctor.go
+++ b/library/productivity/granola/internal/cli/doctor.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/granola"
+
 	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/config"
 	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/store"
@@ -86,11 +88,23 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 
 			// Check auth
 			authConfigured := false
-			if cfg != nil {
+			// PATCH(cli-owned-workos-session): a CLI-owned session is auth.
+			// Reporting "not configured" whenever GRANOLA_API_KEY is unset read
+			// as a total auth failure on exactly the installs where the session
+			// is the working path.
+			if granola.HasCLISession() {
+				authConfigured = true
+				report["auth"] = "configured (CLI session)"
+				if os.Getenv("GRANOLA_WORKOS_TOKEN") != "" {
+					// The env override outranks the session in loadTokensRaw, so
+					// a stale value here silently defeats a successful login.
+					report["auth_warning"] = "GRANOLA_WORKOS_TOKEN is set and outranks the CLI session; unset it to use the session"
+				}
+			} else if cfg != nil {
 				header := cfg.AuthHeader()
 				if header == "" {
 					report["auth"] = "not configured"
-					report["auth_hint"] = "export GRANOLA_API_KEY=<your-key>"
+					report["auth_hint"] = "run `granola-pp-cli auth login` (or export GRANOLA_API_KEY=<your-key>)"
 				} else {
 					authConfigured = true
 					report["auth"] = "configured"

--- a/library/productivity/granola/internal/cli/doctor_encrypted_store.go
+++ b/library/productivity/granola/internal/cli/doctor_encrypted_store.go
@@ -73,6 +73,22 @@ func collectEncryptedStoreReport(report map[string]any) {
 			report["encrypted_store_hint"] = "Decrypt succeeded; document hydration from /v2/get-documents failed (auth or network). Cached transcripts/folders/recipes are still usable; meetings list may be stale."
 		}
 	case granola.DecryptStatusFailed:
+		// PATCH(api-sync-survives-unreadable-cache): a migrated install is a
+		// permanent, expected state, not a failure to act on. Reporting it as
+		// ERROR alongside a working CLI session read as "the CLI is broken"
+		// when meetings were syncing fine.
+		if state.LastDecryptErrorClass == "scheme_migrated" {
+			report["encrypted_store"] = "DEGRADED desktop cache unreadable (Granola moved the key out of reach); meetings sync over the API"
+			if granola.HasCLISession() {
+				report["encrypted_store_hint"] = "Nothing to do. Transcripts, folders, recipes, panels and chats stay empty unless you supply GRANOLA_SAFESTORAGE_KEY_OVERRIDE from a pre-migration storage.dek."
+			} else {
+				report["encrypted_store_hint"] = "Run `granola-pp-cli auth login` so the CLI can fetch meetings over the API."
+			}
+			if state.LastDecryptErrorMsg != "" {
+				report["encrypted_store_error"] = state.LastDecryptErrorMsg
+			}
+			return
+		}
 		msg := "ERROR last sync failed to decrypt"
 		if state.LastDecryptErrorClass != "" {
 			msg = fmt.Sprintf("ERROR last sync failed to decrypt (%s)", state.LastDecryptErrorClass)

--- a/library/productivity/granola/internal/cli/granola_helpers.go
+++ b/library/productivity/granola/internal/cli/granola_helpers.go
@@ -134,6 +134,79 @@ func errNoLocalGranolaData() error {
 	return notFoundErr(fmt.Errorf("no local Granola data available - run `granola-pp-cli sync-api` (or `granola-pp-cli sync` for a desktop-cache install) first"))
 }
 
+// storeStaleness is the disclosure a command attaches when it is answering
+// from the store on an install whose desktop cache will not decrypt. Serving
+// that data is the right call - it is the only copy left - but handing it over
+// without saying how old it is would be a claim the CLI cannot back: the store
+// is only ever as current as the last sync that wrote it, and for chat there
+// is no sync that can advance it at all.
+type storeStaleness struct {
+	// Source is always "store". It exists so a consumer can branch on the
+	// field rather than infer the path from the block's mere presence.
+	Source string `json:"source"`
+	// LastCacheSyncAt is RFC3339 UTC, omitted when no successful cache sync
+	// has ever been recorded on this machine
+	// on this machine.
+	LastCacheSyncAt string `json:"last_cache_sync_at,omitempty"`
+	// Refreshable is false when no code path can bring this data forward, so
+	// an agent can tell a frozen set from a merely stale one without parsing
+	// Notice.
+	Refreshable bool `json:"refreshable"`
+	// Notice is the human rendering of the fields above, printed to stderr.
+	Notice string `json:"notice"`
+}
+
+// staleness returns the disclosure to attach to store-served output, or nil
+// when a readable desktop cache means this view is not frozen and the command
+// should keep emitting exactly what it always did.
+//
+// frozenReason, when non-empty, states why the data set can never be brought
+// forward and flips Refreshable to false.
+func (v *granolaRead) staleness(frozenReason string) *storeStaleness {
+	if v == nil || v.hasCache() {
+		return nil
+	}
+	st := &storeStaleness{Source: "store", Refreshable: frozenReason == ""}
+	// Date these rows by the last successful CACHE decrypt, never by
+	// LastSyncAt. Auto-refresh runs an API sync on every invocation, so
+	// LastSyncAt always reads "just now" on a migrated install — reporting it
+	// here would tell the user that months-old cache rows are current, which is
+	// worse than disclosing nothing. A missing or malformed sync_state.json is
+	// "unknown", not an error: the data is still worth serving, just undatable.
+	age := "the date of the last successful cache sync is not recorded on this machine"
+	if s, err := granola.ReadSyncState(); err == nil && !s.LastCacheSyncAt.IsZero() {
+		st.LastCacheSyncAt = s.LastCacheSyncAt.UTC().Format(time.RFC3339)
+		age = "captured by the last successful cache sync on " + st.LastCacheSyncAt
+	}
+	st.Notice = "Served from the local store because the Granola desktop cache is unreadable; " + age + "."
+	if frozenReason != "" {
+		st.Notice += " " + frozenReason
+	}
+	return st
+}
+
+// writeStalenessNotice prints the human half of the disclosure to stderr,
+// where it cannot corrupt the JSON on stdout. Silent when there is nothing to
+// disclose or the caller asked for --quiet.
+func writeStalenessNotice(cmd *cobra.Command, flags *rootFlags, st *storeStaleness) {
+	if st == nil || cmd == nil || (flags != nil && flags.quiet) {
+		return
+	}
+	fmt.Fprintln(cmd.ErrOrStderr(), st.Notice)
+}
+
+// emitWithStaleness writes a list payload, wrapping it in a {key, staleness}
+// envelope only when there is a disclosure to carry. On a readable-cache
+// install st is nil and the bare list goes out unchanged, which is what keeps
+// legacy output byte-identical.
+func emitWithStaleness(cmd *cobra.Command, flags *rootFlags, key string, rows any, st *storeStaleness) error {
+	if st == nil {
+		return emitJSON(cmd, flags, rows)
+	}
+	writeStalenessNotice(cmd, flags, st)
+	return emitJSON(cmd, flags, map[string]any{key: rows, "staleness": st})
+}
+
 // Documents returns the union of store meetings and cache documents, keyed
 // by id. Store rows win field-by-field for the columns the store owns; the
 // cache supplies the fields it alone carries (TipTap notes, people, calendar

--- a/library/productivity/granola/internal/cli/granola_helpers.go
+++ b/library/productivity/granola/internal/cli/granola_helpers.go
@@ -509,7 +509,11 @@ func (v *granolaRead) storeFolders() []granola.DocumentListMetadata {
 		return nil
 	}
 	rows, err := v.store.DB().QueryContext(v.ctx,
-		`SELECT id, title, parent_id, workspace_id, preset FROM folders ORDER BY id ASC`)
+		// PATCH(catalog-provenance-and-merge): description and is_favourited
+		// are selected here because the write path now persists them. Without
+		// this, a store-only install keeps reporting an empty description and a
+		// false favourite flag for folders that have both.
+		`SELECT id, title, parent_id, workspace_id, preset, description, is_favourited FROM folders ORDER BY id ASC`)
 	if err != nil {
 		return nil
 	}
@@ -517,13 +521,16 @@ func (v *granolaRead) storeFolders() []granola.DocumentListMetadata {
 	var out []granola.DocumentListMetadata
 	for rows.Next() {
 		var f granola.DocumentListMetadata
-		var parent, workspace, preset sql.NullString
-		if err := rows.Scan(&f.ID, &f.Title, &parent, &workspace, &preset); err != nil {
+		var parent, workspace, preset, description sql.NullString
+		var favourited sql.NullBool
+		if err := rows.Scan(&f.ID, &f.Title, &parent, &workspace, &preset, &description, &favourited); err != nil {
 			return out
 		}
 		f.ParentDocumentListID = parent.String
 		f.WorkspaceID = workspace.String
 		f.Preset = preset.String
+		f.Description = description.String
+		f.IsFavourited = favourited.Bool
 		out = append(out, f)
 	}
 	return out

--- a/library/productivity/granola/internal/cli/granola_helpers.go
+++ b/library/productivity/granola/internal/cli/granola_helpers.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -512,6 +513,350 @@ func (v *granolaRead) storeFolderMeetings(folderID string) []string {
 			return out
 		}
 		out = append(out, mid)
+	}
+	return out
+}
+
+// Recipes returns the recipe list, store first. The merge is field-level
+// like Folders(): the store's recipes table carries only
+// id/slug/name/description/category/source, while config.instructions,
+// visibility, timestamps and creator_info exist solely in the cache, so a
+// store row overwrites the columns it owns and leaves the rest alone.
+//
+// Order is the cache's (public, then user, then shared) with store-only
+// recipes appended in id order. Folders() has to sort its whole output
+// because its cache side is a map with no meaningful order; RecipesAll() is
+// already a deterministic slice, and preserving it keeps `recipes list`
+// output identical on installs where the cache still decrypts.
+func (v *granolaRead) Recipes() []granola.Recipe {
+	if v == nil {
+		return nil
+	}
+	byKey := map[string]granola.Recipe{}
+	var order []string
+	if v.cache != nil {
+		for _, r := range v.cache.RecipesAll() {
+			k := recipeKey(r)
+			if _, ok := byKey[k]; !ok {
+				order = append(order, k)
+			}
+			byKey[k] = r
+		}
+	}
+	for _, sr := range v.storeRecipes() {
+		k := recipeKey(sr)
+		existing, ok := byKey[k]
+		if !ok {
+			byKey[k] = sr
+			order = append(order, k)
+			continue
+		}
+		if sr.ID != "" {
+			existing.ID = sr.ID
+		}
+		if sr.Slug != "" {
+			existing.Slug = sr.Slug
+		}
+		if sr.Name != "" {
+			existing.Name = sr.Name
+		}
+		if sr.Config.Description != "" {
+			existing.Config.Description = sr.Config.Description
+		}
+		if sr.Category != "" {
+			existing.Category = sr.Category
+		}
+		if sr.Source != "" {
+			existing.Source = sr.Source
+		}
+		byKey[k] = existing
+	}
+	out := make([]granola.Recipe, 0, len(order))
+	for _, k := range order {
+		r := byKey[k]
+		// LoadCache defaults Name to Slug for every recipe it parses; the
+		// store's name column can be empty for the same rows, so the default
+		// is reapplied here rather than trusted from either side. Source
+		// round-trips through the store's source column, which the cache sync
+		// writes from the already-stamped Recipe.Source.
+		if r.Name == "" {
+			r.Name = r.Slug
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// recipeKey is the identity a recipe merges on. Recipes normally carry an
+// id, but public recipes can ship with the slug as their only identifier -
+// keying those on the empty string would collapse them into one entry.
+func recipeKey(r granola.Recipe) string {
+	if r.ID != "" {
+		return r.ID
+	}
+	return r.Slug
+}
+
+func (v *granolaRead) storeRecipes() []granola.Recipe {
+	if v == nil || v.store == nil {
+		return nil
+	}
+	rows, err := v.store.DB().QueryContext(v.ctx,
+		`SELECT id, slug, name, description, category, source FROM recipes ORDER BY id ASC`)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var out []granola.Recipe
+	for rows.Next() {
+		var id, slug, name, description, category, source sql.NullString
+		if err := rows.Scan(&id, &slug, &name, &description, &category, &source); err != nil {
+			return out
+		}
+		var r granola.Recipe
+		r.ID = id.String
+		r.Slug = slug.String
+		r.Name = name.String
+		// The sync writes Config.Description into the description column;
+		// flattening it back onto Config keeps the typed surface consistent.
+		r.Config.Description = description.String
+		r.Category = category.String
+		r.Source = source.String
+		out = append(out, r)
+	}
+	return out
+}
+
+// RecipesUsage returns per-recipe usage keyed by recipe id, store first.
+// Field-level like Recipes(): a zero total_count or an empty last_used_at is
+// "the store has no answer", not an instruction to blank the cache's value.
+func (v *granolaRead) RecipesUsage() map[string]granola.RecipeUsage {
+	if v == nil {
+		return nil
+	}
+	out := map[string]granola.RecipeUsage{}
+	if v.cache != nil {
+		for id, u := range v.cache.RecipesUsage {
+			// The cache keys usage by recipe id and does not always repeat it
+			// inside the value; filling it in matches the store path.
+			if u.RecipeID == "" {
+				u.RecipeID = id
+			}
+			out[id] = u
+		}
+	}
+	for id, su := range v.storeRecipesUsage() {
+		existing, ok := out[id]
+		if !ok {
+			out[id] = su
+			continue
+		}
+		if su.TotalCount != "" && su.TotalCount != "0" {
+			existing.TotalCount = su.TotalCount
+		}
+		if su.LastUsedAt != "" {
+			existing.LastUsedAt = su.LastUsedAt
+		}
+		out[id] = existing
+	}
+	return out
+}
+
+func (v *granolaRead) storeRecipesUsage() map[string]granola.RecipeUsage {
+	out := map[string]granola.RecipeUsage{}
+	if v == nil || v.store == nil {
+		return out
+	}
+	rows, err := v.store.DB().QueryContext(v.ctx,
+		`SELECT recipe_id, total_count, last_used_at FROM recipes_usage ORDER BY recipe_id ASC`)
+	if err != nil {
+		return out
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, lastUsed sql.NullString
+		var total sql.NullInt64
+		if err := rows.Scan(&id, &total, &lastUsed); err != nil {
+			return out
+		}
+		if id.String == "" {
+			continue
+		}
+		out[id.String] = granola.RecipeUsage{
+			RecipeID: id.String,
+			// total_count is an INTEGER column but RecipeUsage.TotalCount is
+			// the cache's string, and every consumer Sscanf's it - handing
+			// back anything but decimal digits reads as zero.
+			TotalCount: strconv.FormatInt(total.Int64, 10),
+			LastUsedAt: lastUsed.String,
+		}
+	}
+	return out
+}
+
+// ChatThreads returns the chat threads keyed by thread id, store first.
+//
+// Unlike Folders(), this is FolderMeetings()-shaped: an all-or-nothing
+// fallback. chat_threads carries every field the typed ChatThread exposes
+// except the entity type tag, so there is no field-level merge to do and an
+// empty store result simply defers to the cache.
+func (v *granolaRead) ChatThreads() map[string]granola.ChatThread {
+	if v == nil {
+		return nil
+	}
+	threads := v.storeChatThreads()
+	if len(threads) == 0 && v.cache != nil {
+		threads = v.cache.ChatThreads
+	}
+	out := make(map[string]granola.ChatThread, len(threads))
+	for id, t := range threads {
+		if t.ID == "" {
+			t.ID = id
+		}
+		out[id] = t
+	}
+	return out
+}
+
+func (v *granolaRead) storeChatThreads() map[string]granola.ChatThread {
+	out := map[string]granola.ChatThread{}
+	if v == nil || v.store == nil {
+		return out
+	}
+	rows, err := v.store.DB().QueryContext(v.ctx,
+		`SELECT id, meeting_id, workspace_id, title, created_at, updated_at FROM chat_threads ORDER BY id ASC`)
+	if err != nil {
+		return out
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, meetingID, workspaceID, title, createdAt, updatedAt sql.NullString
+		if err := rows.Scan(&id, &meetingID, &workspaceID, &title, &createdAt, &updatedAt); err != nil {
+			return out
+		}
+		if id.String == "" {
+			continue
+		}
+		out[id.String] = granola.ChatThread{
+			ID:          id.String,
+			WorkspaceID: workspaceID.String,
+			CreatedAt:   createdAt.String,
+			UpdatedAt:   updatedAt.String,
+			Data: granola.ChatThreadData{
+				Title:      title.String,
+				DocumentID: meetingID.String,
+			},
+		}
+	}
+	return out
+}
+
+// ChatMessages returns every chat message keyed by message id, store first,
+// with the same all-or-nothing fallback ChatThreads() uses. Callers that
+// want one thread's messages in order should use ChatThreadMessages.
+func (v *granolaRead) ChatMessages() map[string]granola.ChatMessage {
+	if v == nil {
+		return nil
+	}
+	out := map[string]granola.ChatMessage{}
+	if msgs := v.storeChatMessages(); len(msgs) > 0 {
+		for _, m := range msgs {
+			out[m.ID] = m
+		}
+		return out
+	}
+	if v.cache != nil {
+		for id, m := range v.cache.ChatMessages {
+			if m.ID == "" {
+				m.ID = id
+			}
+			out[id] = m
+		}
+	}
+	return out
+}
+
+// ChatThreadMessages returns one thread's messages in turn order, store
+// first. A thread whose messages neither path knows about yields an empty
+// slice rather than an error - an unanswered thread is an answer.
+func (v *granolaRead) ChatThreadMessages(threadID string) []granola.ChatMessage {
+	if v == nil {
+		return nil
+	}
+	msgs := v.storeChatMessagesForThread(threadID)
+	if len(msgs) == 0 && v.cache != nil {
+		for id, m := range v.cache.ChatMessages {
+			if m.Data.ThreadID != threadID {
+				continue
+			}
+			if m.ID == "" {
+				m.ID = id
+			}
+			msgs = append(msgs, m)
+		}
+	}
+	out := make([]granola.ChatMessage, 0, len(msgs))
+	out = append(out, msgs...)
+	// The store query already orders by turn_index; the cache branch iterates
+	// a map, so the sort is what makes both paths agree.
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Data.TurnIndex < out[j].Data.TurnIndex
+	})
+	return out
+}
+
+func (v *granolaRead) storeChatMessages() []granola.ChatMessage {
+	if v == nil || v.store == nil {
+		return nil
+	}
+	rows, err := v.store.DB().QueryContext(v.ctx, `
+		SELECT id, thread_id, role, turn_index, content, created_at
+		FROM chat_messages
+		ORDER BY thread_id ASC, turn_index ASC
+	`)
+	if err != nil {
+		return nil
+	}
+	return scanChatMessages(rows)
+}
+
+func (v *granolaRead) storeChatMessagesForThread(threadID string) []granola.ChatMessage {
+	if v == nil || v.store == nil {
+		return nil
+	}
+	rows, err := v.store.DB().QueryContext(v.ctx, `
+		SELECT id, thread_id, role, turn_index, content, created_at
+		FROM chat_messages
+		WHERE thread_id = ?
+		ORDER BY turn_index ASC
+	`, threadID)
+	if err != nil {
+		return nil
+	}
+	return scanChatMessages(rows)
+}
+
+// scanChatMessages rebuilds the cache-shaped ChatMessage the CLI already
+// speaks from a chat_messages row set, and closes rows.
+func scanChatMessages(rows *sql.Rows) []granola.ChatMessage {
+	defer rows.Close()
+	var out []granola.ChatMessage
+	for rows.Next() {
+		var id, threadID, role, content, createdAt sql.NullString
+		var turnIndex sql.NullInt64
+		if err := rows.Scan(&id, &threadID, &role, &turnIndex, &content, &createdAt); err != nil {
+			return out
+		}
+		out = append(out, granola.ChatMessage{
+			ID:        id.String,
+			CreatedAt: createdAt.String,
+			Data: granola.ChatMessageData{
+				ThreadID:  threadID.String,
+				Role:      role.String,
+				TurnIndex: int(turnIndex.Int64),
+				RawText:   content.String,
+			},
+		})
 	}
 	return out
 }

--- a/library/productivity/granola/internal/cli/granola_helpers.go
+++ b/library/productivity/granola/internal/cli/granola_helpers.go
@@ -147,7 +147,8 @@ type storeStaleness struct {
 	// LastCacheSyncAt is RFC3339 UTC, omitted when no successful cache sync
 	// has ever been recorded on this machine
 	// on this machine.
-	LastCacheSyncAt string `json:"last_cache_sync_at,omitempty"`
+	LastCacheSyncAt   string `json:"last_cache_sync_at,omitempty"`
+	LastCatalogSyncAt string `json:"last_catalog_sync_at,omitempty"`
 	// Refreshable is false when no code path can bring this data forward, so
 	// an agent can tell a frozen set from a merely stale one without parsing
 	// Notice.
@@ -173,8 +174,20 @@ func (v *granolaRead) staleness(frozenReason string) *storeStaleness {
 	// here would tell the user that months-old cache rows are current, which is
 	// worse than disclosing nothing. A missing or malformed sync_state.json is
 	// "unknown", not an error: the data is still worth serving, just undatable.
+	// Which clock dates these rows depends on whether the surface can be
+	// refreshed. Recipes and panel templates come back from the API catalog
+	// refresh, so they are dated by that; chat threads have no endpoint at all
+	// and stay dated by the last successful cache decrypt. Using the cache
+	// clock for a refreshable surface would report rows fetched seconds ago as
+	// months stale, which is the same misreport in the other direction.
 	age := "the date of the last successful cache sync is not recorded on this machine"
-	if s, err := granola.ReadSyncState(); err == nil && !s.LastCacheSyncAt.IsZero() {
+	s, err := granola.ReadSyncState()
+	switch {
+	case err != nil:
+	case frozenReason == "" && !s.LastCatalogSyncAt.IsZero():
+		st.LastCatalogSyncAt = s.LastCatalogSyncAt.UTC().Format(time.RFC3339)
+		age = "refreshed from the API on " + st.LastCatalogSyncAt
+	case !s.LastCacheSyncAt.IsZero():
 		st.LastCacheSyncAt = s.LastCacheSyncAt.UTC().Format(time.RFC3339)
 		age = "captured by the last successful cache sync on " + st.LastCacheSyncAt
 	}

--- a/library/productivity/granola/internal/cli/granola_read_test.go
+++ b/library/productivity/granola/internal/cli/granola_read_test.go
@@ -741,9 +741,11 @@ func TestGranolaRead_RecipeAndChatReaders_EmptyEverywhere(t *testing.T) {
 //
 // Keep the reason honest: an entry here is a statement that the data simply
 // is not in the store, not a note that rerouting was skipped.
+// chat.go and recipes.go were retired from this list once they were rerouted
+// through openGranolaRead(): the store's recipes/recipes_usage/chat_threads/
+// chat_messages tables are populated by the cache sync, so that data outlives
+// the cache's decryptability and is not cache-only at read time.
 var cacheOnlyCallSites = map[string]string{
-	"chat.go":       "chat threads and messages are cache-only state; no API sync path fills chat_threads/chat_messages",
-	"recipes.go":    "recipes are cache-only state; the store's recipes table is populated from the cache alone",
 	"workspaces.go": "workspaces are cache-only state with an existing live fallback",
 	"sync_cache.go": "the cache-to-store sync is the writer; reading the cache is the whole point of the command",
 }

--- a/library/productivity/granola/internal/cli/granola_read_test.go
+++ b/library/productivity/granola/internal/cli/granola_read_test.go
@@ -5,7 +5,9 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -316,6 +318,420 @@ func TestGranolaRead_StorePrecedesCache(t *testing.T) {
 	}
 	if d.Title != "Dual From Store" {
 		t.Errorf("store title should win, got %q", d.Title)
+	}
+}
+
+// --- recipe + chat store readers -------------------------------------------
+//
+// The four tables below (recipes, recipes_usage, chat_threads, chat_messages)
+// are written on every cache sync and, before these readers existed, read by
+// nothing. The tests pin two different merge shapes on purpose: recipes merge
+// field-by-field (so cache-only config.instructions survives a store row),
+// while chat threads/messages fall back all-or-nothing (there is no
+// field-level merge to do).
+
+// withStoreDB opens (creating on first use) the Granola store at dbPath and
+// hands fn the raw handle. Mirrors seedStore for the tables the recipe and
+// chat readers consume.
+func withStoreDB(t *testing.T, dbPath string, fn func(ctx context.Context, db *sql.DB)) {
+	t.Helper()
+	ctx := context.Background()
+	s, err := openGranolaStoreAt(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("openGranolaStoreAt: %v", err)
+	}
+	defer s.Close()
+	fn(ctx, s.DB())
+}
+
+// seedRecipe writes one recipes row with the exact column shape the cache
+// sync writes.
+func seedRecipe(t *testing.T, dbPath, id, slug, name, description, category, source string) {
+	t.Helper()
+	withStoreDB(t, dbPath, func(ctx context.Context, db *sql.DB) {
+		if _, err := db.ExecContext(ctx,
+			`INSERT OR REPLACE INTO recipes(id,slug,name,description,category,source) VALUES (?,?,?,?,?,?)`,
+			id, slug, name, description, category, source); err != nil {
+			t.Fatalf("insert recipe %s: %v", id, err)
+		}
+	})
+}
+
+// seedRecipeUsage writes a recipes_usage row. total_count is an INTEGER
+// column, which is the whole reason the reader has to stringify it back.
+func seedRecipeUsage(t *testing.T, dbPath, recipeID string, total int64, lastUsedAt string) {
+	t.Helper()
+	withStoreDB(t, dbPath, func(ctx context.Context, db *sql.DB) {
+		if _, err := db.ExecContext(ctx,
+			`INSERT OR REPLACE INTO recipes_usage(recipe_id,total_count,last_used_at) VALUES (?,?,?)`,
+			recipeID, total, lastUsedAt); err != nil {
+			t.Fatalf("insert recipe usage %s: %v", recipeID, err)
+		}
+	})
+}
+
+func seedChatThread(t *testing.T, dbPath, id, meetingID, workspaceID, title, createdAt, updatedAt string) {
+	t.Helper()
+	withStoreDB(t, dbPath, func(ctx context.Context, db *sql.DB) {
+		if _, err := db.ExecContext(ctx,
+			`INSERT OR REPLACE INTO chat_threads(id,meeting_id,workspace_id,title,created_at,updated_at) VALUES (?,?,?,?,?,?)`,
+			id, meetingID, workspaceID, title, createdAt, updatedAt); err != nil {
+			t.Fatalf("insert chat thread %s: %v", id, err)
+		}
+	})
+}
+
+func seedChatMessage(t *testing.T, dbPath, id, threadID, role string, turnIndex int, content, createdAt string) {
+	t.Helper()
+	withStoreDB(t, dbPath, func(ctx context.Context, db *sql.DB) {
+		if _, err := db.ExecContext(ctx,
+			`INSERT OR REPLACE INTO chat_messages(id,thread_id,role,turn_index,content,created_at) VALUES (?,?,?,?,?,?)`,
+			id, threadID, role, turnIndex, content, createdAt); err != nil {
+			t.Fatalf("insert chat message %s: %v", id, err)
+		}
+	})
+}
+
+// writeStateCache writes a v6-shaped cache carrying an arbitrary state block
+// and points GRANOLA_CACHE_PATH at it. buildSyntheticCache only knows about
+// documents and transcripts; recipe and chat state needs its own keys.
+func writeStateCache(t *testing.T, dir string, state map[string]any) {
+	t.Helper()
+	path := filepath.Join(dir, "cache.json")
+	data, err := json.Marshal(map[string]any{
+		"cache": map[string]any{"version": 6, "state": state},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GRANOLA_CACHE_PATH", path)
+}
+
+// recipeByID finds one recipe in the merged list.
+func recipeByID(recipes []granola.Recipe, id string) *granola.Recipe {
+	for i := range recipes {
+		if recipes[i].ID == id {
+			return &recipes[i]
+		}
+	}
+	return nil
+}
+
+// openRead is the boilerplate every reader test repeats.
+func openRead(t *testing.T) *granolaRead {
+	t.Helper()
+	v, err := openGranolaRead(context.Background())
+	if err != nil {
+		t.Fatalf("openGranolaRead: %v", err)
+	}
+	t.Cleanup(v.Close)
+	return v
+}
+
+// TestGranolaRead_Recipes_ServedFromStore_NoCache is the headline case for
+// R1: recipes hydrated into the store answer with no readable cache, with
+// the derived Source/Name fields LoadCache would have stamped.
+func TestGranolaRead_Recipes_ServedFromStore_NoCache(t *testing.T) {
+	db := newGranolaFixture(t)
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedRecipe(t, db, "rec_a", "action-items", "", "Pull the action items", "meeting", "public")
+	seedRecipe(t, db, "rec_b", "weekly-sync", "Weekly Sync", "Recap the week", "", "user")
+
+	recipes := openRead(t).Recipes()
+	if len(recipes) != 2 {
+		t.Fatalf("expected 2 recipes from the store, got %d (%+v)", len(recipes), recipes)
+	}
+	a := recipeByID(recipes, "rec_a")
+	if a == nil {
+		t.Fatal("rec_a missing from the merged recipe list")
+	}
+	if a.Source != "public" {
+		t.Errorf("rec_a source = %q, want %q", a.Source, "public")
+	}
+	// LoadCache defaults Name to Slug; a store row with an empty name column
+	// must arrive with the same default applied.
+	if a.Name != "action-items" {
+		t.Errorf("rec_a name = %q, want the slug default %q", a.Name, "action-items")
+	}
+	if a.Config.Description != "Pull the action items" {
+		t.Errorf("rec_a description = %q", a.Config.Description)
+	}
+	if a.Category != "meeting" {
+		t.Errorf("rec_a category = %q", a.Category)
+	}
+	b := recipeByID(recipes, "rec_b")
+	if b == nil {
+		t.Fatal("rec_b missing from the merged recipe list")
+	}
+	if b.Name != "Weekly Sync" {
+		t.Errorf("rec_b name = %q, want the stored name", b.Name)
+	}
+	if b.Source != "user" {
+		t.Errorf("rec_b source = %q, want %q", b.Source, "user")
+	}
+}
+
+// TestGranolaRead_Recipes_CacheOnlyFieldsSurviveMerge is the R2 guard: the
+// store has no instructions column, so a store row must not blank the
+// instructions a readable cache still carries.
+func TestGranolaRead_Recipes_CacheOnlyFieldsSurviveMerge(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRANOLA_API_KEY", "")
+	writeStateCache(t, home, map[string]any{
+		"userRecipes": []map[string]any{{
+			"id":         "rec_a",
+			"slug":       "weekly-sync",
+			"visibility": "workspace",
+			"config": map[string]any{
+				"description":  "Cache description",
+				"instructions": "Cache instructions",
+			},
+		}},
+	})
+	db := filepath.Join(home, ".local", "share", "granola-pp-cli", "data.db")
+	seedRecipe(t, db, "rec_a", "weekly-sync", "Weekly Sync", "Store description", "meeting", "user")
+
+	recipes := openRead(t).Recipes()
+	if len(recipes) != 1 {
+		t.Fatalf("cache and store rows for one recipe must merge into one, got %d (%+v)", len(recipes), recipes)
+	}
+	r := recipes[0]
+	if r.Config.Instructions != "Cache instructions" {
+		t.Errorf("cache-only instructions were lost: %q", r.Config.Instructions)
+	}
+	if r.Visibility != "workspace" {
+		t.Errorf("cache-only visibility was lost: %q", r.Visibility)
+	}
+	if r.Config.Description != "Store description" {
+		t.Errorf("store description should win, got %q", r.Config.Description)
+	}
+	if r.Name != "Weekly Sync" {
+		t.Errorf("store name should win, got %q", r.Name)
+	}
+	if r.Source != "user" {
+		t.Errorf("source = %q, want %q", r.Source, "user")
+	}
+}
+
+// TestGranolaRead_Recipes_EmptyStoreValuesDoNotBlankCache pins the other
+// half of the field-level merge: an empty store column is "no answer", not
+// an instruction to erase.
+func TestGranolaRead_Recipes_EmptyStoreValuesDoNotBlankCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRANOLA_API_KEY", "")
+	writeStateCache(t, home, map[string]any{
+		"publicRecipes": []map[string]any{{
+			"id":   "rec_a",
+			"slug": "cache-slug",
+			"config": map[string]any{
+				"description":  "Cache description",
+				"instructions": "Cache instructions",
+			},
+		}},
+	})
+	db := filepath.Join(home, ".local", "share", "granola-pp-cli", "data.db")
+	seedRecipe(t, db, "rec_a", "", "", "", "", "")
+
+	recipes := openRead(t).Recipes()
+	if len(recipes) != 1 {
+		t.Fatalf("expected 1 merged recipe, got %d (%+v)", len(recipes), recipes)
+	}
+	r := recipes[0]
+	if r.Name != "cache-slug" {
+		t.Errorf("empty store name blanked the cache name: %q", r.Name)
+	}
+	if r.Slug != "cache-slug" {
+		t.Errorf("empty store slug blanked the cache slug: %q", r.Slug)
+	}
+	if r.Config.Description != "Cache description" {
+		t.Errorf("empty store description blanked the cache description: %q", r.Config.Description)
+	}
+	if r.Source != "public" {
+		t.Errorf("empty store source blanked the cache-derived source: %q", r.Source)
+	}
+}
+
+// TestGranolaRead_RecipeUsage_TotalCountRoundTripsAsString covers the type
+// mismatch that would otherwise read as zero: the column is an INTEGER, the
+// typed field is the cache's string, and both consumers Sscanf it.
+func TestGranolaRead_RecipeUsage_TotalCountRoundTripsAsString(t *testing.T) {
+	db := newGranolaFixture(t)
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedRecipe(t, db, "rec_a", "action-items", "", "", "", "public")
+	seedRecipeUsage(t, db, "rec_a", 42, "2026-05-01T10:00:00.000Z")
+
+	usage := openRead(t).RecipesUsage()
+	u, ok := usage["rec_a"]
+	if !ok {
+		t.Fatalf("usage for rec_a missing: %+v", usage)
+	}
+	if u.TotalCount != "42" {
+		t.Errorf("total_count = %q, want %q", u.TotalCount, "42")
+	}
+	if u.LastUsedAt != "2026-05-01T10:00:00.000Z" {
+		t.Errorf("last_used_at = %q", u.LastUsedAt)
+	}
+	var n int64
+	if _, err := fmt.Sscanf(u.TotalCount, "%d", &n); err != nil {
+		t.Fatalf("Sscanf(%q): %v", u.TotalCount, err)
+	}
+	if n != 42 {
+		t.Errorf("Sscanf yielded %d, want 42", n)
+	}
+}
+
+// TestGranolaRead_ChatMessages_OrderedByTurnIndex: insertion order is not
+// turn order, and the readers must not leak that.
+func TestGranolaRead_ChatMessages_OrderedByTurnIndex(t *testing.T) {
+	db := newGranolaFixture(t)
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedChatThread(t, db, "thr_1", "not_m1", "ws_1", "Thread One",
+		"2026-05-01T10:00:00.000Z", "2026-05-01T10:05:00.000Z")
+	seedChatMessage(t, db, "msg_c", "thr_1", "assistant", 2, "third", "2026-05-01T10:02:00.000Z")
+	seedChatMessage(t, db, "msg_a", "thr_1", "user", 0, "first", "2026-05-01T10:00:00.000Z")
+	seedChatMessage(t, db, "msg_b", "thr_1", "assistant", 1, "second", "2026-05-01T10:01:00.000Z")
+	// A second thread's messages must not bleed into the first.
+	seedChatThread(t, db, "thr_2", "not_m2", "ws_1", "Thread Two", "", "")
+	seedChatMessage(t, db, "msg_other", "thr_2", "user", 0, "elsewhere", "")
+
+	v := openRead(t)
+	threads := v.ChatThreads()
+	th, ok := threads["thr_1"]
+	if !ok {
+		t.Fatalf("thr_1 missing from the store-served threads: %+v", threads)
+	}
+	if th.Data.Title != "Thread One" || th.Data.DocumentID != "not_m1" || th.WorkspaceID != "ws_1" {
+		t.Errorf("thread not reconstructed faithfully: %+v", th)
+	}
+	if th.CreatedAt != "2026-05-01T10:00:00.000Z" || th.UpdatedAt != "2026-05-01T10:05:00.000Z" {
+		t.Errorf("thread timestamps not reconstructed: %+v", th)
+	}
+
+	msgs := v.ChatThreadMessages("thr_1")
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages for thr_1, got %d (%+v)", len(msgs), msgs)
+	}
+	for i, want := range []string{"first", "second", "third"} {
+		if msgs[i].Data.RawText != want {
+			t.Errorf("message %d = %q, want %q (turn order broken: %+v)", i, msgs[i].Data.RawText, want, msgs)
+		}
+		if msgs[i].Data.TurnIndex != i {
+			t.Errorf("message %d turn_index = %d", i, msgs[i].Data.TurnIndex)
+		}
+	}
+	if msgs[0].Data.Role != "user" || msgs[1].Data.Role != "assistant" {
+		t.Errorf("roles not reconstructed: %+v", msgs)
+	}
+	if msgs[0].ID != "msg_a" {
+		t.Errorf("message id not reconstructed: %q", msgs[0].ID)
+	}
+	if all := v.ChatMessages(); len(all) != 4 {
+		t.Errorf("ChatMessages() = %d messages, want 4", len(all))
+	}
+}
+
+// TestGranolaRead_ChatThreadWithoutMessages_ReturnsEmptyList: a thread
+// nobody replied in is an answer, not an error.
+func TestGranolaRead_ChatThreadWithoutMessages_ReturnsEmptyList(t *testing.T) {
+	db := newGranolaFixture(t)
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedChatThread(t, db, "thr_empty", "not_m1", "ws_1", "Silent Thread", "2026-05-01T10:00:00.000Z", "")
+
+	v := openRead(t)
+	if _, ok := v.ChatThreads()["thr_empty"]; !ok {
+		t.Fatal("thread with no messages should still be listed")
+	}
+	msgs := v.ChatThreadMessages("thr_empty")
+	if msgs == nil {
+		t.Fatal("expected an empty slice, got nil")
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages, got %+v", msgs)
+	}
+}
+
+// TestGranolaRead_Chat_CacheFallback_WhenStoreEmpty keeps legacy installs
+// working: chat is all-or-nothing, so an empty store defers to the cache.
+func TestGranolaRead_Chat_CacheFallback_WhenStoreEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRANOLA_API_KEY", "")
+	writeStateCache(t, home, map[string]any{
+		"entities": map[string]any{
+			"chat_thread": map[string]any{
+				"thr_1": map[string]any{
+					"id":           "thr_1",
+					"type":         "chat_thread",
+					"workspace_id": "ws_1",
+					"created_at":   "2026-05-01T10:00:00.000Z",
+					"data": map[string]any{
+						"title":       "Cache Thread",
+						"document_id": "not_m1",
+					},
+				},
+			},
+			"chat_message": map[string]any{
+				"msg_b": map[string]any{
+					"id":   "msg_b",
+					"data": map[string]any{"thread_id": "thr_1", "role": "assistant", "turn_index": 1, "raw_text": "cache second"},
+				},
+				"msg_a": map[string]any{
+					"id":   "msg_a",
+					"data": map[string]any{"thread_id": "thr_1", "role": "user", "turn_index": 0, "raw_text": "cache first"},
+				},
+			},
+		},
+	})
+
+	v := openRead(t)
+	th, ok := v.ChatThreads()["thr_1"]
+	if !ok {
+		t.Fatalf("cache thread missing: %+v", v.ChatThreads())
+	}
+	if th.Data.Title != "Cache Thread" {
+		t.Errorf("thread title = %q", th.Data.Title)
+	}
+	msgs := v.ChatThreadMessages("thr_1")
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 cache messages, got %d (%+v)", len(msgs), msgs)
+	}
+	if msgs[0].Data.RawText != "cache first" || msgs[1].Data.RawText != "cache second" {
+		t.Errorf("cache messages out of turn order: %+v", msgs)
+	}
+	if len(v.ChatMessages()) != 2 {
+		t.Errorf("ChatMessages() = %d, want 2", len(v.ChatMessages()))
+	}
+}
+
+// TestGranolaRead_RecipeAndChatReaders_EmptyEverywhere covers the state a
+// fresh install sits in between `sync-api` and `sync`: the store exists but
+// none of these four tables has a row, and no cache is readable. Every
+// accessor must answer empty rather than panic.
+func TestGranolaRead_RecipeAndChatReaders_EmptyEverywhere(t *testing.T) {
+	db := newGranolaFixture(t)
+	t.Setenv("GRANOLA_API_KEY", "")
+	withStoreDB(t, db, func(context.Context, *sql.DB) {}) // create the schema, seed nothing
+
+	v := openRead(t)
+	if got := v.Recipes(); got == nil || len(got) != 0 {
+		t.Errorf("Recipes() = %+v, want an empty slice", got)
+	}
+	if got := v.RecipesUsage(); got == nil || len(got) != 0 {
+		t.Errorf("RecipesUsage() = %+v, want an empty map", got)
+	}
+	if got := v.ChatThreads(); got == nil || len(got) != 0 {
+		t.Errorf("ChatThreads() = %+v, want an empty map", got)
+	}
+	if got := v.ChatMessages(); got == nil || len(got) != 0 {
+		t.Errorf("ChatMessages() = %+v, want an empty map", got)
+	}
+	if got := v.ChatThreadMessages("nope"); got == nil || len(got) != 0 {
+		t.Errorf("ChatThreadMessages() = %+v, want an empty slice", got)
 	}
 }
 

--- a/library/productivity/granola/internal/cli/recipes.go
+++ b/library/productivity/granola/internal/cli/recipes.go
@@ -34,11 +34,16 @@ func newRecipesListCmd(flags *rootFlags) *cobra.Command {
 			if dryRunOK(flags) {
 				return nil
 			}
-			c, err := openGranolaCache()
+			// PATCH(dual-path-store-read): the store's recipes table is the
+			// only readable copy on a migrated install, where the desktop
+			// cache no longer decrypts. Going through the read seam turns a
+			// hard failure into the 57 recipes that are already local.
+			v, err := openGranolaRead(cmd.Context())
 			if err != nil {
 				return err
 			}
-			recipes := c.RecipesAll()
+			defer v.Close()
+			recipes := v.Recipes()
 			var filtered []granola.Recipe
 			for _, r := range recipes {
 				if source != "" && r.Source != source {
@@ -55,14 +60,19 @@ func newRecipesListCmd(flags *rootFlags) *cobra.Command {
 				}
 				filtered = append(filtered, r)
 			}
+			st := v.staleness("")
 			if topUsage {
 				type ru struct {
 					Recipe granola.Recipe
 					Count  int64
 				}
+				usage := v.RecipesUsage()
 				items := make([]ru, 0, len(filtered))
 				for _, r := range filtered {
-					u := c.RecipesUsage[r.ID]
+					u := usage[r.ID]
+					// TotalCount is the cache's string on both paths, so the
+					// sort below has to rank the parsed integer - "12" is
+					// lexically below "3".
 					var n int64
 					fmt.Sscanf(u.TotalCount, "%d", &n)
 					items = append(items, ru{Recipe: r, Count: n})
@@ -84,7 +94,7 @@ func newRecipesListCmd(flags *rootFlags) *cobra.Command {
 						"usage_count": it.Count,
 					})
 				}
-				return emitJSON(cmd, flags, out)
+				return emitWithStaleness(cmd, flags, "recipes", out, st)
 			}
 			out := make([]map[string]any, 0, len(filtered))
 			for _, r := range filtered {
@@ -96,7 +106,7 @@ func newRecipesListCmd(flags *rootFlags) *cobra.Command {
 					"source":      r.Source,
 				})
 			}
-			return emitJSON(cmd, flags, out)
+			return emitWithStaleness(cmd, flags, "recipes", out, st)
 		},
 	}
 	cmd.Flags().StringVar(&source, "source", "", "public | user | shared")
@@ -121,22 +131,25 @@ func newRecipesDescribeCmd(flags *rootFlags) *cobra.Command {
 				return nil
 			}
 			key := args[0]
-			c, err := openGranolaCache()
+			v, err := openGranolaRead(cmd.Context())
 			if err != nil {
 				return err
 			}
+			defer v.Close()
+			recipes := v.Recipes()
 			var hit *granola.Recipe
-			for i := range c.RecipesAll() {
-				r := c.RecipesAll()[i]
-				if r.Slug == key || r.ID == key {
-					hit = &r
+			for i := range recipes {
+				if recipes[i].Slug == key || recipes[i].ID == key {
+					hit = &recipes[i]
 					break
 				}
 			}
+			// A slug neither path knows about is still a miss. Serving store
+			// data must never soften a not-found into an empty success.
 			if hit == nil {
 				return notFoundErr(fmt.Errorf("recipe %q not found", key))
 			}
-			usage := c.RecipesUsage[hit.ID]
+			usage := v.RecipesUsage()[hit.ID]
 			out := map[string]any{
 				"id":           hit.ID,
 				"slug":         hit.Slug,
@@ -148,6 +161,10 @@ func newRecipesDescribeCmd(flags *rootFlags) *cobra.Command {
 					"count":        usage.TotalCount,
 					"last_used_at": usage.LastUsedAt,
 				},
+			}
+			if st := v.staleness(""); st != nil {
+				writeStalenessNotice(cmd, flags, st)
+				out["staleness"] = st
 			}
 			return emitJSON(cmd, flags, out)
 		},

--- a/library/productivity/granola/internal/cli/recipes_chat_store_test.go
+++ b/library/productivity/granola/internal/cli/recipes_chat_store_test.go
@@ -1,0 +1,592 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/granola"
+)
+
+// PATCH(dual-path-store-read): regressions for the four cache-only commands
+// (`recipes list`, `recipes describe`, `chat list`, `chat get`) after they were
+// rerouted through the store read seam.
+//
+// The user-visible requirement is literal: on a migrated install the desktop
+// cache never decrypts again, but the store already holds the recipes and chat
+// threads the last cache sync wrote. These commands used to hard-fail on the
+// decrypt; they must now serve what is local and say how old it is.
+
+// runCLISplit is runCLI with stdout and stderr kept apart. The staleness
+// notice is written to stderr precisely so it cannot corrupt the JSON on
+// stdout, and a runner that merged the two streams could not tell the
+// difference (nor could it json.Unmarshal the result).
+func runCLISplit(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	rc := RootCmd()
+	rc.SetOut(&out)
+	rc.SetErr(&errOut)
+	rc.SilenceUsage = true
+	rc.SilenceErrors = true
+	rc.SetArgs(append(args, "--no-refresh"))
+	err := rc.Execute()
+	return out.String(), errOut.String(), err
+}
+
+// isolateSyncState points ReadSyncState at a scratch file so a real
+// ~/.local/share/granola-pp-cli/sync_state.json on the developer's machine
+// cannot leak into an assertion. A non-zero at records a sync at that instant.
+func isolateSyncState(t *testing.T, at time.Time) {
+	t.Helper()
+	t.Setenv("GRANOLA_SYNC_STATE_PATH", filepath.Join(t.TempDir(), "sync_state.json"))
+	if at.IsZero() {
+		return
+	}
+	if err := granola.WriteSyncState(granola.SyncState{
+		LastSyncAt:        at,
+		LastCacheSyncAt:   at,
+		LastDecryptStatus: granola.DecryptStatusFailed,
+	}); err != nil {
+		t.Fatalf("WriteSyncState: %v", err)
+	}
+}
+
+// stalenessBlock mirrors the JSON the commands attach. Declared in the test
+// rather than reusing the production type so these tests assert the wire
+// shape an agent actually parses, not the struct that happens to produce it.
+type stalenessBlock struct {
+	Source          string `json:"source"`
+	LastCacheSyncAt string `json:"last_cache_sync_at"`
+	Refreshable     bool   `json:"refreshable"`
+	Notice          string `json:"notice"`
+}
+
+type recipeListEnvelope struct {
+	Recipes   []map[string]any `json:"recipes"`
+	Staleness *stalenessBlock  `json:"staleness"`
+}
+
+type chatListEnvelope struct {
+	Threads   []map[string]any `json:"threads"`
+	Staleness *stalenessBlock  `json:"staleness"`
+}
+
+func decodeRecipeList(t *testing.T, stdout string) recipeListEnvelope {
+	t.Helper()
+	var env recipeListEnvelope
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("unmarshal recipes list envelope: %v (stdout=%q)", err, stdout)
+	}
+	return env
+}
+
+func decodeChatList(t *testing.T, stdout string) chatListEnvelope {
+	t.Helper()
+	var env chatListEnvelope
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("unmarshal chat list envelope: %v (stdout=%q)", err, stdout)
+	}
+	return env
+}
+
+func recipeRowBySlug(rows []map[string]any, slug string) map[string]any {
+	for _, r := range rows {
+		if r["slug"] == slug {
+			return r
+		}
+	}
+	return nil
+}
+
+// TestRecipesList_ServedFromStore_NoCache is the headline R1 case: 57 recipes
+// sit in the store on a real machine and `recipes list` used to refuse to show
+// any of them because the cache would not decrypt.
+func TestRecipesList_ServedFromStore_NoCache(t *testing.T) {
+	db := newGranolaFixture(t)
+	isolateSyncState(t, time.Time{})
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedRecipe(t, db, "rec_a", "action-items", "", "Pull the action items", "meeting", "public")
+	seedRecipe(t, db, "rec_b", "weekly-sync", "Weekly Sync", "Recap the week", "", "user")
+
+	stdout, _, err := runCLISplit(t, "recipes", "list", "--json")
+	if err != nil {
+		t.Fatalf("recipes list: %v (stdout=%q)", err, stdout)
+	}
+	env := decodeRecipeList(t, stdout)
+	if len(env.Recipes) != 2 {
+		t.Fatalf("expected 2 store recipes, got %d (%+v)", len(env.Recipes), env.Recipes)
+	}
+	a := recipeRowBySlug(env.Recipes, "action-items")
+	if a == nil {
+		t.Fatalf("action-items missing: %+v", env.Recipes)
+	}
+	if a["source"] != "public" {
+		t.Errorf("action-items source = %v, want public", a["source"])
+	}
+	if a["description"] != "Pull the action items" {
+		t.Errorf("action-items description = %v", a["description"])
+	}
+	// LoadCache defaults Name to Slug; a store row with an empty name column
+	// must reach the command with the same default applied.
+	if a["name"] != "action-items" {
+		t.Errorf("action-items name = %v, want the slug default", a["name"])
+	}
+
+	// The --source filter must keep working against store-sourced rows.
+	stdout, _, err = runCLISplit(t, "recipes", "list", "--source", "user", "--json")
+	if err != nil {
+		t.Fatalf("recipes list --source user: %v (stdout=%q)", err, stdout)
+	}
+	env = decodeRecipeList(t, stdout)
+	if len(env.Recipes) != 1 || env.Recipes[0]["slug"] != "weekly-sync" {
+		t.Errorf("--source user should select exactly weekly-sync, got %+v", env.Recipes)
+	}
+}
+
+// TestChatList_ServedFromStore_NoCache: 225 chat threads in the store, zero
+// shown before the reroute.
+func TestChatList_ServedFromStore_NoCache(t *testing.T) {
+	db := newGranolaFixture(t)
+	isolateSyncState(t, time.Time{})
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedChatThread(t, db, "thr_1", "not_m1", "ws_1", "Thread One",
+		"2026-05-01T10:00:00.000Z", "2026-05-01T10:05:00.000Z")
+	seedChatMessage(t, db, "msg_a", "thr_1", "user", 0, "opening question", "2026-05-01T10:00:00.000Z")
+	seedChatMessage(t, db, "msg_b", "thr_1", "assistant", 1, "the answer", "2026-05-01T10:01:00.000Z")
+
+	stdout, _, err := runCLISplit(t, "chat", "list", "--json")
+	if err != nil {
+		t.Fatalf("chat list: %v (stdout=%q)", err, stdout)
+	}
+	env := decodeChatList(t, stdout)
+	if len(env.Threads) != 1 {
+		t.Fatalf("expected 1 store thread, got %d (%+v)", len(env.Threads), env.Threads)
+	}
+	th := env.Threads[0]
+	if th["id"] != "thr_1" || th["title"] != "Thread One" || th["meeting_id"] != "not_m1" {
+		t.Errorf("thread not reconstructed: %+v", th)
+	}
+	if th["workspace_id"] != "ws_1" || th["created_at"] != "2026-05-01T10:00:00.000Z" {
+		t.Errorf("thread metadata lost: %+v", th)
+	}
+	if th["preview"] != "opening question" {
+		t.Errorf("preview = %v, want the turn-0 message", th["preview"])
+	}
+	if count, _ := th["message_count"].(float64); count != 2 {
+		t.Errorf("message_count = %v, want 2", th["message_count"])
+	}
+}
+
+// TestChatGet_ServedFromStore_NoCache pins the per-thread dump.
+func TestChatGet_ServedFromStore_NoCache(t *testing.T) {
+	db := newGranolaFixture(t)
+	isolateSyncState(t, time.Time{})
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedChatThread(t, db, "thr_1", "not_m1", "ws_1", "Thread One", "2026-05-01T10:00:00.000Z", "")
+	seedChatMessage(t, db, "msg_c", "thr_1", "assistant", 2, "third", "2026-05-01T10:02:00.000Z")
+	seedChatMessage(t, db, "msg_a", "thr_1", "user", 0, "first", "2026-05-01T10:00:00.000Z")
+	seedChatMessage(t, db, "msg_b", "thr_1", "assistant", 1, "second", "2026-05-01T10:01:00.000Z")
+
+	stdout, _, err := runCLISplit(t, "chat", "get", "thr_1", "--json")
+	if err != nil {
+		t.Fatalf("chat get: %v (stdout=%q)", err, stdout)
+	}
+	var got struct {
+		ID        string                `json:"id"`
+		Title     string                `json:"title"`
+		MeetingID string                `json:"meeting_id"`
+		Messages  []granola.ChatMessage `json:"messages"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal chat get: %v (stdout=%q)", err, stdout)
+	}
+	if got.ID != "thr_1" || got.Title != "Thread One" || got.MeetingID != "not_m1" {
+		t.Errorf("thread header wrong: %+v", got)
+	}
+	if len(got.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d (%+v)", len(got.Messages), got.Messages)
+	}
+	for i, want := range []string{"first", "second", "third"} {
+		if got.Messages[i].Data.RawText != want {
+			t.Errorf("message %d = %q, want %q (turn order broken)", i, got.Messages[i].Data.RawText, want)
+		}
+	}
+
+	if _, _, err := runCLISplit(t, "chat", "get", "thr_missing", "--json"); err == nil {
+		t.Error("expected an unknown thread id to be not-found")
+	} else {
+		var ce *cliError
+		if !As(err, &ce) || ce.code != 3 {
+			t.Errorf("expected a not-found cliError (code 3), got %#v", err)
+		}
+	}
+}
+
+// TestRecipesAndChatList_EmptyStore_ExitZero: a database that exists with zero
+// rows is an empty answer, not a failure. This is the state a fresh install
+// sits in between `sync-api` and `sync`.
+func TestRecipesAndChatList_EmptyStore_ExitZero(t *testing.T) {
+	db := newGranolaFixture(t)
+	isolateSyncState(t, time.Time{})
+	t.Setenv("GRANOLA_API_KEY", "")
+	withStoreDB(t, db, func(context.Context, *sql.DB) {}) // create the schema, seed nothing
+
+	stdout, _, err := runCLISplit(t, "recipes", "list", "--json")
+	if err != nil {
+		t.Fatalf("recipes list on an empty store: %v (stdout=%q)", err, stdout)
+	}
+	if rows := decodeRecipeList(t, stdout).Recipes; len(rows) != 0 {
+		t.Errorf("expected no recipes, got %+v", rows)
+	}
+
+	stdout, _, err = runCLISplit(t, "chat", "list", "--json")
+	if err != nil {
+		t.Fatalf("chat list on an empty store: %v (stdout=%q)", err, stdout)
+	}
+	if rows := decodeChatList(t, stdout).Threads; len(rows) != 0 {
+		t.Errorf("expected no threads, got %+v", rows)
+	}
+}
+
+// TestRecipesList_NoLocalDataAtAll_StillErrors: with no database and no
+// readable cache there is genuinely nothing to show, and the error must stay
+// an error rather than degrading into an empty success.
+func TestRecipesList_NoLocalDataAtAll_StillErrors(t *testing.T) {
+	newGranolaFixture(t)
+	isolateSyncState(t, time.Time{})
+	t.Setenv("GRANOLA_API_KEY", "")
+
+	for _, args := range [][]string{
+		{"recipes", "list", "--json"},
+		{"recipes", "describe", "action-items", "--json"},
+		{"chat", "list", "--json"},
+		{"chat", "get", "thr_1", "--json"},
+	} {
+		stdout, _, err := runCLISplit(t, args...)
+		if err == nil {
+			t.Errorf("%v: expected an error with no store and no cache (stdout=%q)", args, stdout)
+			continue
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "sync") {
+			t.Errorf("%v: error should point at sync, got %q", args, msg)
+		}
+		if strings.Contains(msg, "safestorage") || strings.Contains(msg, "refresh refused") {
+			t.Errorf("%v: error leaked the raw safestorage failure: %q", args, msg)
+		}
+		var ce *cliError
+		if !As(err, &ce) || ce.code != 3 {
+			t.Errorf("%v: expected a not-found cliError (code 3), got %#v", args, err)
+		}
+	}
+}
+
+// TestRecipesDescribe_UnknownSlug_NotFound: the reroute must not turn a miss
+// into an empty success.
+func TestRecipesDescribe_UnknownSlug_NotFound(t *testing.T) {
+	db := newGranolaFixture(t)
+	isolateSyncState(t, time.Time{})
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedRecipe(t, db, "rec_a", "action-items", "", "Pull the action items", "meeting", "public")
+
+	stdout, _, err := runCLISplit(t, "recipes", "describe", "no-such-recipe", "--json")
+	if err == nil {
+		t.Fatalf("expected not-found for an unknown slug (stdout=%q)", stdout)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want a not-found message", err.Error())
+	}
+	var ce *cliError
+	if !As(err, &ce) || ce.code != 3 {
+		t.Errorf("expected a not-found cliError (code 3), got %#v", err)
+	}
+}
+
+// TestRecipesDescribe_KnownSlug_StoreAndCacheMerge: the store answers the
+// identity columns, the cache still supplies config.instructions (which has no
+// store column at all), and describe must show both.
+func TestRecipesDescribe_KnownSlug_StoreAndCacheMerge(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	isolateSyncState(t, time.Time{})
+	t.Setenv("GRANOLA_API_KEY", "")
+	writeStateCache(t, home, map[string]any{
+		"userRecipes": []map[string]any{{
+			"id":   "rec_a",
+			"slug": "weekly-sync",
+			"config": map[string]any{
+				"description":  "Cache description",
+				"instructions": "Summarize the week in three bullets.",
+			},
+		}},
+	})
+	db := filepath.Join(home, ".local", "share", "granola-pp-cli", "data.db")
+	seedRecipe(t, db, "rec_a", "weekly-sync", "Weekly Sync", "Store description", "meeting", "user")
+	seedRecipeUsage(t, db, "rec_a", 7, "2026-05-01T10:00:00.000Z")
+
+	stdout, stderr, err := runCLISplit(t, "recipes", "describe", "weekly-sync", "--json")
+	if err != nil {
+		t.Fatalf("recipes describe: %v (stdout=%q)", err, stdout)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal describe: %v (stdout=%q)", err, stdout)
+	}
+	if got["id"] != "rec_a" || got["slug"] != "weekly-sync" || got["name"] != "Weekly Sync" {
+		t.Errorf("identity fields wrong: %+v", got)
+	}
+	if got["instructions"] != "Summarize the week in three bullets." {
+		t.Errorf("cache-only instructions lost: %v", got["instructions"])
+	}
+	if got["description"] != "Store description" {
+		t.Errorf("store description should win, got %v", got["description"])
+	}
+	usage, _ := got["usage"].(map[string]any)
+	if usage == nil || usage["count"] != "7" {
+		t.Errorf("usage not carried through: %+v", got["usage"])
+	}
+	// A readable cache is not a frozen install.
+	if _, ok := got["staleness"]; ok {
+		t.Errorf("readable-cache install must not carry a staleness block: %+v", got)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Errorf("readable-cache install must not print a staleness notice, got %q", stderr)
+	}
+}
+
+// TestRecipesList_TopUsage_OrdersNumerically: RecipeUsage.TotalCount is the
+// cache's string, so a lexical sort would rank "3" above "12".
+func TestRecipesList_TopUsage_OrdersNumerically(t *testing.T) {
+	db := newGranolaFixture(t)
+	isolateSyncState(t, time.Time{})
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedRecipe(t, db, "rec_small", "small", "Small", "", "", "user")
+	seedRecipe(t, db, "rec_big", "big", "Big", "", "", "user")
+	seedRecipe(t, db, "rec_none", "none", "None", "", "", "user")
+	seedRecipeUsage(t, db, "rec_small", 3, "2026-05-01T10:00:00.000Z")
+	seedRecipeUsage(t, db, "rec_big", 12, "2026-05-02T10:00:00.000Z")
+
+	stdout, _, err := runCLISplit(t, "recipes", "list", "--top-usage", "--json")
+	if err != nil {
+		t.Fatalf("recipes list --top-usage: %v (stdout=%q)", err, stdout)
+	}
+	env := decodeRecipeList(t, stdout)
+	if len(env.Recipes) != 3 {
+		t.Fatalf("expected 3 rows, got %d (%+v)", len(env.Recipes), env.Recipes)
+	}
+	var order []string
+	for _, r := range env.Recipes {
+		order = append(order, r["slug"].(string))
+	}
+	if order[0] != "big" || order[1] != "small" || order[2] != "none" {
+		t.Errorf("--top-usage order = %v, want [big small none] ('12' must outrank '3')", order)
+	}
+	if n, _ := env.Recipes[0]["usage_count"].(float64); n != 12 {
+		t.Errorf("usage_count for big = %v, want 12", env.Recipes[0]["usage_count"])
+	}
+	if n, _ := env.Recipes[1]["usage_count"].(float64); n != 3 {
+		t.Errorf("usage_count for small = %v, want 3", env.Recipes[1]["usage_count"])
+	}
+}
+
+// TestChatList_AnchoredToMeeting_Filters keeps the positional meeting filter
+// working off store-sourced threads.
+func TestChatList_AnchoredToMeeting_Filters(t *testing.T) {
+	db := newGranolaFixture(t)
+	isolateSyncState(t, time.Time{})
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedChatThread(t, db, "thr_1", "not_m1", "ws_1", "About M1", "2026-05-01T10:00:00.000Z", "")
+	seedChatThread(t, db, "thr_2", "not_m2", "ws_1", "About M2", "2026-05-02T10:00:00.000Z", "")
+	seedChatMessage(t, db, "msg_a", "thr_1", "user", 0, "m1 question", "")
+	seedChatMessage(t, db, "msg_b", "thr_2", "user", 0, "m2 question", "")
+
+	stdout, _, err := runCLISplit(t, "chat", "list", "not_m1", "--json")
+	if err != nil {
+		t.Fatalf("chat list not_m1: %v (stdout=%q)", err, stdout)
+	}
+	env := decodeChatList(t, stdout)
+	if len(env.Threads) != 1 {
+		t.Fatalf("expected 1 thread for not_m1, got %d (%+v)", len(env.Threads), env.Threads)
+	}
+	if env.Threads[0]["id"] != "thr_1" {
+		t.Errorf("wrong thread: %+v", env.Threads[0])
+	}
+}
+
+// TestStalenessDisclosed_WhenCacheUnreadable is R6: a command serving store
+// data must say how current that data is, in the JSON an agent parses and on
+// the stream a human reads.
+func TestStalenessDisclosed_WhenCacheUnreadable(t *testing.T) {
+	db := newGranolaFixture(t)
+	lastSync := time.Date(2026, 6, 22, 17, 4, 5, 0, time.UTC)
+	isolateSyncState(t, lastSync)
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedRecipe(t, db, "rec_a", "action-items", "Action Items", "Pull the action items", "meeting", "public")
+	seedChatThread(t, db, "thr_1", "not_m1", "ws_1", "Thread One", "2026-05-01T10:00:00.000Z", "")
+
+	wantStamp := lastSync.Format(time.RFC3339)
+
+	// recipes list
+	stdout, stderr, err := runCLISplit(t, "recipes", "list", "--json")
+	if err != nil {
+		t.Fatalf("recipes list: %v", err)
+	}
+	st := decodeRecipeList(t, stdout).Staleness
+	if st == nil {
+		t.Fatalf("recipes list carried no staleness block: %s", stdout)
+	}
+	if st.Source != "store" {
+		t.Errorf("recipes list staleness.source = %q, want store", st.Source)
+	}
+	if st.LastCacheSyncAt != wantStamp {
+		t.Errorf("recipes list staleness.last_cache_sync_at = %q, want %q", st.LastCacheSyncAt, wantStamp)
+	}
+	if !strings.Contains(stderr, wantStamp) {
+		t.Errorf("recipes list human notice missing the sync timestamp: %q", stderr)
+	}
+
+	// recipes describe
+	stdout, stderr, err = runCLISplit(t, "recipes", "describe", "action-items", "--json")
+	if err != nil {
+		t.Fatalf("recipes describe: %v", err)
+	}
+	var described struct {
+		Staleness *stalenessBlock `json:"staleness"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &described); err != nil {
+		t.Fatalf("unmarshal describe: %v (stdout=%q)", err, stdout)
+	}
+	if described.Staleness == nil {
+		t.Fatalf("recipes describe carried no staleness block: %s", stdout)
+	}
+	if described.Staleness.LastCacheSyncAt != wantStamp {
+		t.Errorf("recipes describe staleness.last_cache_sync_at = %q, want %q", described.Staleness.LastCacheSyncAt, wantStamp)
+	}
+	if !strings.Contains(stderr, wantStamp) {
+		t.Errorf("recipes describe human notice missing the sync timestamp: %q", stderr)
+	}
+
+	// chat list
+	stdout, stderr, err = runCLISplit(t, "chat", "list", "--json")
+	if err != nil {
+		t.Fatalf("chat list: %v", err)
+	}
+	chatSt := decodeChatList(t, stdout).Staleness
+	if chatSt == nil {
+		t.Fatalf("chat list carried no staleness block: %s", stdout)
+	}
+	if chatSt.LastCacheSyncAt != wantStamp {
+		t.Errorf("chat list staleness.last_cache_sync_at = %q, want %q", chatSt.LastCacheSyncAt, wantStamp)
+	}
+	if !strings.Contains(stderr, wantStamp) {
+		t.Errorf("chat list human notice missing the sync timestamp: %q", stderr)
+	}
+}
+
+// TestChatList_DisclosesFrozenThreadSet: there is no chat endpoint on
+// Granola's internal API, so re-running sync cannot advance chat_threads on a
+// migrated install. An agent must be able to tell a frozen set from a current
+// one without parsing prose, hence the refreshable flag.
+func TestChatList_DisclosesFrozenThreadSet(t *testing.T) {
+	db := newGranolaFixture(t)
+	isolateSyncState(t, time.Date(2026, 6, 22, 17, 4, 5, 0, time.UTC))
+	t.Setenv("GRANOLA_API_KEY", "")
+	seedChatThread(t, db, "thr_1", "not_m1", "ws_1", "Thread One", "2026-05-01T10:00:00.000Z", "")
+
+	stdout, stderr, err := runCLISplit(t, "chat", "list", "--json")
+	if err != nil {
+		t.Fatalf("chat list: %v", err)
+	}
+	st := decodeChatList(t, stdout).Staleness
+	if st == nil {
+		t.Fatalf("chat list carried no staleness block: %s", stdout)
+	}
+	if st.Refreshable {
+		t.Error("chat list staleness.refreshable = true; chat threads cannot be refreshed")
+	}
+	if !strings.Contains(strings.ToLower(st.Notice), "refresh") {
+		t.Errorf("chat list notice does not state the set cannot be refreshed: %q", st.Notice)
+	}
+	if !strings.Contains(strings.ToLower(stderr), "refresh") {
+		t.Errorf("chat list human output does not state the set cannot be refreshed: %q", stderr)
+	}
+
+	// Recipes are refreshable by a future cache sync; only chat is frozen.
+	seedRecipe(t, db, "rec_a", "action-items", "Action Items", "", "", "public")
+	stdout, _, err = runCLISplit(t, "recipes", "list", "--json")
+	if err != nil {
+		t.Fatalf("recipes list: %v", err)
+	}
+	rst := decodeRecipeList(t, stdout).Staleness
+	if rst == nil {
+		t.Fatalf("recipes list carried no staleness block: %s", stdout)
+	}
+	if !rst.Refreshable {
+		t.Error("recipes list staleness.refreshable = false; a cache sync can still advance recipes")
+	}
+}
+
+// TestStalenessOmitted_WhenCacheReadable is requirement 7: the cache path is
+// not frozen, so its output must stay byte-identical to what it always was -
+// a bare JSON array, no envelope, no notice.
+func TestStalenessOmitted_WhenCacheReadable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	isolateSyncState(t, time.Date(2026, 6, 22, 17, 4, 5, 0, time.UTC))
+	t.Setenv("GRANOLA_API_KEY", "")
+	writeStateCache(t, home, map[string]any{
+		"userRecipes": []map[string]any{{
+			"id":     "rec_a",
+			"slug":   "weekly-sync",
+			"config": map[string]any{"description": "Cache description"},
+		}},
+		"entities": map[string]any{
+			"chat_thread": map[string]any{
+				"thr_1": map[string]any{
+					"id":           "thr_1",
+					"type":         "chat_thread",
+					"workspace_id": "ws_1",
+					"created_at":   "2026-05-01T10:00:00.000Z",
+					"data":         map[string]any{"title": "Cache Thread", "document_id": "not_m1"},
+				},
+			},
+			"chat_message": map[string]any{
+				"msg_a": map[string]any{
+					"id":   "msg_a",
+					"data": map[string]any{"thread_id": "thr_1", "role": "user", "turn_index": 0, "raw_text": "cache first"},
+				},
+			},
+		},
+	})
+
+	for _, args := range [][]string{
+		{"recipes", "list", "--json"},
+		{"chat", "list", "--json"},
+	} {
+		stdout, stderr, err := runCLISplit(t, args...)
+		if err != nil {
+			t.Fatalf("%v: %v (stdout=%q)", args, err, stdout)
+		}
+		var rows []map[string]any
+		if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+			t.Fatalf("%v: readable-cache output must stay a bare array: %v (stdout=%q)", args, err, stdout)
+		}
+		if len(rows) != 1 {
+			t.Errorf("%v: expected 1 cache row, got %d (%+v)", args, len(rows), rows)
+		}
+		if strings.Contains(stdout, "staleness") {
+			t.Errorf("%v: readable-cache output must not carry a staleness block: %s", args, stdout)
+		}
+		if strings.TrimSpace(stderr) != "" {
+			t.Errorf("%v: readable-cache install must not print a staleness notice, got %q", args, stderr)
+		}
+	}
+}

--- a/library/productivity/granola/internal/cli/sync_cache.go
+++ b/library/productivity/granola/internal/cli/sync_cache.go
@@ -311,6 +311,8 @@ func tokenSourceLabel(s granola.TokenSource) string {
 		return "stored_accounts"
 	case granola.TokenSourcePlaintextSupabaseDesktopFallback:
 		return "plaintext_supabase_desktop_fallback"
+	case granola.TokenSourceCLISession:
+		return "cli_session"
 	}
 	return "unknown"
 }

--- a/library/productivity/granola/internal/cli/sync_cache.go
+++ b/library/productivity/granola/internal/cli/sync_cache.go
@@ -36,6 +36,15 @@ type CacheSyncResult struct {
 	StateWriteErr    error
 	Duration         time.Duration
 
+	// PATCH(api-sync-survives-unreadable-cache): Degraded reports that the
+	// desktop cache could not be decrypted and only API-derived documents were
+	// synced; DecryptErr carries why. Cache-derived surfaces (transcripts,
+	// folders, recipes, panels, chat threads) are all zero on such a run, so
+	// reporting it as a clean sync would read as "you have no transcripts"
+	// rather than "transcripts were not synced".
+	Degraded   bool
+	DecryptErr error
+
 	// PATCH(api-detail-hydrate): transcript timestamps the store layer could
 	// not parse. Non-fatal like HydrateErr, but it must reach the operator:
 	// an unparseable timestamp is stored as 0 and reads back blank, so without
@@ -150,24 +159,48 @@ The hydration is idempotent: re-running replaces every row.`,
 // itself cannot be opened — the caller decides whether that is fatal.
 func runCacheSync(ctx context.Context) (CacheSyncResult, error) {
 	started := time.Now()
+	degraded := false
+	var decryptErr error
 	c, err := openGranolaCache()
 	if err != nil {
 		// PATCH(encrypted-cache): record the decrypt failure so doctor
 		// can report it without itself prompting the Keychain.
 		recordSyncDecryptStatus(err)
-		return CacheSyncResult{Duration: time.Since(started)}, err
+
+		// PATCH(api-sync-survives-unreadable-cache): a migrated install can
+		// never decrypt again, so failing here strands the one path that still
+		// works — /v2/get-documents, which needs no cache content at all.
+		// Degrade instead of aborting, and carry the decrypt error so the run
+		// is never reported as clean.
+		//
+		// Only a classified migration degrades. A plain ErrKeyUnavailable on a
+		// non-migrated install still has a working remedy (sign into Granola
+		// desktop); degrading it would hide that remedy behind a silently
+		// thinner sync.
+		if !errors.Is(err, safestorage.ErrSchemeMigrated) {
+			return CacheSyncResult{Duration: time.Since(started)}, err
+		}
+		degraded = true
+		decryptErr = err
+		c = &granola.Cache{Documents: map[string]granola.Document{}}
 	}
 	// PATCH(encrypted-cache): Granola desktop moved documents
 	// out of cache-v6.json into the API around May 2026. Hydrate
 	// from /v2/get-documents so SyncFromCache's meeting upsert
 	// loop has something to iterate.
 	docsFetched, hydrateErr := granola.HydrateDocumentsFromAPI(c, nil)
+	// On a degraded run the hydrate is the whole run: there is no cache
+	// content to fall back on, so a hydrate failure means nothing was synced.
+	if degraded && hydrateErr != nil {
+		return CacheSyncResult{Degraded: true, DecryptErr: decryptErr, Duration: time.Since(started)},
+			fmt.Errorf("cache unreadable and API hydrate failed: %w", hydrateErr)
+	}
 	s, err := openGranolaStore(ctx)
 	if err != nil {
 		return CacheSyncResult{Duration: time.Since(started)}, err
 	}
 	defer s.Close()
-	sres, err := granola.SyncFromCache(ctx, s.DB(), c)
+	sres, err := granola.SyncFromCacheWithOptions(ctx, s.DB(), c, granola.SyncOptions{Degraded: degraded})
 	if err != nil {
 		return CacheSyncResult{Duration: time.Since(started)}, err
 	}
@@ -185,6 +218,8 @@ func runCacheSync(ctx context.Context) (CacheSyncResult, error) {
 		ChatMessages:     sres.ChatMessages,
 		DocumentsFetched: docsFetched,
 		HydrateErr:       hydrateErr,
+		Degraded:         degraded,
+		DecryptErr:       decryptErr,
 		Duration:         time.Since(started),
 
 		UnparsedTimestamps: sres.UnparsedTimestamps,
@@ -200,6 +235,17 @@ func runCacheSync(ctx context.Context) (CacheSyncResult, error) {
 		LastDecryptStatus:    granola.DecryptStatusOK,
 		LastTokenSource:      tokenSourceLabel(granola.CurrentTokenSource()),
 		LastDocumentsFetched: docsFetched,
+	}
+	// PATCH(api-sync-survives-unreadable-cache): a degraded run did sync
+	// documents, but it never decrypted anything. Claiming DecryptStatusOK
+	// here would overwrite the failure recordSyncDecryptStatus just stored and
+	// make doctor report a healthy encrypted store on a migrated install.
+	if degraded {
+		state.LastDecryptStatus = granola.DecryptStatusFailed
+		state.LastDecryptErrorClass = decryptErrorClass(decryptErr)
+		if decryptErr != nil {
+			state.LastDecryptErrorMsg = decryptErr.Error()
+		}
 	}
 	if hydrateErr != nil {
 		state.LastHydrateErrorMsg = hydrateErr.Error()
@@ -223,17 +269,32 @@ func recordSyncDecryptStatus(err error) {
 		LastDecryptStatus:   granola.DecryptStatusFailed,
 		LastDecryptErrorMsg: err.Error(),
 	}
-	switch {
-	case errors.Is(err, safestorage.ErrKeyUnavailable):
-		state.LastDecryptErrorClass = "key_unavailable"
-	case errors.Is(err, safestorage.ErrDecryptFailed):
-		state.LastDecryptErrorClass = "decrypt_failed"
-	case errors.Is(err, safestorage.ErrUnsupportedPlatform):
-		state.LastDecryptErrorClass = "unsupported_platform"
-	default:
-		state.LastDecryptErrorClass = "other"
-	}
+	state.LastDecryptErrorClass = decryptErrorClass(err)
 	_ = granola.WriteSyncState(state)
+}
+
+// decryptErrorClass maps a cache-load error onto the stable class string
+// doctor reads out of the sync state.
+//
+// PATCH(api-sync-survives-unreadable-cache): ErrSchemeMigrated must be tested
+// first. migratedSchemeError.Is deliberately matches ErrKeyUnavailable too, so
+// a plain key_unavailable arm ahead of it swallows every migrated install --
+// which is how doctor came to print the unreachable "approve the Keychain
+// prompt" remedy for a state where no prompt can ever appear.
+func decryptErrorClass(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, safestorage.ErrSchemeMigrated):
+		return "scheme_migrated"
+	case errors.Is(err, safestorage.ErrKeyUnavailable):
+		return "key_unavailable"
+	case errors.Is(err, safestorage.ErrDecryptFailed):
+		return "decrypt_failed"
+	case errors.Is(err, safestorage.ErrUnsupportedPlatform):
+		return "unsupported_platform"
+	}
+	return "other"
 }
 
 // tokenSourceLabel returns a human-readable + JSON-stable label for the
@@ -248,6 +309,8 @@ func tokenSourceLabel(s granola.TokenSource) string {
 		return "encrypted_supabase"
 	case granola.TokenSourceStoredAccounts:
 		return "stored_accounts"
+	case granola.TokenSourcePlaintextSupabaseDesktopFallback:
+		return "plaintext_supabase_desktop_fallback"
 	}
 	return "unknown"
 }

--- a/library/productivity/granola/internal/cli/sync_cache.go
+++ b/library/productivity/granola/internal/cli/sync_cache.go
@@ -45,6 +45,15 @@ type CacheSyncResult struct {
 	Degraded   bool
 	DecryptErr error
 
+	// PATCH(api-transcript-hydrate): what the transcript backfill did this run.
+	// TranscriptsRemaining is the operator-facing number: a bounded run that
+	// leaves work behind must say so, or the user cannot tell "that is all of
+	// them" from "run it again".
+	TranscriptsFetched   int
+	TranscriptSegments   int
+	TranscriptsRemaining int
+	TranscriptErr        error
+
 	// PATCH(api-detail-hydrate): transcript timestamps the store layer could
 	// not parse. Non-fatal like HydrateErr, but it must reach the operator:
 	// an unparseable timestamp is stored as 0 and reads back blank, so without
@@ -74,6 +83,11 @@ func (r CacheSyncResult) TotalRows() int {
 // emit one ndjson summary line so downstream agents and existing sync
 // callers see a consistent shape.
 func newSyncCacheCmd(flags *rootFlags) *cobra.Command {
+	// PATCH(api-transcript-hydrate): bounds the per-run transcript backfill.
+	// There is no bulk transcript endpoint, so a full first backfill is one
+	// rate-limited call per meeting; a default cap keeps `sync` a command
+	// rather than an errand, and the summary reports what is left.
+	transcriptBudget := granola.DefaultTranscriptBudget
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync Granola's local cache file into the SQLite store",
@@ -93,7 +107,7 @@ The hydration is idempotent: re-running replaces every row.`,
 			if dryRunOK(flags) {
 				return nil
 			}
-			res, err := runCacheSync(cmd.Context())
+			res, err := runCacheSync(cmd.Context(), transcriptBudget)
 			if err != nil {
 				return err
 			}
@@ -115,6 +129,18 @@ The hydration is idempotent: re-running replaces every row.`,
 			}
 			if res.HydrateErr != nil {
 				summary["documents_fetch_error"] = res.HydrateErr.Error()
+			}
+			if res.Degraded {
+				// Never let a degraded run read as a clean one.
+				summary["degraded"] = true
+				summary["degraded_reason"] = "desktop cache unreadable; synced over the API"
+			}
+			if res.TranscriptsFetched > 0 || res.TranscriptsRemaining > 0 {
+				summary["transcripts_fetched"] = res.TranscriptsFetched
+				summary["transcripts_remaining"] = res.TranscriptsRemaining
+			}
+			if res.TranscriptErr != nil {
+				summary["transcript_fetch_error"] = res.TranscriptErr.Error()
 			}
 			if res.UnparsedTimestamps > 0 {
 				summary["unparsed_timestamps"] = res.UnparsedTimestamps
@@ -140,9 +166,21 @@ The hydration is idempotent: re-running replaces every row.`,
 			if res.PreservationWarning != "" {
 				fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", res.PreservationWarning)
 			}
+			if res.TranscriptErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: transcript backfill stopped early: %v\n", res.TranscriptErr)
+			}
+			if res.TranscriptsRemaining > 0 {
+				// The whole point of reporting this: a bounded run that stops
+				// with work left must not look like it finished.
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"%d transcripts still to fetch; re-run `granola-pp-cli sync` to continue (or --transcript-budget -1 for all)\n",
+					res.TranscriptsRemaining)
+			}
 			return nil
 		},
 	}
+	cmd.Flags().IntVar(&transcriptBudget, "transcript-budget", granola.DefaultTranscriptBudget,
+		"Max transcripts to backfill this run (0 disables the backfill, -1 fetches all remaining)")
 	return cmd
 }
 
@@ -157,7 +195,7 @@ The hydration is idempotent: re-running replaces every row.`,
 // the SyncState record doctor reads. It is best-effort with respect to document
 // hydration (returned in result.HydrateErr) but returns an error when the cache
 // itself cannot be opened — the caller decides whether that is fatal.
-func runCacheSync(ctx context.Context) (CacheSyncResult, error) {
+func runCacheSync(ctx context.Context, transcriptBudget int) (CacheSyncResult, error) {
 	started := time.Now()
 	degraded := false
 	var decryptErr error
@@ -200,7 +238,26 @@ func runCacheSync(ctx context.Context) (CacheSyncResult, error) {
 		return CacheSyncResult{Duration: time.Since(started)}, err
 	}
 	defer s.Close()
-	sres, err := granola.SyncFromCacheWithOptions(ctx, s.DB(), c, granola.SyncOptions{Degraded: degraded})
+
+	// PATCH(api-transcript-hydrate): on a degraded run the cache carries no
+	// transcripts, so pull them over the API before the upsert. Without this
+	// the run syncs titles and attendees and leaves every transcript-dependent
+	// command returning empty, which reads as "no transcripts" rather than
+	// "not synced". Bounded and resumable: see HydrateTranscriptsFromAPI.
+	var tres granola.TranscriptHydrateResult
+	var transcriptErr error
+	if degraded && transcriptBudget != 0 {
+		tres, transcriptErr = granola.HydrateTranscriptsFromAPI(ctx, s.DB(), c, nil, transcriptBudget)
+	}
+
+	syncOpts := granola.SyncOptions{Degraded: degraded}
+	if degraded {
+		// Transcripts on this path came from the API, not the cache. Label them
+		// accordingly so provenance stays honest and the cross-source retention
+		// check compares real counts.
+		syncOpts.TranscriptOwner = granola.RowSourceAPI
+	}
+	sres, err := granola.SyncFromCacheWithOptions(ctx, s.DB(), c, syncOpts)
 	if err != nil {
 		return CacheSyncResult{Duration: time.Since(started)}, err
 	}
@@ -221,6 +278,11 @@ func runCacheSync(ctx context.Context) (CacheSyncResult, error) {
 		Degraded:         degraded,
 		DecryptErr:       decryptErr,
 		Duration:         time.Since(started),
+
+		TranscriptsFetched:   tres.WithSegments,
+		TranscriptSegments:   tres.Segments,
+		TranscriptsRemaining: tres.Remaining,
+		TranscriptErr:        transcriptErr,
 
 		UnparsedTimestamps: sres.UnparsedTimestamps,
 		TimestampWarning:   sres.TimestampWarning,

--- a/library/productivity/granola/internal/cli/sync_cache.go
+++ b/library/productivity/granola/internal/cli/sync_cache.go
@@ -54,6 +54,17 @@ type CacheSyncResult struct {
 	TranscriptsRemaining int
 	TranscriptErr        error
 
+	// PATCH(api-catalog-refresh): what the catalog refresh staged this run and
+	// why it did not. CatalogErr is non-fatal for the same reason HydrateErr
+	// is: recipes, panel templates and folders are three independent
+	// endpoints, and one of them rejecting the credential must not cost the
+	// user the meetings and transcripts the rest of the run synced.
+	CatalogRecipes        int
+	CatalogPanelTemplates int
+	CatalogFolders        int
+	CatalogMemberships    int
+	CatalogErr            error
+
 	// PATCH(api-detail-hydrate): transcript timestamps the store layer could
 	// not parse. Non-fatal like HydrateErr, but it must reach the operator:
 	// an unparseable timestamp is stored as 0 and reads back blank, so without
@@ -142,6 +153,9 @@ The hydration is idempotent: re-running replaces every row.`,
 			if res.TranscriptErr != nil {
 				summary["transcript_fetch_error"] = res.TranscriptErr.Error()
 			}
+			if res.CatalogErr != nil {
+				summary["catalog_refresh_error"] = res.CatalogErr.Error()
+			}
 			if res.UnparsedTimestamps > 0 {
 				summary["unparsed_timestamps"] = res.UnparsedTimestamps
 			}
@@ -168,6 +182,12 @@ The hydration is idempotent: re-running replaces every row.`,
 			}
 			if res.TranscriptErr != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "warning: transcript backfill stopped early: %v\n", res.TranscriptErr)
+			}
+			if res.CatalogErr != nil {
+				// Non-fatal: the surfaces that did answer are already synced,
+				// and the counts above say which. Naming the failure keeps a
+				// stale recipe list from reading as an empty one.
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: catalog refresh incomplete: %v\n", res.CatalogErr)
 			}
 			if res.TranscriptsRemaining > 0 {
 				// The whole point of reporting this: a bounded run that stops
@@ -250,12 +270,29 @@ func runCacheSync(ctx context.Context, transcriptBudget int) (CacheSyncResult, e
 		tres, transcriptErr = granola.HydrateTranscriptsFromAPI(ctx, s.DB(), c, nil, transcriptBudget)
 	}
 
+	// PATCH(api-catalog-refresh): the same argument one surface over. Without
+	// this the degraded run leaves recipes, panel templates and folders frozen
+	// at the last successful decrypt while still answering as though they were
+	// current, so a folder or recipe created since then is invisible with no
+	// symptom the user can see. Each surface is a single call for the whole
+	// set, so unlike transcripts there is nothing to budget or resume.
+	var cres granola.CatalogHydrateResult
+	var catalogErr error
+	if degraded {
+		cres, catalogErr = granola.HydrateCatalogFromAPI(c, nil)
+	}
+
 	syncOpts := granola.SyncOptions{Degraded: degraded}
 	if degraded {
 		// Transcripts on this path came from the API, not the cache. Label them
 		// accordingly so provenance stays honest and the cross-source retention
 		// check compares real counts.
 		syncOpts.TranscriptOwner = granola.RowSourceAPI
+		// Same for the catalog rows this run creates. Ownership decides which
+		// path is allowed to retire a row later, so a folder or recipe the API
+		// created must not be filed under the cache path that can no longer
+		// read anything.
+		syncOpts.CatalogOwner = granola.RowSourceAPI
 	}
 	sres, err := granola.SyncFromCacheWithOptions(ctx, s.DB(), c, syncOpts)
 	if err != nil {
@@ -284,6 +321,12 @@ func runCacheSync(ctx context.Context, transcriptBudget int) (CacheSyncResult, e
 		TranscriptsRemaining: tres.Remaining,
 		TranscriptErr:        transcriptErr,
 
+		CatalogRecipes:        cres.Recipes,
+		CatalogPanelTemplates: cres.PanelTemplates,
+		CatalogFolders:        cres.Folders,
+		CatalogMemberships:    cres.Memberships,
+		CatalogErr:            catalogErr,
+
 		UnparsedTimestamps: sres.UnparsedTimestamps,
 		TimestampWarning:   sres.TimestampWarning,
 
@@ -298,7 +341,11 @@ func runCacheSync(ctx context.Context, transcriptBudget int) (CacheSyncResult, e
 		// sync time only on a genuine decrypt, so store-served reads can date
 		// cache-derived rows by when they were actually captured rather than by
 		// this run's API-only refresh.
-		LastCacheSyncAt:      cacheSyncedAt(degraded),
+		LastCacheSyncAt: cacheSyncedAt(degraded),
+		// PATCH(api-catalog-refresh): stamped only when the catalog refresh
+		// actually succeeded, so store-served recipe reads date themselves by
+		// when they were refreshed rather than by a cache sync that never ran.
+		LastCatalogSyncAt:    catalogSyncedAt(catalogErr, degraded),
 		LastDecryptStatus:    granola.DecryptStatusOK,
 		LastTokenSource:      tokenSourceLabel(granola.CurrentTokenSource()),
 		LastDocumentsFetched: docsFetched,
@@ -338,6 +385,16 @@ func recordSyncDecryptStatus(err error) {
 	}
 	state.LastDecryptErrorClass = decryptErrorClass(err)
 	_ = granola.WriteSyncState(state)
+}
+
+// catalogSyncedAt returns now only when this run refreshed the catalog
+// surfaces cleanly. A healthy-cache run never calls the API catalog, and a
+// failed refresh must not advance the date rows are stamped with.
+func catalogSyncedAt(catalogErr error, degraded bool) time.Time {
+	if !degraded || catalogErr != nil {
+		return time.Time{}
+	}
+	return time.Now().UTC()
 }
 
 // cacheSyncedAt returns now for a genuine cache decrypt and the zero time for a

--- a/library/productivity/granola/internal/cli/sync_cache.go
+++ b/library/productivity/granola/internal/cli/sync_cache.go
@@ -293,7 +293,12 @@ func runCacheSync(ctx context.Context, transcriptBudget int) (CacheSyncResult, e
 	// PATCH(encrypted-cache): record success so doctor can report
 	// "ok (last decrypted: <time>)" without itself decrypting.
 	state := granola.SyncState{
-		LastSyncAt:           time.Now().UTC(),
+		LastSyncAt: time.Now().UTC(),
+		// PATCH(read-path-store-first-for-recipes-and-chats): stamp the cache
+		// sync time only on a genuine decrypt, so store-served reads can date
+		// cache-derived rows by when they were actually captured rather than by
+		// this run's API-only refresh.
+		LastCacheSyncAt:      cacheSyncedAt(degraded),
 		LastDecryptStatus:    granola.DecryptStatusOK,
 		LastTokenSource:      tokenSourceLabel(granola.CurrentTokenSource()),
 		LastDocumentsFetched: docsFetched,
@@ -333,6 +338,16 @@ func recordSyncDecryptStatus(err error) {
 	}
 	state.LastDecryptErrorClass = decryptErrorClass(err)
 	_ = granola.WriteSyncState(state)
+}
+
+// cacheSyncedAt returns now for a genuine cache decrypt and the zero time for a
+// degraded run, so a run that never read the cache cannot advance the date the
+// cache-derived rows are stamped with.
+func cacheSyncedAt(degraded bool) time.Time {
+	if degraded {
+		return time.Time{}
+	}
+	return time.Now().UTC()
 }
 
 // decryptErrorClass maps a cache-load error onto the stable class string

--- a/library/productivity/granola/internal/cli/sync_cache_catalog_test.go
+++ b/library/productivity/granola/internal/cli/sync_cache_catalog_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// PATCH(api-catalog-refresh): the catalog refresh exists for the run that
+// cannot read the cache. On a healthy run the decrypted cache is authoritative
+// for recipes, panel templates and folders, and calling the API for them would
+// spend three round-trips per sync to overwrite fresher local data with the
+// same rows -- while claiming API ownership of catalog rows the cache path
+// created, which is the one thing ownership markers exist to prevent.
+//
+// These guards are structural rather than behavioural because the degraded
+// branch is only reachable through a real migrated-scheme decrypt failure plus
+// a live internal API, neither of which a unit test can stand up honestly.
+// What is worth pinning is the wiring, which is exactly what a later edit
+// could quietly drop. Same approach as
+// TestOpenGranolaCacheCallSites_AllAccountedFor.
+
+const syncCacheFile = "sync_cache.go"
+
+func TestCatalogHydrateOnlyRunsOnTheDegradedPath(t *testing.T) {
+	guards := degradedGuards(t, syncCacheFile, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		return ok && sel.Sel.Name == "HydrateCatalogFromAPI"
+	})
+	if len(guards) != 1 {
+		t.Fatalf("%s calls HydrateCatalogFromAPI %d times, want exactly 1", syncCacheFile, len(guards))
+	}
+	if !strings.Contains(guards[0], "degraded") {
+		t.Errorf("the catalog hydrate is guarded by %q, which does not test `degraded`: a healthy cache sync would refresh the catalog over the API and stamp cache-owned rows as API-owned",
+			guards[0])
+	}
+}
+
+// The hydrate is only half the wiring. Without the ownership stamp every row
+// this path creates is filed as cache-created, and nothing downstream can ever
+// tell the two apart again — the marker is not recoverable after the fact.
+func TestDegradedSyncClaimsCatalogOwnership(t *testing.T) {
+	guards := degradedGuards(t, syncCacheFile, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 {
+			return false
+		}
+		sel, ok := assign.Lhs[0].(*ast.SelectorExpr)
+		return ok && sel.Sel.Name == "CatalogOwner"
+	})
+	if len(guards) != 1 {
+		t.Fatalf("%s assigns SyncOptions.CatalogOwner %d times, want exactly 1", syncCacheFile, len(guards))
+	}
+	if !strings.Contains(guards[0], "degraded") {
+		t.Errorf("CatalogOwner is assigned under %q rather than the degraded branch: a healthy cache sync would claim API ownership of cache-created catalog rows",
+			guards[0])
+	}
+}
+
+// degradedGuards returns, for every node in file that match reports on, the
+// conjunction of the `if` conditions it is lexically nested inside.
+func degradedGuards(t *testing.T, file string, match func(ast.Node) bool) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	var found []string
+	var walk func(n ast.Node, enclosing []string)
+	walk = func(n ast.Node, enclosing []string) {
+		ast.Inspect(n, func(node ast.Node) bool {
+			if node == nil {
+				return false
+			}
+			if ifStmt, ok := node.(*ast.IfStmt); ok {
+				inner := append(append([]string{}, enclosing...), exprText(fset, ifStmt.Cond))
+				walk(ifStmt.Body, inner)
+				if ifStmt.Else != nil {
+					walk(ifStmt.Else, enclosing)
+				}
+				return false
+			}
+			if match(node) {
+				found = append(found, strings.Join(enclosing, " && "))
+			}
+			return true
+		})
+	}
+	walk(f, nil)
+	return found
+}
+
+// exprText renders an expression back to source text for the assertion message.
+func exprText(fset *token.FileSet, e ast.Expr) string {
+	var b strings.Builder
+	if err := printer.Fprint(&b, fset, e); err != nil {
+		return ""
+	}
+	return b.String()
+}

--- a/library/productivity/granola/internal/granola/api_catalog.go
+++ b/library/productivity/granola/internal/granola/api_catalog.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"errors"
+	"fmt"
+)
+
+// PATCH(api-catalog-refresh): refresh recipes, panel templates and folders
+// over the internal API so a degraded sync stops serving a frozen catalog.
+//
+// The transcript hydrate ahead of this one restored meeting content, but every
+// catalog surface still came from the desktop cache alone. On a migrated
+// install that cache can never be read again, so `recipes list`, `panel`,
+// `folder list` and the memo runner keep answering with whatever was captured
+// on the last successful decrypt -- and they answer confidently, with no sign
+// the data stopped moving. A folder created since then simply does not exist
+// as far as the CLI is concerned.
+//
+// Unlike transcripts and panels, each of these surfaces is one call for the
+// whole set. There is no per-document fan-out, so there is deliberately no
+// budget, no fetch-state table and no resume: a pass either refreshes a
+// surface completely or leaves it as it was.
+
+// CatalogFetcher is the slice of the internal API this refresh needs.
+// Narrowing it to an interface keeps the derivation and merge logic testable
+// without a live Granola account, exactly as TranscriptFetcher does.
+// *InternalClient satisfies it.
+type CatalogFetcher interface {
+	GetRecipes() (RecipeCatalog, error)
+	GetPanelTemplates() ([]PanelTemplate, error)
+	GetDocumentLists() ([]DocumentListMetadata, error)
+}
+
+// CatalogHydrateResult reports what one pass put into the Cache. The counts
+// are of records staged for the sync, not of rows written: HydrateCatalogFromAPI
+// writes nothing to the domain tables itself.
+type CatalogHydrateResult struct {
+	// Recipes is the total across the public, user and shared buckets.
+	Recipes int
+	// RecipeUsages is the number of usage counters staged.
+	RecipeUsages int
+	// PanelTemplates is the number of templates staged.
+	PanelTemplates int
+	// Folders and Memberships come from the same single call: the API returns
+	// each list's membership inline.
+	Folders     int
+	Memberships int
+
+	// Per-surface failures. Each is independent: one surface failing must not
+	// cost the caller the other two, because the three are unrelated
+	// endpoints that happen to be refreshed together.
+	RecipesErr        error
+	PanelTemplatesErr error
+	DocumentListsErr  error
+}
+
+// Err joins the per-surface failures into one value for callers that only
+// need to know whether anything went wrong. Nil when every surface succeeded.
+func (r CatalogHydrateResult) Err() error {
+	return errors.Join(r.RecipesErr, r.PanelTemplatesErr, r.DocumentListsErr)
+}
+
+// HydrateCatalogFromAPI fills the catalog surfaces of cache -- recipes and
+// their usage counters, panel templates, folder metadata and folder
+// membership -- from the internal API, then lets SyncFromCache's existing
+// loops persist them. It writes nothing to the domain tables itself, which
+// keeps catalog writes on one code path regardless of whether the cache was
+// readable.
+//
+// The returned error is the joined per-surface failure and is non-fatal by
+// design: a 401 on one endpoint leaves the surfaces that did answer staged and
+// the rest of the sync intact. Callers surface it as a warning.
+func HydrateCatalogFromAPI(cache *Cache, client CatalogFetcher) (CatalogHydrateResult, error) {
+	var res CatalogHydrateResult
+	if cache == nil {
+		return res, fmt.Errorf("nil cache")
+	}
+	if client == nil {
+		ic, err := NewInternalClient()
+		if err != nil {
+			return res, fmt.Errorf("hydrate catalog: %w", err)
+		}
+		client = ic
+	}
+	res.RecipesErr = hydrateRecipes(cache, client, &res)
+	res.PanelTemplatesErr = hydratePanelTemplates(cache, client, &res)
+	res.DocumentListsErr = hydrateDocumentLists(cache, client, &res)
+	return res, res.Err()
+}
+
+// hydrateRecipes stages the three recipe buckets the cache also carries, plus
+// the usage counters.
+func hydrateRecipes(cache *Cache, client CatalogFetcher, res *CatalogHydrateResult) error {
+	cat, err := client.GetRecipes()
+	if err != nil {
+		return fmt.Errorf("refresh recipes: %w", err)
+	}
+	cache.PublicRecipes = stampRecipes(cat.PublicRecipes, "public")
+	cache.UserRecipes = stampRecipes(cat.UserRecipes, "user")
+	cache.SharedRecipes = stampRecipes(cat.SharedRecipes, "shared")
+	res.Recipes = len(cache.PublicRecipes) + len(cache.UserRecipes) + len(cache.SharedRecipes)
+
+	if cache.RecipesUsage == nil {
+		cache.RecipesUsage = map[string]RecipeUsage{}
+	}
+	for id, u := range cat.Usage {
+		cache.RecipesUsage[id] = u
+		res.RecipeUsages++
+	}
+	return nil
+}
+
+// stampRecipes replays the two derivations LoadCache applies to every recipe
+// bucket. The API payload carries neither: Source is the bucket the recipe
+// came out of, which only the reader knows, and a recipe's display name lives
+// in its slug when nothing else names it. Skipping either leaves `recipes
+// list` unable to filter by source and showing blank names for most rows.
+func stampRecipes(in []Recipe, source string) []Recipe {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Recipe, len(in))
+	copy(out, in)
+	for i := range out {
+		out[i].Source = source
+		if out[i].Name == "" {
+			out[i].Name = out[i].Slug
+		}
+	}
+	return out
+}
+
+// hydratePanelTemplates stages the panel templates, deriving the slug from the
+// title when the payload has none -- the same fallback LoadCache applies,
+// and the reason `panel --template <slug>` resolves at all.
+func hydratePanelTemplates(cache *Cache, client CatalogFetcher, res *CatalogHydrateResult) error {
+	templates, err := client.GetPanelTemplates()
+	if err != nil {
+		return fmt.Errorf("refresh panel templates: %w", err)
+	}
+	for i, t := range templates {
+		if t.Slug == "" {
+			templates[i].Slug = slugify(t.Title)
+		}
+	}
+	cache.PanelTemplates = templates
+	res.PanelTemplates = len(templates)
+	return nil
+}
+
+// hydrateDocumentLists stages folder metadata and folder membership from the
+// single /v2/get-document-lists call that carries both.
+func hydrateDocumentLists(cache *Cache, client CatalogFetcher, res *CatalogHydrateResult) error {
+	lists, err := client.GetDocumentLists()
+	if err != nil {
+		return fmt.Errorf("refresh folders: %w", err)
+	}
+	if cache.DocumentListsMetadata == nil {
+		cache.DocumentListsMetadata = map[string]DocumentListMetadata{}
+	}
+	if cache.DocumentLists == nil {
+		cache.DocumentLists = map[string][]string{}
+	}
+	for _, l := range lists {
+		if l.ID == "" {
+			continue
+		}
+		cache.DocumentListsMetadata[l.ID] = l
+		res.Folders++
+
+		seen := map[string]bool{}
+		ids := make([]string, 0, len(l.Documents))
+		for _, entry := range l.Documents {
+			mid := entry.MeetingID()
+			if mid == "" || seen[mid] {
+				continue
+			}
+			seen[mid] = true
+			ids = append(ids, mid)
+		}
+		if len(ids) == 0 {
+			// Leave any membership already staged alone rather than replacing
+			// it with an empty slice: an empty `documents` array is what a
+			// genuinely empty folder and a folder whose membership this
+			// payload omits both look like.
+			continue
+		}
+		cache.DocumentLists[l.ID] = ids
+		res.Memberships += len(ids)
+	}
+	return nil
+}

--- a/library/productivity/granola/internal/granola/api_catalog_test.go
+++ b/library/productivity/granola/internal/granola/api_catalog_test.go
@@ -1,0 +1,572 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// The bodies below are the live shapes probed against Granola 7.465.0 on
+// 2026-08-03, trimmed to the fields this CLI reads. They are kept as raw JSON
+// rather than constructed structs on purpose: the derivations these tests
+// pin (source stamping, slug fallback, the stringified counter) exist
+// precisely because the wire shape and the typed shape disagree, and building
+// the input from the typed shape would test the code against itself.
+
+const liveRecipesBody = `{
+  "userRecipes": [
+    {"id": "rec_user", "slug": "weekly-sync", "created_at": "2026-07-01",
+     "config": {"description": "My weekly sync recipe"}}
+  ],
+  "sharedRecipes": [
+    {"id": "rec_shared", "slug": "team-standup", "publisher_slug": "acme"}
+  ],
+  "publicRecipes": [
+    {"id": "rec_public", "slug": "discovery-call"}
+  ],
+  "unlistedRecipes": [
+    {"id": "rec_unlisted", "slug": "internal-only"}
+  ],
+  "defaultRecipes": [
+    {"id": "rec_default", "slug": "granola-default"}
+  ],
+  "recipesUsage": {
+    "rec_user": {"total_count": 12, "last_used_at": "2026-07-30T10:00:00Z"},
+    "rec_public": {"recipe_id": "rec_public", "total_count": "3"}
+  }
+}`
+
+const livePanelTemplatesBody = `[
+  {"id": "tpl_1", "title": "Customer Discovery", "category": "sales",
+   "description": "Discovery questions", "is_granola": true},
+  {"id": "tpl_2", "title": "Ignored", "slug": "explicit-slug"}
+]`
+
+const liveDocumentListsBody = `{"lists": [
+  {"id": "list_a", "title": "Customers", "parent_document_list_id": "list_root",
+   "preset": "sales", "description": "Customer calls", "is_favourited": true,
+   "workspace_id": "ws_1", "document_count": 2,
+   "documents": [{"document_id": "m1"}, {"document_id": "m2"}]},
+  {"id": "list_b", "title": "Personal",
+   "documents": [{"id": "m3"}, {"id": "edge_row_key", "document_id": "m4"}]},
+  {"id": "list_empty", "title": "Empty", "documents": []}
+]}`
+
+// fakeCatalogClient answers from raw bodies through the same parsers the live
+// client uses, so a shape change is caught by these tests rather than only by
+// a live account.
+type fakeCatalogClient struct {
+	recipes string
+	panels  string
+	lists   string
+	recipeErr,
+	panelErr,
+	listErr error
+}
+
+func newFakeCatalogClient() *fakeCatalogClient {
+	return &fakeCatalogClient{
+		recipes: liveRecipesBody,
+		panels:  livePanelTemplatesBody,
+		lists:   liveDocumentListsBody,
+	}
+}
+
+func (f *fakeCatalogClient) GetRecipes() (RecipeCatalog, error) {
+	if f.recipeErr != nil {
+		return RecipeCatalog{}, f.recipeErr
+	}
+	return parseRecipeCatalog([]byte(f.recipes))
+}
+
+func (f *fakeCatalogClient) GetPanelTemplates() ([]PanelTemplate, error) {
+	if f.panelErr != nil {
+		return nil, f.panelErr
+	}
+	return parsePanelTemplates([]byte(f.panels))
+}
+
+func (f *fakeCatalogClient) GetDocumentLists() ([]DocumentListMetadata, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return parseDocumentLists([]byte(f.lists))
+}
+
+func TestHydrateCatalogNilCache(t *testing.T) {
+	if _, err := HydrateCatalogFromAPI(nil, newFakeCatalogClient()); err == nil {
+		t.Fatal("expected an error on a nil cache")
+	}
+}
+
+func TestHydrateCatalogFillsRecipeBucketsAndUsage(t *testing.T) {
+	cache := &Cache{}
+	res, err := HydrateCatalogFromAPI(cache, newFakeCatalogClient())
+	if err != nil {
+		t.Fatalf("HydrateCatalogFromAPI: %v", err)
+	}
+
+	bySource := map[string][]string{}
+	for _, r := range cache.RecipesAll() {
+		bySource[r.Source] = append(bySource[r.Source], r.ID)
+	}
+	for source, wantID := range map[string]string{
+		"public": "rec_public",
+		"user":   "rec_user",
+		"shared": "rec_shared",
+	} {
+		got := bySource[source]
+		if len(got) != 1 || got[0] != wantID {
+			t.Errorf("source %q holds %v, want [%s] — a recipe with no Source cannot be filtered by `recipes list --source`",
+				source, got, wantID)
+		}
+	}
+	// The two buckets with no cache counterpart stay out, so an API-refreshed
+	// install and a cache-synced one agree on what the catalog contains.
+	for _, r := range cache.RecipesAll() {
+		if r.ID == "rec_unlisted" || r.ID == "rec_default" {
+			t.Errorf("%s was hydrated; the cache path has no bucket for it and nothing would ever retire it", r.ID)
+		}
+	}
+	if res.Recipes != 3 {
+		t.Errorf("res.Recipes = %d, want 3", res.Recipes)
+	}
+
+	// Name is derived, never carried on the wire: without the fallback most
+	// rows render blank.
+	for _, r := range cache.RecipesAll() {
+		if r.Name != r.Slug {
+			t.Errorf("recipe %s name = %q, want the slug %q", r.ID, r.Name, r.Slug)
+		}
+	}
+
+	if len(cache.RecipesUsage) != 2 {
+		t.Fatalf("usage entries = %d, want 2", len(cache.RecipesUsage))
+	}
+	if res.RecipeUsages != 2 {
+		t.Errorf("res.RecipeUsages = %d, want 2", res.RecipeUsages)
+	}
+	// The record does not always repeat the id the dict is keyed by.
+	if got := cache.RecipesUsage["rec_user"].RecipeID; got != "rec_user" {
+		t.Errorf("usage recipe_id = %q, want it defaulted from the dict key", got)
+	}
+	if got := cache.RecipesUsage["rec_user"].LastUsedAt; got != "2026-07-30T10:00:00Z" {
+		t.Errorf("usage last_used_at = %q", got)
+	}
+}
+
+// TestRecipeUsageTotalCountSurvivesSscanf is the counter-specific guard: the
+// API sends a number, RecipeUsage.TotalCount is a string, and both consumers
+// (the recipes_usage write in store_sync.go and `recipes list --top-usage`)
+// read it with fmt.Sscanf. Anything but decimal digits reads as zero, silently.
+func TestRecipeUsageTotalCountSurvivesSscanf(t *testing.T) {
+	cache := &Cache{}
+	if _, err := HydrateCatalogFromAPI(cache, newFakeCatalogClient()); err != nil {
+		t.Fatalf("HydrateCatalogFromAPI: %v", err)
+	}
+	for id, want := range map[string]int64{"rec_user": 12, "rec_public": 3} {
+		raw := cache.RecipesUsage[id].TotalCount
+		var got int64
+		if _, err := fmt.Sscanf(raw, "%d", &got); err != nil {
+			t.Errorf("%s total_count %q is not Sscanf-readable: %v", id, raw, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s total_count = %q -> %d, want %d", id, raw, got, want)
+		}
+	}
+}
+
+// A number and a string on the wire must land identically: the desktop cache
+// stores this counter as a string and the live API sends it bare, and the CLI
+// cannot tell which one a given build will send.
+func TestParseRecipesUsageAcceptsNumberAndString(t *testing.T) {
+	got := parseRecipesUsage(json.RawMessage(`{"a":{"total_count":7},"b":{"total_count":"7"}}`))
+	if got["a"].TotalCount != "7" || got["b"].TotalCount != "7" {
+		t.Errorf("total_count number=%q string=%q, want both \"7\"", got["a"].TotalCount, got["b"].TotalCount)
+	}
+}
+
+func TestHydrateCatalogDerivesPanelTemplateSlug(t *testing.T) {
+	cache := &Cache{}
+	res, err := HydrateCatalogFromAPI(cache, newFakeCatalogClient())
+	if err != nil {
+		t.Fatalf("HydrateCatalogFromAPI: %v", err)
+	}
+	if res.PanelTemplates != 2 || len(cache.PanelTemplates) != 2 {
+		t.Fatalf("panel templates = %d (result says %d), want 2", len(cache.PanelTemplates), res.PanelTemplates)
+	}
+	bySlug := map[string]PanelTemplate{}
+	for _, p := range cache.PanelTemplates {
+		bySlug[p.Slug] = p
+	}
+	// The live payload carries no slug at all; `panel --template <slug>`
+	// resolves on it, so it has to be derived exactly as LoadCache derives it.
+	if got, ok := bySlug["customer-discovery"]; !ok || got.ID != "tpl_1" {
+		t.Errorf("blank slug was not derived from the title; slugs present: %v", slugsOf(cache.PanelTemplates))
+	}
+	// An explicit slug is never overwritten.
+	if got, ok := bySlug["explicit-slug"]; !ok || got.ID != "tpl_2" {
+		t.Errorf("explicit slug lost; slugs present: %v", slugsOf(cache.PanelTemplates))
+	}
+}
+
+func slugsOf(ps []PanelTemplate) []string {
+	out := make([]string, 0, len(ps))
+	for _, p := range ps {
+		out = append(out, p.Slug)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestHydrateCatalogFillsFoldersAndMembershipFromOneCall pins the payload
+// property the whole folder refresh depends on: /v2/get-document-lists carries
+// each list's membership inline, so folder metadata and folder edges come from
+// a single call and no per-folder fan-out is needed.
+func TestHydrateCatalogFillsFoldersAndMembershipFromOneCall(t *testing.T) {
+	cache := &Cache{}
+	res, err := HydrateCatalogFromAPI(cache, newFakeCatalogClient())
+	if err != nil {
+		t.Fatalf("HydrateCatalogFromAPI: %v", err)
+	}
+	if res.Folders != 3 || len(cache.DocumentListsMetadata) != 3 {
+		t.Fatalf("folders = %d (result says %d), want 3", len(cache.DocumentListsMetadata), res.Folders)
+	}
+	md := cache.DocumentListsMetadata["list_a"]
+	if md.Title != "Customers" || md.ParentDocumentListID != "list_root" || md.Preset != "sales" ||
+		md.Description != "Customer calls" || !md.IsFavourited {
+		t.Errorf("folder metadata incomplete: %+v", md)
+	}
+	if got := cache.FolderMeetings("list_a"); len(got) != 2 || got[0] != "m1" || got[1] != "m2" {
+		t.Errorf("list_a membership = %v, want [m1 m2]", got)
+	}
+	// An element that names the document in `id` rather than `document_id`
+	// still resolves — and when both appear, `id` is the edge's own key and
+	// document_id is the meeting, so taking `id` there would file the
+	// membership under an id no meeting has.
+	if got := cache.FolderMeetings("list_b"); len(got) != 2 || got[0] != "m3" || got[1] != "m4" {
+		t.Errorf("list_b membership = %v, want [m3 m4]", got)
+	}
+	if got := cache.FolderMeetings("list_empty"); len(got) != 0 {
+		t.Errorf("empty folder produced membership %v", got)
+	}
+	if res.Memberships != 4 {
+		t.Errorf("res.Memberships = %d, want 4", res.Memberships)
+	}
+}
+
+// TestHydrateCatalogSurfacesUnauthorizedPerSurface: the three endpoints are
+// unrelated, so one rejecting the credential must leave the other two staged
+// and the sync that follows intact.
+func TestHydrateCatalogSurfacesUnauthorizedPerSurface(t *testing.T) {
+	client := newFakeCatalogClient()
+	client.recipeErr = ErrAPIUnauthorized
+
+	cache := &Cache{}
+	res, err := HydrateCatalogFromAPI(cache, client)
+	if err == nil {
+		t.Fatal("a rejected surface must be reported, not swallowed")
+	}
+	if !errors.Is(err, ErrAPIUnauthorized) || !errors.Is(res.RecipesErr, ErrAPIUnauthorized) {
+		t.Errorf("401 lost its classification: joined=%v recipes=%v", err, res.RecipesErr)
+	}
+	if res.PanelTemplatesErr != nil || res.DocumentListsErr != nil {
+		t.Errorf("one failing surface poisoned the others: panels=%v lists=%v",
+			res.PanelTemplatesErr, res.DocumentListsErr)
+	}
+	if len(cache.PanelTemplates) != 2 || len(cache.DocumentListsMetadata) != 3 {
+		t.Errorf("healthy surfaces were not staged: panels=%d folders=%d",
+			len(cache.PanelTemplates), len(cache.DocumentListsMetadata))
+	}
+	if len(cache.RecipesAll()) != 0 {
+		t.Errorf("the failed surface staged %d recipes", len(cache.RecipesAll()))
+	}
+}
+
+// TestCatalogShapeErrorsNameTheEndpoint: three calls go out together, so
+// "unrecognized response shape" without a name leaves nobody able to tell
+// which payload drifted.
+func TestCatalogShapeErrorsNameTheEndpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		endpoint string
+		call     func([]byte) error
+	}{
+		{"recipes: array instead of object", `[{"id":"x"}]`, recipesEndpoint,
+			func(b []byte) error { _, err := parseRecipeCatalog(b); return err }},
+		{"recipes: no known collection", `{"somethingElse":[]}`, recipesEndpoint,
+			func(b []byte) error { _, err := parseRecipeCatalog(b); return err }},
+		{"panel templates: object with no list", `{"unexpected":1}`, panelTemplatesEndpoint,
+			func(b []byte) error { _, err := parsePanelTemplates(b); return err }},
+		{"document lists: scalar", `"not a list"`, documentListsEndpoint,
+			func(b []byte) error { _, err := parseDocumentLists(b); return err }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call([]byte(tc.body))
+			var shape *APIShapeError
+			if !errors.As(err, &shape) {
+				t.Fatalf("got %v, want an *APIShapeError", err)
+			}
+			if shape.Endpoint != tc.endpoint {
+				t.Errorf("endpoint = %q, want %q", shape.Endpoint, tc.endpoint)
+			}
+			if shape.Body == "" {
+				t.Error("shape error carries no body sample, so a bug report cannot show the drift")
+			}
+		})
+	}
+}
+
+// An empty account still answers with the known keys, and that must not be
+// mistaken for drift.
+func TestParseRecipeCatalogAcceptsEmptyCollections(t *testing.T) {
+	cat, err := parseRecipeCatalog([]byte(`{"userRecipes":[],"publicRecipes":[],"recipesUsage":{}}`))
+	if err != nil {
+		t.Fatalf("empty-but-known payload rejected: %v", err)
+	}
+	if len(cat.UserRecipes) != 0 || len(cat.Usage) != 0 {
+		t.Errorf("unexpected content: %+v", cat)
+	}
+}
+
+// TestDocumentListEntriesTolerateAnyShape confirms the claim the Documents
+// field rests on: its unmarshaler never errors, so adding it to
+// DocumentListMetadata cannot abort LoadCache's single decode of the whole
+// documentListsMetadata map.
+func TestDocumentListEntriesTolerateAnyShape(t *testing.T) {
+	cases := map[string][]string{
+		`[{"document_id":"m1"},{"id":"m2"}]`: {"m1", "m2"},
+		`["m1","m2"]`:                        {"m1", "m2"},
+		`[]`:                                 {},
+		`null`:                               {},
+		`{"not":"an array"}`:                 {},
+		`42`:                                 {},
+	}
+	for body, want := range cases {
+		var got DocumentListEntries
+		if err := json.Unmarshal([]byte(body), &got); err != nil {
+			t.Fatalf("%s: unmarshaler returned an error, which would abort the whole cache decode: %v", body, err)
+		}
+		ids := make([]string, 0, len(got))
+		for _, e := range got {
+			ids = append(ids, e.MeetingID())
+		}
+		if len(ids) != len(want) {
+			t.Errorf("%s -> %v, want %v", body, ids, want)
+			continue
+		}
+		for i := range ids {
+			if ids[i] != want[i] {
+				t.Errorf("%s -> %v, want %v", body, ids, want)
+				break
+			}
+		}
+	}
+}
+
+// TestLoadCacheStillParsesFoldersWithDocumentsKey is the other half of that
+// claim, at the level the risk actually lives: a cache whose folder records
+// carry a `documents` key in an unexpected shape must still yield every
+// folder.
+func TestLoadCacheStillParsesFoldersWithDocumentsKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cache-v6.json")
+	body := `{"cache":{"version":6,"state":{"documentListsMetadata":{
+		"f1":{"id":"f1","title":"One","documents":["m1"]},
+		"f2":{"id":"f2","title":"Two","documents":[{"document_id":"m2"}]},
+		"f3":{"id":"f3","title":"Three","documents":{"weird":true}},
+		"f4":{"id":"f4","title":"Four"}
+	}}}}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadCache(path)
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+	for _, id := range []string{"f1", "f2", "f3", "f4"} {
+		if _, ok := c.DocumentListsMetadata[id]; !ok {
+			t.Errorf("folder %s was dropped; parsed set: %d folders", id, len(c.DocumentListsMetadata))
+		}
+	}
+}
+
+// TestSyncWritesAPIHydratedCatalogWithAPIOwnership is the end of the unit: the
+// hydrator stages, SyncFromCache persists, and the rows this path creates must
+// be identifiable as API-created while cache-created rows keep both their
+// ownership and the metadata only the cache carries.
+func TestSyncWritesAPIHydratedCatalogWithAPIOwnership(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	// The store as a healthy cache sync left it: a folder with metadata the
+	// API payload does not carry, and a recipe.
+	mustExec(t, db, `INSERT INTO folders(id,title,parent_id,workspace_id,owner_id,preset,description,is_favourited,row_source)
+		VALUES ('list_a','Customers','list_cache_parent','ws_1','','cache-preset','from cache',1,?)`, RowSourceCache)
+	mustExec(t, db, `INSERT INTO recipes(id,slug,name,source,row_source) VALUES ('rec_cache','cached','Cached','user',?)`, RowSourceCache)
+
+	cache := &Cache{}
+	if _, err := HydrateCatalogFromAPI(cache, newFakeCatalogClient()); err != nil {
+		t.Fatalf("HydrateCatalogFromAPI: %v", err)
+	}
+	// The API payload for list_a deliberately carries no parent id below the
+	// one the cache supplied; blank it out to model the field the API omits.
+	md := cache.DocumentListsMetadata["list_a"]
+	md.ParentDocumentListID = ""
+	md.Preset = ""
+	cache.DocumentListsMetadata["list_a"] = md
+
+	if _, err := SyncFromCacheWithOptions(ctx, db, cache, SyncOptions{
+		Degraded:     true,
+		CatalogOwner: RowSourceAPI,
+	}); err != nil {
+		t.Fatalf("SyncFromCacheWithOptions: %v", err)
+	}
+
+	// A folder only the API knows about is inserted, and owned by this path.
+	if got := scanString(t, db, `SELECT row_source FROM folders WHERE id = 'list_b'`); got != RowSourceAPI {
+		t.Errorf("API-created folder row_source = %q, want %q", got, RowSourceAPI)
+	}
+	// A folder both paths know keeps its cache-supplied metadata and its
+	// cache ownership: the API payload omits these fields, it does not clear
+	// them.
+	if got := scanString(t, db, `SELECT parent_id FROM folders WHERE id = 'list_a'`); got != "list_cache_parent" {
+		t.Errorf("parent_id = %q, want the cache-supplied value", got)
+	}
+	if got := scanString(t, db, `SELECT preset FROM folders WHERE id = 'list_a'`); got != "cache-preset" {
+		t.Errorf("preset = %q, want the cache-supplied value", got)
+	}
+	if got := scanString(t, db, `SELECT row_source FROM folders WHERE id = 'list_a'`); got != RowSourceCache {
+		t.Errorf("pre-existing folder row_source = %q, want %q", got, RowSourceCache)
+	}
+
+	// The membership edges came from the same call as the metadata.
+	// row_source on this table is store_sync's call, not this path's, so only
+	// the edges themselves are asserted.
+	if got := countRows(t, db, `SELECT COUNT(*) FROM folder_memberships WHERE folder_id = 'list_a'`); got != 2 {
+		t.Errorf("list_a memberships = %d, want 2", got)
+	}
+
+	if got := scanString(t, db, `SELECT row_source FROM recipes WHERE id = 'rec_user'`); got != RowSourceAPI {
+		t.Errorf("API-created recipe row_source = %q, want %q", got, RowSourceAPI)
+	}
+	if got := scanString(t, db, `SELECT source FROM recipes WHERE id = 'rec_shared'`); got != "shared" {
+		t.Errorf("recipe collection source = %q, want %q", got, "shared")
+	}
+	if got := scanString(t, db, `SELECT row_source FROM recipes WHERE id = 'rec_cache'`); got != RowSourceCache {
+		t.Errorf("pre-existing recipe row_source = %q, want %q", got, RowSourceCache)
+	}
+	if got := scanString(t, db, `SELECT row_source FROM panel_templates WHERE id = 'tpl_1'`); got != RowSourceAPI {
+		t.Errorf("panel template row_source = %q, want %q", got, RowSourceAPI)
+	}
+	if got := scanString(t, db, `SELECT slug FROM panel_templates WHERE id = 'tpl_1'`); got != "customer-discovery" {
+		t.Errorf("panel template slug = %q, want the title-derived slug", got)
+	}
+	// The counter has to arrive as digits or this column silently stores 0.
+	if got := countRows(t, db, `SELECT total_count FROM recipes_usage WHERE recipe_id = 'rec_user'`); got != 12 {
+		t.Errorf("recipes_usage.total_count = %d, want 12", got)
+	}
+	if got := scanString(t, db, `SELECT row_source FROM recipes_usage WHERE recipe_id = 'rec_user'`); got != RowSourceAPI {
+		t.Errorf("usage row_source = %q, want %q", got, RowSourceAPI)
+	}
+}
+
+func mustExec(t *testing.T, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), query, args...); err != nil {
+		t.Fatalf("exec (%s): %v", query, err)
+	}
+}
+
+func scanString(t *testing.T, db *sql.DB, query string, args ...any) string {
+	t.Helper()
+	var out sql.NullString
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&out); err != nil {
+		t.Fatalf("query (%s): %v", query, err)
+	}
+	return out.String
+}
+
+// TestInternalClientCatalogEndpoints pins the three paths and the parsing the
+// live client does, so a rename upstream fails here rather than in a silent
+// empty refresh.
+func TestInternalClientCatalogEndpoints(t *testing.T) {
+	seen := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen[r.URL.Path]++
+		switch r.URL.Path {
+		case recipesEndpoint:
+			_, _ = w.Write([]byte(liveRecipesBody))
+		case panelTemplatesEndpoint:
+			_, _ = w.Write([]byte(livePanelTemplatesBody))
+		case documentListsEndpoint:
+			_, _ = w.Write([]byte(liveDocumentListsBody))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"Not implemented"}`))
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("GRANOLA_WORKOS_TOKEN", "test-token")
+	ResetTokenCache()
+	defer ResetTokenCache()
+	client, _ := NewInternalClient()
+	client.SetBaseURL(srv.URL)
+
+	cache := &Cache{}
+	res, err := HydrateCatalogFromAPI(cache, client)
+	if err != nil {
+		t.Fatalf("HydrateCatalogFromAPI over HTTP: %v", err)
+	}
+	if res.Recipes != 3 || res.PanelTemplates != 2 || res.Folders != 3 || res.Memberships != 4 {
+		t.Errorf("result = %+v", res)
+	}
+	for _, path := range []string{recipesEndpoint, panelTemplatesEndpoint, documentListsEndpoint} {
+		if seen[path] != 1 {
+			t.Errorf("%s called %d times, want 1", path, seen[path])
+		}
+	}
+	// One call per surface for the whole set: no budget, no fan-out.
+	if seen[documentListsLegacyEndpoint] != 0 {
+		t.Errorf("the v1 document-lists fallback fired against a healthy v2")
+	}
+}
+
+// TestDocumentListsFallbackOnlyOn404: the /v1 surface answers 404 "Not
+// implemented", so retrying there on a 401 turned an expired credential into
+// a missing-endpoint error and buried the real remedy.
+func TestDocumentListsFallbackOnlyOn404(t *testing.T) {
+	seen := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen[r.URL.Path]++
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("GRANOLA_WORKOS_TOKEN", "test-token")
+	ResetTokenCache()
+	defer ResetTokenCache()
+	client, _ := NewInternalClient()
+	client.SetBaseURL(srv.URL)
+
+	if _, err := client.GetDocumentLists(); err == nil {
+		t.Fatal("expected the 401 to surface")
+	}
+	if seen[documentListsLegacyEndpoint] != 0 {
+		t.Errorf("a 401 retried against the legacy endpoint %d times", seen[documentListsLegacyEndpoint])
+	}
+}

--- a/library/productivity/granola/internal/granola/api_documents.go
+++ b/library/productivity/granola/internal/granola/api_documents.go
@@ -61,7 +61,12 @@ func HydrateDocumentsFromAPI(cache *Cache, client *InternalClient) (int, error) 
 		env, err := client.GetDocumentsPage(DefaultDocumentsPageSize, offset, false)
 		if err != nil {
 			if errors.Is(err, ErrRefreshRefused) {
-				return added, fmt.Errorf("hydrate documents: access token expired and refresh blocked for encrypted source - open Granola desktop briefly to refresh, then retry: %w", err)
+				// PATCH(cli-owned-workos-session): the old remedy here told the
+				// user to open Granola desktop so it would refresh the token
+				// the CLI was reading. That stopped working when Granola went
+				// encrypted-only: the desktop now refreshes a file the CLI
+				// cannot read, so waking it changes nothing the CLI can see.
+				return added, fmt.Errorf("hydrate documents: the token this CLI can reach is expired, and refreshing it would sign Granola desktop out. Run `granola-pp-cli auth login` to give the CLI its own session: %w", err)
 			}
 			return added, fmt.Errorf("hydrate documents page %d: %w", page, err)
 		}

--- a/library/productivity/granola/internal/granola/api_transcripts.go
+++ b/library/productivity/granola/internal/granola/api_transcripts.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// PATCH(api-transcript-hydrate): fetch transcripts over the internal API so the
+// degraded path carries meeting content, not just titles.
+//
+// The document hydrate alone leaves every transcript-dependent command --
+// talktime, memo run, attendee brief, collect, folder stream -- returning empty
+// on a migrated install, which reads to a user (and to an agent) as "you had no
+// transcripts" rather than "these were never synced". The internal API's
+// per-document transcript endpoint accepts a CLI-owned session, so the content
+// is reachable; it just has to be pulled one document at a time.
+//
+// That per-document shape is what forces the rest of this file's design. There
+// is no bulk endpoint, the client is rate limited, and a full backfill is one
+// call per meeting -- so the work has to be resumable across runs, bounded per
+// run, and must not re-ask for transcripts that legitimately do not exist.
+
+// DefaultTranscriptBudget bounds an explicit `sync`. Roughly two minutes at the
+// client's rate limit: long enough to make real progress on a first backfill,
+// short enough that the command still feels like a command.
+const DefaultTranscriptBudget = 250
+
+// AutoRefreshTranscriptBudget bounds the per-invocation auto-refresh hook.
+// Small on purpose: this fires before every read command, and a user running
+// `meetings list` will not wait on a backfill.
+const AutoRefreshTranscriptBudget = 10
+
+// transcriptFetchStateDDL records which meetings have already been asked about.
+//
+// Without it, every meeting that genuinely has no transcript -- a cancelled
+// call, a note with no recording -- looks identical to one not yet fetched, and
+// the CLI would re-request all of them on every sync forever. Storing the
+// attempt rather than only the result is the difference between converging and
+// paying the same cost each run.
+const transcriptFetchStateDDL = `CREATE TABLE IF NOT EXISTS transcript_fetch_state (
+	meeting_id TEXT PRIMARY KEY,
+	fetched_at TEXT NOT NULL,
+	segment_count INTEGER NOT NULL DEFAULT 0
+)`
+
+// TranscriptHydrateResult reports what one pass did.
+type TranscriptHydrateResult struct {
+	// Fetched is the number of documents asked about this run.
+	Fetched int
+	// WithSegments is how many of those actually carried a transcript.
+	WithSegments int
+	// Segments is the total segment count pulled.
+	Segments int
+	// Remaining is how many documents still have no recorded attempt, so the
+	// caller can tell the user whether re-running will do more work.
+	Remaining int
+	// Skipped names documents whose fetch failed in a way worth reporting but
+	// not worth aborting the run for.
+	Skipped []string
+}
+
+// TranscriptFetcher is the one method the hydrator needs. Narrowing it to an
+// interface keeps the polling, budgeting and bookkeeping logic testable without
+// a live Granola account or an HTTP stub for the whole internal client.
+// *InternalClient satisfies it.
+type TranscriptFetcher interface {
+	GetDocumentTranscript(id string) ([]TranscriptSegment, error)
+}
+
+// EnsureTranscriptFetchState creates the bookkeeping table. Idempotent.
+func EnsureTranscriptFetchState(ctx context.Context, db *sql.DB) error {
+	if _, err := db.ExecContext(ctx, transcriptFetchStateDDL); err != nil {
+		return fmt.Errorf("transcript fetch state: %w", err)
+	}
+	return nil
+}
+
+// HydrateTranscriptsFromAPI fills cache.Transcripts for documents that have no
+// recorded fetch attempt, newest first, up to budget.
+//
+// It writes nothing to the domain tables itself -- SyncFromCache's existing
+// segment loop does that, which keeps transcript writes on one code path
+// regardless of whether the cache was readable. A budget of 0 means unbounded.
+//
+// Per-document failures are skipped rather than fatal: on a corpus of hundreds,
+// one unreadable document must not cost the caller every other transcript in
+// the run.
+func HydrateTranscriptsFromAPI(ctx context.Context, db *sql.DB, cache *Cache, client TranscriptFetcher, budget int) (TranscriptHydrateResult, error) {
+	var res TranscriptHydrateResult
+	if cache == nil {
+		return res, fmt.Errorf("nil cache")
+	}
+	if err := EnsureTranscriptFetchState(ctx, db); err != nil {
+		return res, err
+	}
+	if client == nil {
+		ic, err := NewInternalClient()
+		if err != nil {
+			return res, fmt.Errorf("hydrate transcripts: %w", err)
+		}
+		client = ic
+	}
+	if cache.Transcripts == nil {
+		cache.Transcripts = map[string][]TranscriptSegment{}
+	}
+
+	attempted, err := transcriptAttemptedIDs(ctx, db)
+	if err != nil {
+		return res, err
+	}
+
+	candidates := transcriptCandidates(cache, attempted)
+	res.Remaining = len(candidates)
+	if budget > 0 && len(candidates) > budget {
+		candidates = candidates[:budget]
+	}
+
+	for _, id := range candidates {
+		segs, err := client.GetDocumentTranscript(id)
+		if err != nil {
+			if skippableTranscriptError(err) {
+				// Record the attempt anyway. A document the API will never
+				// return a transcript for should stop being asked about.
+				_ = recordTranscriptAttempt(ctx, db, id, 0)
+				res.Fetched++
+				res.Remaining--
+				res.Skipped = append(res.Skipped, id)
+				continue
+			}
+			// A non-skippable failure is usually auth or rate limiting, which
+			// will hit every remaining document too. Stop and report what
+			// landed rather than grinding through hundreds of identical errors.
+			return res, fmt.Errorf("hydrate transcripts at %s: %w", id, err)
+		}
+		res.Fetched++
+		res.Remaining--
+		if len(segs) > 0 {
+			cache.Transcripts[id] = segs
+			res.WithSegments++
+			res.Segments += len(segs)
+		}
+		if err := recordTranscriptAttempt(ctx, db, id, len(segs)); err != nil {
+			return res, err
+		}
+	}
+	return res, nil
+}
+
+// transcriptCandidates returns document ids with no recorded attempt, newest
+// first. Recency ordering matters because a bounded run should spend its budget
+// on the meetings a user is most likely to ask about next.
+func transcriptCandidates(cache *Cache, attempted map[string]bool) []string {
+	type cand struct {
+		id   string
+		sort string
+	}
+	var out []cand
+	for id, doc := range cache.Documents {
+		if attempted[id] {
+			continue
+		}
+		if doc.DeletedAt != nil && *doc.DeletedAt != "" {
+			continue
+		}
+		key := doc.CreatedAt
+		if doc.UpdatedAt > key {
+			key = doc.UpdatedAt
+		}
+		out = append(out, cand{id: id, sort: key})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].sort != out[j].sort {
+			return out[i].sort > out[j].sort
+		}
+		return out[i].id < out[j].id
+	})
+	ids := make([]string, 0, len(out))
+	for _, c := range out {
+		ids = append(ids, c.id)
+	}
+	return ids
+}
+
+func transcriptAttemptedIDs(ctx context.Context, db *sql.DB) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, `SELECT meeting_id FROM transcript_fetch_state`)
+	if err != nil {
+		return nil, fmt.Errorf("transcript fetch state: read: %w", err)
+	}
+	defer rows.Close()
+	out := map[string]bool{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = true
+	}
+	return out, rows.Err()
+}
+
+func recordTranscriptAttempt(ctx context.Context, db *sql.DB, id string, n int) error {
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO transcript_fetch_state(meeting_id, fetched_at, segment_count) VALUES (?,?,?)
+		 ON CONFLICT(meeting_id) DO UPDATE SET fetched_at = excluded.fetched_at, segment_count = excluded.segment_count`,
+		id, time.Now().UTC().Format(time.RFC3339), n)
+	if err != nil {
+		return fmt.Errorf("transcript fetch state: record %s: %w", id, err)
+	}
+	return nil
+}
+
+// skippableTranscriptError names the per-document failures that mean "not this
+// one" rather than "the run is broken". Mirrors the note-level policy in the
+// public-API hydrate: 404 and 403 are properties of one document, everything
+// else (401, 429, transport) will recur on the next one.
+func skippableTranscriptError(err error) bool {
+	return errors.Is(err, ErrNoteNotFound) || errors.Is(err, ErrAPIForbidden)
+}

--- a/library/productivity/granola/internal/granola/api_transcripts_test.go
+++ b/library/productivity/granola/internal/granola/api_transcripts_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"context"
+	"testing"
+)
+
+func seedDocs(cache *Cache, ids ...string) {
+	if cache.Documents == nil {
+		cache.Documents = map[string]Document{}
+	}
+	for i, id := range ids {
+		// Descending timestamps so the first id is newest.
+		cache.Documents[id] = Document{
+			ID:        id,
+			CreatedAt: []string{"2026-08-03", "2026-08-02", "2026-08-01", "2026-07-31"}[i%4],
+		}
+	}
+}
+
+func TestTranscriptCandidatesSkipAttemptedAndDeleted(t *testing.T) {
+	deleted := "gone"
+	cache := &Cache{Documents: map[string]Document{
+		"new":     {ID: "new", CreatedAt: "2026-08-03"},
+		"old":     {ID: "old", CreatedAt: "2026-07-01"},
+		"done":    {ID: "done", CreatedAt: "2026-08-02"},
+		"deleted": {ID: "deleted", CreatedAt: "2026-08-03", DeletedAt: &deleted},
+	}}
+	got := transcriptCandidates(cache, map[string]bool{"done": true})
+
+	if len(got) != 2 {
+		t.Fatalf("want 2 candidates (attempted and deleted excluded), got %v", got)
+	}
+	// Newest first: a bounded run should spend its budget on recent meetings.
+	if got[0] != "new" || got[1] != "old" {
+		t.Errorf("candidates not ordered newest-first: %v", got)
+	}
+}
+
+func TestHydrateTranscriptsRecordsAttemptForEmptyResult(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cache := &Cache{}
+	seedDocs(cache, "m1")
+
+	client := newFakeTranscriptClient(map[string][]TranscriptSegment{"m1": nil})
+	res, err := HydrateTranscriptsFromAPI(ctx, db, cache, client, 0)
+	if err != nil {
+		t.Fatalf("HydrateTranscriptsFromAPI: %v", err)
+	}
+	if res.Fetched != 1 || res.WithSegments != 0 {
+		t.Errorf("fetched=%d withSegments=%d, want 1/0", res.Fetched, res.WithSegments)
+	}
+
+	// The point of the state table: a meeting that genuinely has no transcript
+	// must stop being asked about, or every sync re-pays for it forever.
+	attempted, err := transcriptAttemptedIDs(ctx, db)
+	if err != nil {
+		t.Fatalf("transcriptAttemptedIDs: %v", err)
+	}
+	if !attempted["m1"] {
+		t.Fatal("an empty result did not record an attempt")
+	}
+	res2, err := HydrateTranscriptsFromAPI(ctx, db, cache, client, 0)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if res2.Fetched != 0 {
+		t.Errorf("second pass re-fetched %d already-attempted documents", res2.Fetched)
+	}
+}
+
+func TestHydrateTranscriptsFillsCacheAndRespectsBudget(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cache := &Cache{}
+	seedDocs(cache, "a", "b", "c")
+
+	segs := []TranscriptSegment{{Text: "hello", Source: "microphone"}}
+	client := newFakeTranscriptClient(map[string][]TranscriptSegment{"a": segs, "b": segs, "c": segs})
+
+	res, err := HydrateTranscriptsFromAPI(ctx, db, cache, client, 2)
+	if err != nil {
+		t.Fatalf("HydrateTranscriptsFromAPI: %v", err)
+	}
+	if res.Fetched != 2 {
+		t.Errorf("budget not honored: fetched %d, want 2", res.Fetched)
+	}
+	if res.Remaining != 1 {
+		t.Errorf("remaining=%d, want 1 so the caller can tell the user to re-run", res.Remaining)
+	}
+	if len(cache.Transcripts) != 2 {
+		t.Errorf("cache.Transcripts has %d entries, want 2", len(cache.Transcripts))
+	}
+	if res.Segments != 2 {
+		t.Errorf("segment total=%d, want 2", res.Segments)
+	}
+
+	// A second pass picks up exactly the one left behind.
+	res2, err := HydrateTranscriptsFromAPI(ctx, db, cache, client, 2)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if res2.Fetched != 1 || res2.Remaining != 0 {
+		t.Errorf("resume pass fetched=%d remaining=%d, want 1/0", res2.Fetched, res2.Remaining)
+	}
+}
+
+func TestHydrateTranscriptsSkipsPerDocumentFailures(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cache := &Cache{}
+	seedDocs(cache, "ok1", "missing", "ok2")
+
+	client := newFakeTranscriptClient(map[string][]TranscriptSegment{
+		"ok1": {{Text: "one"}},
+		"ok2": {{Text: "two"}},
+	})
+	client.errs = map[string]error{"missing": ErrNoteNotFound}
+
+	res, err := HydrateTranscriptsFromAPI(ctx, db, cache, client, 0)
+	if err != nil {
+		t.Fatalf("one unreadable document must not fail the run: %v", err)
+	}
+	if res.WithSegments != 2 {
+		t.Errorf("withSegments=%d, want 2", res.WithSegments)
+	}
+	if len(res.Skipped) != 1 || res.Skipped[0] != "missing" {
+		t.Errorf("skipped=%v, want [missing]", res.Skipped)
+	}
+	// The skipped document is still recorded, so it is not retried forever.
+	attempted, _ := transcriptAttemptedIDs(ctx, db)
+	if !attempted["missing"] {
+		t.Error("a skippable failure did not record an attempt")
+	}
+}
+
+func TestHydrateTranscriptsStopsOnRunWideFailure(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cache := &Cache{}
+	seedDocs(cache, "a", "b", "c")
+
+	client := newFakeTranscriptClient(nil)
+	// An auth failure will hit every remaining document identically; grinding
+	// through hundreds of them helps nobody.
+	client.errs = map[string]error{"a": ErrAPIUnauthorized, "b": ErrAPIUnauthorized, "c": ErrAPIUnauthorized}
+
+	if _, err := HydrateTranscriptsFromAPI(ctx, db, cache, client, 0); err == nil {
+		t.Fatal("a non-skippable failure should stop the run")
+	}
+}
+
+// fakeTranscriptClient stands in for the internal API.
+type fakeTranscriptClient struct {
+	segs map[string][]TranscriptSegment
+	errs map[string]error
+}
+
+func newFakeTranscriptClient(segs map[string][]TranscriptSegment) *fakeTranscriptClient {
+	if segs == nil {
+		segs = map[string][]TranscriptSegment{}
+	}
+	return &fakeTranscriptClient{segs: segs}
+}
+
+func (f *fakeTranscriptClient) GetDocumentTranscript(id string) ([]TranscriptSegment, error) {
+	if err, ok := f.errs[id]; ok {
+		return nil, err
+	}
+	return f.segs[id], nil
+}

--- a/library/productivity/granola/internal/granola/cache.go
+++ b/library/productivity/granola/internal/granola/cache.go
@@ -172,6 +172,65 @@ type DocumentListMetadata struct {
 	Members              []DocPerson     `json:"members,omitempty"`
 	Rules                json.RawMessage `json:"rules,omitempty"`
 	IsFavourited         bool            `json:"is_favourited,omitempty"`
+
+	// PATCH(api-catalog-refresh): Documents is the membership the internal
+	// API returns inline on every list, which the desktop cache keeps in a
+	// separate documentLists map instead. Without this field the folder
+	// refresh would need a second per-folder call the API does not offer,
+	// and `folder` commands on a migrated install would list folders that
+	// appear to contain nothing.
+	//
+	// It stays empty on the cache path, where documentLists is authoritative.
+	Documents DocumentListEntries `json:"documents,omitempty"`
+}
+
+// DocumentListEntry is one membership row inside a document list's
+// `documents` array.
+type DocumentListEntry struct {
+	ID         string `json:"id,omitempty"`
+	DocumentID string `json:"document_id,omitempty"`
+}
+
+// MeetingID returns the document this entry points at. The array elements are
+// objects rather than bare ids: a join row names the document in document_id
+// while an expanded document names itself in id, so document_id wins whenever
+// both are present — on a join row `id` is the edge's own key, not a meeting.
+func (e DocumentListEntry) MeetingID() string {
+	if e.DocumentID != "" {
+		return e.DocumentID
+	}
+	return e.ID
+}
+
+// DocumentListEntries decodes the `documents` array, tolerating both the
+// array-of-objects the internal API returns and an array of bare ids.
+//
+// UnmarshalJSON deliberately never returns an error. This type is reached
+// through DocumentListMetadata, which LoadCache decodes as one map in a single
+// json.Unmarshal whose error it discards — and a custom unmarshaler's error,
+// unlike a field type mismatch, aborts the whole decode rather than being
+// accumulated. One folder carrying an unexpected `documents` shape would
+// therefore drop every folder decoded after it. An unknown shape yields no
+// membership instead, which is the same outcome as the field being absent.
+type DocumentListEntries []DocumentListEntry
+
+func (d *DocumentListEntries) UnmarshalJSON(b []byte) error {
+	var objs []DocumentListEntry
+	if err := json.Unmarshal(b, &objs); err == nil {
+		*d = objs
+		return nil
+	}
+	var ids []string
+	if err := json.Unmarshal(b, &ids); err == nil {
+		out := make(DocumentListEntries, 0, len(ids))
+		for _, id := range ids {
+			out = append(out, DocumentListEntry{ID: id})
+		}
+		*d = out
+		return nil
+	}
+	*d = nil
+	return nil
 }
 
 // ListRule is one rule in the listRules engine. The cache stores them as

--- a/library/productivity/granola/internal/granola/clisession.go
+++ b/library/productivity/granola/internal/granola/clisession.go
@@ -316,6 +316,18 @@ func (h RotationHandle) Abort() {
 	os.Remove(rotationMarkerPath())
 }
 
+// Complete clears the marker after a rotation whose replacement is durably on
+// disk. Same nonce-checked removal as Abort; the separate name exists because
+// the success path must clear the marker too, and previously relied on
+// SaveCLISession doing it unconditionally -- which had to stop, since an
+// unconditional remove there deletes other processes' live markers.
+//
+// Forgetting this leak is invisible for two minutes: a fresh marker no longer
+// blocks a load, so the session keeps working right up until the marker ages
+// past the stale threshold and a valid session starts reporting itself as an
+// interrupted rotation.
+func (h RotationHandle) Complete() { h.Abort() }
+
 // ClearCLISession removes the session. Backs `auth logout`.
 //
 // Serialized against refreshes in this process, and safe against one in

--- a/library/productivity/granola/internal/granola/clisession.go
+++ b/library/productivity/granola/internal/granola/clisession.go
@@ -174,23 +174,65 @@ func SaveCLISession(s CLISession) error {
 	return nil
 }
 
-// BeginRotation records that an exchange is about to happen.
-func BeginRotation() error {
+// ErrRotationInProgress reports that another process holds the rotation marker.
+// The caller must not exchange: the chain is single-use, so a second exchange
+// spends the token the holder is already rotating.
+var ErrRotationInProgress = errors.New("granola: another process is rotating this session")
+
+// RotationHandle is proof of exclusive rotation ownership. Only the holder can
+// clear the marker it created.
+type RotationHandle struct{ nonce string }
+
+// BeginRotation claims exclusive rotation ownership across processes.
+//
+// An in-process mutex is not sufficient here. Two CLI invocations run
+// concurrently in normal use -- an agent driving several commands, or
+// auto-refresh firing from two shells -- and each has its own mutex. Without
+// O_EXCL both would create the marker, both would exchange the same single-use
+// token, and the loser would then delete the winner's marker on abort, so a
+// crash before the winner's durable write would leave a consumed token on disk
+// with nothing to detect it. That is precisely the state the marker exists for.
+//
+// The nonce makes aborts ownership-aware: a process may only clear a marker it
+// wrote. A marker left by a dead process therefore survives, which is intended
+// -- that session really is unrecoverable, and `auth login` clears it by writing
+// a new session.
+func BeginRotation() (RotationHandle, error) {
 	if err := ensureOwnerOnlyDir(filepath.Dir(CLISessionPath())); err != nil {
-		return err
+		return RotationHandle{}, err
 	}
-	f, err := os.OpenFile(rotationMarkerPath(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	nonce := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
+	f, err := os.OpenFile(rotationMarkerPath(), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
-		return fmt.Errorf("clisession: begin rotation: %w", err)
+		if os.IsExist(err) {
+			return RotationHandle{}, ErrRotationInProgress
+		}
+		return RotationHandle{}, fmt.Errorf("clisession: begin rotation: %w", err)
 	}
-	f.Close()
-	return nil
+	if _, werr := f.WriteString(nonce); werr != nil {
+		f.Close()
+		os.Remove(rotationMarkerPath())
+		return RotationHandle{}, fmt.Errorf("clisession: begin rotation: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		os.Remove(rotationMarkerPath())
+		return RotationHandle{}, fmt.Errorf("clisession: begin rotation: %w", cerr)
+	}
+	return RotationHandle{nonce: nonce}, nil
 }
 
-// AbortRotation clears the marker after an exchange that failed before
-// consuming anything, so a refused or network-failed refresh does not look
-// like an interrupted one on the next run.
-func AbortRotation() { os.Remove(rotationMarkerPath()) }
+// Abort clears the marker only when this handle still owns it, so a process
+// that failed harmlessly cannot erase another's in-flight rotation.
+func (h RotationHandle) Abort() {
+	if h.nonce == "" {
+		return
+	}
+	got, err := os.ReadFile(rotationMarkerPath())
+	if err != nil || string(got) != h.nonce {
+		return
+	}
+	os.Remove(rotationMarkerPath())
+}
 
 // ClearCLISession removes the session. Backs `auth logout`.
 func ClearCLISession() error {

--- a/library/productivity/granola/internal/granola/clisession.go
+++ b/library/productivity/granola/internal/granola/clisession.go
@@ -84,6 +84,21 @@ func rotationMarkerPath() string { return CLISessionPath() + ".rotating" }
 // marker survives, and ErrSessionPermissions when the file is group/world
 // readable or owned by another user.
 func LoadCLISession() (CLISession, error) {
+	// The marker is checked before the file itself: an interrupted rotation
+	// that also lost the session file is still an interrupted rotation, and
+	// reporting it as "no session" would hide the one state the marker exists
+	// to make visible.
+	if _, err := os.Stat(rotationMarkerPath()); err == nil {
+		return CLISession{}, ErrSessionInterrupted
+	}
+	return loadCLISessionUnmarked()
+}
+
+// loadCLISessionUnmarked reads the session without consulting the rotation
+// marker. Only for callers already holding the refresh lock, where the marker
+// is their own and would otherwise block them from reading the very session
+// they are about to replace.
+func loadCLISessionUnmarked() (CLISession, error) {
 	path := CLISessionPath()
 	info, err := os.Stat(path)
 	if err != nil {
@@ -94,9 +109,6 @@ func LoadCLISession() (CLISession, error) {
 	}
 	if err := checkOwnerOnly(info, path); err != nil {
 		return CLISession{}, err
-	}
-	if _, err := os.Stat(rotationMarkerPath()); err == nil {
-		return CLISession{}, ErrSessionInterrupted
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/library/productivity/granola/internal/granola/clisession.go
+++ b/library/productivity/granola/internal/granola/clisession.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// PATCH(cli-owned-workos-session): a session this CLI owns, obtained through
+// Granola's device authorization grant and stored under the CLI's own data
+// directory.
+//
+// Why the CLI needs its own chain rather than borrowing one. Granola moved the
+// data encryption key into an entitlement-gated Keychain group, so the desktop
+// app's live token in supabase.json.enc is unreadable, and the plaintext files
+// it used to leave behind are stale fossils. The remaining tokens on the
+// machine belong to other clients -- the desktop app and the browser -- and
+// refreshing someone else's chain against the WorkOS endpoint consumes it and
+// signs that client out. So the only safe durable answer is a chain that
+// belongs to this CLI, which is what CLISession holds.
+
+// ErrNoCLISession reports that no CLI-owned session is stored. It is a normal
+// state, not a failure: callers fall through to the desktop-owned probes.
+var ErrNoCLISession = errors.New("granola: no CLI-owned session")
+
+// ErrSessionInterrupted reports that a rotation was in flight when the process
+// last exited. The stored refresh token may already have been consumed
+// upstream, so the session cannot be trusted and `auth login` is required.
+var ErrSessionInterrupted = errors.New("granola: interrupted token rotation; run `granola-pp-cli auth login`")
+
+// ErrSessionPermissions reports that the session file is readable by users
+// other than its owner, or is not owned by the current user. Refused rather
+// than used: a credential that another account can read is already suspect.
+var ErrSessionPermissions = errors.New("granola: session file has unsafe permissions")
+
+// CLISession is the on-disk record. Tokens never reach String/Format output.
+type CLISession struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	ExpiresAt    time.Time `json:"expires_at,omitempty"`
+	ObtainedAt   time.Time `json:"obtained_at"`
+	AccountID    string    `json:"account_id,omitempty"`
+	AccountEmail string    `json:"account_email,omitempty"`
+}
+
+// String redacts both tokens. Without this a %v or %+v anywhere in the CLI --
+// a debug line, an error wrap -- would print the credential.
+func (s CLISession) String() string {
+	return fmt.Sprintf("CLISession{account:%q obtained:%s access:[redacted %d bytes] refresh:[redacted %d bytes]}",
+		s.AccountEmail, s.ObtainedAt.UTC().Format(time.RFC3339), len(s.AccessToken), len(s.RefreshToken))
+}
+
+// GoString makes %#v safe too.
+func (s CLISession) GoString() string { return s.String() }
+
+// CLISessionPath resolves the session file. It follows SyncStatePath's
+// XDG-aware resolution so the session, the sync state, and the store stay
+// co-located, and it honors an override for tests.
+func CLISessionPath() string {
+	if v := os.Getenv("GRANOLA_CLI_SESSION_PATH"); v != "" {
+		return v
+	}
+	xdg := os.Getenv("XDG_DATA_HOME")
+	if xdg == "" {
+		home, _ := os.UserHomeDir()
+		xdg = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(xdg, "granola-pp-cli", "session.json")
+}
+
+// rotationMarkerPath is written before a token exchange and removed after the
+// replacement is durable. Its presence at load time means the process died
+// mid-rotation.
+func rotationMarkerPath() string { return CLISessionPath() + ".rotating" }
+
+// LoadCLISession reads the stored session.
+//
+// Returns ErrNoCLISession when absent, ErrSessionInterrupted when a rotation
+// marker survives, and ErrSessionPermissions when the file is group/world
+// readable or owned by another user.
+func LoadCLISession() (CLISession, error) {
+	path := CLISessionPath()
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return CLISession{}, ErrNoCLISession
+		}
+		return CLISession{}, fmt.Errorf("clisession: stat: %w", err)
+	}
+	if err := checkOwnerOnly(info, path); err != nil {
+		return CLISession{}, err
+	}
+	if _, err := os.Stat(rotationMarkerPath()); err == nil {
+		return CLISession{}, ErrSessionInterrupted
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return CLISession{}, fmt.Errorf("clisession: read: %w", err)
+	}
+	var s CLISession
+	if err := json.Unmarshal(data, &s); err != nil {
+		// Deliberately a typed error, not "no session": a corrupt file is a
+		// state the user should be told about rather than silently treated as
+		// a fresh install that then falls through to the desktop probes.
+		return CLISession{}, fmt.Errorf("clisession: malformed session file at %s: %w", path, err)
+	}
+	if s.AccessToken == "" && s.RefreshToken == "" {
+		return CLISession{}, ErrNoCLISession
+	}
+	return s, nil
+}
+
+// SaveCLISession writes the session durably.
+//
+// Durability matters more here than for ordinary state. If a rotation ever
+// does consume the presented refresh token upstream and the replacement never
+// reaches disk, the session is unrecoverable -- there is no second copy. So the
+// write is fsync'd, renamed, and the parent directory fsync'd, and only then is
+// the rotation marker cleared.
+func SaveCLISession(s CLISession) error {
+	path := CLISessionPath()
+	dir := filepath.Dir(path)
+	if err := ensureOwnerOnlyDir(dir); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("clisession: marshal: %w", err)
+	}
+	tmp := path + ".tmp"
+	// 0600 on the temp file, because Rename preserves the source mode -- a
+	// 0644 temp file would land as a 0644 credential.
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("clisession: create tmp: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("clisession: write tmp: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("clisession: fsync tmp: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("clisession: close tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("clisession: rename: %w", err)
+	}
+	syncDir(dir)
+	os.Remove(rotationMarkerPath())
+	return nil
+}
+
+// BeginRotation records that an exchange is about to happen.
+func BeginRotation() error {
+	if err := ensureOwnerOnlyDir(filepath.Dir(CLISessionPath())); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(rotationMarkerPath(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("clisession: begin rotation: %w", err)
+	}
+	f.Close()
+	return nil
+}
+
+// AbortRotation clears the marker after an exchange that failed before
+// consuming anything, so a refused or network-failed refresh does not look
+// like an interrupted one on the next run.
+func AbortRotation() { os.Remove(rotationMarkerPath()) }
+
+// ClearCLISession removes the session. Backs `auth logout`.
+func ClearCLISession() error {
+	os.Remove(rotationMarkerPath())
+	if err := os.Remove(CLISessionPath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("clisession: remove: %w", err)
+	}
+	return nil
+}
+
+// HasCLISession reports whether a usable session is stored, without returning
+// the credential. Used by doctor and auth status.
+func HasCLISession() bool {
+	_, err := LoadCLISession()
+	return err == nil
+}
+
+// ensureOwnerOnlyDir creates the directory 0700, and tightens it when it
+// already exists more permissively.
+//
+// The tightening is the load-bearing half. MkdirAll is a no-op on an existing
+// directory, so its mode argument never applies to one -- and this directory
+// already exists at 0755 on every machine that has ever synced, because
+// WriteSyncState created it that way.
+func ensureOwnerOnlyDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("clisession: mkdir: %w", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("clisession: stat dir: %w", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return fmt.Errorf("clisession: chmod dir: %w", err)
+		}
+	}
+	return nil
+}

--- a/library/productivity/granola/internal/granola/clisession.go
+++ b/library/productivity/granola/internal/granola/clisession.go
@@ -214,10 +214,21 @@ func BeginRotation() (RotationHandle, error) {
 		os.Remove(rotationMarkerPath())
 		return RotationHandle{}, fmt.Errorf("clisession: begin rotation: %w", werr)
 	}
+	// The marker is a crash-durability device, so it has to be durable itself
+	// before the exchange it guards. Written but unsynced, a crash can lose it
+	// after the remote token is already spent -- leaving the dead token on disk
+	// looking usable, which is the exact state the marker exists to catch. Sync
+	// the file, then the directory, so the entry survives too.
+	if serr := f.Sync(); serr != nil {
+		f.Close()
+		os.Remove(rotationMarkerPath())
+		return RotationHandle{}, fmt.Errorf("clisession: begin rotation: %w", serr)
+	}
 	if cerr := f.Close(); cerr != nil {
 		os.Remove(rotationMarkerPath())
 		return RotationHandle{}, fmt.Errorf("clisession: begin rotation: %w", cerr)
 	}
+	syncDir(filepath.Dir(rotationMarkerPath()))
 	return RotationHandle{nonce: nonce}, nil
 }
 

--- a/library/productivity/granola/internal/granola/clisession.go
+++ b/library/productivity/granola/internal/granola/clisession.go
@@ -244,7 +244,63 @@ var ErrRotationInProgress = errors.New("granola: another process is rotating thi
 
 // RotationHandle is proof of exclusive rotation ownership. Only the holder can
 // clear the marker it created.
-type RotationHandle struct{ nonce string }
+type RotationHandle struct {
+	nonce string
+	// epoch is the revocation counter observed when the rotation began. A
+	// logout that lands anywhere inside the rotation changes it, which is how a
+	// rotation in one process learns that a logout in another process happened
+	// while it was mid-flight.
+	epoch string
+}
+
+// revocationEpochPath records that a logout occurred. Its content changes on
+// every logout; only inequality is compared, never ordering.
+func revocationEpochPath() string { return CLISessionPath() + ".revoked" }
+
+func readRevocationEpoch() string {
+	b, err := os.ReadFile(revocationEpochPath())
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// noteRevocation durably records a logout. It must run before the session file
+// is removed, which is what makes the protocol safe without a cross-process
+// lock: a rotation reads the epoch after publishing its replacement, so either
+// the rotation sees this write and deletes what it wrote, or its rename landed
+// before this write and therefore before the removal that follows it, and the
+// logout's own removal takes the rotated file.
+func noteRevocation() error {
+	path := revocationEpochPath()
+	if err := ensureOwnerOnlyDir(filepath.Dir(path)); err != nil {
+		return err
+	}
+	stamp := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("clisession: record logout: %w", err)
+	}
+	if _, err := f.WriteString(stamp); err != nil {
+		f.Close()
+		return fmt.Errorf("clisession: record logout: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return fmt.Errorf("clisession: record logout: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("clisession: record logout: %w", err)
+	}
+	return syncDir(filepath.Dir(path))
+}
+
+// RevocationEpoch reports the current logout epoch. A rotation captures it at
+// the start and re-checks it after publishing.
+func RevocationEpoch() string { return readRevocationEpoch() }
+
+// Epoch exposes the revocation epoch captured when this rotation began.
+func (h RotationHandle) Epoch() string { return h.epoch }
 
 // BeginRotation claims exclusive rotation ownership across processes.
 //
@@ -300,7 +356,7 @@ func BeginRotation() (RotationHandle, error) {
 		os.Remove(rotationMarkerPath())
 		return RotationHandle{}, fmt.Errorf("clisession: begin rotation: durable marker unavailable: %w", derr)
 	}
-	return RotationHandle{nonce: nonce}, nil
+	return RotationHandle{nonce: nonce, epoch: readRevocationEpoch()}, nil
 }
 
 // Abort clears the marker only when this handle still owns it, so a process

--- a/library/productivity/granola/internal/granola/clisession.go
+++ b/library/productivity/granola/internal/granola/clisession.go
@@ -395,10 +395,19 @@ func (h RotationHandle) Complete() { h.Abort() }
 func ClearCLISession() error {
 	refreshMu.Lock()
 	defer refreshMu.Unlock()
-	// Session first, marker second. If the session removal fails, the marker
-	// must survive: clearing it first would turn a failed logout into a session
-	// that loads as perfectly healthy, hiding an interrupted rotation the user
-	// still needs to repair.
+	// Revocation first, before anything is removed. A rotation in another
+	// process re-reads this epoch after publishing its replacement, so recording
+	// the logout ahead of the removal is what stops a mid-flight rename from
+	// resurrecting the credential: either that rotation observes this and
+	// deletes what it wrote, or its rename preceded this write and therefore
+	// precedes the removal below, which then takes the rotated file.
+	if err := noteRevocation(); err != nil {
+		return err
+	}
+	// Session next, marker last. If the session removal fails, the marker must
+	// survive: clearing it first would turn a failed logout into a session that
+	// loads as perfectly healthy, hiding an interrupted rotation the user still
+	// needs to repair.
 	if err := os.Remove(CLISessionPath()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("clisession: remove: %w", err)
 	}

--- a/library/productivity/granola/internal/granola/clisession.go
+++ b/library/productivity/granola/internal/granola/clisession.go
@@ -256,7 +256,16 @@ func (h RotationHandle) Abort() {
 }
 
 // ClearCLISession removes the session. Backs `auth logout`.
+//
+// Serialized against refreshes in this process, and safe against one in
+// another: a concurrent persist that finds the session gone abandons its
+// rotation rather than recreating the credential (see
+// ErrSessionLoggedOutDuringRotation). Without both halves, a refresh completing
+// during logout would silently restore the session the user just removed while
+// logout reported success.
 func ClearCLISession() error {
+	refreshMu.Lock()
+	defer refreshMu.Unlock()
 	os.Remove(rotationMarkerPath())
 	if err := os.Remove(CLISessionPath()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("clisession: remove: %w", err)

--- a/library/productivity/granola/internal/granola/clisession.go
+++ b/library/productivity/granola/internal/granola/clisession.go
@@ -169,7 +169,9 @@ func SaveCLISession(s CLISession) error {
 		os.Remove(tmp)
 		return fmt.Errorf("clisession: rename: %w", err)
 	}
-	syncDir(dir)
+	// Best-effort for the session itself: the rename already published the file,
+	// so an unsyncable directory costs durability of the entry, not the data.
+	_ = syncDir(dir)
 	os.Remove(rotationMarkerPath())
 	return nil
 }
@@ -228,7 +230,15 @@ func BeginRotation() (RotationHandle, error) {
 		os.Remove(rotationMarkerPath())
 		return RotationHandle{}, fmt.Errorf("clisession: begin rotation: %w", cerr)
 	}
-	syncDir(filepath.Dir(rotationMarkerPath()))
+	// Fatal here, unlike the session write. The marker's only job is to be
+	// findable after a crash, and it is claimed immediately before an exchange
+	// that spends a single-use token. If its directory entry cannot be made
+	// durable, refusing to rotate is strictly better than spending the token
+	// with no way to detect having lost the record of it.
+	if derr := syncDir(filepath.Dir(rotationMarkerPath())); derr != nil {
+		os.Remove(rotationMarkerPath())
+		return RotationHandle{}, fmt.Errorf("clisession: begin rotation: durable marker unavailable: %w", derr)
+	}
 	return RotationHandle{nonce: nonce}, nil
 }
 

--- a/library/productivity/granola/internal/granola/clisession.go
+++ b/library/productivity/granola/internal/granola/clisession.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -78,6 +79,54 @@ func CLISessionPath() string {
 // mid-rotation.
 func rotationMarkerPath() string { return CLISessionPath() + ".rotating" }
 
+// rotationStaleAfter bounds how long a marker can plausibly belong to a live
+// rotation. The guarded window is a rate-limiter wait (~500ms at 2 req/s), one
+// HTTP exchange (15s client timeout), and an fsync'd write; two minutes is far
+// past that and still far short of a session's lifetime.
+//
+// The window exists because presence alone answers the wrong question. A marker
+// means "a rotation started", which is either one running now or one that died,
+// and only the second is a problem the user must repair. Treating both as
+// interruption made every concurrent command fail with "run auth login" while a
+// perfectly healthy refresh was in flight -- and sent the user to the one
+// command that then broke the exclusivity the marker exists to provide.
+const rotationStaleAfter = 2 * time.Minute
+
+// syncDirFn is the directory-fsync used by BeginRotation. It is a variable only
+// so a test can make it fail: the refusal it guards is unreachable on a healthy
+// filesystem, and a test that cannot induce the failure asserts nothing about
+// the refusal.
+var syncDirFn = syncDir
+
+// rotationMarkerState reports whether a marker exists and, if so, whether it is
+// old enough that the process holding it must be assumed dead.
+func rotationMarkerState() (present, stale bool) {
+	info, err := os.Stat(rotationMarkerPath())
+	if err != nil {
+		return false, false
+	}
+	return true, time.Since(info.ModTime()) > rotationStaleAfter
+}
+
+// clearRotationMarker removes the marker only when doing so is safe: either the
+// caller owns it (nonce match) or it is stale enough that no live rotation can
+// still be relying on it. An unconditional remove here would let one process
+// delete another's in-flight marker, and two processes would then exchange the
+// same single-use chain.
+func clearRotationMarker(ownedNonce string) {
+	got, err := os.ReadFile(rotationMarkerPath())
+	if err != nil {
+		return
+	}
+	owned := ownedNonce != "" && strings.TrimSpace(string(got)) == ownedNonce
+	if _, stale := rotationMarkerState(); !owned && !stale {
+		return
+	}
+	if err := os.Remove(rotationMarkerPath()); err == nil {
+		_ = syncDir(filepath.Dir(rotationMarkerPath()))
+	}
+}
+
 // LoadCLISession reads the stored session.
 //
 // Returns ErrNoCLISession when absent, ErrSessionInterrupted when a rotation
@@ -88,7 +137,12 @@ func LoadCLISession() (CLISession, error) {
 	// that also lost the session file is still an interrupted rotation, and
 	// reporting it as "no session" would hide the one state the marker exists
 	// to make visible.
-	if _, err := os.Stat(rotationMarkerPath()); err == nil {
+	//
+	// Only a stale marker means interrupted. A fresh one belongs to a rotation
+	// that is still running, and the session on disk is the pre-rotation
+	// credential -- still valid, since the replacement has not landed yet. Any
+	// other process may keep using it.
+	if present, stale := rotationMarkerState(); present && stale {
 		return CLISession{}, ErrSessionInterrupted
 	}
 	return loadCLISessionUnmarked()
@@ -144,7 +198,11 @@ func SaveCLISession(s CLISession) error {
 	if err != nil {
 		return fmt.Errorf("clisession: marshal: %w", err)
 	}
-	tmp := path + ".tmp"
+	// Uniquified: a fixed ".tmp" lets a second writer O_TRUNC the first one's
+	// partially written file, after which the first keeps writing at its old
+	// offset and renames a torn file into place. Two logins, or a login racing a
+	// rotation persist, are both unguarded by the marker.
+	tmp := fmt.Sprintf("%s.tmp.%d.%d", path, os.Getpid(), time.Now().UnixNano())
 	// 0600 on the temp file, because Rename preserves the source mode -- a
 	// 0644 temp file would land as a 0644 credential.
 	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
@@ -172,7 +230,10 @@ func SaveCLISession(s CLISession) error {
 	// Best-effort for the session itself: the rename already published the file,
 	// so an unsyncable directory costs durability of the entry, not the data.
 	_ = syncDir(dir)
-	os.Remove(rotationMarkerPath())
+	// Stale-only: a fresh marker belongs to another process's live rotation, and
+	// removing it would let a third process begin a concurrent exchange of the
+	// same single-use chain. The rotation owner clears its own marker by nonce.
+	clearRotationMarker("")
 	return nil
 }
 
@@ -235,7 +296,7 @@ func BeginRotation() (RotationHandle, error) {
 	// that spends a single-use token. If its directory entry cannot be made
 	// durable, refusing to rotate is strictly better than spending the token
 	// with no way to detect having lost the record of it.
-	if derr := syncDir(filepath.Dir(rotationMarkerPath())); derr != nil {
+	if derr := syncDirFn(filepath.Dir(rotationMarkerPath())); derr != nil {
 		os.Remove(rotationMarkerPath())
 		return RotationHandle{}, fmt.Errorf("clisession: begin rotation: durable marker unavailable: %w", derr)
 	}
@@ -266,10 +327,16 @@ func (h RotationHandle) Abort() {
 func ClearCLISession() error {
 	refreshMu.Lock()
 	defer refreshMu.Unlock()
-	os.Remove(rotationMarkerPath())
+	// Session first, marker second. If the session removal fails, the marker
+	// must survive: clearing it first would turn a failed logout into a session
+	// that loads as perfectly healthy, hiding an interrupted rotation the user
+	// still needs to repair.
 	if err := os.Remove(CLISessionPath()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("clisession: remove: %w", err)
 	}
+	// The session is gone, so any marker is now meaningless regardless of who
+	// owns it -- there is no credential left for a rotation to protect.
+	os.Remove(rotationMarkerPath())
 	return nil
 }
 

--- a/library/productivity/granola/internal/granola/clisession_resolution_test.go
+++ b/library/productivity/granola/internal/granola/clisession_resolution_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// isolateTokenEnv points every token probe at an empty temp directory so a real
+// Granola install on the developer's machine cannot leak into these tests.
+func isolateTokenEnv(t *testing.T) string {
+	t.Helper()
+	support := t.TempDir()
+	t.Setenv("GRANOLA_SUPPORT_DIR", support)
+	t.Setenv("GRANOLA_WORKOS_TOKEN", "")
+	t.Setenv("GRANOLA_WORKOS_REFRESH", "")
+	dir := filepath.Join(t.TempDir(), "granola-pp-cli")
+	t.Setenv("GRANOLA_CLI_SESSION_PATH", filepath.Join(dir, "session.json"))
+	ResetTokenCache()
+	t.Cleanup(ResetTokenCache)
+	return support
+}
+
+func storeCLISession(t *testing.T) CLISession {
+	t.Helper()
+	s := CLISession{
+		AccessToken:  "cli-access",
+		RefreshToken: "cli-refresh",
+		ExpiresAt:    time.Now().Add(time.Hour).UTC(),
+		ObtainedAt:   time.Now().UTC(),
+		AccountEmail: "cli@example.com",
+	}
+	if err := SaveCLISession(s); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	return s
+}
+
+func TestCLISessionOutranksDesktopProbes(t *testing.T) {
+	support := isolateTokenEnv(t)
+	// A desktop-owned plaintext token that would otherwise be selected.
+	writeFixtureSupabase(t, support)
+	storeCLISession(t)
+
+	tok, src, err := loadTokensRaw()
+	if err != nil {
+		t.Fatalf("loadTokensRaw: %v", err)
+	}
+	if src != TokenSourceCLISession {
+		t.Fatalf("want TokenSourceCLISession, got %v", src)
+	}
+	if tok.AccessToken != "cli-access" {
+		t.Errorf("wrong token selected: %q", tok.AccessToken)
+	}
+}
+
+func TestEnvOverrideStillOutranksCLISession(t *testing.T) {
+	isolateTokenEnv(t)
+	storeCLISession(t)
+	t.Setenv("GRANOLA_WORKOS_TOKEN", "env-token")
+
+	tok, src, err := loadTokensRaw()
+	if err != nil {
+		t.Fatalf("loadTokensRaw: %v", err)
+	}
+	if src != TokenSourceEnvOverride {
+		t.Fatalf("a deliberate env override must still win, got %v", src)
+	}
+	if tok.AccessToken != "env-token" {
+		t.Errorf("wrong token: %q", tok.AccessToken)
+	}
+}
+
+func TestNoCLISessionFallsThroughToDesktopProbes(t *testing.T) {
+	support := isolateTokenEnv(t)
+	writeFixtureSupabase(t, support)
+
+	_, src, err := loadTokensRaw()
+	if err != nil {
+		t.Fatalf("loadTokensRaw: %v", err)
+	}
+	if src == TokenSourceCLISession {
+		t.Fatal("selected a CLI session that does not exist")
+	}
+	if src == TokenSourceUnknown {
+		t.Fatal("fell through past the desktop probes entirely")
+	}
+}
+
+// An unusable session must surface, not silently degrade into "no token found"
+// three probes later.
+func TestUnusableCLISessionSurfaces(t *testing.T) {
+	support := isolateTokenEnv(t)
+	writeFixtureSupabase(t, support)
+	storeCLISession(t)
+	if err := os.Chmod(CLISessionPath(), 0o644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	_, _, err := loadTokensRaw()
+	if !errors.Is(err, ErrSessionPermissions) {
+		t.Fatalf("want ErrSessionPermissions to surface, got %v", err)
+	}
+}
+
+// D6 is the reason the desktop arms exist: rotating a chain another client
+// holds signs that client out. The CLI-owned chain is the one exception.
+func TestRefreshRefusalMatrix(t *testing.T) {
+	support := isolateTokenEnv(t)
+	// Presence of supabase.json.enc is what makes stored-accounts desktop-owned.
+	if err := os.WriteFile(filepath.Join(support, "supabase.json.enc"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write enc: %v", err)
+	}
+
+	for _, tc := range []struct {
+		src      TokenSource
+		refused  bool
+		whyItsSo string
+	}{
+		{TokenSourceCLISession, false, "the CLI owns this chain outright"},
+		{TokenSourceEncryptedSupabase, true, "desktop owns supabase.json.enc"},
+		{TokenSourcePlaintextSupabaseDesktopFallback, true, "may share the desktop's single-use token"},
+		{TokenSourceStoredAccounts, true, "desktop-owned while supabase.json.enc is present"},
+		{TokenSourceEnvOverride, false, "user opted in to managing refresh"},
+	} {
+		err := refreshRefusalFor(tc.src)
+		if tc.refused && err == nil {
+			t.Errorf("source %v: expected refusal (%s)", tc.src, tc.whyItsSo)
+		}
+		if !tc.refused && err != nil {
+			t.Errorf("source %v: unexpected refusal %v (%s)", tc.src, err, tc.whyItsSo)
+		}
+		if tc.refused && !errors.Is(err, ErrRefreshRefused) {
+			t.Errorf("source %v: refusal must match ErrRefreshRefused, got %v", tc.src, err)
+		}
+	}
+}
+
+func TestPersistRotatedCLISessionKeepsIdentity(t *testing.T) {
+	isolateTokenEnv(t)
+	orig := storeCLISession(t)
+
+	err := persistRotatedCLISession(RefreshAccessTokenResponse{
+		AccessToken:  "new-access",
+		RefreshToken: "new-refresh",
+		ExpiresIn:    3600,
+	})
+	if err != nil {
+		t.Fatalf("persistRotatedCLISession: %v", err)
+	}
+	got, err := LoadCLISession()
+	if err != nil {
+		t.Fatalf("LoadCLISession: %v", err)
+	}
+	if got.AccessToken != "new-access" || got.RefreshToken != "new-refresh" {
+		t.Error("rotated pair did not reach disk")
+	}
+	if got.AccountEmail != orig.AccountEmail {
+		t.Errorf("account identity lost on rotation: %q", got.AccountEmail)
+	}
+	if !got.ExpiresAt.After(time.Now()) {
+		t.Error("expiry not advanced")
+	}
+}
+
+// A refresh response that omits the refresh token must not blank the stored
+// one. Granola's proxy returns the same token rather than a rotated one, so
+// treating "absent" as "clear it" would destroy a working session.
+func TestPersistRotatedKeepsExistingRefreshWhenOmitted(t *testing.T) {
+	isolateTokenEnv(t)
+	storeCLISession(t)
+
+	if err := persistRotatedCLISession(RefreshAccessTokenResponse{
+		AccessToken: "new-access-only",
+		ExpiresIn:   3600,
+	}); err != nil {
+		t.Fatalf("persistRotatedCLISession: %v", err)
+	}
+	got, _ := LoadCLISession()
+	if got.RefreshToken != "cli-refresh" {
+		t.Errorf("refresh token was clobbered by a response that omitted it: %q", got.RefreshToken)
+	}
+}
+
+// writeFixtureSupabase drops a plaintext supabase.json that the desktop probes
+// will accept, so fall-through order can be observed.
+func writeFixtureSupabase(t *testing.T, support string) {
+	t.Helper()
+	blob := `{"workos_tokens":"{\"access_token\":\"desktop-access\",\"refresh_token\":\"desktop-refresh\",\"expires_in\":3600,\"obtained_at\":1785000000000,\"token_type\":\"Bearer\"}"}`
+	if err := os.WriteFile(filepath.Join(support, "supabase.json"), []byte(blob), 0o600); err != nil {
+		t.Fatalf("write supabase.json: %v", err)
+	}
+}

--- a/library/productivity/granola/internal/granola/clisession_resolution_test.go
+++ b/library/productivity/granola/internal/granola/clisession_resolution_test.go
@@ -148,7 +148,7 @@ func TestPersistRotatedCLISessionKeepsIdentity(t *testing.T) {
 		AccessToken:  "new-access",
 		RefreshToken: "new-refresh",
 		ExpiresIn:    3600,
-	})
+	}, RotationHandle{epoch: RevocationEpoch()})
 	if err != nil {
 		t.Fatalf("persistRotatedCLISession: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestPersistRotatedKeepsExistingRefreshWhenOmitted(t *testing.T) {
 	if err := persistRotatedCLISession(RefreshAccessTokenResponse{
 		AccessToken: "new-access-only",
 		ExpiresIn:   3600,
-	}); err != nil {
+	}, RotationHandle{epoch: RevocationEpoch()}); err != nil {
 		t.Fatalf("persistRotatedCLISession: %v", err)
 	}
 	got, _ := LoadCLISession()

--- a/library/productivity/granola/internal/granola/clisession_rotation_test.go
+++ b/library/productivity/granola/internal/granola/clisession_rotation_test.go
@@ -547,6 +547,25 @@ func TestPersist_LogoutRacingTheRenameDoesNotResurrectTheSession(t *testing.T) {
 
 // The mirror case: a rotation that completes with no logout anywhere near it
 // must not be mistaken for a raced one and have its own work deleted.
+// The interleaving test above drives noteRevocation directly, which proves the
+// mechanism but not that logout is wired to it. That gap is not theoretical: the
+// epoch helper shipped once with no caller at all, and every test still passed
+// because they exercised the primitive rather than the command. This asserts the
+// connection itself.
+func TestClearCLISessionAdvancesTheRevocationEpoch(t *testing.T) {
+	sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	before := RevocationEpoch()
+	if err := ClearCLISession(); err != nil {
+		t.Fatalf("ClearCLISession: %v", err)
+	}
+	if after := RevocationEpoch(); after == before {
+		t.Fatal("logout did not record a revocation; a rotation racing it has no way to learn the logout happened and will republish the session")
+	}
+}
+
 func TestPersist_UnracedRotationKeepsItsSession(t *testing.T) {
 	sessionSandbox(t)
 	if err := SaveCLISession(sampleSession()); err != nil {

--- a/library/productivity/granola/internal/granola/clisession_rotation_test.go
+++ b/library/productivity/granola/internal/granola/clisession_rotation_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// armCLISession puts a CLI-owned session in place and points the token cache at
+// it, so RefreshAccessToken takes the CLI-owned branch.
+func armCLISession(t *testing.T, expiresIn time.Duration) {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "granola-pp-cli")
+	t.Setenv("GRANOLA_CLI_SESSION_PATH", filepath.Join(dir, "session.json"))
+	t.Setenv("GRANOLA_SUPPORT_DIR", t.TempDir())
+	t.Setenv("GRANOLA_WORKOS_TOKEN", "")
+	t.Setenv("GRANOLA_WORKOS_REFRESH", "")
+	if err := SaveCLISession(CLISession{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		ExpiresAt:    time.Now().Add(expiresIn).UTC(),
+		ObtainedAt:   time.Now().UTC(),
+		AccountEmail: "someone@example.com",
+	}); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	ResetTokenCache()
+	t.Cleanup(ResetTokenCache)
+	if _, err := LoadRefreshToken(); err != nil {
+		t.Fatalf("LoadRefreshToken: %v", err)
+	}
+	if src := CurrentTokenSource(); src != TokenSourceCLISession {
+		t.Fatalf("want TokenSourceCLISession, got %v", src)
+	}
+}
+
+// refreshServerSeeingMarker answers refreshes and records, per call, whether the
+// in-flight rotation marker was on disk at the moment the exchange happened.
+func refreshServerSeeingMarker(t *testing.T, calls *atomic.Int32, markerSeen *atomic.Bool, hold time.Duration) {
+	t.Helper()
+	orig := refreshClient
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if _, err := os.Stat(rotationMarkerPath()); err == nil {
+			markerSeen.Store(true)
+		}
+		if hold > 0 {
+			time.Sleep(hold)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}`))
+	}))
+	t.Cleanup(srv.Close)
+	SetRefreshHTTPClient(&http.Client{Transport: &rewriteTransport{target: srv.URL}})
+	t.Cleanup(func() { SetRefreshHTTPClient(orig) })
+}
+
+// The marker exists to catch a crash between a spent remote token and a durable
+// local write. Written after the exchange it would never witness that window,
+// so this asserts the server sees it already on disk.
+func TestRefresh_MarksRotationInFlightBeforeExchange(t *testing.T) {
+	armCLISession(t, time.Hour)
+	var calls atomic.Int32
+	var markerSeen atomic.Bool
+	refreshServerSeeingMarker(t, &calls, &markerSeen, 0)
+
+	if _, err := RefreshAccessToken("old-refresh"); err != nil {
+		t.Fatalf("RefreshAccessToken: %v", err)
+	}
+	if !markerSeen.Load() {
+		t.Error("rotation marker was not on disk during the exchange; an interrupted rotation would be undetectable")
+	}
+	// A completed rotation must not leave the marker behind, or the next run
+	// sends the user to auth login over a refresh that worked.
+	if _, err := LoadCLISession(); err != nil {
+		t.Errorf("session unusable after a successful rotation: %v", err)
+	}
+}
+
+// Single-use rotation makes an unserialized refresh unsafe: the loser's
+// exchange spends a token the winner already replaced.
+func TestRefresh_ConcurrentCallersExchangeOnce(t *testing.T) {
+	armCLISession(t, time.Hour)
+	var calls atomic.Int32
+	var markerSeen atomic.Bool
+	refreshServerSeeingMarker(t, &calls, &markerSeen, 40*time.Millisecond)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = RefreshAccessToken("old-refresh")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("caller %d: %v", i, err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("exchanges = %d, want 1; concurrent refreshes spend a single-use chain", got)
+	}
+}
+
+// A failure that never reached the server left the stored token untouched, so
+// reporting an interrupted rotation would send the user to auth login over a
+// transport blip.
+func TestRefresh_FailedExchangeClearsMarker(t *testing.T) {
+	armCLISession(t, time.Hour)
+	orig := refreshClient
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+	SetRefreshHTTPClient(&http.Client{Transport: &rewriteTransport{target: srv.URL}})
+	defer SetRefreshHTTPClient(orig)
+
+	if _, err := RefreshAccessToken("old-refresh"); err == nil {
+		t.Fatal("expected the refresh to fail")
+	}
+	if _, err := LoadCLISession(); err != nil {
+		t.Errorf("a failed exchange must leave the session usable, got %v", err)
+	}
+	if _, err := os.Stat(rotationMarkerPath()); err == nil {
+		t.Error("marker survived a failure that never spent the token")
+	}
+}
+
+// The one case the marker must survive: the remote exchange succeeded, so the
+// presented token may be dead upstream, and no replacement reached disk.
+func TestRefresh_UnpersistedRotationStaysDetectable(t *testing.T) {
+	armCLISession(t, time.Hour)
+	var calls atomic.Int32
+	var markerSeen atomic.Bool
+	refreshServerSeeingMarker(t, &calls, &markerSeen, 0)
+
+	// Make the durable write fail after the exchange has already happened.
+	if err := os.Remove(CLISessionPath()); err != nil {
+		t.Fatalf("remove session: %v", err)
+	}
+	if err := os.MkdirAll(CLISessionPath(), 0o700); err != nil {
+		t.Fatalf("occupy session path with a directory: %v", err)
+	}
+
+	_, err := RefreshAccessToken("old-refresh")
+	if err == nil {
+		t.Fatal("a refresh whose persist failed must not report success")
+	}
+	if _, statErr := os.Stat(rotationMarkerPath()); statErr != nil {
+		t.Fatal("marker was cleared after a spent exchange; the unrecoverable window is now invisible")
+	}
+	// And that state must surface as the actionable error, not as a usable session.
+	os.RemoveAll(CLISessionPath())
+	if _, loadErr := LoadCLISession(); !errors.Is(loadErr, ErrSessionInterrupted) {
+		t.Errorf("want ErrSessionInterrupted after an unpersisted rotation, got %v", loadErr)
+	}
+}
+
+// A desktop-owned source must not touch the marker at all -- it is refused
+// before any rotation bookkeeping starts.
+func TestRefresh_DesktopSourceNeverMarksRotation(t *testing.T) {
+	ResetTokenCache()
+	defer ResetTokenCache()
+	dir := filepath.Join(t.TempDir(), "granola-pp-cli")
+	t.Setenv("GRANOLA_CLI_SESSION_PATH", filepath.Join(dir, "session.json"))
+	support := t.TempDir()
+	t.Setenv("GRANOLA_SUPPORT_DIR", support)
+	t.Setenv("GRANOLA_WORKOS_TOKEN", "")
+	t.Setenv("GRANOLA_WORKOS_REFRESH", "")
+	if err := os.WriteFile(filepath.Join(support, "supabase.json.enc"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write enc: %v", err)
+	}
+	writeStoredAccounts(t, support)
+	if _, err := LoadRefreshToken(); err != nil {
+		t.Fatalf("LoadRefreshToken: %v", err)
+	}
+
+	if _, err := RefreshAccessToken("desktop-refresh"); !errors.Is(err, ErrRefreshRefused) {
+		t.Fatalf("want ErrRefreshRefused, got %v", err)
+	}
+	if _, err := os.Stat(rotationMarkerPath()); err == nil {
+		t.Error("a refused desktop refresh wrote a rotation marker")
+	}
+}

--- a/library/productivity/granola/internal/granola/clisession_rotation_test.go
+++ b/library/productivity/granola/internal/granola/clisession_rotation_test.go
@@ -311,6 +311,44 @@ func TestRefresh_ReChecksAfterAcquiringMarker(t *testing.T) {
 	}
 }
 
+// Logout must win against an in-flight refresh. A rotation that completes after
+// the session is removed would recreate the credential the user just deleted,
+// while logout had already reported success.
+func TestRefresh_LogoutDuringRotationIsNotReversed(t *testing.T) {
+	armCLISession(t, time.Hour)
+
+	orig := refreshClient
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The user logs out while this exchange is in flight. Remove the
+		// session directly rather than via ClearCLISession, which would block
+		// on the refresh lock this caller holds -- the point here is the
+		// cross-process case, where no shared lock exists.
+		os.Remove(CLISessionPath())
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"post-logout","refresh_token":"post-logout-r","expires_in":3600}`))
+	}))
+	defer srv.Close()
+	SetRefreshHTTPClient(&http.Client{Transport: &rewriteTransport{target: srv.URL}})
+	defer SetRefreshHTTPClient(orig)
+
+	_, err := RefreshAccessToken("old-refresh")
+	if !errors.Is(err, ErrSessionLoggedOutDuringRotation) {
+		t.Fatalf("want ErrSessionLoggedOutDuringRotation, got %v", err)
+	}
+	// The credential must stay gone.
+	if _, statErr := os.Stat(CLISessionPath()); statErr == nil {
+		t.Error("the rotation recreated a session the user had logged out of")
+	}
+	if _, loadErr := LoadCLISession(); !errors.Is(loadErr, ErrNoCLISession) {
+		t.Errorf("want ErrNoCLISession after logout, got %v", loadErr)
+	}
+	// And no marker is left implying an interrupted rotation on a session that
+	// no longer exists.
+	if _, mErr := os.Stat(rotationMarkerPath()); mErr == nil {
+		t.Error("marker survived a logout-abandoned rotation")
+	}
+}
+
 // A marker whose directory entry cannot be made durable must not authorize an
 // exchange: spending a single-use token with no recoverable record of it is the
 // failure the marker exists to prevent.

--- a/library/productivity/granola/internal/granola/clisession_rotation_test.go
+++ b/library/productivity/granola/internal/granola/clisession_rotation_test.go
@@ -178,8 +178,10 @@ func TestRefresh_UnpersistedRotationStaysDetectable(t *testing.T) {
 	if _, statErr := os.Stat(rotationMarkerPath()); statErr != nil {
 		t.Fatal("marker was cleared after a spent exchange; the unrecoverable window is now invisible")
 	}
-	// And that state must surface as the actionable error, not as a usable session.
+	// And that state must surface as the actionable error, not as a usable
+	// session, once the marker outlives any live rotation.
 	os.RemoveAll(CLISessionPath())
+	ageRotationMarker(t)
 	if _, loadErr := LoadCLISession(); !errors.Is(loadErr, ErrSessionInterrupted) {
 		t.Errorf("want ErrSessionInterrupted after an unpersisted rotation, got %v", loadErr)
 	}
@@ -357,13 +359,19 @@ func TestBeginRotation_RefusesWithoutDurableDirectory(t *testing.T) {
 	if err := SaveCLISession(sampleSession()); err != nil {
 		t.Fatalf("SaveCLISession: %v", err)
 	}
-	if _, err := BeginRotation(); err != nil {
-		t.Fatalf("BeginRotation should succeed on a healthy directory: %v", err)
+	// The marker's whole job is surviving a crash. If the directory entry cannot
+	// be made durable, a crash can lose the marker after the token is already
+	// spent, so beginning the rotation at all is worse than refusing it.
+	orig := syncDirFn
+	syncDirFn = func(string) error { return errors.New("simulated fsync failure") }
+	t.Cleanup(func() { syncDirFn = orig })
+
+	if _, err := BeginRotation(); err == nil {
+		t.Fatal("BeginRotation succeeded despite an undurable directory; a crash could now lose the marker on a spent token")
 	}
-	// The marker must be gone on the refusal path, not left blocking the next
-	// attempt; covered here by the success path leaving exactly one marker.
-	if _, err := os.Stat(rotationMarkerPath()); err != nil {
-		t.Errorf("marker missing after a successful BeginRotation: %v", err)
+	// And it must not leave the marker it could not make durable.
+	if _, err := os.Stat(rotationMarkerPath()); err == nil {
+		t.Error("a refused rotation left its marker behind")
 	}
 }
 
@@ -391,5 +399,39 @@ func TestRefresh_DesktopSourceNeverMarksRotation(t *testing.T) {
 	}
 	if _, err := os.Stat(rotationMarkerPath()); err == nil {
 		t.Error("a refused desktop refresh wrote a rotation marker")
+	}
+}
+
+// The dedup check compares the stored session against what the caller held when
+// it decided to refresh. That snapshot is taken before the lock, so it can land
+// in the window after the winner updates the cache and before it releases --
+// making the loser compare the winner's new token against itself, conclude
+// nothing rotated, and present its own already-spent refresh token a second
+// time. Spending a single-use chain twice breaks it permanently, so the spent
+// token is tracked exactly rather than inferred from the cache.
+func TestRefresh_SpentTokenIsNotPresentedTwice(t *testing.T) {
+	armCLISession(t, time.Hour)
+	var calls atomic.Int32
+	orig := refreshClient
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"rotated-access","refresh_token":"rotated-refresh","expires_in":3600}`))
+	}))
+	t.Cleanup(srv.Close)
+	SetRefreshHTTPClient(&http.Client{Transport: &rewriteTransport{target: srv.URL}})
+	t.Cleanup(func() { SetRefreshHTTPClient(orig) })
+
+	if _, err := RefreshAccessToken("chain-token-1"); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+	// Re-presenting the consumed token is the lost-snapshot case: the cache now
+	// holds the winner's result, so nothing cache-visible says a rotation
+	// happened, and only the spent-token record can stop a second exchange.
+	if _, err := RefreshAccessToken("chain-token-1"); err != nil {
+		t.Fatalf("second refresh with the spent token: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("the spent refresh token was presented again: %d exchanges, want 1", got)
 	}
 }

--- a/library/productivity/granola/internal/granola/clisession_rotation_test.go
+++ b/library/productivity/granola/internal/granola/clisession_rotation_test.go
@@ -63,6 +63,22 @@ func refreshServerSeeingMarker(t *testing.T, calls *atomic.Int32, markerSeen *at
 	t.Cleanup(func() { SetRefreshHTTPClient(orig) })
 }
 
+// refreshServerRefusing arms a server that must never be reached. It keeps
+// these tests offline and turns "the code exchanged when it should not have"
+// into a clear failure rather than a call to the real endpoint.
+func refreshServerRefusing(t *testing.T, calls *atomic.Int32, markerSeen *atomic.Bool) {
+	t.Helper()
+	orig := refreshClient
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusTeapot)
+		w.Write([]byte(`{"error":"this exchange should not have happened"}`))
+	}))
+	t.Cleanup(srv.Close)
+	SetRefreshHTTPClient(&http.Client{Transport: &rewriteTransport{target: srv.URL}})
+	t.Cleanup(func() { SetRefreshHTTPClient(orig) })
+}
+
 // The marker exists to catch a crash between a spent remote token and a durable
 // local write. Written after the exchange it would never witness that window,
 // so this asserts the server sees it already on disk.
@@ -187,6 +203,10 @@ func TestRefresh_WaiterAdoptsRotatedTokensIntoCache(t *testing.T) {
 		t.Fatalf("SaveCLISession: %v", err)
 	}
 
+	var calls atomic.Int32
+	var seenMarker atomic.Bool
+	refreshServerRefusing(t, &calls, &seenMarker)
+
 	got, err := RefreshAccessToken("old-refresh")
 	if err != nil {
 		t.Fatalf("RefreshAccessToken: %v", err)
@@ -202,6 +222,51 @@ func TestRefresh_WaiterAdoptsRotatedTokensIntoCache(t *testing.T) {
 	}
 	if cached != "winner-access" {
 		t.Errorf("in-process cache = %q, want winner-access; the retry would replay a rejected token", cached)
+	}
+}
+
+// Granola's refresh proxy is observed to return the SAME refresh token, so
+// detection keyed on that token changing would never fire for the provider this
+// CLI actually talks to: the waiter would time out while a valid new access
+// token sat on disk.
+func TestRefresh_DetectsRotationWhenRefreshTokenIsPreserved(t *testing.T) {
+	armCLISession(t, time.Hour)
+
+	// Winner publishes a new access token while preserving the refresh token,
+	// exactly as Granola's proxy does.
+	if err := SaveCLISession(CLISession{
+		AccessToken:  "winner-access",
+		RefreshToken: "old-refresh", // unchanged on purpose
+		ExpiresAt:    time.Now().Add(time.Hour).UTC(),
+		ObtainedAt:   time.Now().Add(time.Second).UTC(),
+		AccountEmail: "someone@example.com",
+	}); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+
+	// Arm a server that fails loudly. If the code exchanges instead of
+	// recognising the winner, the test fails on this rather than reaching the
+	// real endpoint.
+	var calls atomic.Int32
+	var seenMarker atomic.Bool
+	refreshServerRefusing(t, &calls, &seenMarker)
+
+	got, err := RefreshAccessToken("old-refresh")
+	if err != nil {
+		t.Fatalf("waiter did not recognise a rotation that preserved the refresh token: %v", err)
+	}
+	if got.AccessToken != "winner-access" {
+		t.Errorf("returned %q, want winner-access", got.AccessToken)
+	}
+	cached, _, err := LoadAccessToken()
+	if err != nil {
+		t.Fatalf("LoadAccessToken: %v", err)
+	}
+	if cached != "winner-access" {
+		t.Errorf("in-process cache = %q, want winner-access", cached)
+	}
+	if calls.Load() != 0 {
+		t.Errorf("exchanged %d times despite a published winner", calls.Load())
 	}
 }
 

--- a/library/productivity/granola/internal/granola/clisession_rotation_test.go
+++ b/library/productivity/granola/internal/granola/clisession_rotation_test.go
@@ -465,3 +465,37 @@ func TestRefresh_SpentTokenWithUnusableBodyKeepsMarker(t *testing.T) {
 		t.Error("the spent-token state must surface as an actionable error")
 	}
 }
+
+// A rotation that fully succeeded must leave no marker. This is easy to get
+// wrong and slow to notice: a fresh marker does not block a load, so the
+// session keeps working for as long as the staleness window, and only then does
+// a perfectly valid session begin reporting itself as an interrupted rotation
+// and demanding a fresh login.
+func TestRefresh_SuccessfulRotationLeavesNoMarker(t *testing.T) {
+	armCLISession(t, time.Hour)
+	orig := refreshClient
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"rotated-access","refresh_token":"rotated-refresh","expires_in":3600}`))
+	}))
+	t.Cleanup(srv.Close)
+	SetRefreshHTTPClient(&http.Client{Transport: &rewriteTransport{target: srv.URL}})
+	t.Cleanup(func() { SetRefreshHTTPClient(orig) })
+
+	if _, err := RefreshAccessToken("old-refresh"); err != nil {
+		t.Fatalf("RefreshAccessToken: %v", err)
+	}
+	if _, err := os.Stat(rotationMarkerPath()); err == nil {
+		t.Fatal("a successful rotation left its marker behind; the session will demand a re-login once it goes stale")
+	}
+	// Prove it by aging what should not be there: the session must still load.
+	if _, err := LoadCLISession(); err != nil {
+		t.Errorf("session unusable after a successful rotation: %v", err)
+	}
+	// And the next rotation must be able to acquire the marker.
+	h, err := BeginRotation()
+	if err != nil {
+		t.Fatalf("a leaked marker blocked the next rotation: %v", err)
+	}
+	h.Abort()
+}

--- a/library/productivity/granola/internal/granola/clisession_rotation_test.go
+++ b/library/productivity/granola/internal/granola/clisession_rotation_test.go
@@ -270,6 +270,47 @@ func TestRefresh_DetectsRotationWhenRefreshTokenIsPreserved(t *testing.T) {
 	}
 }
 
+// The first generation check and the marker acquire are not atomic. A winner
+// that publishes and releases in that gap must still be seen, or this caller
+// holds a fresh marker and spends a refresh token that is already consumed.
+func TestRefresh_ReChecksAfterAcquiringMarker(t *testing.T) {
+	armCLISession(t, time.Hour)
+	var calls atomic.Int32
+	var seenMarker atomic.Bool
+	refreshServerRefusing(t, &calls, &seenMarker)
+
+	// Publish the winner's result only once this caller has passed its first
+	// check, so the sole chance to notice is the re-check under the marker.
+	orig := beforeAcquireHook
+	beforeAcquireHook = func() {
+		if err := SaveCLISession(CLISession{
+			AccessToken:  "winner-access",
+			RefreshToken: "old-refresh",
+			ExpiresAt:    time.Now().Add(time.Hour).UTC(),
+			ObtainedAt:   time.Now().Add(time.Second).UTC(),
+			AccountEmail: "someone@example.com",
+		}); err != nil {
+			t.Errorf("winner SaveCLISession: %v", err)
+		}
+	}
+	t.Cleanup(func() { beforeAcquireHook = orig })
+
+	got, err := RefreshAccessToken("old-refresh")
+	if err != nil {
+		t.Fatalf("a rotation published in the check/acquire gap was missed: %v", err)
+	}
+	if got.AccessToken != "winner-access" {
+		t.Errorf("returned %q, want winner-access", got.AccessToken)
+	}
+	if calls.Load() != 0 {
+		t.Errorf("spent the stale token %d times despite a published winner", calls.Load())
+	}
+	// The marker must not be left behind by the re-check path.
+	if _, err := os.Stat(rotationMarkerPath()); err == nil {
+		t.Error("marker survived a re-check early return")
+	}
+}
+
 // A marker whose directory entry cannot be made durable must not authorize an
 // exchange: spending a single-use token with no recoverable record of it is the
 // failure the marker exists to prevent.

--- a/library/productivity/granola/internal/granola/clisession_rotation_test.go
+++ b/library/productivity/granola/internal/granola/clisession_rotation_test.go
@@ -499,3 +499,107 @@ func TestRefresh_SuccessfulRotationLeavesNoMarker(t *testing.T) {
 	}
 	h.Abort()
 }
+
+// refreshMu only serializes logout against rotation inside one process. Across
+// processes -- the normal case, since each CLI invocation is its own process --
+// a logout can land after the rotation confirms the session still exists and
+// before its rename publishes the replacement. The rename then recreates the
+// credential after logout has already reported success, leaving the user signed
+// in with no indication anything went wrong.
+//
+// The interleaving is reproduced directly rather than by timing: logout's first
+// durable step is recording the revocation, and this test performs that step
+// while the session is still present, which is exactly the window where the
+// existence check cannot help.
+func TestPersist_LogoutRacingTheRenameDoesNotResurrectTheSession(t *testing.T) {
+	sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	h, err := BeginRotation()
+	if err != nil {
+		t.Fatalf("BeginRotation: %v", err)
+	}
+	t.Cleanup(h.Abort)
+
+	// Another process begins logging out: the revocation is recorded, but its
+	// removal of the session file has not happened yet. The rotation's existence
+	// check therefore still succeeds.
+	if err := noteRevocation(); err != nil {
+		t.Fatalf("noteRevocation: %v", err)
+	}
+
+	err = persistRotatedCLISession(RefreshAccessTokenResponse{
+		AccessToken:  "rotated-access",
+		RefreshToken: "rotated-refresh",
+		ExpiresIn:    3600,
+	}, h)
+	if !errors.Is(err, ErrSessionLoggedOutDuringRotation) {
+		t.Fatalf("want ErrSessionLoggedOutDuringRotation, got %v", err)
+	}
+	if _, statErr := os.Stat(CLISessionPath()); !os.IsNotExist(statErr) {
+		t.Error("the rotation republished a session after logout had been recorded; the user is signed in again despite logging out")
+	}
+	if HasCLISession() {
+		t.Error("still signed in after a logout that raced a rotation")
+	}
+}
+
+// The mirror case: a rotation that completes with no logout anywhere near it
+// must not be mistaken for a raced one and have its own work deleted.
+func TestPersist_UnracedRotationKeepsItsSession(t *testing.T) {
+	sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	h, err := BeginRotation()
+	if err != nil {
+		t.Fatalf("BeginRotation: %v", err)
+	}
+	if err := persistRotatedCLISession(RefreshAccessTokenResponse{
+		AccessToken:  "rotated-access",
+		RefreshToken: "rotated-refresh",
+		ExpiresIn:    3600,
+	}, h); err != nil {
+		t.Fatalf("persistRotatedCLISession: %v", err)
+	}
+	h.Complete()
+	got, err := LoadCLISession()
+	if err != nil {
+		t.Fatalf("LoadCLISession: %v", err)
+	}
+	if got.AccessToken != "rotated-access" {
+		t.Errorf("rotated token did not survive: %q", got.AccessToken)
+	}
+}
+
+// A logout that happens entirely before a later rotation must not make that
+// rotation delete its own result. The epoch is captured when the rotation
+// begins, so an older logout is already accounted for.
+func TestPersist_EarlierLogoutDoesNotAffectALaterRotation(t *testing.T) {
+	sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	if err := ClearCLISession(); err != nil {
+		t.Fatalf("ClearCLISession: %v", err)
+	}
+	// A fresh login after that logout.
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession after re-login: %v", err)
+	}
+	h, err := BeginRotation()
+	if err != nil {
+		t.Fatalf("BeginRotation: %v", err)
+	}
+	if err := persistRotatedCLISession(RefreshAccessTokenResponse{
+		AccessToken: "rotated-access",
+		ExpiresIn:   3600,
+	}, h); err != nil {
+		t.Fatalf("a rotation after an unrelated earlier logout must succeed: %v", err)
+	}
+	h.Complete()
+	if !HasCLISession() {
+		t.Error("a stale logout record deleted a healthy rotation's session")
+	}
+}

--- a/library/productivity/granola/internal/granola/clisession_rotation_test.go
+++ b/library/productivity/granola/internal/granola/clisession_rotation_test.go
@@ -169,6 +169,60 @@ func TestRefresh_UnpersistedRotationStaysDetectable(t *testing.T) {
 	}
 }
 
+// A caller that defers to another process's rotation must also adopt its
+// tokens. Returning them while leaving the local cache holding the rejected
+// access token means the 401 retry that triggered the refresh replays the same
+// dead credential.
+func TestRefresh_WaiterAdoptsRotatedTokensIntoCache(t *testing.T) {
+	armCLISession(t, time.Hour)
+
+	// Simulate the winner having already published a rotated session.
+	if err := SaveCLISession(CLISession{
+		AccessToken:  "winner-access",
+		RefreshToken: "winner-refresh",
+		ExpiresAt:    time.Now().Add(time.Hour).UTC(),
+		ObtainedAt:   time.Now().UTC(),
+		AccountEmail: "someone@example.com",
+	}); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+
+	got, err := RefreshAccessToken("old-refresh")
+	if err != nil {
+		t.Fatalf("RefreshAccessToken: %v", err)
+	}
+	if got.AccessToken != "winner-access" {
+		t.Fatalf("returned token = %q, want the winner's", got.AccessToken)
+	}
+	// The cache the next API call reads must hold the winner's token, not the
+	// rejected one this caller started with.
+	cached, _, err := LoadAccessToken()
+	if err != nil {
+		t.Fatalf("LoadAccessToken: %v", err)
+	}
+	if cached != "winner-access" {
+		t.Errorf("in-process cache = %q, want winner-access; the retry would replay a rejected token", cached)
+	}
+}
+
+// A marker whose directory entry cannot be made durable must not authorize an
+// exchange: spending a single-use token with no recoverable record of it is the
+// failure the marker exists to prevent.
+func TestBeginRotation_RefusesWithoutDurableDirectory(t *testing.T) {
+	sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	if _, err := BeginRotation(); err != nil {
+		t.Fatalf("BeginRotation should succeed on a healthy directory: %v", err)
+	}
+	// The marker must be gone on the refusal path, not left blocking the next
+	// attempt; covered here by the success path leaving exactly one marker.
+	if _, err := os.Stat(rotationMarkerPath()); err != nil {
+		t.Errorf("marker missing after a successful BeginRotation: %v", err)
+	}
+}
+
 // A desktop-owned source must not touch the marker at all -- it is refused
 // before any rotation bookkeeping starts.
 func TestRefresh_DesktopSourceNeverMarksRotation(t *testing.T) {

--- a/library/productivity/granola/internal/granola/clisession_rotation_test.go
+++ b/library/productivity/granola/internal/granola/clisession_rotation_test.go
@@ -435,3 +435,33 @@ func TestRefresh_SpentTokenIsNotPresentedTwice(t *testing.T) {
 		t.Errorf("the spent refresh token was presented again: %d exchanges, want 1", got)
 	}
 }
+
+// A 200 is proof the endpoint rotated, so the presented token is spent no
+// matter what the body turns out to contain. Clearing the marker on a body that
+// fails to parse would delete the only record of the one unrecoverable state:
+// a consumed remote token with no replacement on disk. The session then looks
+// perfectly healthy while its refresh half is dead.
+func TestRefresh_SpentTokenWithUnusableBodyKeepsMarker(t *testing.T) {
+	armCLISession(t, time.Hour)
+	orig := refreshClient
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Rotated upstream, but the body never arrives intact.
+		w.Write([]byte(`{"access_token": "trunc`))
+	}))
+	t.Cleanup(srv.Close)
+	SetRefreshHTTPClient(&http.Client{Transport: &rewriteTransport{target: srv.URL}})
+	t.Cleanup(func() { SetRefreshHTTPClient(orig) })
+
+	if _, err := RefreshAccessToken("old-refresh"); err == nil {
+		t.Fatal("an unparseable refresh response must not report success")
+	}
+	if _, err := os.Stat(rotationMarkerPath()); err != nil {
+		t.Fatal("marker was cleared after a 200; the spent token now looks healthy and the loss is undetectable")
+	}
+	ageRotationMarker(t)
+	if _, err := LoadCLISession(); !errors.Is(err, ErrSessionInterrupted) {
+		t.Error("the spent-token state must surface as an actionable error")
+	}
+}

--- a/library/productivity/granola/internal/granola/clisession_test.go
+++ b/library/productivity/granola/internal/granola/clisession_test.go
@@ -140,7 +140,7 @@ func TestCLISessionInterruptedRotationDetected(t *testing.T) {
 	if err := SaveCLISession(sampleSession()); err != nil {
 		t.Fatalf("SaveCLISession: %v", err)
 	}
-	if err := BeginRotation(); err != nil {
+	if _, err := BeginRotation(); err != nil {
 		t.Fatalf("BeginRotation: %v", err)
 	}
 	// Process "dies" here: marker present, replacement never written.
@@ -162,12 +162,44 @@ func TestCLISessionAbortRotationClearsMarker(t *testing.T) {
 	if err := SaveCLISession(sampleSession()); err != nil {
 		t.Fatalf("SaveCLISession: %v", err)
 	}
-	if err := BeginRotation(); err != nil {
+	h, err := BeginRotation()
+	if err != nil {
 		t.Fatalf("BeginRotation: %v", err)
 	}
-	AbortRotation()
+	h.Abort()
 	if _, err := LoadCLISession(); err != nil {
 		t.Fatalf("a refused refresh must not look like an interrupted one: %v", err)
+	}
+}
+
+// Two CLI processes run concurrently in normal use, and each has its own
+// in-process mutex. Only an exclusive marker stops both from spending the same
+// single-use chain.
+func TestCLISessionRotationIsExclusiveAcrossProcesses(t *testing.T) {
+	sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	first, err := BeginRotation()
+	if err != nil {
+		t.Fatalf("first BeginRotation: %v", err)
+	}
+	if _, err := BeginRotation(); !errors.Is(err, ErrRotationInProgress) {
+		t.Fatalf("second process acquired the marker; want ErrRotationInProgress, got %v", err)
+	}
+	// A loser must not be able to clear the winner's marker, or a crash before
+	// the winner's durable write leaves a spent token undetectable.
+	loser := RotationHandle{}
+	loser.Abort()
+	if _, err := os.Stat(rotationMarkerPath()); err != nil {
+		t.Error("a non-owning abort removed the marker")
+	}
+	if _, err := LoadCLISession(); !errors.Is(err, ErrSessionInterrupted) {
+		t.Error("marker no longer signals an interrupted rotation")
+	}
+	first.Abort()
+	if _, err := os.Stat(rotationMarkerPath()); err == nil {
+		t.Error("the owning handle failed to clear its own marker")
 	}
 }
 

--- a/library/productivity/granola/internal/granola/clisession_test.go
+++ b/library/productivity/granola/internal/granola/clisession_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func sessionSandbox(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "granola-pp-cli")
+	path := filepath.Join(dir, "session.json")
+	t.Setenv("GRANOLA_CLI_SESSION_PATH", path)
+	return path
+}
+
+func sampleSession() CLISession {
+	return CLISession{
+		AccessToken:  "access-token-value-aaaaaaaaaaaaaaaa",
+		RefreshToken: "refresh-token-value-bbbb",
+		ExpiresAt:    time.Now().Add(time.Hour).UTC().Truncate(time.Second),
+		ObtainedAt:   time.Now().UTC().Truncate(time.Second),
+		AccountID:    "user_123",
+		AccountEmail: "someone@example.com",
+	}
+}
+
+func TestCLISessionRoundTrip(t *testing.T) {
+	sessionSandbox(t)
+	want := sampleSession()
+	if err := SaveCLISession(want); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	got, err := LoadCLISession()
+	if err != nil {
+		t.Fatalf("LoadCLISession: %v", err)
+	}
+	if got.AccessToken != want.AccessToken || got.RefreshToken != want.RefreshToken {
+		t.Errorf("tokens did not round-trip")
+	}
+	if got.AccountEmail != want.AccountEmail || got.AccountID != want.AccountID {
+		t.Errorf("account fields did not round-trip: %+v", got.AccountEmail)
+	}
+	if !got.ExpiresAt.Equal(want.ExpiresAt) {
+		t.Errorf("ExpiresAt: got %v want %v", got.ExpiresAt, want.ExpiresAt)
+	}
+}
+
+func TestCLISessionAbsentReturnsSentinel(t *testing.T) {
+	sessionSandbox(t)
+	if _, err := LoadCLISession(); !errors.Is(err, ErrNoCLISession) {
+		t.Fatalf("want ErrNoCLISession, got %v", err)
+	}
+	if HasCLISession() {
+		t.Error("HasCLISession true with no session on disk")
+	}
+}
+
+func TestCLISessionFilePermissions(t *testing.T) {
+	path := sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("session file mode: got %#o want 0600", perm)
+	}
+	di, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := di.Mode().Perm(); perm != 0o700 {
+		t.Errorf("session dir mode: got %#o want 0700", perm)
+	}
+}
+
+// The MkdirAll no-op is the real-world case: ~/.local/share/granola-pp-cli
+// already exists at 0755 on every machine that has ever synced, because
+// WriteSyncState created it that way. A fresh-tempdir test would never catch it.
+func TestCLISessionTightensPreExistingLooseDir(t *testing.T) {
+	path := sessionSandbox(t)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("pre-create dir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod 0755: %v", err)
+	}
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	di, _ := os.Stat(dir)
+	if perm := di.Mode().Perm(); perm != 0o700 {
+		t.Errorf("pre-existing 0755 dir was not tightened: got %#o want 0700", perm)
+	}
+}
+
+func TestCLISessionRefusesWorldReadableFile(t *testing.T) {
+	path := sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	_, err := LoadCLISession()
+	if !errors.Is(err, ErrSessionPermissions) {
+		t.Fatalf("want ErrSessionPermissions for a 0644 session file, got %v", err)
+	}
+}
+
+func TestCLISessionMalformedIsTypedNotMissing(t *testing.T) {
+	path := sessionSandbox(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"access_token": "trunc`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := LoadCLISession()
+	if err == nil {
+		t.Fatal("expected an error for a truncated session file")
+	}
+	if errors.Is(err, ErrNoCLISession) {
+		t.Error("a corrupt session must not be reported as absent; that silently falls through to desktop probes")
+	}
+}
+
+func TestCLISessionInterruptedRotationDetected(t *testing.T) {
+	sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	if err := BeginRotation(); err != nil {
+		t.Fatalf("BeginRotation: %v", err)
+	}
+	// Process "dies" here: marker present, replacement never written.
+	_, err := LoadCLISession()
+	if !errors.Is(err, ErrSessionInterrupted) {
+		t.Fatalf("want ErrSessionInterrupted, got %v", err)
+	}
+	// A completed save clears it.
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession after rotation: %v", err)
+	}
+	if _, err := LoadCLISession(); err != nil {
+		t.Fatalf("session should load once rotation completed: %v", err)
+	}
+}
+
+func TestCLISessionAbortRotationClearsMarker(t *testing.T) {
+	sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	if err := BeginRotation(); err != nil {
+		t.Fatalf("BeginRotation: %v", err)
+	}
+	AbortRotation()
+	if _, err := LoadCLISession(); err != nil {
+		t.Fatalf("a refused refresh must not look like an interrupted one: %v", err)
+	}
+}
+
+func TestCLISessionRedactsTokens(t *testing.T) {
+	s := sampleSession()
+	for _, rendered := range []string{s.String(), fmt.Sprintf("%v", s), fmt.Sprintf("%+v", s), fmt.Sprintf("%#v", s)} {
+		if strings.Contains(rendered, s.AccessToken) {
+			t.Errorf("access token leaked into %q", rendered)
+		}
+		if strings.Contains(rendered, s.RefreshToken) {
+			t.Errorf("refresh token leaked into %q", rendered)
+		}
+	}
+}
+
+func TestCLISessionClear(t *testing.T) {
+	path := sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	if err := ClearCLISession(); err != nil {
+		t.Fatalf("ClearCLISession: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("session file still present after clear")
+	}
+	if _, err := LoadCLISession(); !errors.Is(err, ErrNoCLISession) {
+		t.Errorf("want ErrNoCLISession after clear, got %v", err)
+	}
+	if err := ClearCLISession(); err != nil {
+		t.Errorf("clearing an already-absent session should be a no-op: %v", err)
+	}
+}

--- a/library/productivity/granola/internal/granola/clisession_test.go
+++ b/library/productivity/granola/internal/granola/clisession_test.go
@@ -203,6 +203,32 @@ func TestCLISessionRotationIsExclusiveAcrossProcesses(t *testing.T) {
 	}
 }
 
+// The marker guards a crash window, so it must be on disk before the exchange
+// it guards -- not merely written into a buffer that a crash discards.
+func TestCLISessionRotationMarkerIsDurableBeforeReturn(t *testing.T) {
+	sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	h, err := BeginRotation()
+	if err != nil {
+		t.Fatalf("BeginRotation: %v", err)
+	}
+	// Readable by an independent open the moment BeginRotation returns, with
+	// the owning nonce intact.
+	got, err := os.ReadFile(rotationMarkerPath())
+	if err != nil {
+		t.Fatalf("marker not readable after BeginRotation returned: %v", err)
+	}
+	if len(got) == 0 {
+		t.Error("marker is empty; a non-owning abort could not be distinguished from an owning one")
+	}
+	if _, err := LoadCLISession(); !errors.Is(err, ErrSessionInterrupted) {
+		t.Errorf("want ErrSessionInterrupted while a rotation is in flight, got %v", err)
+	}
+	h.Abort()
+}
+
 func TestCLISessionRedactsTokens(t *testing.T) {
 	s := sampleSession()
 	for _, rendered := range []string{s.String(), fmt.Sprintf("%v", s), fmt.Sprintf("%+v", s), fmt.Sprintf("%#v", s)} {

--- a/library/productivity/granola/internal/granola/clisession_test.go
+++ b/library/productivity/granola/internal/granola/clisession_test.go
@@ -20,6 +20,18 @@ func sessionSandbox(t *testing.T) string {
 	return path
 }
 
+// ageRotationMarker backdates the marker past rotationStaleAfter, standing in
+// for the process that created it having died. Presence alone no longer means
+// interruption -- a fresh marker is a live rotation -- so every test about the
+// interrupted state has to age it first.
+func ageRotationMarker(t *testing.T) {
+	t.Helper()
+	old := time.Now().Add(-2 * rotationStaleAfter)
+	if err := os.Chtimes(rotationMarkerPath(), old, old); err != nil {
+		t.Fatalf("backdate marker: %v", err)
+	}
+}
+
 func sampleSession() CLISession {
 	return CLISession{
 		AccessToken:  "access-token-value-aaaaaaaaaaaaaaaa",
@@ -143,7 +155,14 @@ func TestCLISessionInterruptedRotationDetected(t *testing.T) {
 	if _, err := BeginRotation(); err != nil {
 		t.Fatalf("BeginRotation: %v", err)
 	}
-	// Process "dies" here: marker present, replacement never written.
+	// Still running: the session on disk is the pre-rotation credential, which
+	// is valid until the replacement lands. Other processes must keep working.
+	if _, err := LoadCLISession(); err != nil {
+		t.Fatalf("a live rotation must not break concurrent readers: %v", err)
+	}
+	// Process dies here: marker present, replacement never written, and enough
+	// time passes that no live rotation could still own it.
+	ageRotationMarker(t)
 	_, err := LoadCLISession()
 	if !errors.Is(err, ErrSessionInterrupted) {
 		t.Fatalf("want ErrSessionInterrupted, got %v", err)
@@ -188,12 +207,16 @@ func TestCLISessionRotationIsExclusiveAcrossProcesses(t *testing.T) {
 		t.Fatalf("second process acquired the marker; want ErrRotationInProgress, got %v", err)
 	}
 	// A loser must not be able to clear the winner's marker, or a crash before
-	// the winner's durable write leaves a spent token undetectable.
-	loser := RotationHandle{}
+	// the winner's durable write leaves a spent token undetectable. The nonce is
+	// non-empty and different: a zero handle is short-circuited by the empty-nonce
+	// guard, so it would pass even against an implementation that removed the
+	// marker unconditionally once a nonce was present.
+	loser := RotationHandle{nonce: "a-different-process-nonce"}
 	loser.Abort()
 	if _, err := os.Stat(rotationMarkerPath()); err != nil {
 		t.Error("a non-owning abort removed the marker")
 	}
+	ageRotationMarker(t)
 	if _, err := LoadCLISession(); !errors.Is(err, ErrSessionInterrupted) {
 		t.Error("marker no longer signals an interrupted rotation")
 	}
@@ -223,8 +246,9 @@ func TestCLISessionRotationMarkerIsDurableBeforeReturn(t *testing.T) {
 	if len(got) == 0 {
 		t.Error("marker is empty; a non-owning abort could not be distinguished from an owning one")
 	}
+	ageRotationMarker(t)
 	if _, err := LoadCLISession(); !errors.Is(err, ErrSessionInterrupted) {
-		t.Errorf("want ErrSessionInterrupted while a rotation is in flight, got %v", err)
+		t.Errorf("want ErrSessionInterrupted once the marker outlives a live rotation, got %v", err)
 	}
 	h.Abort()
 }
@@ -238,6 +262,43 @@ func TestCLISessionRedactsTokens(t *testing.T) {
 		if strings.Contains(rendered, s.RefreshToken) {
 			t.Errorf("refresh token leaked into %q", rendered)
 		}
+	}
+}
+
+// A login completing while another process rotates must not delete that
+// process's marker: a third process could then begin a concurrent exchange of
+// the same single-use chain, which is the one outcome the marker prevents.
+func TestSaveDoesNotClearAnotherProcessLiveMarker(t *testing.T) {
+	sessionSandbox(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	holder, err := BeginRotation()
+	if err != nil {
+		t.Fatalf("BeginRotation: %v", err)
+	}
+	// An unrelated `auth login` lands mid-rotation.
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession during rotation: %v", err)
+	}
+	if _, err := os.Stat(rotationMarkerPath()); err != nil {
+		t.Fatal("a concurrent save removed a live rotation's marker; two processes can now exchange the same chain")
+	}
+	if _, err := BeginRotation(); !errors.Is(err, ErrRotationInProgress) {
+		t.Error("exclusivity lost after a concurrent save")
+	}
+	holder.Abort()
+	// A stale marker is different: nothing live owns it, and a save is the
+	// recovery path, so it must be cleared or the user can never get out.
+	if _, err := BeginRotation(); err != nil {
+		t.Fatalf("re-acquire: %v", err)
+	}
+	ageRotationMarker(t)
+	if err := SaveCLISession(sampleSession()); err != nil {
+		t.Fatalf("SaveCLISession: %v", err)
+	}
+	if _, err := os.Stat(rotationMarkerPath()); err == nil {
+		t.Error("a stale marker survived a completed save; the user cannot recover")
 	}
 }
 

--- a/library/productivity/granola/internal/granola/clisession_unix.go
+++ b/library/productivity/granola/internal/granola/clisession_unix.go
@@ -30,14 +30,14 @@ func checkOwnerOnly(info os.FileInfo, path string) error {
 	return nil
 }
 
-// syncDir flushes the directory entry so the rename that published the session
-// survives a crash. Best-effort: a filesystem that rejects the open still
-// leaves the renamed file in place.
-func syncDir(dir string) {
+// syncDir flushes the directory entry so a newly created or renamed file
+// survives a crash. The error is returned rather than swallowed: callers differ
+// on whether an unsyncable directory is tolerable, and only they can judge.
+func syncDir(dir string) error {
 	d, err := os.Open(dir)
 	if err != nil {
-		return
+		return err
 	}
 	defer d.Close()
-	_ = d.Sync()
+	return d.Sync()
 }

--- a/library/productivity/granola/internal/granola/clisession_unix.go
+++ b/library/productivity/granola/internal/granola/clisession_unix.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+//go:build !windows
+
+package granola
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// checkOwnerOnly refuses a session file that another account can read or that
+// this user does not own.
+//
+// Both halves matter. A group- or world-readable credential is readable by
+// anyone on a shared box; a file owned by someone else is one they can rewrite,
+// which would let them choose which account this CLI talks to.
+func checkOwnerOnly(info os.FileInfo, path string) error {
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("%w: %s is mode %#o, want 0600", ErrSessionPermissions, path, info.Mode().Perm())
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+	if uint32(st.Uid) != uint32(os.Getuid()) {
+		return fmt.Errorf("%w: %s is owned by uid %d, not %d", ErrSessionPermissions, path, st.Uid, os.Getuid())
+	}
+	return nil
+}
+
+// syncDir flushes the directory entry so the rename that published the session
+// survives a crash. Best-effort: a filesystem that rejects the open still
+// leaves the renamed file in place.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	defer d.Close()
+	_ = d.Sync()
+}

--- a/library/productivity/granola/internal/granola/clisession_windows.go
+++ b/library/productivity/granola/internal/granola/clisession_windows.go
@@ -12,6 +12,9 @@ import "os"
 // path is left to the user profile directory's own ACLs.
 func checkOwnerOnly(info os.FileInfo, path string) error { return nil }
 
-// syncDir is a no-op on Windows: directory handles are not syncable the way
-// they are on Unix, and the rename above is already atomic on NTFS.
-func syncDir(dir string) {}
+// syncDir is a no-op on Windows and reports success. Directory handles are not
+// syncable there the way they are on Unix; durability of a newly created entry
+// comes from the file's own FlushFileBuffers, which callers perform before
+// reaching here. Returning nil is therefore accurate rather than optimistic --
+// there is no pending directory flush left outstanding.
+func syncDir(dir string) error { return nil }

--- a/library/productivity/granola/internal/granola/clisession_windows.go
+++ b/library/productivity/granola/internal/granola/clisession_windows.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+//go:build windows
+
+package granola
+
+import "os"
+
+// checkOwnerOnly is a no-op on Windows. Go's os.FileMode does not carry NTFS
+// ACLs, so the Unix permission bits are not meaningful here and enforcing them
+// would reject every legitimate session file. Windows access control for this
+// path is left to the user profile directory's own ACLs.
+func checkOwnerOnly(info os.FileInfo, path string) error { return nil }
+
+// syncDir is a no-op on Windows: directory handles are not syncable the way
+// they are on Unix, and the rename above is already atomic on NTFS.
+func syncDir(dir string) {}

--- a/library/productivity/granola/internal/granola/deviceauth.go
+++ b/library/productivity/granola/internal/granola/deviceauth.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// PATCH(cli-owned-workos-session): OAuth 2.0 device authorization grant against
+// Granola's WorkOS deployment. This is how the CLI obtains a session of its
+// own, which is the only durable option once the desktop's DEK moved out of
+// reach -- see safestorage/testdata/scheme.md for the derived contract.
+
+const (
+	// DeviceAuthorizeEndpoint issues a device code.
+	DeviceAuthorizeEndpoint = "https://auth.granola.ai/user_management/authorize/device"
+	// DeviceTokenEndpoint is polled until the user approves.
+	DeviceTokenEndpoint = "https://auth.granola.ai/user_management/authenticate"
+	// DeviceGrantType is the RFC 8628 grant type.
+	DeviceGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+	// GranolaDeviceClientID is Granola's public OAuth client. A public client
+	// id is not a secret; it identifies the application, not the user.
+	GranolaDeviceClientID = "client_01JZJ0XBDAT8PHJWQY09Y0VD61"
+)
+
+// ErrDeviceCodeExpired reports that the user did not approve in time.
+var ErrDeviceCodeExpired = errors.New("granola: device code expired before approval")
+
+// ErrDeviceAuthDenied reports that the user declined the request.
+var ErrDeviceAuthDenied = errors.New("granola: device authorization denied")
+
+// DeviceCode is the issuing response. UserCode and VerificationURIComplete are
+// what the operator acts on.
+type DeviceCode struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// deviceTokenResponse is the success envelope from the token endpoint.
+type deviceTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	User         struct {
+		ID    string `json:"id"`
+		Email string `json:"email"`
+	} `json:"user"`
+	AuthenticationMethod string `json:"authentication_method"`
+}
+
+// deviceHTTPClient is overridable so tests can drive the polling loop against
+// an httptest server rather than the live service.
+var deviceHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+// SetDeviceHTTPClient swaps the client used for the device grant.
+func SetDeviceHTTPClient(c *http.Client) { deviceHTTPClient = c }
+
+// deviceEndpoints are overridable for the same reason.
+var (
+	deviceAuthorizeURL = DeviceAuthorizeEndpoint
+	deviceTokenURL     = DeviceTokenEndpoint
+)
+
+// SetDeviceEndpoints overrides both endpoints. Tests only.
+func SetDeviceEndpoints(authorize, token string) {
+	deviceAuthorizeURL, deviceTokenURL = authorize, token
+}
+
+// RequestDeviceCode starts the grant.
+func RequestDeviceCode(ctx context.Context) (DeviceCode, error) {
+	form := url.Values{"client_id": {GranolaDeviceClientID}}
+	req, err := http.NewRequestWithContext(ctx, "POST", deviceAuthorizeURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return DeviceCode{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := deviceHTTPClient.Do(req)
+	if err != nil {
+		return DeviceCode{}, fmt.Errorf("device authorize: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return DeviceCode{}, fmt.Errorf("device authorize: status %d: %s", resp.StatusCode, truncateBody(string(body), 200))
+	}
+	var dc DeviceCode
+	if err := json.Unmarshal(body, &dc); err != nil {
+		return DeviceCode{}, fmt.Errorf("device authorize: parse response: %w", err)
+	}
+	if dc.DeviceCode == "" || dc.UserCode == "" {
+		return DeviceCode{}, fmt.Errorf("device authorize: response missing device_code or user_code")
+	}
+	if dc.Interval <= 0 {
+		dc.Interval = 5
+	}
+	if dc.ExpiresIn <= 0 {
+		dc.ExpiresIn = 300
+	}
+	return dc, nil
+}
+
+// PollDeviceToken polls until the user approves, the code expires, or ctx is
+// cancelled.
+//
+// Per RFC 8628 the two waiting states are not failures: authorization_pending
+// means keep going at the current cadence, and slow_down means the same but
+// lengthen the interval. Treating either as an error would abandon a grant the
+// user is about to approve.
+func PollDeviceToken(ctx context.Context, dc DeviceCode) (CLISession, error) {
+	interval := time.Duration(dc.Interval) * time.Second
+	deadline := time.Now().Add(time.Duration(dc.ExpiresIn) * time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return CLISession{}, ctx.Err()
+		case <-time.After(interval):
+		}
+		if time.Now().After(deadline) {
+			return CLISession{}, ErrDeviceCodeExpired
+		}
+
+		form := url.Values{
+			"client_id":   {GranolaDeviceClientID},
+			"grant_type":  {DeviceGrantType},
+			"device_code": {dc.DeviceCode},
+		}
+		req, err := http.NewRequestWithContext(ctx, "POST", deviceTokenURL, strings.NewReader(form.Encode()))
+		if err != nil {
+			return CLISession{}, err
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := deviceHTTPClient.Do(req)
+		if err != nil {
+			if ctx.Err() != nil {
+				return CLISession{}, ctx.Err()
+			}
+			return CLISession{}, fmt.Errorf("device token: %w", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			var tr deviceTokenResponse
+			if err := json.Unmarshal(body, &tr); err != nil {
+				return CLISession{}, fmt.Errorf("device token: parse response: %w", err)
+			}
+			if tr.AccessToken == "" {
+				return CLISession{}, fmt.Errorf("device token: response carried no access_token")
+			}
+			now := time.Now().UTC()
+			return CLISession{
+				AccessToken:  tr.AccessToken,
+				RefreshToken: tr.RefreshToken,
+				ObtainedAt:   now,
+				AccountID:    tr.User.ID,
+				AccountEmail: tr.User.Email,
+			}, nil
+		}
+
+		switch deviceErrorCode(body) {
+		case "authorization_pending":
+			continue
+		case "slow_down":
+			interval += 5 * time.Second
+		case "expired_token":
+			return CLISession{}, ErrDeviceCodeExpired
+		case "access_denied":
+			return CLISession{}, ErrDeviceAuthDenied
+		default:
+			return CLISession{}, fmt.Errorf("device token: status %d: %s", resp.StatusCode, truncateBody(string(body), 200))
+		}
+	}
+}
+
+func deviceErrorCode(body []byte) string {
+	var e struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &e); err != nil {
+		return ""
+	}
+	return e.Error
+}
+
+func truncateBody(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/library/productivity/granola/internal/granola/deviceauth_test.go
+++ b/library/productivity/granola/internal/granola/deviceauth_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// deviceServer stands in for Granola's WorkOS endpoints. tokenStages is walked
+// one entry per poll, so a test can script pending -> pending -> success.
+func deviceServer(t *testing.T, expiresIn, interval int, tokenStages []func(w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	var polls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"device_code":"dev-code","user_code":"ABCD-EFGH",` +
+			`"verification_uri":"https://example.test/device",` +
+			`"verification_uri_complete":"https://example.test/device?user_code=ABCD-EFGH",` +
+			`"expires_in":` + itoa(expiresIn) + `,"interval":` + itoa(interval) + `}`))
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		i := int(atomic.AddInt32(&polls, 1)) - 1
+		if i >= len(tokenStages) {
+			i = len(tokenStages) - 1
+		}
+		tokenStages[i](w)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	SetDeviceEndpoints(srv.URL+"/authorize", srv.URL+"/token")
+	SetDeviceHTTPClient(srv.Client())
+	t.Cleanup(func() {
+		SetDeviceEndpoints(DeviceAuthorizeEndpoint, DeviceTokenEndpoint)
+		SetDeviceHTTPClient(&http.Client{Timeout: 30 * time.Second})
+	})
+	return srv
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	if neg {
+		return "-" + string(b)
+	}
+	return string(b)
+}
+
+func pendingStage(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	w.Write([]byte(`{"error":"authorization_pending"}`))
+}
+
+func successStage(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"access_token":"at-value","refresh_token":"rt-value",` +
+		`"user":{"id":"user_1","email":"someone@example.com"},"authentication_method":"GoogleOAuth"}`))
+}
+
+func TestDeviceAuthPendingThenSuccess(t *testing.T) {
+	deviceServer(t, 60, 0, []func(http.ResponseWriter){pendingStage, pendingStage, successStage})
+	ctx := context.Background()
+	dc, err := RequestDeviceCode(ctx)
+	if err != nil {
+		t.Fatalf("RequestDeviceCode: %v", err)
+	}
+	if dc.UserCode != "ABCD-EFGH" {
+		t.Errorf("user code: got %q", dc.UserCode)
+	}
+	// A zero interval from the server must be defaulted, not used as a
+	// busy-loop.
+	if dc.Interval <= 0 {
+		t.Errorf("interval should default to a positive value, got %d", dc.Interval)
+	}
+	dc.Interval = 0 // keep the test fast; the loop still polls
+	s, err := PollDeviceToken(ctx, dc)
+	if err != nil {
+		t.Fatalf("PollDeviceToken: %v", err)
+	}
+	if s.AccessToken != "at-value" || s.RefreshToken != "rt-value" {
+		t.Error("tokens not carried out of the success envelope")
+	}
+	if s.AccountEmail != "someone@example.com" || s.AccountID != "user_1" {
+		t.Errorf("account identity not captured: %q %q", s.AccountEmail, s.AccountID)
+	}
+}
+
+// slow_down must lengthen the interval, not abort. Aborting would drop a grant
+// the user is in the middle of approving.
+func TestDeviceAuthSlowDownBacksOff(t *testing.T) {
+	slow := func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"slow_down"}`))
+	}
+	deviceServer(t, 60, 0, []func(http.ResponseWriter){slow, successStage})
+	dc, err := RequestDeviceCode(context.Background())
+	if err != nil {
+		t.Fatalf("RequestDeviceCode: %v", err)
+	}
+	dc.Interval = 0
+	start := time.Now()
+	s, err := PollDeviceToken(context.Background(), dc)
+	if err != nil {
+		t.Fatalf("slow_down should not abort the grant: %v", err)
+	}
+	if s.AccessToken == "" {
+		t.Error("no token after backoff")
+	}
+	if time.Since(start) < 5*time.Second {
+		t.Error("slow_down did not lengthen the poll interval")
+	}
+}
+
+func TestDeviceAuthExpiredToken(t *testing.T) {
+	expired := func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"expired_token"}`))
+	}
+	deviceServer(t, 60, 0, []func(http.ResponseWriter){expired})
+	dc, _ := RequestDeviceCode(context.Background())
+	dc.Interval = 0
+	if _, err := PollDeviceToken(context.Background(), dc); !errors.Is(err, ErrDeviceCodeExpired) {
+		t.Fatalf("want ErrDeviceCodeExpired, got %v", err)
+	}
+}
+
+func TestDeviceAuthDeadlineElapses(t *testing.T) {
+	deviceServer(t, 0, 0, []func(http.ResponseWriter){pendingStage})
+	dc, _ := RequestDeviceCode(context.Background())
+	dc.Interval = 0
+	dc.ExpiresIn = 0 // already past
+	if _, err := PollDeviceToken(context.Background(), dc); !errors.Is(err, ErrDeviceCodeExpired) {
+		t.Fatalf("want ErrDeviceCodeExpired once the window lapses, got %v", err)
+	}
+}
+
+func TestDeviceAuthDenied(t *testing.T) {
+	denied := func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"access_denied"}`))
+	}
+	deviceServer(t, 60, 0, []func(http.ResponseWriter){denied})
+	dc, _ := RequestDeviceCode(context.Background())
+	dc.Interval = 0
+	if _, err := PollDeviceToken(context.Background(), dc); !errors.Is(err, ErrDeviceAuthDenied) {
+		t.Fatalf("want ErrDeviceAuthDenied, got %v", err)
+	}
+}
+
+func TestDeviceAuthContextCancel(t *testing.T) {
+	deviceServer(t, 60, 0, []func(http.ResponseWriter){pendingStage})
+	ctx, cancel := context.WithCancel(context.Background())
+	dc, _ := RequestDeviceCode(ctx)
+	dc.Interval = 1
+	go func() { time.Sleep(150 * time.Millisecond); cancel() }()
+	_, err := PollDeviceToken(ctx, dc)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}

--- a/library/productivity/granola/internal/granola/internalapi.go
+++ b/library/productivity/granola/internal/granola/internalapi.go
@@ -170,6 +170,49 @@ func truncate(s string, n int) string {
 	return s[:n] + "...(truncated)"
 }
 
+// PATCH(api-catalog-refresh): endpoints for the catalog surfaces. Named
+// constants because each one appears three times -- the request, the shape
+// error, and the test that pins the path -- and a typo in any of them reads
+// as "Granola changed the payload" rather than "we asked the wrong URL".
+//
+// The document-list surface is v2. /v1/get-document-lists answers 404 "Not
+// implemented" on the live API, so the fallback below is a legacy-install
+// courtesy, not the primary path.
+const (
+	recipesEndpoint               = "/v1/get-recipes"
+	panelTemplatesEndpoint        = "/v1/get-panel-templates"
+	documentListsEndpoint         = "/v2/get-document-lists"
+	documentListsLegacyEndpoint   = "/v1/get-document-lists"
+	documentListsNotImplemented   = "status 404"
+	shapeErrorBodySampleMaxLength = 200
+)
+
+// APIShapeError reports a response body the client could not map onto any
+// known shape.
+//
+// Typed rather than a bare fmt.Errorf so a caller that makes several calls in
+// one pass can tell "Granola changed this payload" apart from a transport,
+// auth or rate-limit failure -- the first needs a code change here, the others
+// need the user to do something. Endpoint is a field and not only prose in the
+// message for the same reason: the catalog refresh calls three endpoints
+// together, and "unrecognized response shape" without a name leaves both the
+// operator and the test assertion guessing which one drifted.
+type APIShapeError struct {
+	// Endpoint is the API path whose response could not be parsed.
+	Endpoint string
+	// Body is a truncated sample of what came back, so a bug report carries
+	// the actual drift rather than a description of it.
+	Body string
+}
+
+func (e *APIShapeError) Error() string {
+	return fmt.Sprintf("granola %s: unrecognized response shape: %s", e.Endpoint, e.Body)
+}
+
+func shapeError(endpoint string, raw []byte) error {
+	return &APIShapeError{Endpoint: endpoint, Body: truncate(string(raw), shapeErrorBodySampleMaxLength)}
+}
+
 // GetDocumentsRequest is the body for /v2/get-documents.
 type GetDocumentsRequest struct {
 	Limit                  int  `json:"limit,omitempty"`
@@ -365,21 +408,32 @@ func (c *InternalClient) GetWorkspaces() ([]Workspace, error) {
 	return nil, fmt.Errorf("granola get-workspaces: unrecognized response shape")
 }
 
-// GetDocumentLists lists folders. Tries /v2 first then falls back to /v1
-// on 404 — Granola has shipped both.
+// GetDocumentLists lists folders, with each list's membership inline on
+// DocumentListMetadata.Documents. Tries /v2 first then falls back to /v1 on
+// 404 — Granola has shipped both.
+//
+// PATCH(api-catalog-refresh): the fallback used to fire on any 4xx, which
+// meant a 401 on /v2 was retried against a /v1 that answers 404 "Not
+// implemented" — so an expired credential surfaced as a missing endpoint and
+// the real remedy never reached the user. Only a 404 means "this surface is
+// not here"; every other 4xx is about the caller, not the path.
 func (c *InternalClient) GetDocumentLists() ([]DocumentListMetadata, error) {
-	raw, err := c.post("/v2/get-document-lists", map[string]any{})
+	raw, err := c.post(documentListsEndpoint, map[string]any{})
 	if err != nil {
-		// Fall back to /v1 on 4xx (likely 404 because endpoint not present)
-		if strings.Contains(err.Error(), "status 4") {
-			raw, err = c.post("/v1/get-document-lists", map[string]any{})
-			if err != nil {
-				return nil, err
-			}
-		} else {
+		if !strings.Contains(err.Error(), documentListsNotImplemented) {
+			return nil, err
+		}
+		raw, err = c.post(documentListsLegacyEndpoint, map[string]any{})
+		if err != nil {
 			return nil, err
 		}
 	}
+	return parseDocumentLists(raw)
+}
+
+// parseDocumentLists accepts both shapes Granola has shipped: the live
+// {"lists":[...]} envelope and the bare array older builds returned.
+func parseDocumentLists(raw []byte) ([]DocumentListMetadata, error) {
 	var env struct {
 		Lists []DocumentListMetadata `json:"lists"`
 	}
@@ -390,7 +444,150 @@ func (c *InternalClient) GetDocumentLists() ([]DocumentListMetadata, error) {
 	if err := json.Unmarshal(raw, &arr); err == nil {
 		return arr, nil
 	}
-	return nil, fmt.Errorf("granola get-document-lists: unrecognized response shape")
+	return nil, shapeError(documentListsEndpoint, raw)
+}
+
+// RecipeCatalog is the /v1/get-recipes payload: every recipe collection the
+// account can see, plus the usage counters keyed by recipe id.
+//
+// UnlistedRecipes and DefaultRecipes are decoded but deliberately not
+// hydrated into the Cache: the desktop cache has no counterpart key for
+// either, and writing rows that only ever appear on API-refreshed installs
+// would make the two sync paths disagree about what the catalog contains
+// while nothing retires the extras. They are kept on the typed surface so the
+// live shape stays documented at the call site.
+type RecipeCatalog struct {
+	UserRecipes     []Recipe
+	SharedRecipes   []Recipe
+	PublicRecipes   []Recipe
+	UnlistedRecipes []Recipe
+	DefaultRecipes  []Recipe
+	// Usage is keyed by recipe id.
+	Usage map[string]RecipeUsage
+}
+
+// GetRecipes calls /v1/get-recipes. One call returns the whole catalog, so
+// unlike transcripts there is nothing to page or budget.
+func (c *InternalClient) GetRecipes() (RecipeCatalog, error) {
+	raw, err := c.post(recipesEndpoint, map[string]any{})
+	if err != nil {
+		return RecipeCatalog{}, err
+	}
+	return parseRecipeCatalog(raw)
+}
+
+// parseRecipeCatalog decodes the get-recipes envelope key by key so one
+// unreadable collection cannot cost the caller the other four.
+func parseRecipeCatalog(raw []byte) (RecipeCatalog, error) {
+	cat := RecipeCatalog{Usage: map[string]RecipeUsage{}}
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return cat, shapeError(recipesEndpoint, raw)
+	}
+	buckets := []struct {
+		key string
+		dst *[]Recipe
+	}{
+		{"userRecipes", &cat.UserRecipes},
+		{"sharedRecipes", &cat.SharedRecipes},
+		{"publicRecipes", &cat.PublicRecipes},
+		{"unlistedRecipes", &cat.UnlistedRecipes},
+		{"defaultRecipes", &cat.DefaultRecipes},
+	}
+	recognized := false
+	for _, b := range buckets {
+		v, ok := probe[b.key]
+		if !ok {
+			continue
+		}
+		recognized = true
+		_ = json.Unmarshal(v, b.dst)
+	}
+	if v, ok := probe["recipesUsage"]; ok {
+		recognized = true
+		cat.Usage = parseRecipesUsage(v)
+	}
+	if !recognized {
+		// An object with none of the six known keys is not "an account with
+		// no recipes" — every account gets defaultRecipes. It is a payload we
+		// no longer understand, and reporting it as empty would quietly wipe
+		// the catalog on the next sync.
+		return cat, shapeError(recipesEndpoint, raw)
+	}
+	return cat, nil
+}
+
+// parseRecipesUsage decodes the recipesUsage dict.
+//
+// total_count is json.Number rather than string or int64 because the wire
+// carries it as a bare number while the desktop cache stores it as a string,
+// and json.Number is the one type encoding/json fills from either. Every
+// consumer of RecipeUsage.TotalCount runs fmt.Sscanf over it, so the value
+// stored here has to be decimal digits: hand back "" or a float rendering and
+// both the store write and `recipes list --top-usage` silently read zero.
+func parseRecipesUsage(raw json.RawMessage) map[string]RecipeUsage {
+	out := map[string]RecipeUsage{}
+	var entries map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return out
+	}
+	for id, entry := range entries {
+		if id == "" {
+			continue
+		}
+		var u struct {
+			RecipeID   string      `json:"recipe_id,omitempty"`
+			TotalCount json.Number `json:"total_count,omitempty"`
+			LastUsedAt string      `json:"last_used_at,omitempty"`
+		}
+		if err := json.Unmarshal(entry, &u); err != nil {
+			// One unreadable counter, not a broken catalog.
+			continue
+		}
+		recipeID := u.RecipeID
+		if recipeID == "" {
+			// The dict key is the recipe id; the record does not always
+			// repeat it, and the cache-path record leaves it blank too.
+			recipeID = id
+		}
+		out[id] = RecipeUsage{
+			RecipeID:   recipeID,
+			TotalCount: u.TotalCount.String(),
+			LastUsedAt: u.LastUsedAt,
+		}
+	}
+	return out
+}
+
+// GetPanelTemplates calls /v1/get-panel-templates. The live response is a
+// bare list; the envelope shapes are accepted too because every other
+// collection endpoint on this API has shipped both at some point.
+func (c *InternalClient) GetPanelTemplates() ([]PanelTemplate, error) {
+	raw, err := c.post(panelTemplatesEndpoint, map[string]any{})
+	if err != nil {
+		return nil, err
+	}
+	return parsePanelTemplates(raw)
+}
+
+func parsePanelTemplates(raw []byte) ([]PanelTemplate, error) {
+	var arr []PanelTemplate
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr, nil
+	}
+	var env struct {
+		PanelTemplates []PanelTemplate `json:"panelTemplates"`
+		Templates      []PanelTemplate `json:"templates"`
+	}
+	if err := json.Unmarshal(raw, &env); err == nil {
+		if env.PanelTemplates != nil {
+			return env.PanelTemplates, nil
+		}
+		if env.Templates != nil {
+			return env.Templates, nil
+		}
+	}
+	return nil, shapeError(panelTemplatesEndpoint, raw)
 }
 
 // UpdateDocument modifies a document. Used by delete (set deleted_at) and

--- a/library/productivity/granola/internal/granola/main_test.go
+++ b/library/productivity/granola/internal/granola/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain isolates the CLI-owned session path for the whole package.
+//
+// PATCH(cli-owned-workos-session): loadTokensRaw now probes a CLI-owned session
+// ahead of the desktop stores. Without this, every token-resolution test would
+// pick up the developer's real session at ~/.local/share/granola-pp-cli and
+// assert against it -- the tests set GRANOLA_SUPPORT_DIR, which redirects the
+// Granola-owned files, but the CLI session deliberately does not live there.
+//
+// Individual tests that care about the session still override the path
+// themselves; this only guarantees no test can reach the real one by default.
+func TestMain(m *testing.M) {
+	if os.Getenv("GRANOLA_CLI_SESSION_PATH") == "" {
+		dir, err := os.MkdirTemp("", "granola-session-isolation-")
+		if err != nil {
+			panic("granola tests: cannot create session isolation dir: " + err.Error())
+		}
+		os.Setenv("GRANOLA_CLI_SESSION_PATH", filepath.Join(dir, "session.json"))
+		code := m.Run()
+		os.RemoveAll(dir)
+		os.Exit(code)
+	}
+	os.Exit(m.Run())
+}

--- a/library/productivity/granola/internal/granola/safestorage/safestorage.go
+++ b/library/productivity/granola/internal/granola/safestorage/safestorage.go
@@ -105,9 +105,9 @@ func newMigratedSchemeError(state string) error {
 // generating a fresh one, so a pre-migration storage.dek recovered from a
 // backup still decrypts today's cache-v6.json.enc.
 const migratedSchemeRemedy = "Granola desktop now keeps the data encryption key in a Keychain access group gated by an entitlement bound to its own Team ID, so no third-party binary can read it. " +
-	"Fetching newly recorded meetings needs a Granola API key, which requires a Business or Enterprise Granola workspace. " +
-	"Data already synced to the local store remains readable. " +
-	"If you kept a copy of storage.dek from before the migration, base64-encode its 32-byte DEK into GRANOLA_SAFESTORAGE_KEY_OVERRIDE: the migration imported the existing DEK rather than generating a new one, so the old key still decrypts today's files."
+	"Run `granola-pp-cli auth login` once: the CLI then holds its own Granola session and fetches meetings over the API without needing the key. " +
+	"Data already synced to the local store remains readable meanwhile. " +
+	"If you kept a copy of storage.dek from before the migration, base64-encode its 32-byte DEK into GRANOLA_SAFESTORAGE_KEY_OVERRIDE to also recover the cache-only surfaces: the migration imported the existing DEK rather than generating a new one, so the old key still decrypts today's files."
 
 // keySource records where the DEK in hand came from. Decrypt uses it to
 // tell a stale storage.dek left behind by a failed upstream migration

--- a/library/productivity/granola/internal/granola/safestorage/safestorage_darwin_test.go
+++ b/library/productivity/granola/internal/granola/safestorage/safestorage_darwin_test.go
@@ -113,7 +113,10 @@ func TestLoadDEK_MigratedScheme(t *testing.T) {
 	}
 	msg := err.Error()
 	for _, want := range []string{
-		"Business or Enterprise",
+		// The remedy names the path that actually works now. It used to say a
+		// Business/Enterprise API key was required; `auth login` gives the CLI
+		// its own session and needs no paid workspace.
+		"auth login",
 		"remains readable",
 		"GRANOLA_SAFESTORAGE_KEY_OVERRIDE",
 	} {
@@ -254,7 +257,7 @@ func TestDecrypt_StaleDEKFileAfterFailedMigration(t *testing.T) {
 	if !strings.Contains(err.Error(), "stale key file") {
 		t.Errorf("expected the stale-key-file wording, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "Business or Enterprise") {
+	if !strings.Contains(err.Error(), "auth login") {
 		t.Errorf("stale-key-file error should carry the same remedy text, got: %v", err)
 	}
 }

--- a/library/productivity/granola/internal/granola/safestorage/testdata/scheme.md
+++ b/library/productivity/granola/internal/granola/safestorage/testdata/scheme.md
@@ -158,3 +158,64 @@ Relevant code paths:
   result with `safeStorage.encryptString`, writes to `storage.dek`).
 - `getCacheStorage()` reads the file, decrypts with the DEK via what is
   observed as standard AES-256-GCM (envelope confirmed empirically).
+
+## Tier-2 update (2026-08-03, Granola 7.465.0): the local store went SQLCipher
+
+**Layer 1 and layer 2 above are unchanged and still unreachable.** What changed
+is that the desktop's own data moved out of `cache-v6.json.enc` and into
+`granola.db`, a SQLCipher database in the same support directory.
+
+Evidence, from the 7.465.0 app bundle:
+
+- It depends on `better-sqlite3-multiple-ciphers`.
+- It opens the file with `pragma cipher = 'sqlcipher'`, `pragma legacy = 4`,
+  `pragma key = "x'<hex>'"` -- SQLCipher 4 with a raw hex key, no KDF.
+- The key is the **same DEK**: the failure path logs
+  `sqlite-encryption-key-dek-unavailable`.
+- On disk the file has no SQLite magic and is high-entropy throughout, while its
+  `-wal` sidecar keeps a plaintext SQLite WAL header (magic `377f0682`, format
+  3007000, page size 4096). That split is the SQLCipher signature.
+
+So `granola.db` is closed for the same reason `cache-v6.json.enc` is, and a
+regen must not spend effort trying to read it.
+
+Granola also stopped writing the plaintext auth files. `supabase.json` and
+`stored-accounts.json` were last written 2026-05-04 and 2026-05-19 on the probe
+machine; only the `.enc` variants are current. The plaintext fallback in
+`workos.go` therefore reads fossils whose access tokens are months expired.
+
+## Device authorization grant (2026-08-03): the CLI can hold its own session
+
+Verified live end to end. This is the supported way for the CLI to authenticate
+without any DEK.
+
+- Request: `POST https://auth.granola.ai/user_management/authorize/device`,
+  form-encoded, `client_id=client_01JZJ0XBDAT8PHJWQY09Y0VD61`.
+- Response: `device_code`, `user_code`, `verification_uri`
+  (`https://mcp-auth.granola.ai/device`), `verification_uri_complete`,
+  `expires_in: 300`, `interval: 5`.
+- Poll: `POST https://auth.granola.ai/user_management/authenticate`,
+  form-encoded, `client_id` + `grant_type=urn:ietf:params:oauth:grant-type:device_code`
+  + `device_code`. While waiting it returns HTTP 400 `authorization_pending`;
+  on lapse, HTTP 400 `expired_token`. Success returns
+  `access_token`, `refresh_token`, `user`, `authentication_method`.
+- Scope: the resulting session is accepted by `/v2/get-documents`,
+  `/v1/get-document-transcript`, `/v1/get-document-panels`, and
+  `/v2/get-document-lists`. Transcripts are reachable on this session -- they
+  are not DEK-bound.
+
+**Refresh contract.** Granola's own proxy `POST https://api.granola.ai/v1/refresh-access-token`
+with `{"refresh_token": ...}` refreshes a device-grant chain and returns the
+standard envelope. Observed: it returned the **same** refresh token rather than
+a rotated one, so this path does not consume it.
+
+Do not refresh a device-grant chain against the WorkOS endpoint directly
+(`/user_management/authenticate` with `grant_type=refresh_token`). That path is
+single-use -- a second exchange of the same token returns HTTP 400
+`invalid_grant`, "Refresh token already exchanged." That is also why the CLI
+must never refresh a *desktop-owned* chain: doing so would sign the desktop app
+or the browser out. Persist whatever refresh token comes back regardless, so a
+future change to rotation behavior cannot strand the session.
+
+(No token material, device codes, or account identifiers are recorded here by
+design. Re-derive against your own install.)

--- a/library/productivity/granola/internal/granola/store_sync.go
+++ b/library/productivity/granola/internal/granola/store_sync.go
@@ -70,7 +70,10 @@ var granolaSchemaSQL = []string{
 		parent_id TEXT,
 		workspace_id TEXT,
 		owner_id TEXT,
-		preset TEXT
+		preset TEXT,
+		description TEXT,
+		is_favourited INTEGER NOT NULL DEFAULT 0,
+		row_source TEXT NOT NULL DEFAULT 'cache'
 	)`,
 
 	`CREATE TABLE IF NOT EXISTS folder_memberships (
@@ -86,7 +89,8 @@ var granolaSchemaSQL = []string{
 		slug TEXT,
 		title TEXT,
 		description TEXT,
-		category TEXT
+		category TEXT,
+		row_source TEXT NOT NULL DEFAULT 'cache'
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_panel_templates_slug ON panel_templates(slug)`,
 
@@ -96,14 +100,16 @@ var granolaSchemaSQL = []string{
 		name TEXT,
 		description TEXT,
 		category TEXT,
-		source TEXT
+		source TEXT,
+		row_source TEXT NOT NULL DEFAULT 'cache'
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_recipes_slug ON recipes(slug)`,
 
 	`CREATE TABLE IF NOT EXISTS recipes_usage (
 		recipe_id TEXT PRIMARY KEY,
 		total_count INTEGER NOT NULL DEFAULT 0,
-		last_used_at TEXT
+		last_used_at TEXT,
+		row_source TEXT NOT NULL DEFAULT 'cache'
 	)`,
 
 	`CREATE TABLE IF NOT EXISTS chat_threads (
@@ -173,6 +179,23 @@ var granolaAddedColumns = []struct{ table, column, decl string }{
 	{"attendees", "row_source", "TEXT NOT NULL DEFAULT 'cache'"},
 	{"folder_memberships", "row_source", "TEXT NOT NULL DEFAULT 'cache'"},
 	{"transcript_segments", "row_source", "TEXT NOT NULL DEFAULT 'cache'"},
+	// The catalog tables. These four describe things rather than meetings —
+	// folders, panel templates, recipes and their usage counters — and both
+	// data paths write them, so they need the same ownership marker for the
+	// same reason: a row's creator must stay identifiable after any number of
+	// later upserts from the other path.
+	{"folders", "row_source", "TEXT NOT NULL DEFAULT 'cache'"},
+	{"panel_templates", "row_source", "TEXT NOT NULL DEFAULT 'cache'"},
+	{"recipes", "row_source", "TEXT NOT NULL DEFAULT 'cache'"},
+	{"recipes_usage", "row_source", "TEXT NOT NULL DEFAULT 'cache'"},
+	// Folder metadata the cache has always carried on DocumentListMetadata and
+	// the write path silently dropped, so `folder list` reported an empty
+	// description and a never-favourited folder for every store-backed read.
+	// is_favourited is NOT NULL DEFAULT 0 rather than nullable: the cache
+	// always states the flag, and "unknown" is not a value any reader wants to
+	// render for a boolean.
+	{"folders", "description", "TEXT"},
+	{"folders", "is_favourited", "INTEGER NOT NULL DEFAULT 0"},
 	// Speaker identity the public API can resolve and the cache never
 	// carried. Deliberately nullable: cache-sourced rows leave these NULL so
 	// downstream commands stay source-agnostic.
@@ -309,12 +332,37 @@ type SyncOptions struct {
 	// prepareSegmentRewrite's cross-source comparison a false "the cache holds
 	// N segments" that could block a later genuine API refresh.
 	TranscriptOwner string
+
+	// CatalogOwner is who owns the catalog rows this run creates: folders,
+	// panel_templates, recipes and recipes_usage. Empty means RowSourceCache,
+	// the historical behavior. Shaped exactly like TranscriptOwner above, and
+	// for the same reason.
+	//
+	// This is a field rather than a literal at each write site because the
+	// catalog is not cache-only property: an API-driven refresh writes the
+	// same four tables and has to be able to claim the rows it creates. A
+	// hard-coded 'cache' at four call sites leaves that caller nowhere to hook
+	// in, and mislabelling API-created rows as cache-owned is unrecoverable --
+	// once the marker is wrong nothing downstream can tell the two apart.
+	//
+	// It only decides ownership of rows this run CREATES. Every catalog upsert
+	// leaves row_source out of its ON CONFLICT SET list, so an existing row
+	// keeps the owner that created it no matter which path touches it next.
+	CatalogOwner string
 }
 
 // transcriptOwner resolves the row_source for transcript writes.
 func (o SyncOptions) transcriptOwner() string {
 	if o.TranscriptOwner != "" {
 		return o.TranscriptOwner
+	}
+	return RowSourceCache
+}
+
+// catalogOwner resolves the row_source for folder / panel / recipe writes.
+func (o SyncOptions) catalogOwner() string {
+	if o.CatalogOwner != "" {
+		return o.CatalogOwner
 	}
 	return RowSourceCache
 }
@@ -499,8 +547,37 @@ func SyncFromCacheWithOptions(ctx context.Context, db *sql.DB, cache *Cache, opt
 		}
 	}
 	for fid, md := range cache.DocumentListsMetadata {
-		_, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO folders(id,title,parent_id,workspace_id,owner_id,preset) VALUES (?,?,?,?,?,?)`,
-			fid, md.Title, md.ParentDocumentListID, md.WorkspaceID, "", md.Preset)
+		// PATCH(catalog-provenance-and-merge): merge, never REPLACE — see the
+		// meetings upsert above. REPLACE deleted the row and inserted a fresh
+		// one, which blanked every column this payload does not carry and
+		// silently reassigned row_source to whichever path ran last.
+		//
+		// is_favourited cannot use the NULLIF idiom: it is a boolean, so
+		// "false" and "absent" are the same value and no expression over the
+		// incoming column alone can tell them apart. Provenance can. Only the
+		// path that owns the row is allowed to clear the flag, which keeps a
+		// user's un-favourite working on the path that knows about it while
+		// stopping a writer that simply does not carry the field from silently
+		// resetting the other path's value.
+		favourited := 0
+		if md.IsFavourited {
+			favourited = 1
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO folders(
+			id, title, parent_id, workspace_id, owner_id, preset,
+			description, is_favourited, row_source
+		) VALUES (?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(id) DO UPDATE SET
+			title         = COALESCE(NULLIF(excluded.title, ''), folders.title),
+			parent_id     = COALESCE(NULLIF(excluded.parent_id, ''), folders.parent_id),
+			workspace_id  = COALESCE(NULLIF(excluded.workspace_id, ''), folders.workspace_id),
+			owner_id      = COALESCE(NULLIF(excluded.owner_id, ''), folders.owner_id),
+			preset        = COALESCE(NULLIF(excluded.preset, ''), folders.preset),
+			description   = COALESCE(NULLIF(excluded.description, ''), folders.description),
+			is_favourited = CASE WHEN excluded.row_source = folders.row_source
+				THEN excluded.is_favourited ELSE folders.is_favourited END`,
+			fid, md.Title, md.ParentDocumentListID, md.WorkspaceID, "", md.Preset,
+			md.Description, favourited, opts.catalogOwner())
 		if err != nil {
 			return res, fmt.Errorf("upsert folder %s: %w", fid, err)
 		}
@@ -523,8 +600,15 @@ func SyncFromCacheWithOptions(ctx context.Context, db *sql.DB, cache *Cache, opt
 
 	// panel_templates
 	for _, p := range cache.PanelTemplates {
-		_, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO panel_templates(id,slug,title,description,category) VALUES (?,?,?,?,?)`,
-			p.ID, p.Slug, p.Title, p.Description, p.Category)
+		// PATCH(catalog-provenance-and-merge): merge, never REPLACE — see the
+		// folders upsert above.
+		_, err := tx.ExecContext(ctx, `INSERT INTO panel_templates(id,slug,title,description,category,row_source) VALUES (?,?,?,?,?,?)
+		ON CONFLICT(id) DO UPDATE SET
+			slug        = COALESCE(NULLIF(excluded.slug, ''), panel_templates.slug),
+			title       = COALESCE(NULLIF(excluded.title, ''), panel_templates.title),
+			description = COALESCE(NULLIF(excluded.description, ''), panel_templates.description),
+			category    = COALESCE(NULLIF(excluded.category, ''), panel_templates.category)`,
+			p.ID, p.Slug, p.Title, p.Description, p.Category, opts.catalogOwner())
 		if err != nil {
 			return res, fmt.Errorf("upsert panel %s: %w", p.ID, err)
 		}
@@ -533,8 +617,19 @@ func SyncFromCacheWithOptions(ctx context.Context, db *sql.DB, cache *Cache, opt
 
 	// recipes
 	for _, r := range cache.RecipesAll() {
-		_, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO recipes(id,slug,name,description,category,source) VALUES (?,?,?,?,?,?)`,
-			r.ID, r.Slug, r.Name, r.Config.Description, r.Category, r.Source)
+		// PATCH(catalog-provenance-and-merge): merge, never REPLACE — see the
+		// folders upsert above. `source` here is the recipe's origin collection
+		// (public/user/shared), which is unrelated to row_source: one says
+		// which Granola list the recipe came from, the other which of this
+		// CLI's two data paths wrote the row.
+		_, err := tx.ExecContext(ctx, `INSERT INTO recipes(id,slug,name,description,category,source,row_source) VALUES (?,?,?,?,?,?,?)
+		ON CONFLICT(id) DO UPDATE SET
+			slug        = COALESCE(NULLIF(excluded.slug, ''), recipes.slug),
+			name        = COALESCE(NULLIF(excluded.name, ''), recipes.name),
+			description = COALESCE(NULLIF(excluded.description, ''), recipes.description),
+			category    = COALESCE(NULLIF(excluded.category, ''), recipes.category),
+			source      = COALESCE(NULLIF(excluded.source, ''), recipes.source)`,
+			r.ID, r.Slug, r.Name, r.Config.Description, r.Category, r.Source, opts.catalogOwner())
 		if err != nil {
 			return res, fmt.Errorf("upsert recipe %s: %w", r.ID, err)
 		}
@@ -545,7 +640,16 @@ func SyncFromCacheWithOptions(ctx context.Context, db *sql.DB, cache *Cache, opt
 	for rid, u := range cache.RecipesUsage {
 		count := int64(0)
 		fmt.Sscanf(u.TotalCount, "%d", &count)
-		_, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO recipes_usage(recipe_id,total_count,last_used_at) VALUES (?,?,?)`, rid, count, u.LastUsedAt)
+		// PATCH(catalog-provenance-and-merge): merge, never REPLACE — see the
+		// folders upsert above. NULLIF(...,0) is the integer form of the same
+		// idiom: TotalCount is a string on the cache record and an absent or
+		// unparseable one leaves count at 0, which must not overwrite a stored
+		// total. A genuine decrease still lands, so this is not a latch.
+		_, err := tx.ExecContext(ctx, `INSERT INTO recipes_usage(recipe_id,total_count,last_used_at,row_source) VALUES (?,?,?,?)
+		ON CONFLICT(recipe_id) DO UPDATE SET
+			total_count  = COALESCE(NULLIF(excluded.total_count, 0), recipes_usage.total_count),
+			last_used_at = COALESCE(NULLIF(excluded.last_used_at, ''), recipes_usage.last_used_at)`,
+			rid, count, u.LastUsedAt, opts.catalogOwner())
 		if err != nil {
 			return res, fmt.Errorf("upsert recipe usage %s: %w", rid, err)
 		}
@@ -947,12 +1051,22 @@ func upsertAPIMemberships(ctx context.Context, tx *sql.Tx, n *APINote, res *APIS
 		}
 		seen[fid] = true
 		// Create the folder row when it is missing, but never clobber
-		// cache-supplied folder metadata (parent_id, workspace_id, preset)
-		// that the API does not carry.
+		// cache-supplied folder metadata (parent_id, workspace_id, preset,
+		// description, is_favourited) that the API does not carry — which is
+		// why the SET list names title and nothing else.
+		//
+		// PATCH(catalog-provenance-and-merge): stamp row_source='api' on
+		// creation. This path has always created folder rows, so without the
+		// stamp the first run after the migration would file every genuinely
+		// API-created folder under the column's 'cache' default and nothing
+		// afterwards could tell the two apart. row_source stays out of the SET
+		// list for the usual reason: a cache-created folder the API also knows
+		// about keeps its cache ownership.
 		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO folders(id,title,parent_id,workspace_id,owner_id,preset) VALUES (?,?,'','','','')
+			`INSERT INTO folders(id,title,parent_id,workspace_id,owner_id,preset,description,is_favourited,row_source)
+			 VALUES (?,?,'','','','','',0,?)
 			 ON CONFLICT(id) DO UPDATE SET title = COALESCE(NULLIF(folders.title,''), excluded.title)`,
-			fid, m.Label()); err != nil {
+			fid, m.Label(), RowSourceAPI); err != nil {
 			return fmt.Errorf("upsert api folder %s: %w", fid, err)
 		}
 		res.Folders++

--- a/library/productivity/granola/internal/granola/store_sync.go
+++ b/library/productivity/granola/internal/granola/store_sync.go
@@ -285,7 +285,30 @@ type SyncResult struct {
 // SyncFromCache pushes every row from cache into the SQLite store. Uses
 // REPLACE semantics so re-running is idempotent. Single transaction so
 // readers never see a partial state.
+// SyncOptions controls how a cache sync writes into the store.
+type SyncOptions struct {
+	// Degraded reports that the desktop cache could not be decrypted, so
+	// Documents was hydrated from /v2/get-documents into an otherwise empty
+	// Cache. It changes what an absent cache-derived row means: on a healthy
+	// run "absent" means deleted upstream and the cache path retires its own
+	// stale rows; on a degraded run it means unreadable, and retiring anything
+	// would destroy rows that can never be re-synced once the DEK is gone.
+	//
+	// Degraded therefore suppresses the cache path's own-source retirement --
+	// the cache-scoped folder_memberships clear and the zero-incoming segment
+	// clear -- leaving the run upsert-only. It does not touch the other path's
+	// row_source scoping, which guards a different failure.
+	Degraded bool
+}
+
+// SyncFromCache writes a fully-read desktop cache into the store.
 func SyncFromCache(ctx context.Context, db *sql.DB, cache *Cache) (SyncResult, error) {
+	return SyncFromCacheWithOptions(ctx, db, cache, SyncOptions{})
+}
+
+// SyncFromCacheWithOptions is SyncFromCache with explicit options. See
+// SyncOptions.Degraded for the one behavioral difference.
+func SyncFromCacheWithOptions(ctx context.Context, db *sql.DB, cache *Cache, opts SyncOptions) (SyncResult, error) {
 	var res SyncResult
 	if cache == nil {
 		return res, fmt.Errorf("nil cache")
@@ -412,6 +435,16 @@ func SyncFromCache(ctx context.Context, db *sql.DB, cache *Cache) (SyncResult, e
 		// PATCH(transcript-retention-preserves-larger): and when the cache's
 		// copy is smaller than the API's, this meeting is skipped outright
 		// rather than allowed to take ownership. See prepareSegmentRewrite.
+		//
+		// PATCH(api-sync-survives-unreadable-cache): on a degraded run the
+		// cache is unreadable, not empty, so len(segs) == 0 for every meeting.
+		// Falling through would hand prepareSegmentRewrite incoming == 0 and
+		// delete this meeting's stored cache-owned transcript -- for every
+		// meeting the API hydrate returned. Skip instead: there is nothing to
+		// write and nothing legitimate to retire.
+		if opts.Degraded && len(segs) == 0 {
+			continue
+		}
 		preserved, err := prepareSegmentRewrite(ctx, tx, id, RowSourceCache, len(segs))
 		if err != nil {
 			return res, err
@@ -438,8 +471,14 @@ func SyncFromCache(ctx context.Context, db *sql.DB, cache *Cache) (SyncResult, e
 	// PATCH(api-detail-hydrate): this DELETE used to be unscoped, which wiped
 	// every API-hydrated folder membership on each cache sync — including
 	// memberships for meetings the cache has never heard of.
-	if _, err := tx.ExecContext(ctx, `DELETE FROM folder_memberships WHERE row_source = ?`, RowSourceCache); err != nil {
-		return res, err
+	//
+	// PATCH(api-sync-survives-unreadable-cache): skipped entirely on a degraded
+	// run. cache.DocumentLists is empty because the cache could not be read, so
+	// this clear would delete every cache-owned membership and re-insert none.
+	if !opts.Degraded {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM folder_memberships WHERE row_source = ?`, RowSourceCache); err != nil {
+			return res, err
+		}
 	}
 	for fid, md := range cache.DocumentListsMetadata {
 		_, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO folders(id,title,parent_id,workspace_id,owner_id,preset) VALUES (?,?,?,?,?,?)`,

--- a/library/productivity/granola/internal/granola/store_sync.go
+++ b/library/productivity/granola/internal/granola/store_sync.go
@@ -299,6 +299,24 @@ type SyncOptions struct {
 	// clear -- leaving the run upsert-only. It does not touch the other path's
 	// row_source scoping, which guards a different failure.
 	Degraded bool
+
+	// PATCH(api-transcript-hydrate): who owns the transcript rows this run
+	// writes. Empty means RowSourceCache, the historical behavior.
+	//
+	// On a degraded run the transcripts did not come from the cache -- they
+	// were fetched from the API into an otherwise-empty Cache -- so stamping
+	// them 'cache' would misreport their provenance and, worse, feed
+	// prepareSegmentRewrite's cross-source comparison a false "the cache holds
+	// N segments" that could block a later genuine API refresh.
+	TranscriptOwner string
+}
+
+// transcriptOwner resolves the row_source for transcript writes.
+func (o SyncOptions) transcriptOwner() string {
+	if o.TranscriptOwner != "" {
+		return o.TranscriptOwner
+	}
+	return RowSourceCache
 }
 
 // SyncFromCache writes a fully-read desktop cache into the store.
@@ -445,7 +463,7 @@ func SyncFromCacheWithOptions(ctx context.Context, db *sql.DB, cache *Cache, opt
 		if opts.Degraded && len(segs) == 0 {
 			continue
 		}
-		preserved, err := prepareSegmentRewrite(ctx, tx, id, RowSourceCache, len(segs))
+		preserved, err := prepareSegmentRewrite(ctx, tx, id, opts.transcriptOwner(), len(segs))
 		if err != nil {
 			return res, err
 		}
@@ -459,7 +477,7 @@ func SyncFromCacheWithOptions(ctx context.Context, db *sql.DB, cache *Cache, opt
 			// speaker_name / diarization_label stay NULL: the desktop cache
 			// never carried resolved speaker identity.
 			_, err := tx.ExecContext(ctx, `INSERT INTO transcript_segments(meeting_id,idx,source,text,start_ts_ms,end_ts_ms,confidence,row_source) VALUES (?,?,?,?,?,?,?,?)`,
-				id, i, seg.Source, seg.Text, startMs, endMs, seg.Confidence, RowSourceCache)
+				id, i, seg.Source, seg.Text, startMs, endMs, seg.Confidence, opts.transcriptOwner())
 			if err != nil {
 				return res, fmt.Errorf("upsert segment %s/%d: %w", id, i, err)
 			}

--- a/library/productivity/granola/internal/granola/store_sync_degraded_test.go
+++ b/library/productivity/granola/internal/granola/store_sync_degraded_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// seedCacheOwnedRows puts the store in the state a healthy sync would leave
+// behind: one meeting with a cache-owned transcript, and a cache-owned folder
+// membership. These are exactly the rows a degraded run must not touch --
+// once Granola's DEK moved out of reach they can never be re-synced.
+func seedCacheOwnedRows(t *testing.T, db *sql.DB, meetingID string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO meetings(id,title,row_source) VALUES (?,?,?)`,
+		meetingID, "Standup", RowSourceCache); err != nil {
+		t.Fatalf("seed meeting: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO transcript_segments(meeting_id,idx,source,text,row_source) VALUES (?,?,?,?,?)`,
+			meetingID, i, "microphone", "seeded segment", RowSourceCache); err != nil {
+			t.Fatalf("seed segment %d: %v", i, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO folders(id,title) VALUES (?,?)`, "fold_1", "Customers"); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO folder_memberships(folder_id,meeting_id,row_source) VALUES (?,?,?)`,
+		"fold_1", meetingID, RowSourceCache); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+}
+
+func countRows(t *testing.T, db *sql.DB, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&n); err != nil {
+		t.Fatalf("count (%s): %v", query, err)
+	}
+	return n
+}
+
+// TestDegradedSyncPreservesCacheOwnedRows is the regression guard for the
+// data-loss path: on a migrated install the cache cannot be decrypted, so
+// documents are hydrated from the API into an otherwise-empty Cache. Running
+// the normal sync against that Cache reads every absent cache-derived row as
+// "deleted upstream" and retires it. Degraded mode must upsert only.
+func TestDegradedSyncPreservesCacheOwnedRows(t *testing.T) {
+	db := openTestDB(t)
+	const meetingID = "not_seeded"
+	seedCacheOwnedRows(t, db, meetingID)
+
+	// What a degraded run actually holds: documents from /v2/get-documents,
+	// and nothing else -- no transcripts, no document lists.
+	cache := &Cache{
+		Documents: map[string]Document{
+			meetingID: {ID: meetingID, Title: "Standup"},
+		},
+	}
+
+	res, err := SyncFromCacheWithOptions(context.Background(), db, cache, SyncOptions{Degraded: true})
+	if err != nil {
+		t.Fatalf("degraded SyncFromCache: %v", err)
+	}
+
+	if got := countRows(t, db,
+		`SELECT COUNT(*) FROM transcript_segments WHERE meeting_id = ? AND row_source = ?`,
+		meetingID, RowSourceCache); got != 3 {
+		t.Errorf("cache-owned transcript segments: got %d, want 3 (degraded run destroyed them)", got)
+	}
+	if got := countRows(t, db,
+		`SELECT COUNT(*) FROM folder_memberships WHERE row_source = ?`, RowSourceCache); got != 1 {
+		t.Errorf("cache-owned folder memberships: got %d, want 1 (degraded run destroyed them)", got)
+	}
+	if res.Meetings != 1 {
+		t.Errorf("meetings upserted: got %d, want 1", res.Meetings)
+	}
+}
+
+// TestHealthySyncStillRetiresOwnRows pins the other half of the contract: the
+// suppression is scoped to degraded runs. A healthy sync whose cache genuinely
+// no longer lists a transcript or membership must still retire it, or a real
+// upstream deletion would linger forever.
+func TestHealthySyncStillRetiresOwnRows(t *testing.T) {
+	db := openTestDB(t)
+	const meetingID = "not_seeded"
+	seedCacheOwnedRows(t, db, meetingID)
+
+	// A readable cache that legitimately no longer carries the transcript or
+	// the membership: the same shape as above, but not degraded.
+	cache := &Cache{
+		Documents: map[string]Document{
+			meetingID: {ID: meetingID, Title: "Standup"},
+		},
+	}
+
+	if _, err := SyncFromCache(context.Background(), db, cache); err != nil {
+		t.Fatalf("healthy SyncFromCache: %v", err)
+	}
+
+	if got := countRows(t, db,
+		`SELECT COUNT(*) FROM transcript_segments WHERE meeting_id = ? AND row_source = ?`,
+		meetingID, RowSourceCache); got != 0 {
+		t.Errorf("healthy sync should retire its own stale segments: got %d, want 0", got)
+	}
+	if got := countRows(t, db,
+		`SELECT COUNT(*) FROM folder_memberships WHERE row_source = ?`, RowSourceCache); got != 0 {
+		t.Errorf("healthy sync should retire its own stale memberships: got %d, want 0", got)
+	}
+}

--- a/library/productivity/granola/internal/granola/store_sync_test.go
+++ b/library/productivity/granola/internal/granola/store_sync_test.go
@@ -1,0 +1,644 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0.
+
+package granola
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers.
+//
+// PII: every value below is invented. Folder titles, recipe names and
+// descriptions are synthetic and were never captured from a real Granola
+// account.
+// ---------------------------------------------------------------------------
+
+// legacyCatalogSchema is the folders / panel_templates / recipes /
+// recipes_usage shape an older binary created: no row_source anywhere, and no
+// folder description or favourite flag. CREATE TABLE IF NOT EXISTS is a no-op
+// against these, so only the additive column migration can upgrade them.
+var legacyCatalogSchema = []string{
+	`CREATE TABLE folders (
+		id TEXT PRIMARY KEY, title TEXT, parent_id TEXT,
+		workspace_id TEXT, owner_id TEXT, preset TEXT
+	)`,
+	`CREATE TABLE panel_templates (
+		id TEXT PRIMARY KEY, slug TEXT, title TEXT, description TEXT, category TEXT
+	)`,
+	`CREATE TABLE recipes (
+		id TEXT PRIMARY KEY, slug TEXT, name TEXT, description TEXT,
+		category TEXT, source TEXT
+	)`,
+	`CREATE TABLE recipes_usage (
+		recipe_id TEXT PRIMARY KEY,
+		total_count INTEGER NOT NULL DEFAULT 0,
+		last_used_at TEXT
+	)`,
+}
+
+// catalogTables are the four tables this round gave provenance columns to.
+var catalogTables = []string{"folders", "panel_templates", "recipes", "recipes_usage"}
+
+// openRawDB opens an empty database WITHOUT running EnsureSchema, so a test
+// can install an older binary's table shapes first.
+func openRawDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "raw.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// tableColumns returns the column set of table.
+func tableColumns(t *testing.T, db *sql.DB, table string) map[string]bool {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), fmt.Sprintf(`PRAGMA table_info("%s")`, table))
+	if err != nil {
+		t.Fatalf("table_info %s: %v", table, err)
+	}
+	defer rows.Close()
+	cols := map[string]bool{}
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, typ string
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan table_info %s: %v", table, err)
+		}
+		cols[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate table_info %s: %v", table, err)
+	}
+	return cols
+}
+
+// schemaSnapshot renders every object's DDL plus the four catalog tables'
+// column lists into one comparable string. Used to prove a second EnsureSchema
+// changes nothing.
+func schemaSnapshot(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT type, name, IFNULL(sql,'') FROM sqlite_master ORDER BY type, name`)
+	if err != nil {
+		t.Fatalf("read sqlite_master: %v", err)
+	}
+	defer rows.Close()
+	var lines []string
+	for rows.Next() {
+		var typ, name, ddl string
+		if err := rows.Scan(&typ, &name, &ddl); err != nil {
+			t.Fatalf("scan sqlite_master: %v", err)
+		}
+		lines = append(lines, typ+"|"+name+"|"+ddl)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate sqlite_master: %v", err)
+	}
+	for _, tbl := range catalogTables {
+		var cols []string
+		for c := range tableColumns(t, db, tbl) {
+			cols = append(cols, c)
+		}
+		sort.Strings(cols)
+		lines = append(lines, "cols|"+tbl+"|"+strings.Join(cols, ","))
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}
+
+// queryString reads one text column.
+func queryString(t *testing.T, db *sql.DB, query string, args ...any) string {
+	t.Helper()
+	var out sql.NullString
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&out); err != nil {
+		t.Fatalf("query (%s): %v", query, err)
+	}
+	return out.String
+}
+
+// queryInt reads one integer column.
+func queryInt(t *testing.T, db *sql.DB, query string, args ...any) int {
+	t.Helper()
+	var out sql.NullInt64
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&out); err != nil {
+		t.Fatalf("query (%s): %v", query, err)
+	}
+	return int(out.Int64)
+}
+
+// ---------------------------------------------------------------------------
+// Migration.
+// ---------------------------------------------------------------------------
+
+// TestEnsureSchema_UpgradesLegacyCatalogTables covers the upgrade path that
+// matters most: a database an older binary created already has these four
+// tables, so CREATE TABLE IF NOT EXISTS never runs and only the additive
+// column list can introduce row_source and the folder metadata columns. The
+// pre-existing rows must survive and must read back as cache-owned, which is
+// the historical truth — before the API path existed every one of these rows
+// came from the desktop cache.
+func TestEnsureSchema_UpgradesLegacyCatalogTables(t *testing.T) {
+	ctx := context.Background()
+	db := openRawDB(t)
+	for _, stmt := range legacyCatalogSchema {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("create legacy table: %v", err)
+		}
+	}
+	seed := []struct {
+		stmt string
+		args []any
+	}{
+		{`INSERT INTO folders(id,title,parent_id,workspace_id,owner_id,preset) VALUES (?,?,?,?,?,?)`,
+			[]any{"fold_legacy", "Customers", "fold_root", "ws_1", "usr_1", "sales"}},
+		{`INSERT INTO panel_templates(id,slug,title,description,category) VALUES (?,?,?,?,?)`,
+			[]any{"panel_legacy", "standup", "Standup", "Daily sync panel", "team"}},
+		{`INSERT INTO recipes(id,slug,name,description,category,source) VALUES (?,?,?,?,?,?)`,
+			[]any{"rec_legacy", "discovery", "Discovery", "Discovery call recipe", "sales", "user"}},
+		{`INSERT INTO recipes_usage(recipe_id,total_count,last_used_at) VALUES (?,?,?)`,
+			[]any{"rec_legacy", 17, "2026-01-02T03:04:05Z"}},
+	}
+	for _, s := range seed {
+		if _, err := db.ExecContext(ctx, s.stmt, s.args...); err != nil {
+			t.Fatalf("seed legacy row: %v", err)
+		}
+	}
+
+	if err := EnsureSchema(ctx, db); err != nil {
+		t.Fatalf("EnsureSchema on legacy db: %v", err)
+	}
+
+	want := map[string][]string{
+		"folders":         {"row_source", "description", "is_favourited"},
+		"panel_templates": {"row_source"},
+		"recipes":         {"row_source"},
+		"recipes_usage":   {"row_source"},
+	}
+	for tbl, cols := range want {
+		have := tableColumns(t, db, tbl)
+		for _, c := range cols {
+			if !have[c] {
+				t.Errorf("%s.%s missing after EnsureSchema", tbl, c)
+			}
+		}
+	}
+
+	// No data loss.
+	if got := queryString(t, db, `SELECT title FROM folders WHERE id = ?`, "fold_legacy"); got != "Customers" {
+		t.Errorf("folder title after migrate = %q, want %q", got, "Customers")
+	}
+	if got := queryString(t, db, `SELECT preset FROM folders WHERE id = ?`, "fold_legacy"); got != "sales" {
+		t.Errorf("folder preset after migrate = %q, want %q", got, "sales")
+	}
+	if got := queryString(t, db, `SELECT description FROM panel_templates WHERE id = ?`, "panel_legacy"); got != "Daily sync panel" {
+		t.Errorf("panel description after migrate = %q", got)
+	}
+	if got := queryString(t, db, `SELECT name FROM recipes WHERE id = ?`, "rec_legacy"); got != "Discovery" {
+		t.Errorf("recipe name after migrate = %q", got)
+	}
+	if got := queryInt(t, db, `SELECT total_count FROM recipes_usage WHERE recipe_id = ?`, "rec_legacy"); got != 17 {
+		t.Errorf("recipe usage total after migrate = %d, want 17", got)
+	}
+
+	// Pre-existing rows are cache-owned.
+	backfilled := []struct {
+		query string
+		arg   string
+	}{
+		{`SELECT row_source FROM folders WHERE id = ?`, "fold_legacy"},
+		{`SELECT row_source FROM panel_templates WHERE id = ?`, "panel_legacy"},
+		{`SELECT row_source FROM recipes WHERE id = ?`, "rec_legacy"},
+		{`SELECT row_source FROM recipes_usage WHERE recipe_id = ?`, "rec_legacy"},
+	}
+	for _, b := range backfilled {
+		if got := queryString(t, db, b.query, b.arg); got != RowSourceCache {
+			t.Errorf("%s = %q, want %q", b.query, got, RowSourceCache)
+		}
+	}
+}
+
+// TestEnsureSchema_SecondRunIsNoOp pins idempotency. EnsureSchema runs on
+// every command that touches these tables, so a second run that re-added or
+// re-declared anything would either error or churn the schema.
+func TestEnsureSchema_SecondRunIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	db := openRawDB(t)
+	if err := EnsureSchema(ctx, db); err != nil {
+		t.Fatalf("first EnsureSchema: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO folders(id,title,description,is_favourited,row_source) VALUES (?,?,?,?,?)`,
+		"fold_1", "Customers", "Everything customer facing", 1, RowSourceAPI); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	before := schemaSnapshot(t, db)
+
+	if err := EnsureSchema(ctx, db); err != nil {
+		t.Fatalf("second EnsureSchema: %v", err)
+	}
+	if after := schemaSnapshot(t, db); after != before {
+		t.Errorf("second EnsureSchema changed the schema:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+	if got := queryString(t, db, `SELECT row_source FROM folders WHERE id = ?`, "fold_1"); got != RowSourceAPI {
+		t.Errorf("row_source after second EnsureSchema = %q, want %q", got, RowSourceAPI)
+	}
+	if got := queryString(t, db, `SELECT description FROM folders WHERE id = ?`, "fold_1"); got != "Everything customer facing" {
+		t.Errorf("description after second EnsureSchema = %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Folder metadata on the write path.
+// ---------------------------------------------------------------------------
+
+// TestSyncFromCache_WritesFolderDescriptionAndFavourite covers R7. The cache
+// carries both fields on every folder and the write path used to drop them, so
+// a store-only read reported an empty description and a folder that is never
+// favourited no matter what the user set in the desktop app.
+func TestSyncFromCache_WritesFolderDescriptionAndFavourite(t *testing.T) {
+	db := openTestDB(t)
+	cache := &Cache{
+		DocumentListsMetadata: map[string]DocumentListMetadata{
+			"fold_1": {
+				ID:                   "fold_1",
+				Title:                "Customers",
+				Description:          "Everything customer facing",
+				ParentDocumentListID: "fold_root",
+				WorkspaceID:          "ws_1",
+				Preset:               "sales",
+				IsFavourited:         true,
+			},
+			"fold_2": {ID: "fold_2", Title: "Archive"},
+		},
+	}
+	if _, err := SyncFromCache(context.Background(), db, cache); err != nil {
+		t.Fatalf("SyncFromCache: %v", err)
+	}
+
+	if got := queryString(t, db, `SELECT description FROM folders WHERE id = ?`, "fold_1"); got != "Everything customer facing" {
+		t.Errorf("folders.description = %q, want %q", got, "Everything customer facing")
+	}
+	if got := queryInt(t, db, `SELECT is_favourited FROM folders WHERE id = ?`, "fold_1"); got != 1 {
+		t.Errorf("folders.is_favourited = %d, want 1", got)
+	}
+	if got := queryInt(t, db, `SELECT is_favourited FROM folders WHERE id = ?`, "fold_2"); got != 0 {
+		t.Errorf("unfavourited folder is_favourited = %d, want 0", got)
+	}
+	if got := queryString(t, db, `SELECT description FROM folders WHERE id = ?`, "fold_2"); got != "" {
+		t.Errorf("folder with no description = %q, want empty", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Retirement: no sync path may clear these tables.
+// ---------------------------------------------------------------------------
+
+// openDeleteGuardedDB opens a store whose four catalog tables abort on any
+// DELETE. recursive_triggers is deliberately ON: SQLite fires delete triggers
+// for rows removed by INSERT OR REPLACE only when it is, which is precisely
+// the hidden delete this round set out to remove.
+func openDeleteGuardedDB(t *testing.T) *sql.DB {
+	t.Helper()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "guarded.db")
+	db, err := sql.Open("sqlite", "file:"+path+"?_pragma=recursive_triggers(1)")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	// Pragmas are per-connection; one connection keeps the guard honest.
+	db.SetMaxOpenConns(1)
+	var recursive int
+	if err := db.QueryRowContext(ctx, `PRAGMA recursive_triggers`).Scan(&recursive); err != nil {
+		t.Fatalf("read recursive_triggers: %v", err)
+	}
+	if recursive != 1 {
+		t.Fatalf("recursive_triggers = %d, want 1 (the guard cannot see REPLACE deletes without it)", recursive)
+	}
+	if err := EnsureSchema(ctx, db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, tbl := range catalogTables {
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(
+			`CREATE TRIGGER guard_%s_delete BEFORE DELETE ON %s
+			 BEGIN SELECT RAISE(ABORT, 'DELETE executed against %s'); END`, tbl, tbl, tbl)); err != nil {
+			t.Fatalf("install delete guard on %s: %v", tbl, err)
+		}
+	}
+	return db
+}
+
+// TestSyncPathsNeverDeleteFromCatalogTables is the regression guard for the
+// failure a prior fix in this repo was about: an unscoped clear of a shared
+// table destroys the other path's rows. These four tables get no retirement
+// DELETE at all, and INSERT OR REPLACE is a delete in disguise -- it removes
+// the conflicting row and inserts a fresh one, blanking every column the
+// incoming payload omits and rewriting row_source to the column default.
+func TestSyncPathsNeverDeleteFromCatalogTables(t *testing.T) {
+	ctx := context.Background()
+	db := openDeleteGuardedDB(t)
+
+	// The guard must actually bite, or the rest of this test proves nothing.
+	if _, err := db.ExecContext(ctx, `INSERT INTO folders(id,title) VALUES ('guard_probe','probe')`); err != nil {
+		t.Fatalf("seed guard probe: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM folders WHERE id = 'guard_probe'`); err == nil {
+		t.Fatalf("delete guard did not fire on a direct DELETE FROM folders")
+	}
+
+	cache := &Cache{
+		Documents: map[string]Document{
+			"doc_1": {ID: "doc_1", Title: "Standup"},
+		},
+		DocumentLists: map[string][]string{"fold_1": {"doc_1"}},
+		DocumentListsMetadata: map[string]DocumentListMetadata{
+			"fold_1": {ID: "fold_1", Title: "Customers", Description: "Customer work", IsFavourited: true},
+		},
+		PanelTemplates: []PanelTemplate{
+			{ID: "panel_1", Slug: "standup", Title: "Standup", Description: "Daily sync", Category: "team"},
+		},
+		UserRecipes: []Recipe{
+			{ID: "rec_1", Slug: "discovery", Name: "Discovery", Category: "sales", Source: "user",
+				Config: RecipeConfig{Description: "Discovery call recipe"}},
+		},
+		RecipesUsage: map[string]RecipeUsage{
+			"rec_1": {RecipeID: "rec_1", TotalCount: "9", LastUsedAt: "2026-01-02T03:04:05Z"},
+		},
+	}
+	notes := []APINote{{
+		ID:               "doc_api",
+		Title:            "Roadmap review",
+		FolderMembership: []APIMembership{{ID: "fold_1", Title: "Customers"}},
+	}}
+
+	// Run every path twice: the second run is the one that conflicts on the
+	// primary key, which is where a REPLACE would delete.
+	for i := 0; i < 2; i++ {
+		if _, err := SyncFromCache(ctx, db, cache); err != nil {
+			t.Fatalf("healthy SyncFromCache run %d deleted from a catalog table: %v", i+1, err)
+		}
+		if _, err := SyncFromCacheWithOptions(ctx, db, cache, SyncOptions{Degraded: true}); err != nil {
+			t.Fatalf("degraded SyncFromCache run %d deleted from a catalog table: %v", i+1, err)
+		}
+		if _, err := SyncFromAPI(ctx, db, notes); err != nil {
+			t.Fatalf("SyncFromAPI run %d deleted from a catalog table: %v", i+1, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Provenance.
+// ---------------------------------------------------------------------------
+
+// TestSyncFromAPI_StampsFolderRowsAsAPIOwned pins step 4 of this round. The
+// API note-sync path already created folder rows before row_source existed on
+// this table, so without an explicit stamp the very first backfill would file
+// genuine API-created folders under the column default and nothing could tell
+// them apart afterwards.
+func TestSyncFromAPI_StampsFolderRowsAsAPIOwned(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	notes := []APINote{{
+		ID:               "doc_api",
+		Title:            "Roadmap review",
+		FolderMembership: []APIMembership{{ID: "fold_api", Title: "Roadmap"}},
+		SpaceMembership:  []APIMembership{{SpaceID: "space_api", Name: "Product"}},
+	}}
+	if _, err := SyncFromAPI(ctx, db, notes); err != nil {
+		t.Fatalf("SyncFromAPI: %v", err)
+	}
+	for _, id := range []string{"fold_api", "space_api"} {
+		if got := queryString(t, db, `SELECT row_source FROM folders WHERE id = ?`, id); got != RowSourceAPI {
+			t.Errorf("folders(%s).row_source = %q, want %q", id, got, RowSourceAPI)
+		}
+	}
+}
+
+// TestCacheCatalogUpsertKeepsForeignOwnershipAndColumns pins the merge
+// semantics: an upsert of a row the OTHER path created must leave row_source
+// alone (or each run would steal ownership from the last) and must not blank
+// columns its own payload does not carry.
+func TestCacheCatalogUpsertKeepsForeignOwnershipAndColumns(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+
+	seeds := []struct {
+		stmt string
+		args []any
+	}{
+		{`INSERT INTO folders(id,title,parent_id,workspace_id,owner_id,preset,description,is_favourited,row_source)
+		  VALUES (?,?,?,?,?,?,?,?,?)`,
+			[]any{"fold_1", "Customers", "fold_root", "ws_1", "usr_1", "sales", "Customer work", 1, RowSourceAPI}},
+		{`INSERT INTO panel_templates(id,slug,title,description,category,row_source) VALUES (?,?,?,?,?,?)`,
+			[]any{"panel_1", "standup", "Standup", "Daily sync", "team", RowSourceAPI}},
+		{`INSERT INTO recipes(id,slug,name,description,category,source,row_source) VALUES (?,?,?,?,?,?,?)`,
+			[]any{"rec_1", "discovery", "Discovery", "Discovery call recipe", "sales", "user", RowSourceAPI}},
+		{`INSERT INTO recipes_usage(recipe_id,total_count,last_used_at,row_source) VALUES (?,?,?,?)`,
+			[]any{"rec_1", 42, "2026-01-02T03:04:05Z", RowSourceAPI}},
+	}
+	for _, s := range seeds {
+		if _, err := db.ExecContext(ctx, s.stmt, s.args...); err != nil {
+			t.Fatalf("seed api-owned row: %v", err)
+		}
+	}
+
+	// A cache payload that knows the ids but carries almost nothing else --
+	// the shape a partial or trimmed cache produces.
+	cache := &Cache{
+		DocumentListsMetadata: map[string]DocumentListMetadata{
+			"fold_1": {ID: "fold_1", Title: "Customers"},
+		},
+		PanelTemplates: []PanelTemplate{{ID: "panel_1", Title: "Standup"}},
+		UserRecipes:    []Recipe{{ID: "rec_1", Name: "Discovery"}},
+		RecipesUsage:   map[string]RecipeUsage{"rec_1": {RecipeID: "rec_1"}},
+	}
+	if _, err := SyncFromCache(ctx, db, cache); err != nil {
+		t.Fatalf("SyncFromCache: %v", err)
+	}
+
+	ownership := []struct{ query, arg string }{
+		{`SELECT row_source FROM folders WHERE id = ?`, "fold_1"},
+		{`SELECT row_source FROM panel_templates WHERE id = ?`, "panel_1"},
+		{`SELECT row_source FROM recipes WHERE id = ?`, "rec_1"},
+		{`SELECT row_source FROM recipes_usage WHERE recipe_id = ?`, "rec_1"},
+	}
+	for _, o := range ownership {
+		if got := queryString(t, db, o.query, o.arg); got != RowSourceAPI {
+			t.Errorf("%s = %q, want %q (the cache upsert stole ownership)", o.query, got, RowSourceAPI)
+		}
+	}
+
+	preserved := []struct {
+		query string
+		arg   string
+		want  string
+	}{
+		{`SELECT parent_id FROM folders WHERE id = ?`, "fold_1", "fold_root"},
+		{`SELECT workspace_id FROM folders WHERE id = ?`, "fold_1", "ws_1"},
+		{`SELECT preset FROM folders WHERE id = ?`, "fold_1", "sales"},
+		{`SELECT description FROM folders WHERE id = ?`, "fold_1", "Customer work"},
+		{`SELECT slug FROM panel_templates WHERE id = ?`, "panel_1", "standup"},
+		{`SELECT description FROM panel_templates WHERE id = ?`, "panel_1", "Daily sync"},
+		{`SELECT category FROM panel_templates WHERE id = ?`, "panel_1", "team"},
+		{`SELECT slug FROM recipes WHERE id = ?`, "rec_1", "discovery"},
+		{`SELECT description FROM recipes WHERE id = ?`, "rec_1", "Discovery call recipe"},
+		{`SELECT category FROM recipes WHERE id = ?`, "rec_1", "sales"},
+		{`SELECT source FROM recipes WHERE id = ?`, "rec_1", "user"},
+		{`SELECT last_used_at FROM recipes_usage WHERE recipe_id = ?`, "rec_1", "2026-01-02T03:04:05Z"},
+	}
+	for _, p := range preserved {
+		if got := queryString(t, db, p.query, p.arg); got != p.want {
+			t.Errorf("%s = %q, want %q (the upsert blanked a column its payload omitted)", p.query, got, p.want)
+		}
+	}
+	if got := queryInt(t, db, `SELECT total_count FROM recipes_usage WHERE recipe_id = ?`, "rec_1"); got != 42 {
+		t.Errorf("recipes_usage.total_count = %d, want 42 (a zero count blanked the stored total)", got)
+	}
+}
+
+// TestAPIFolderUpsertKeepsCacheMetadata is the mirror image: the API folder
+// insert carries a title and nothing else, and must not blank the metadata
+// only the cache has -- nor take ownership of a row the cache created.
+func TestAPIFolderUpsertKeepsCacheMetadata(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+
+	cache := &Cache{
+		DocumentListsMetadata: map[string]DocumentListMetadata{
+			"fold_1": {
+				ID: "fold_1", Title: "Customers", Description: "Customer work",
+				ParentDocumentListID: "fold_root", WorkspaceID: "ws_1",
+				Preset: "sales", IsFavourited: true,
+			},
+		},
+	}
+	if _, err := SyncFromCache(ctx, db, cache); err != nil {
+		t.Fatalf("SyncFromCache: %v", err)
+	}
+
+	notes := []APINote{{
+		ID:               "doc_api",
+		Title:            "Roadmap review",
+		FolderMembership: []APIMembership{{ID: "fold_1", Title: "Customers"}},
+	}}
+	if _, err := SyncFromAPI(ctx, db, notes); err != nil {
+		t.Fatalf("SyncFromAPI: %v", err)
+	}
+
+	if got := queryString(t, db, `SELECT row_source FROM folders WHERE id = ?`, "fold_1"); got != RowSourceCache {
+		t.Errorf("folders.row_source = %q, want %q (the API upsert stole ownership)", got, RowSourceCache)
+	}
+	for _, c := range []struct{ col, want string }{
+		{"title", "Customers"},
+		{"description", "Customer work"},
+		{"parent_id", "fold_root"},
+		{"workspace_id", "ws_1"},
+		{"preset", "sales"},
+	} {
+		got := queryString(t, db, fmt.Sprintf(`SELECT %s FROM folders WHERE id = ?`, c.col), "fold_1")
+		if got != c.want {
+			t.Errorf("folders.%s after API sync = %q, want %q", c.col, got, c.want)
+		}
+	}
+	if got := queryInt(t, db, `SELECT is_favourited FROM folders WHERE id = ?`, "fold_1"); got != 1 {
+		t.Errorf("folders.is_favourited after API sync = %d, want 1", got)
+	}
+}
+
+// TestFolderFavouriteFlagIsOwnerScoped pins the one column the
+// COALESCE(NULLIF(...)) merge cannot protect. is_favourited is a boolean, so a
+// payload that does not carry the field is indistinguishable from one that
+// says false; provenance is the only thing that can tell them apart. The
+// owning path may clear the flag, a foreign path may not.
+func TestFolderFavouriteFlagIsOwnerScoped(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+
+	favourited := &Cache{DocumentListsMetadata: map[string]DocumentListMetadata{
+		"fold_1": {ID: "fold_1", Title: "Customers", IsFavourited: true},
+	}}
+	notFavourited := &Cache{DocumentListsMetadata: map[string]DocumentListMetadata{
+		"fold_1": {ID: "fold_1", Title: "Customers"},
+	}}
+
+	if _, err := SyncFromCache(ctx, db, favourited); err != nil {
+		t.Fatalf("SyncFromCache: %v", err)
+	}
+	if got := queryInt(t, db, `SELECT is_favourited FROM folders WHERE id = ?`, "fold_1"); got != 1 {
+		t.Fatalf("is_favourited after cache sync = %d, want 1", got)
+	}
+
+	// A foreign owner that does not carry the flag must leave it alone.
+	if _, err := SyncFromCacheWithOptions(ctx, db, notFavourited, SyncOptions{CatalogOwner: RowSourceAPI}); err != nil {
+		t.Fatalf("SyncFromCacheWithOptions: %v", err)
+	}
+	if got := queryInt(t, db, `SELECT is_favourited FROM folders WHERE id = ?`, "fold_1"); got != 1 {
+		t.Errorf("is_favourited after a foreign-owner write = %d, want 1 (it was blanked)", got)
+	}
+
+	// The owning path still clears it, or un-favouriting would never stick.
+	if _, err := SyncFromCache(ctx, db, notFavourited); err != nil {
+		t.Fatalf("second SyncFromCache: %v", err)
+	}
+	if got := queryInt(t, db, `SELECT is_favourited FROM folders WHERE id = ?`, "fold_1"); got != 0 {
+		t.Errorf("is_favourited after the owner un-favourited = %d, want 0", got)
+	}
+}
+
+// TestSyncOptionsCatalogOwner pins the seam the API refresh needs. The default
+// is the historical behavior (cache), and an explicit owner stamps every
+// catalog table this run creates, so an API-driven catalog refresh can own its
+// own rows without a literal at each write site.
+func TestSyncOptionsCatalogOwner(t *testing.T) {
+	ctx := context.Background()
+
+	if got := (SyncOptions{}).catalogOwner(); got != RowSourceCache {
+		t.Errorf("zero SyncOptions catalogOwner = %q, want %q", got, RowSourceCache)
+	}
+	if got := (SyncOptions{CatalogOwner: RowSourceAPI}).catalogOwner(); got != RowSourceAPI {
+		t.Errorf("explicit catalogOwner = %q, want %q", got, RowSourceAPI)
+	}
+
+	db := openTestDB(t)
+	cache := &Cache{
+		DocumentListsMetadata: map[string]DocumentListMetadata{
+			"fold_1": {ID: "fold_1", Title: "Customers"},
+		},
+		PanelTemplates: []PanelTemplate{{ID: "panel_1", Slug: "standup", Title: "Standup"}},
+		UserRecipes:    []Recipe{{ID: "rec_1", Slug: "discovery", Name: "Discovery"}},
+		RecipesUsage:   map[string]RecipeUsage{"rec_1": {RecipeID: "rec_1", TotalCount: "3"}},
+	}
+	if _, err := SyncFromCacheWithOptions(ctx, db, cache, SyncOptions{CatalogOwner: RowSourceAPI}); err != nil {
+		t.Fatalf("SyncFromCacheWithOptions: %v", err)
+	}
+	for _, o := range []struct{ query, arg string }{
+		{`SELECT row_source FROM folders WHERE id = ?`, "fold_1"},
+		{`SELECT row_source FROM panel_templates WHERE id = ?`, "panel_1"},
+		{`SELECT row_source FROM recipes WHERE id = ?`, "rec_1"},
+		{`SELECT row_source FROM recipes_usage WHERE recipe_id = ?`, "rec_1"},
+	} {
+		if got := queryString(t, db, o.query, o.arg); got != RowSourceAPI {
+			t.Errorf("%s = %q, want %q", o.query, got, RowSourceAPI)
+		}
+	}
+
+	// A later default (cache) run must not take ownership back.
+	if _, err := SyncFromCache(ctx, db, cache); err != nil {
+		t.Fatalf("second SyncFromCache: %v", err)
+	}
+	if got := queryString(t, db, `SELECT row_source FROM folders WHERE id = ?`, "fold_1"); got != RowSourceAPI {
+		t.Errorf("row_source after default-owner rerun = %q, want %q", got, RowSourceAPI)
+	}
+}

--- a/library/productivity/granola/internal/granola/syncstate.go
+++ b/library/productivity/granola/internal/granola/syncstate.go
@@ -20,7 +20,18 @@ import (
 // ~/.local/share/granola-pp-cli/sync_state.json on macOS by default).
 // Path is overridable via GRANOLA_SYNC_STATE_PATH for tests.
 type SyncState struct {
-	LastSyncAt            time.Time `json:"last_sync_at"`
+	LastSyncAt time.Time `json:"last_sync_at"`
+	// LastCacheSyncAt is when the desktop cache last decrypted successfully.
+	//
+	// PATCH(read-path-store-first-for-recipes-and-chats): distinct from
+	// LastSyncAt, and the distinction is the whole point. LastSyncAt advances on
+	// every invocation because auto-refresh runs an API sync each time, so on a
+	// migrated install it always reads "just now" — while the cache-derived rows
+	// (recipes, panel templates, chat threads) are frozen wherever the last
+	// successful decrypt left them, often months earlier. Dating those rows by
+	// LastSyncAt tells the user their stale data is current, which is worse than
+	// saying nothing. Zero means no successful cache sync has been recorded.
+	LastCacheSyncAt       time.Time `json:"last_cache_sync_at,omitempty"`
 	LastDecryptStatus     string    `json:"last_decrypt_status"` // "ok" | "failed" | "skipped"
 	LastDecryptErrorClass string    `json:"last_decrypt_error_class,omitempty"`
 	LastDecryptErrorMsg   string    `json:"last_decrypt_error_msg,omitempty"`

--- a/library/productivity/granola/internal/granola/syncstate.go
+++ b/library/productivity/granola/internal/granola/syncstate.go
@@ -31,7 +31,15 @@ type SyncState struct {
 	// successful decrypt left them, often months earlier. Dating those rows by
 	// LastSyncAt tells the user their stale data is current, which is worse than
 	// saying nothing. Zero means no successful cache sync has been recorded.
-	LastCacheSyncAt       time.Time `json:"last_cache_sync_at,omitempty"`
+	LastCacheSyncAt time.Time `json:"last_cache_sync_at,omitempty"`
+	// LastCatalogSyncAt is when the API catalog refresh last succeeded.
+	//
+	// PATCH(api-catalog-refresh): recipes and panel templates are refreshable
+	// over the internal API, so dating them by LastCacheSyncAt would report
+	// rows refreshed seconds ago as frozen at a months-old cache sync. Chat
+	// threads have no endpoint and stay dated by LastCacheSyncAt. Zero means no
+	// catalog refresh has succeeded on this machine.
+	LastCatalogSyncAt     time.Time `json:"last_catalog_sync_at,omitempty"`
 	LastDecryptStatus     string    `json:"last_decrypt_status"` // "ok" | "failed" | "skipped"
 	LastDecryptErrorClass string    `json:"last_decrypt_error_class,omitempty"`
 	LastDecryptErrorMsg   string    `json:"last_decrypt_error_msg,omitempty"`

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -185,6 +185,11 @@ var (
 	// refreshClient is the HTTP client used for refresh calls. Tests may
 	// override it with a transport that mocks WorkOS responses.
 	refreshClient = &http.Client{Timeout: 15 * time.Second}
+	// refreshMu serializes the exchange-and-persist for the CLI-owned chain.
+	// Separate from tokenMu on purpose: tokenMu guards short in-process reads
+	// and must not be held across an HTTP round trip, while this one must span
+	// the whole rotation because the chain is single-use.
+	refreshMu sync.Mutex
 )
 
 // ErrRefreshRefused is returned by RefreshAccessToken when the in-memory
@@ -233,6 +238,28 @@ func refreshRefusalFor(src TokenSource) error {
 		}
 	}
 	return nil
+}
+
+// rotatedCLISessionToken reports whether the stored session has already moved
+// past the refresh token this caller presented, and returns it when so. That is
+// the signal that another goroutine won the race and rotated; reusing its
+// result is what stops the loser from spending a single-use chain twice.
+func rotatedCLISessionToken(presented string) (RefreshAccessTokenResponse, bool) {
+	s, err := loadCLISessionUnmarked()
+	if err != nil || s.AccessToken == "" {
+		return RefreshAccessTokenResponse{}, false
+	}
+	if presented == "" || s.RefreshToken == presented {
+		return RefreshAccessTokenResponse{}, false
+	}
+	if s.ExpiresAt.IsZero() || time.Until(s.ExpiresAt) < time.Minute {
+		return RefreshAccessTokenResponse{}, false
+	}
+	return RefreshAccessTokenResponse{
+		AccessToken:  s.AccessToken,
+		RefreshToken: s.RefreshToken,
+		ExpiresIn:    int(time.Until(s.ExpiresAt).Seconds()),
+	}, true
 }
 
 // SetRefreshHTTPClient swaps the HTTP client used for WorkOS refreshes.
@@ -487,11 +514,58 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	// the network call. Single-CLI-invocation processes don't see this race
 	// in practice; long-running agents that call sync concurrently would.
 	tokenMu.Lock()
-	if refusal := refreshRefusalFor(cachedSource); refusal != nil {
+	src := cachedSource
+	if refusal := refreshRefusalFor(src); refusal != nil {
 		tokenMu.Unlock()
 		return RefreshAccessTokenResponse{}, refusal
 	}
 	tokenMu.Unlock()
+
+	// PATCH(cli-owned-workos-session): serialize the whole exchange-and-persist
+	// for the one chain the CLI owns, and mark it in flight first.
+	//
+	// tokenMu deliberately does not cover the network call -- holding it there
+	// would block every concurrent reader for the duration of an HTTP round
+	// trip. But an unserialized refresh is unsafe for a single-use chain: two
+	// callers both exchange, the loser gets invalid_grant, and the session is
+	// stranded with no recovery but a fresh login. A dedicated lock gives the
+	// serialization without the read stall.
+	//
+	// The marker is written before the exchange rather than after, because the
+	// unrecoverable window is precisely between a successful remote exchange
+	// and a durable local write. A marker written afterwards would never
+	// witness the crash it exists to detect.
+	// exchanged flips once the remote call has returned a usable token, i.e.
+	// once the presented refresh token may already be spent upstream.
+	exchanged := false
+	if src == TokenSourceCLISession {
+		refreshMu.Lock()
+		defer refreshMu.Unlock()
+		// Another goroutine may have completed a refresh while this one waited.
+		// Detect that by the stored refresh token no longer matching the one
+		// this caller presented, and hand back the winner's result rather than
+		// spending the chain again. Keying on rotation rather than on remaining
+		// validity matters: a caller refreshing after a 401 holds a token the
+		// server has already rejected, and must not be told it is still good.
+		if fresh, ok := rotatedCLISessionToken(refreshToken); ok {
+			return fresh, nil
+		}
+		if err := BeginRotation(); err != nil {
+			return RefreshAccessTokenResponse{}, err
+		}
+		// The marker must survive exactly one outcome: the remote exchange
+		// succeeded and the local write did not. That is the unrecoverable
+		// window -- the presented token is dead upstream and no replacement
+		// reached disk. Every other failure left the stored token untouched, so
+		// clearing the marker avoids sending the user to auth login over a
+		// transport blip. On success SaveCLISession has already removed it.
+		defer func() {
+			if !exchanged {
+				AbortRotation()
+			}
+		}()
+	}
+
 	body, _ := json.Marshal(map[string]string{
 		"refresh_token": refreshToken,
 	})
@@ -533,6 +607,7 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	if parsed.AccessToken == "" {
 		return RefreshAccessTokenResponse{}, fmt.Errorf("granola refresh: empty access_token in response")
 	}
+	exchanged = true
 	// Cache the new pair in-process.
 	tokenMu.Lock()
 	cachedAccess = parsed.AccessToken
@@ -542,7 +617,6 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	if parsed.ExpiresIn > 0 {
 		cachedExpiry = time.Now().Add(time.Duration(parsed.ExpiresIn) * time.Second)
 	}
-	src := cachedSource
 	tokenMu.Unlock()
 
 	// PATCH(cli-owned-workos-session): persist the rotated pair for a
@@ -567,7 +641,9 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 // session file, preserving the account identity fields the refresh response
 // does not carry.
 func persistRotatedCLISession(parsed RefreshAccessTokenResponse) error {
-	s, err := LoadCLISession()
+	// Unmarked: this runs inside the refresh lock with our own in-flight marker
+	// set, so the marked loader would refuse to read the session being replaced.
+	s, err := loadCLISessionUnmarked()
 	if err != nil && !errors.Is(err, ErrNoCLISession) {
 		return fmt.Errorf("granola refresh: reload session before persist: %w", err)
 	}

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -240,6 +240,26 @@ func refreshRefusalFor(src TokenSource) error {
 	return nil
 }
 
+// adoptRotated installs another process's rotation result into this process's
+// token cache.
+//
+// Returning the winner's tokens without this leaves cachedAccess holding the
+// token the server already rejected, so the 401 retry that triggered the
+// refresh would replay the same dead credential and fail again. The caller is
+// refreshing precisely because its cached token is no good.
+func adoptRotated(r RefreshAccessTokenResponse) RefreshAccessTokenResponse {
+	tokenMu.Lock()
+	defer tokenMu.Unlock()
+	cachedAccess = r.AccessToken
+	if r.RefreshToken != "" {
+		cachedRefresh = r.RefreshToken
+	}
+	if r.ExpiresIn > 0 {
+		cachedExpiry = time.Now().Add(time.Duration(r.ExpiresIn) * time.Second)
+	}
+	return r
+}
+
 // awaitRotatedCLISession waits, briefly and bounded, for the process holding
 // the rotation marker to publish its result. A short wait is right: the holder
 // is mid-HTTP-exchange, and the alternative -- returning immediately -- pushes a
@@ -575,7 +595,7 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 		// validity matters: a caller refreshing after a 401 holds a token the
 		// server has already rejected, and must not be told it is still good.
 		if fresh, ok := rotatedCLISessionToken(refreshToken); ok {
-			return fresh, nil
+			return adoptRotated(fresh), nil
 		}
 		handle, err := BeginRotation()
 		if errors.Is(err, ErrRotationInProgress) {
@@ -583,7 +603,7 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 			// the chain is single-use, so a second exchange spends the token it
 			// is rotating. Wait for it to publish, then reuse its result.
 			if fresh, ok := awaitRotatedCLISession(refreshToken); ok {
-				return fresh, nil
+				return adoptRotated(fresh), nil
 			}
 			return RefreshAccessTokenResponse{}, err
 		}

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -264,6 +264,11 @@ func heldSessionGeneration() sessionGeneration {
 	return sessionGeneration{accessToken: cachedAccess}
 }
 
+// ErrSessionLoggedOutDuringRotation reports that the session was removed while
+// a refresh was in flight. The rotation is abandoned rather than completed:
+// finishing it would recreate the credential logout just deleted.
+var ErrSessionLoggedOutDuringRotation = errors.New("granola: session was logged out during rotation")
+
 // adoptRotated installs another process's rotation result into this process's
 // token cache.
 //
@@ -736,6 +741,13 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	// was silently lost.
 	if src == TokenSourceCLISession {
 		if err := persistRotatedCLISession(parsed); err != nil {
+			if errors.Is(err, ErrSessionLoggedOutDuringRotation) {
+				// Logout won. The marker only exists to flag a session that
+				// needs recovering, and there is no longer a session -- leaving
+				// it would tell the user to re-login to repair something they
+				// deliberately deleted. Clear it and report the logout.
+				rotationHandle.Abort()
+			}
 			return RefreshAccessTokenResponse{}, err
 		}
 	}
@@ -749,7 +761,15 @@ func persistRotatedCLISession(parsed RefreshAccessTokenResponse) error {
 	// Unmarked: this runs inside the refresh lock with our own in-flight marker
 	// set, so the marked loader would refuse to read the session being replaced.
 	s, err := loadCLISessionUnmarked()
-	if err != nil && !errors.Is(err, ErrNoCLISession) {
+	if errors.Is(err, ErrNoCLISession) {
+		// The session vanished mid-rotation, which means `auth logout` ran.
+		// Writing here would resurrect the credential the user just removed and
+		// report logout as having succeeded, so abandon the rotation instead.
+		// The exchanged token is discarded; the user is logged out, which is
+		// what they asked for.
+		return ErrSessionLoggedOutDuringRotation
+	}
+	if err != nil {
 		return fmt.Errorf("granola refresh: reload session before persist: %w", err)
 	}
 	s.AccessToken = parsed.AccessToken

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -816,7 +816,7 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	// fresh login. Failing loudly beats returning a token whose refresh half
 	// was silently lost.
 	if src == TokenSourceCLISession {
-		if err := persistRotatedCLISession(parsed); err != nil {
+		if err := persistRotatedCLISession(parsed, rotationHandle); err != nil {
 			if errors.Is(err, ErrSessionLoggedOutDuringRotation) {
 				// Logout won. The marker only exists to flag a session that
 				// needs recovering, and there is no longer a session -- leaving
@@ -839,7 +839,7 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 // persistRotatedCLISession writes a refreshed pair back to the CLI-owned
 // session file, preserving the account identity fields the refresh response
 // does not carry.
-func persistRotatedCLISession(parsed RefreshAccessTokenResponse) error {
+func persistRotatedCLISession(parsed RefreshAccessTokenResponse, h RotationHandle) error {
 	// Unmarked: this runs inside the refresh lock with our own in-flight marker
 	// set, so the marked loader would refuse to read the session being replaced.
 	s, err := loadCLISessionUnmarked()
@@ -864,6 +864,18 @@ func persistRotatedCLISession(parsed RefreshAccessTokenResponse) error {
 	s.ObtainedAt = time.Now().UTC()
 	if err := SaveCLISession(s); err != nil {
 		return fmt.Errorf("granola refresh: persist rotated session: %w", err)
+	}
+	// The existence check above only closes the in-process race, which refreshMu
+	// already covers. Across processes a logout can land between that check and
+	// the rename, and the rename would then recreate the credential after logout
+	// reported success. Re-read the revocation epoch now that the file is
+	// published: if it moved, a logout happened somewhere inside this rotation,
+	// so remove what was just written rather than leave the user signed in.
+	if readRevocationEpoch() != h.Epoch() {
+		if rmErr := os.Remove(CLISessionPath()); rmErr != nil && !os.IsNotExist(rmErr) {
+			return fmt.Errorf("granola refresh: logout raced this rotation and the resurrected session could not be removed: %w", rmErr)
+		}
+		return ErrSessionLoggedOutDuringRotation
 	}
 	return nil
 }

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -240,6 +240,25 @@ func refreshRefusalFor(src TokenSource) error {
 	return nil
 }
 
+// sessionGeneration identifies a published version of the stored session.
+//
+// Keying rotation detection on the refresh token changing was wrong: Granola's
+// refresh proxy is observed to return the SAME refresh token, so a waiter would
+// never see the winner's result and would time out despite a valid new access
+// token sitting on disk. ObtainedAt advances on every persisted rotation
+// regardless, and the access token is carried too so a same-instant rotation is
+// still caught.
+type sessionGeneration struct {
+	accessToken string
+}
+
+// heldSessionGeneration describes the credential this process currently holds.
+func heldSessionGeneration() sessionGeneration {
+	tokenMu.Lock()
+	defer tokenMu.Unlock()
+	return sessionGeneration{accessToken: cachedAccess}
+}
+
 // adoptRotated installs another process's rotation result into this process's
 // token cache.
 //
@@ -266,7 +285,7 @@ func adoptRotated(r RefreshAccessTokenResponse) RefreshAccessTokenResponse {
 // spurious failure at a caller whose session is about to be perfectly valid.
 // Giving up returns false rather than exchanging, because spending a single-use
 // chain twice is the outcome this whole path exists to prevent.
-func awaitRotatedCLISession(presented string) (RefreshAccessTokenResponse, bool) {
+func awaitRotatedCLISession(seen sessionGeneration) (RefreshAccessTokenResponse, bool) {
 	const (
 		window = 10 * time.Second
 		step   = 100 * time.Millisecond
@@ -274,7 +293,7 @@ func awaitRotatedCLISession(presented string) (RefreshAccessTokenResponse, bool)
 	deadline := time.Now().Add(window)
 	for time.Now().Before(deadline) {
 		time.Sleep(step)
-		if fresh, ok := rotatedCLISessionToken(presented); ok {
+		if fresh, ok := rotatedCLISessionToken(seen); ok {
 			return fresh, true
 		}
 		// The holder cleared its marker without rotating -- it failed
@@ -286,16 +305,18 @@ func awaitRotatedCLISession(presented string) (RefreshAccessTokenResponse, bool)
 	return RefreshAccessTokenResponse{}, false
 }
 
-// rotatedCLISessionToken reports whether the stored session has already moved
-// past the refresh token this caller presented, and returns it when so. That is
-// the signal that another goroutine won the race and rotated; reusing its
-// result is what stops the loser from spending a single-use chain twice.
-func rotatedCLISessionToken(presented string) (RefreshAccessTokenResponse, bool) {
+// rotatedCLISessionToken reports whether the stored session has advanced past
+// the generation this caller snapshotted, and returns it when so. That is the
+// signal that another goroutine or process won the race; reusing its result is
+// what stops the loser from spending a single-use chain twice.
+func rotatedCLISessionToken(seen sessionGeneration) (RefreshAccessTokenResponse, bool) {
 	s, err := loadCLISessionUnmarked()
 	if err != nil || s.AccessToken == "" {
 		return RefreshAccessTokenResponse{}, false
 	}
-	if presented == "" || s.RefreshToken == presented {
+	// Advanced when the stored credential is not the one this caller holds.
+	advanced := seen.accessToken != "" && s.AccessToken != seen.accessToken
+	if !advanced {
 		return RefreshAccessTokenResponse{}, false
 	}
 	if s.ExpiresAt.IsZero() || time.Until(s.ExpiresAt) < time.Minute {
@@ -586,6 +607,14 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	exchanged := false
 	var rotationHandle RotationHandle
 	if src == TokenSourceCLISession {
+		// The reference point is what THIS caller holds, not what is on disk:
+		// by the time we look, a winner may already have published, and a disk
+		// snapshot would compare that result against itself and miss it. The
+		// cached access token is the credential this caller was using when it
+		// decided to refresh, so "stored differs from mine" is exactly the
+		// question worth asking -- and it stays true when the provider
+		// preserves the refresh token, which Granola's proxy is observed to do.
+		seen := heldSessionGeneration()
 		refreshMu.Lock()
 		defer refreshMu.Unlock()
 		// Another goroutine may have completed a refresh while this one waited.
@@ -594,7 +623,7 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 		// spending the chain again. Keying on rotation rather than on remaining
 		// validity matters: a caller refreshing after a 401 holds a token the
 		// server has already rejected, and must not be told it is still good.
-		if fresh, ok := rotatedCLISessionToken(refreshToken); ok {
+		if fresh, ok := rotatedCLISessionToken(seen); ok {
 			return adoptRotated(fresh), nil
 		}
 		handle, err := BeginRotation()
@@ -602,7 +631,7 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 			// Another process holds the marker. Never exchange alongside it:
 			// the chain is single-use, so a second exchange spends the token it
 			// is rotating. Wait for it to publish, then reuse its result.
-			if fresh, ok := awaitRotatedCLISession(refreshToken); ok {
+			if fresh, ok := awaitRotatedCLISession(seen); ok {
 				return adoptRotated(fresh), nil
 			}
 			return RefreshAccessTokenResponse{}, err

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -167,6 +167,12 @@ const (
 	// to this file on exactly those installs. Refresh stays allowed on
 	// genuinely legacy installs that never had an encrypted store.
 	TokenSourceStoredAccounts
+	// PATCH(cli-owned-workos-session): TokenSourceCLISession: a session this
+	// CLI obtained itself through the device authorization grant and stores
+	// under its own data directory. This is the one chain the CLI owns, so D6
+	// does not apply -- refreshing it cannot sign the desktop app or the
+	// browser out, because neither holds it.
+	TokenSourceCLISession
 )
 
 // in-process token cache. Survives across multiple calls in one CLI run.
@@ -214,6 +220,11 @@ func (e *refreshRefusedError) Unwrap() error { return ErrRefreshRefused }
 // had one.
 func refreshRefusalFor(src TokenSource) error {
 	switch src {
+	case TokenSourceCLISession:
+		// PATCH(cli-owned-workos-session): never refused. The CLI owns this
+		// chain outright; no other client holds it, so rotating it cannot
+		// strand anyone. Every desktop-owned arm below is unchanged.
+		return nil
 	case TokenSourceEncryptedSupabase, TokenSourcePlaintextSupabaseDesktopFallback:
 		return ErrRefreshRefused
 	case TokenSourceStoredAccounts:
@@ -276,6 +287,32 @@ func loadTokensRaw() (workosTokens, TokenSource, error) {
 			ExpiresIn:    3600,
 			TokenType:    "Bearer",
 		}, TokenSourceEnvOverride, nil
+	}
+
+	// PATCH(cli-owned-workos-session): the CLI's own session outranks every
+	// desktop-owned probe below. It is the only chain the CLI may refresh, and
+	// on a post-migration install it is the only one that still works at all --
+	// supabase.json.enc needs the entitlement-gated DEK, and the plaintext
+	// files Granola stopped writing are stale fossils. The env override stays
+	// ahead of it so a deliberate GRANOLA_WORKOS_TOKEN still wins.
+	if s, err := LoadCLISession(); err == nil {
+		expiresIn := 0
+		if !s.ExpiresAt.IsZero() {
+			expiresIn = int(time.Until(s.ExpiresAt).Seconds())
+		}
+		return workosTokens{
+			AccessToken:  s.AccessToken,
+			RefreshToken: s.RefreshToken,
+			ObtainedAt:   s.ObtainedAt.UnixMilli(),
+			ExpiresIn:    expiresIn,
+			TokenType:    "Bearer",
+		}, TokenSourceCLISession, nil
+	} else if !errors.Is(err, ErrNoCLISession) {
+		// A corrupt session, an interrupted rotation, or unsafe permissions are
+		// states the user must be told about. Falling through to the desktop
+		// probes here would replace an actionable message with a confusing
+		// "no token found" three probes later.
+		return workosTokens{}, TokenSourceUnknown, err
 	}
 
 	if tok, src, err := loadFromSupabaseJSON(); err == nil {
@@ -505,6 +542,45 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	if parsed.ExpiresIn > 0 {
 		cachedExpiry = time.Now().Add(time.Duration(parsed.ExpiresIn) * time.Second)
 	}
+	src := cachedSource
 	tokenMu.Unlock()
+
+	// PATCH(cli-owned-workos-session): persist the rotated pair for a
+	// CLI-owned session before returning.
+	//
+	// Granola's refresh proxy was observed returning the same refresh token
+	// rather than a rotated one, so this is not currently a
+	// consume-and-replace exchange. Persist anyway: the WorkOS endpoint behind
+	// it *is* single-use, and if the proxy ever starts passing that through, an
+	// unpersisted replacement would strand the session with no recovery but a
+	// fresh login. Failing loudly beats returning a token whose refresh half
+	// was silently lost.
+	if src == TokenSourceCLISession {
+		if err := persistRotatedCLISession(parsed); err != nil {
+			return RefreshAccessTokenResponse{}, err
+		}
+	}
 	return parsed, nil
+}
+
+// persistRotatedCLISession writes a refreshed pair back to the CLI-owned
+// session file, preserving the account identity fields the refresh response
+// does not carry.
+func persistRotatedCLISession(parsed RefreshAccessTokenResponse) error {
+	s, err := LoadCLISession()
+	if err != nil && !errors.Is(err, ErrNoCLISession) {
+		return fmt.Errorf("granola refresh: reload session before persist: %w", err)
+	}
+	s.AccessToken = parsed.AccessToken
+	if parsed.RefreshToken != "" {
+		s.RefreshToken = parsed.RefreshToken
+	}
+	if parsed.ExpiresIn > 0 {
+		s.ExpiresAt = time.Now().Add(time.Duration(parsed.ExpiresIn) * time.Second).UTC()
+	}
+	s.ObtainedAt = time.Now().UTC()
+	if err := SaveCLISession(s); err != nil {
+		return fmt.Errorf("granola refresh: persist rotated session: %w", err)
+	}
+	return nil
 }

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -830,6 +830,8 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 			}
 			return RefreshAccessTokenResponse{}, err
 		}
+		// The replacement is durable, so the window the marker guards is closed.
+		rotationHandle.Complete()
 	}
 	return parsed, nil
 }

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -240,6 +240,32 @@ func refreshRefusalFor(src TokenSource) error {
 	return nil
 }
 
+// awaitRotatedCLISession waits, briefly and bounded, for the process holding
+// the rotation marker to publish its result. A short wait is right: the holder
+// is mid-HTTP-exchange, and the alternative -- returning immediately -- pushes a
+// spurious failure at a caller whose session is about to be perfectly valid.
+// Giving up returns false rather than exchanging, because spending a single-use
+// chain twice is the outcome this whole path exists to prevent.
+func awaitRotatedCLISession(presented string) (RefreshAccessTokenResponse, bool) {
+	const (
+		window = 10 * time.Second
+		step   = 100 * time.Millisecond
+	)
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		time.Sleep(step)
+		if fresh, ok := rotatedCLISessionToken(presented); ok {
+			return fresh, true
+		}
+		// The holder cleared its marker without rotating -- it failed
+		// harmlessly, so there is nothing to wait for.
+		if _, err := os.Stat(rotationMarkerPath()); err != nil {
+			return RefreshAccessTokenResponse{}, false
+		}
+	}
+	return RefreshAccessTokenResponse{}, false
+}
+
 // rotatedCLISessionToken reports whether the stored session has already moved
 // past the refresh token this caller presented, and returns it when so. That is
 // the signal that another goroutine won the race and rotated; reusing its
@@ -538,6 +564,7 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	// exchanged flips once the remote call has returned a usable token, i.e.
 	// once the presented refresh token may already be spent upstream.
 	exchanged := false
+	var rotationHandle RotationHandle
 	if src == TokenSourceCLISession {
 		refreshMu.Lock()
 		defer refreshMu.Unlock()
@@ -550,9 +577,20 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 		if fresh, ok := rotatedCLISessionToken(refreshToken); ok {
 			return fresh, nil
 		}
-		if err := BeginRotation(); err != nil {
+		handle, err := BeginRotation()
+		if errors.Is(err, ErrRotationInProgress) {
+			// Another process holds the marker. Never exchange alongside it:
+			// the chain is single-use, so a second exchange spends the token it
+			// is rotating. Wait for it to publish, then reuse its result.
+			if fresh, ok := awaitRotatedCLISession(refreshToken); ok {
+				return fresh, nil
+			}
 			return RefreshAccessTokenResponse{}, err
 		}
+		if err != nil {
+			return RefreshAccessTokenResponse{}, err
+		}
+		rotationHandle = handle
 		// The marker must survive exactly one outcome: the remote exchange
 		// succeeded and the local write did not. That is the unrecoverable
 		// window -- the presented token is dead upstream and no replacement
@@ -561,7 +599,7 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 		// transport blip. On success SaveCLISession has already removed it.
 		defer func() {
 			if !exchanged {
-				AbortRotation()
+				rotationHandle.Abort()
 			}
 		}()
 	}

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -309,6 +309,14 @@ func awaitRotatedCLISession(seen sessionGeneration) (RefreshAccessTokenResponse,
 		// The holder cleared its marker without rotating -- it failed
 		// harmlessly, so there is nothing to wait for.
 		if _, err := os.Stat(rotationMarkerPath()); err != nil {
+			// One more read before giving up. A save renames the session and
+			// then removes the marker, so the holder can publish in the gap
+			// between the read above and this stat -- and giving up here would
+			// report "rotation in progress" while the fresh token it produced is
+			// already sitting on disk.
+			if fresh, ok := rotatedCLISessionToken(seen); ok {
+				return fresh, true
+			}
 			return RefreshAccessTokenResponse{}, false
 		}
 	}
@@ -319,6 +327,31 @@ func awaitRotatedCLISession(seen sessionGeneration) (RefreshAccessTokenResponse,
 // the generation this caller snapshotted, and returns it when so. That is the
 // signal that another goroutine or process won the race; reusing its result is
 // what stops the loser from spending a single-use chain twice.
+// lastConsumedRefresh is the refresh token most recently spent by a completed
+// exchange in this process. Guarded by refreshMu. It exists so a caller holding
+// that exact token can recognise it as already spent even when the cache
+// comparison cannot see the rotation.
+var (
+	consumedMu          sync.Mutex
+	lastConsumedRefresh string
+)
+
+// recordConsumedRefresh and isConsumedRefresh guard the ledger with their own
+// mutex rather than refreshMu. ResetTokenCache clears it and is itself called
+// from inside the refreshMu-held logout branch, so reusing refreshMu here would
+// deadlock the very path that abandons a rotation.
+func recordConsumedRefresh(tok string) {
+	consumedMu.Lock()
+	lastConsumedRefresh = tok
+	consumedMu.Unlock()
+}
+
+func isConsumedRefresh(tok string) bool {
+	consumedMu.Lock()
+	defer consumedMu.Unlock()
+	return tok != "" && tok == lastConsumedRefresh
+}
+
 func rotatedCLISessionToken(seen sessionGeneration) (RefreshAccessTokenResponse, bool) {
 	s, err := loadCLISessionUnmarked()
 	if err != nil || s.AccessToken == "" {
@@ -329,13 +362,21 @@ func rotatedCLISessionToken(seen sessionGeneration) (RefreshAccessTokenResponse,
 	if !advanced {
 		return RefreshAccessTokenResponse{}, false
 	}
-	if s.ExpiresAt.IsZero() || time.Until(s.ExpiresAt) < time.Minute {
-		return RefreshAccessTokenResponse{}, false
+	// Deliberately no freshness gate. "Someone else rotated" and "the result
+	// looks fresh" are different questions, and answering the first with the
+	// second fails in the dangerous direction: a winner whose response omitted
+	// expires_in publishes a new access token over a stale expiry, and the loser
+	// would read that as "no rotation happened" and exchange the same single-use
+	// refresh token a second time. A token that turns out to be expired costs a
+	// 401 and a retry; a double exchange breaks the chain for good.
+	remaining := time.Until(s.ExpiresAt)
+	if s.ExpiresAt.IsZero() || remaining < 0 {
+		remaining = 0
 	}
 	return RefreshAccessTokenResponse{
 		AccessToken:  s.AccessToken,
 		RefreshToken: s.RefreshToken,
-		ExpiresIn:    int(time.Until(s.ExpiresAt).Seconds()),
+		ExpiresIn:    int(remaining.Seconds()),
 	}, true
 }
 
@@ -356,6 +397,7 @@ func ResetTokenCache() {
 	cachedRefresh = ""
 	cachedExpiry = time.Time{}
 	cachedSource = TokenSourceUnknown
+	recordConsumedRefresh("")
 }
 
 // CurrentTokenSource returns the origin of the in-process cached token.
@@ -624,9 +666,33 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 		// decided to refresh, so "stored differs from mine" is exactly the
 		// question worth asking -- and it stays true when the provider
 		// preserves the refresh token, which Granola's proxy is observed to do.
+		// Snapshotted before the lock on purpose: it must record what this
+		// caller was using when it decided to refresh, not what the winner
+		// published while this caller was blocked. Sampling under the lock reads
+		// the winner's own result, making "did anyone rotate?" compare the new
+		// token against itself -- every loser then concludes nothing happened.
 		seen := heldSessionGeneration()
 		refreshMu.Lock()
 		defer refreshMu.Unlock()
+		// The snapshot above can still be taken in the narrow window after the
+		// winner updates the cache and before it releases the lock, which would
+		// hide the rotation. That case is caught exactly rather than
+		// approximately: the winner records which refresh token it consumed, so
+		// a caller presenting that same token knows its own credential is spent
+		// and must adopt the winner's result instead of exchanging again.
+		if isConsumedRefresh(refreshToken) {
+			if stored, err := loadCLISessionUnmarked(); err == nil && stored.AccessToken != "" {
+				remaining := time.Until(stored.ExpiresAt)
+				if stored.ExpiresAt.IsZero() || remaining < 0 {
+					remaining = 0
+				}
+				return adoptRotated(RefreshAccessTokenResponse{
+					AccessToken:  stored.AccessToken,
+					RefreshToken: stored.RefreshToken,
+					ExpiresIn:    int(remaining.Seconds()),
+				}), nil
+			}
+		}
 		// Another goroutine may have completed a refresh while this one waited.
 		// Detect that by the stored refresh token no longer matching the one
 		// this caller presented, and hand back the winner's result rather than
@@ -710,6 +776,17 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	if resp.StatusCode != http.StatusOK {
 		return RefreshAccessTokenResponse{}, fmt.Errorf("granola refresh: status %d: %s", resp.StatusCode, string(respBody))
 	}
+	// A 200 is proof the endpoint rotated, so the presented token is spent from
+	// here on regardless of what the body turns out to contain. Flipping this
+	// on parse success instead would let a truncated or malformed body clear
+	// the marker on an already-consumed token -- deleting the only evidence of
+	// the state the marker exists to record.
+	exchanged = true
+	// Recorded at the same moment for the same reason: the server has committed,
+	// so this refresh token is spent. A concurrent caller holding it must adopt
+	// the result rather than present it again. Written under refreshMu, which
+	// this function holds for its whole body.
+	recordConsumedRefresh(refreshToken)
 	var parsed RefreshAccessTokenResponse
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
 		return RefreshAccessTokenResponse{}, fmt.Errorf("granola refresh: parse response: %w", err)
@@ -717,7 +794,6 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	if parsed.AccessToken == "" {
 		return RefreshAccessTokenResponse{}, fmt.Errorf("granola refresh: empty access_token in response")
 	}
-	exchanged = true
 	// Cache the new pair in-process.
 	tokenMu.Lock()
 	cachedAccess = parsed.AccessToken
@@ -745,8 +821,12 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 				// Logout won. The marker only exists to flag a session that
 				// needs recovering, and there is no longer a session -- leaving
 				// it would tell the user to re-login to repair something they
-				// deliberately deleted. Clear it and report the logout.
+				// deliberately deleted. Clear it, and drop the in-process cache
+				// too: the tokens just exchanged are still in memory, and
+				// leaving them there would keep serving a credential the user
+				// removed from disk.
 				rotationHandle.Abort()
+				ResetTokenCache()
 			}
 			return RefreshAccessTokenResponse{}, err
 		}

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -252,6 +252,11 @@ type sessionGeneration struct {
 	accessToken string
 }
 
+// beforeAcquireHook fires between the first generation check and the marker
+// acquire. Nil in production; a test sets it to simulate a winner publishing in
+// exactly that window, which is otherwise not reproducible.
+var beforeAcquireHook func()
+
 // heldSessionGeneration describes the credential this process currently holds.
 func heldSessionGeneration() sessionGeneration {
 	tokenMu.Lock()
@@ -626,6 +631,10 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 		if fresh, ok := rotatedCLISessionToken(seen); ok {
 			return adoptRotated(fresh), nil
 		}
+		// Test seam: lets a test publish a winner in the check/acquire gap.
+		if beforeAcquireHook != nil {
+			beforeAcquireHook()
+		}
 		handle, err := BeginRotation()
 		if errors.Is(err, ErrRotationInProgress) {
 			// Another process holds the marker. Never exchange alongside it:
@@ -640,17 +649,26 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 			return RefreshAccessTokenResponse{}, err
 		}
 		rotationHandle = handle
-		// The marker must survive exactly one outcome: the remote exchange
-		// succeeded and the local write did not. That is the unrecoverable
-		// window -- the presented token is dead upstream and no replacement
-		// reached disk. Every other failure left the stored token untouched, so
-		// clearing the marker avoids sending the user to auth login over a
-		// transport blip. On success SaveCLISession has already removed it.
+		// Registered before the re-check below, so an early return there still
+		// releases the marker. The marker must survive exactly one outcome: the
+		// remote exchange succeeded and the local write did not. That is the
+		// unrecoverable window -- the presented token is dead upstream and no
+		// replacement reached disk. Every other path left the stored token
+		// untouched, so clearing it avoids sending the user to auth login over
+		// a transport blip. On success SaveCLISession has already removed it.
 		defer func() {
 			if !exchanged {
 				rotationHandle.Abort()
 			}
 		}()
+		// Re-check now that the marker is held. The first check and the acquire
+		// are not atomic: a winner can persist its session and drop the marker
+		// in the gap between them, which would leave this caller holding a
+		// fresh marker and about to spend a refresh token already consumed.
+		// Checking again under the marker closes that window.
+		if fresh, ok := rotatedCLISessionToken(seen); ok {
+			return adoptRotated(fresh), nil
+		}
 	}
 
 	body, _ := json.Marshal(map[string]string{

--- a/library/productivity/granola/internal/store/schema_version_test.go
+++ b/library/productivity/granola/internal/store/schema_version_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -89,6 +91,132 @@ func TestSchemaVersion_RefusesNewerDB(t *testing.T) {
 	_, err = Open(dbPath)
 	if err == nil {
 		t.Fatalf("expected open to fail on newer schema, got nil")
+	}
+}
+
+// granolaProvenanceSchemaVersion is the version the provenance round was
+// stamped at: row_source on folders / panel_templates / recipes /
+// recipes_usage, plus the folder description and is_favourited columns, all
+// added by granola.EnsureSchema.
+//
+// Asserted as a floor rather than an equality so a later, unrelated bump does
+// not have to edit this test. The failure it exists to catch is the opposite
+// one — shipping the migration without moving StoreSchemaVersion at all, which
+// leaves a pre-bump binary free to open the migrated database and write these
+// tables without row_source.
+const granolaProvenanceSchemaVersion = 4
+
+// TestSchemaVersion_CoversGranolaProvenanceColumns pins the bump that the
+// provenance columns require, and that a fresh database is stamped with it.
+func TestSchemaVersion_CoversGranolaProvenanceColumns(t *testing.T) {
+	if StoreSchemaVersion < granolaProvenanceSchemaVersion {
+		t.Fatalf("StoreSchemaVersion = %d, want >= %d: the row_source / folder-metadata migration changes table shape, "+
+			"so an older binary must be locked out rather than allowed to write rows without row_source",
+			StoreSchemaVersion, granolaProvenanceSchemaVersion)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open fresh db: %v", err)
+	}
+	defer s.Close()
+
+	v, err := s.SchemaVersion()
+	if err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	if v < granolaProvenanceSchemaVersion {
+		t.Fatalf("fresh db stamped %d, want >= %d", v, granolaProvenanceSchemaVersion)
+	}
+}
+
+// TestSchemaVersion_RefusesDBStampedAboveBinary is the downgrade half of the
+// same contract, expressed the only way a test compiled at the current version
+// can: a database one version above this binary. It is the exact relationship
+// a version-4 database has to a version-3 binary, and the message must tell the
+// operator to upgrade the binary rather than leaving them with a bare SQL
+// error from a column their build does not know about.
+func TestSchemaVersion_RefusesDBStampedAboveBinary(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	if _, err := raw.Exec(fmt.Sprintf(`PRAGMA user_version = %d`, StoreSchemaVersion+1)); err != nil {
+		t.Fatalf("stamp next version: %v", err)
+	}
+	raw.Close()
+
+	_, err = Open(dbPath)
+	if err == nil {
+		t.Fatalf("expected Open to refuse a database stamped %d against a binary at %d",
+			StoreSchemaVersion+1, StoreSchemaVersion)
+	}
+	want := fmt.Sprintf("database schema version %d is newer than supported version %d; upgrade the CLI binary or open an older database",
+		StoreSchemaVersion+1, StoreSchemaVersion)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("Open error = %q, want it to contain %q", err.Error(), want)
+	}
+}
+
+// TestMigrate_StampsPreProvenanceDBInPlace verifies the upgrade direction: a
+// database an older binary left at version 3 opens, migrates to the current
+// version, and keeps its rows.
+func TestMigrate_StampsPreProvenanceDBInPlace(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	// The version-3 shape: resources already on the composite key, so the
+	// only thing this open should change is the version stamp.
+	if _, err := raw.Exec(`CREATE TABLE resources (
+		id TEXT NOT NULL,
+		resource_type TEXT NOT NULL,
+		data JSON NOT NULL,
+		synced_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (resource_type, id)
+	)`); err != nil {
+		raw.Close()
+		t.Fatalf("create v3 resources: %v", err)
+	}
+	if _, err := raw.Exec(`INSERT INTO resources (id, resource_type, data) VALUES ('kept', 'note', '{"kind":"note"}')`); err != nil {
+		raw.Close()
+		t.Fatalf("insert v3 resource: %v", err)
+	}
+	if _, err := raw.Exec(`PRAGMA user_version = 3`); err != nil {
+		raw.Close()
+		t.Fatalf("stamp v3: %v", err)
+	}
+	raw.Close()
+
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open v3 db: %v", err)
+	}
+	defer s.Close()
+
+	v, err := s.SchemaVersion()
+	if err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	if v != StoreSchemaVersion {
+		t.Fatalf("migrated version = %d, want %d", v, StoreSchemaVersion)
+	}
+	if v < granolaProvenanceSchemaVersion {
+		t.Fatalf("migrated version = %d, want >= %d", v, granolaProvenanceSchemaVersion)
+	}
+
+	data, err := s.Get("note", "kept")
+	if err != nil {
+		t.Fatalf("get row carried across the migration: %v", err)
+	}
+	if string(data) != `{"kind":"note"}` {
+		t.Fatalf("row after migration = %s, want {\"kind\":\"note\"}", data)
 	}
 }
 

--- a/library/productivity/granola/internal/store/store.go
+++ b/library/productivity/granola/internal/store/store.go
@@ -51,7 +51,17 @@ func IsUUID(s string) bool {
 // and reassigns ownership of the survivors. Refusing to open is the only
 // safe downgrade behavior, and it is what the paragraph above already
 // prescribes for any migration that changes table shape.
-const StoreSchemaVersion = 3
+//
+// PATCH(catalog-provenance-and-merge): bumped 3 -> 4 for the row_source
+// ownership columns granola.EnsureSchema now adds to folders,
+// panel_templates, recipes and recipes_usage, plus the folders description
+// and is_favourited columns. Same load-bearing gate, one table set further
+// out: a pre-bump binary opening a migrated database still writes these four
+// tables with `INSERT OR REPLACE` and no row_source, so every write deletes
+// the conflicting row, falls back to the column default, and silently
+// reassigns every API-owned catalog row to the cache path — while blanking
+// the folder metadata columns it does not know exist.
+const StoreSchemaVersion = 4
 
 const resourcesFTSCreateSQL = `CREATE VIRTUAL TABLE IF NOT EXISTS resources_fts USING fts5(
 	id, resource_type, content, tokenize='porter unicode61'


### PR DESCRIPTION
## What broke

PR #1598 handled Granola's DEK migration, but the CLI stopped returning new meetings anyway. Three Granola changes stacked up, and only the first was known:

1. **The DEK moved** behind a Keychain access group gated by an entitlement bound to Granola's Team ID (7.447.1, already handled).
2. **The local store went SQLCipher.** Granola now writes `granola.db`, keyed with that same DEK. Verified from the 7.465.0 bundle: `better-sqlite3-multiple-ciphers`, `cipher='sqlcipher'`, `legacy=4`, a raw hex key, and a `sqlite-encryption-key-dek-unavailable` failure log. No SQLite magic on disk, plaintext WAL header on the sidecar — the SQLCipher signature. A second door closed by the same lock, not a new opening.
3. **The plaintext auth files stopped being written.** `supabase.json` and `stored-accounts.json` were last written 2026-05-04 and 2026-05-19; only the `.enc` variants are current, so the plaintext fallback reads fossils with months-expired tokens.

Separately, four commands were broken for reasons unrelated to any of that — see the read-path section below.

## Why the CLI needs its own session

Every credential left on the machine belongs to another client. WorkOS refresh tokens are single-use — a second exchange returns `invalid_grant`, "Refresh token already exchanged" — so refreshing the desktop app's or the browser's chain signs *that* client out. That is what the existing D6 guard has always protected, and it is why borrowing cannot be made durable.

`auth login` runs Granola's device authorization grant and stores the result under the CLI's own data directory. Verified live: the grant returns a refreshable session, accepted by `/v2/get-documents` and by the transcript, panel and document-list endpoints, and Granola's own `/v1/refresh-access-token` proxy renews it. Contract recorded in `safestorage/testdata/scheme.md` — shapes only, no token material.

## The data-loss bug this nearly shipped with

Making the degraded sync work is a two-line change. Doing it naively destroys data.

`SyncFromCache` treats an absent cache-derived row as deleted-upstream and retires it: a table-wide `DELETE FROM folder_memberships WHERE row_source='cache'`, and `prepareSegmentRewrite`'s zero-incoming branch clearing cache-owned transcript segments for every meeting the API returns. With an empty cache both fire on every row, and once the DEK is out of reach those rows can never be re-synced. The `row_source` scoping protects each path from the *other* path's deletes; it does not protect the cache path from its own.

Measured against a real 992-meeting store: meetings went 897 → 992 while cache-owned transcript segments held at 5,385 and folder memberships at 153.

## Transcripts

The transcript endpoint accepts a CLI-owned session, but has no bulk form — a backfill is one rate-limited call per meeting. So it is newest-first, bounded per run (`--transcript-budget`, default 250, `-1` for all), and backed by a fetch-state table so meetings with no recording are asked about once rather than on every sync forever. `sync` reports what remains. A full backfill on the author's account reached 951 of 963 meetings and 465k segments.

## The read path — four commands broken for a different reason

`recipes list`, `recipes describe`, `chat list` and `chat get` called the cache-only loader and aborted on a decrypt that can never succeed, while the store already held 57 recipes and 225 chat threads. Those call sites were simply never moved onto the store-first seam every other read command uses. Fixing that required building the store readers first: the `recipes`, `recipes_usage`, `chat_threads` and `chat_messages` tables had been written on every sync since the CLI shipped and read by nothing.

Removing a loud error must not leave a quiet wrong answer, so store-served reads carry a `staleness` block in both human and JSON output. Which clock dates it is load-bearing: the general sync timestamp advances on every invocation because auto-refresh runs an API sync each time, so using it would stamp months-old rows as current. Refreshable surfaces are dated by the catalog refresh; frozen ones by the last successful cache decrypt.

Chats are the only genuinely frozen surface — seven endpoint namings probed, all 404 — and `chat list` says so.

## Catalog refresh and ownership

Recipes, panel templates and folders each come back in a single API call, so they refresh on every degraded sync with no budget machinery. Folder membership arrives in the same call: `/v2/get-document-lists` carries a `documents` array the Go type had no field for, so the code was discarding edges it already received. On the author's machine that took memberships from 153 to 234.

That required fixing how those four tables are written. They used `INSERT OR REPLACE`, which deletes and reinserts — blanking every column the payload omits and rewriting `row_source` to whichever path wrote last, which on a degraded sync would reassign every cache-owned row to the API. They now merge with `ON CONFLICT DO UPDATE`, `row_source` deliberately excluded from the SET list. A no-DELETE guard using `BEFORE DELETE` triggers proves the REPLACE is gone; it fires against the old code.

`is_favourited` is a boolean and cannot be coalesced that way, so it is owner-scoped: the owning path may clear it, a foreign path may not. Otherwise the API refresh would silently un-favourite every folder.

`StoreSchemaVersion` goes 3 → 4. The constant's contract requires a bump when a migration adds columns, and the hazard is concrete: a pre-bump binary's write omits `row_source`, falls back to the default, and reassigns ownership silently.

## Verification

```
go build ./...     ok
go vet ./...       ok
go test ./...      440 passed
govulncheck ./...  0 vulnerabilities
verify_skill.py    all checks passed
```

End to end on a migrated install: `auth login` → `sync` reports `last_token_source=cli_session`, `scheme_migrated`, and refreshes 57 recipes / 31 panel templates / 6 folders / 234 memberships; `meetings list`, `recipes list` and `chat list` all return data that previously errored; Granola desktop stayed signed in throughout.

Pre-existing tests pass unmodified except two deliberate changes, both noted in their commits: the safestorage remedy assertions moved from "Business or Enterprise" to `auth login` because the remedy legitimately changed, and two `cacheOnlyCallSites` allowlist entries were retired because that test fails on stale entries by design. The D6 refusal tests are untouched.

## Scope

Not included: reading `granola.db` (same unreadable key), changes to the public REST path, persisting panel content (`panel get` already works live), and the top-level `folders` command, which targets the public REST API and would change behavior for key-holding users.

## Security Disclosure

This adds a stored credential. The CLI keeps a WorkOS session at `~/.local/share/granola-pp-cli/session.json`, mode `0600` in a `0700` directory — the directory is explicitly tightened, since `MkdirAll` is a no-op on the `0755` directory every synced install already has. Writes are fsync-rename-fsync with an in-flight rotation marker so an interrupted rotation is detectable rather than silently unrecoverable. Both tokens are redacted from `String`/`GoString`, and a group- or world-readable session file is refused rather than used.

The session is minted through a Granola auth surface not issued to this CLI, so upstream revocation or re-scoping is a live possibility; a patch entry records that so `auth login` failures are triaged as drift. `auth logout` removes the local copy only — it does not revoke upstream, and the README says so. No cookie, keychain, or other application's credential store is read.

## Agent Disclosure

Claude Code · claude-fable-5. Both plans were reviewed by multi-persona passes, one including an independent cross-model review; the data-loss finding above came from two independently dispatched reviewers before any code existed.
