### PR TITLE
test(table-reservation-goat): fix racy explicit-card legacy-slot fixture

### DIFF
--- a/library/food-and-dining/table-reservation-goat/.printing-press-patches/tock-explicit-card-fixture-non-submitting-button.json
+++ b/library/food-and-dining/table-reservation-goat/.printing-press-patches/tock-explicit-card-fixture-non-submitting-button.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "tock-explicit-card-fixture-non-submitting-button",
+  "applied_at": "2026-08-12",
+  "base_run_id": "20260712-223206",
+  "base_printing_press_version": "4.28.0",
+  "summary": "Keep the Tock explicit-card browser fixture button non-submitting so its click marker can be read deterministically.",
+  "reason": "A typeless button inside the fixture form submits and navigates after the synthetic click, racing the test's read of window.clickedOwn. Explicit type=button preserves the form attribution boundary without incidental navigation.",
+  "files": [
+    "internal/source/tock/chrome_book_test.go"
+  ],
+  "validated_outcome": "The focused Chrome-backed regression passes repeatedly without the fixture navigation race."
+}

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book_test.go
@@ -1231,7 +1231,9 @@ func TestClickPinnedSlotByTimeText_ExplicitCardInsulatesFromForeignFormLink(t *t
 		<form>
 		  <a href="/venue/experience/111111">Cross-sell</a>
 		  <section class="experience-card">
-		    <button onclick="window.clickedOwn = true;">6:15 PM Book</button>
+		    <!-- type=button: a typeless button in a form is type=submit, and the
+		         submit navigation races the test's read of window.clickedOwn -->
+		    <button type="button" onclick="window.clickedOwn = true;">6:15 PM Book</button>
 		  </section>
 		</form>`
 	withTockDOMFixtureAtPath(t, "/venue/experience/520126", html, func(ctx context.Context) {


### PR DESCRIPTION
## Problem

`TestClickPinnedSlotByTimeText_ExplicitCardInsulatesFromForeignFormLink` is flaky — on our machine it recently degraded to failing ~8 of 10 solo runs (`explicit-card candidate was not clicked`), and it fails intermittently under full-suite Chrome contention.

## Root cause

The fixture's Book control has no `type` attribute, and a typeless `<button>` inside a `<form>` is implicitly `type=submit`. The production code's synthetic click therefore does two things: fires the `onclick` that sets `window.clickedOwn`, **and submits the form** — navigating/reloading the page and wiping the global. Whether the test's subsequent `chromedp.Evaluate` of `window.clickedOwn` wins the race against that navigation is pure timing. The race has been latent since the fixture was introduced (#1514); a Chrome update shifted the timing enough to make it lose most of the time.

The sibling fixtures in this family (`ForeignCrossSellBeforeOwnSlot`, `SoleUntiedPageOwnSlot`, …) don't flake because none of them wrap the control in a `<form>`.

## Fix

One line: `type="button"`. The form's role in this test is to be an **attribution boundary** (a foreign link sharing the form must not vouch against the explicit card) — submission was never the thing under test, and the boundary semantics are unchanged.

## Verification

- Before: ~2/10 solo passes on a clean checkout (`-count=10`).
- After: 10/10 solo passes on current `main` (`ea0c3cd89`) + this change, and our full Chrome-backed tock suite runs green with it.

Not a production bug — the attribution logic selects and clicks the correct control; only the fixture's observation of the click was racy.

https://claude.ai/code/session_017ZgvVfyPxcLHYy5DPoDf37