### PR TITLE
feat(google-analytics): add gated GA4 Admin write surface

### DIFF
--- a/library/marketing/google-analytics/.printing-press-patches/ga4-admin-write-surface.json
+++ b/library/marketing/google-analytics/.printing-press-patches/ga4-admin-write-surface.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 2,
+  "id": "ga4-admin-write-surface",
+  "applied_at": "2026-08-06",
+  "base_run_id": "ga4-20260612",
+  "base_printing_press_version": "4.20.1",
+  "summary": "feat(google-analytics): add gated GA4 Admin write surface; accept ADC authorized_user credentials",
+  "reason": "The printed CLI was read-only by construction: MintToken hard-coded analytics.readonly and --credentials assumed a service-account key, so ADC authorized_user credentials were rejected and there was no path to create, patch, archive, or delete anything in GA4. Two throwaway Python scripts were filling the gap; this absorbs their surface into the CLI.",
+  "files": [
+    "internal/ga4/types.go",
+    "internal/ga4/auth.go",
+    "internal/ga4/client.go",
+    "internal/ga4/admin.go",
+    "internal/ga4/admin_test.go",
+    "internal/cli/root.go",
+    "internal/cli/health.go",
+    "internal/cli/confirm.go",
+    "internal/cli/admin_write_commands.go",
+    "internal/cli/admin_write_commands_test.go",
+    "internal/cli/agent_context.go",
+    "README.md",
+    "SKILL.md",
+    "AGENTS.md",
+    "CHANGELOG.md",
+    ".printing-press.json"
+  ],
+  "validated_outcome": "go build, go vet, go test (37 tests), govulncheck, go mod tidy, --help and --version all pass. The repo's own .github/scripts/verify-skill/verify_skill.py goes from 6 errors on upstream/main to all checks passing. Destructive-gate behavior smoke-tested against the built binary: delete/archive refuse under --agent alone and proceed only with a typed --yes.",
+  "findings_addressed": ["F1", "F2", "F3", "F4", "F5", "F6", "F7"],
+  "notes": "Three publish-validate failures (manifest schema_version 1 vs required 2, phase5 marker schema_version 0, SKILL.md canonical install-section drift) are pre-existing on upstream/main and reproduce identically on a pristine checkout. They are schema-era artifacts of the original 4.20.1 print and require a reprint, not a patch; the canonical install text is explicitly generator-owned and must not be hand-edited. They were masked on baseline because verify-skill stopped at the shell-var-quotes category this patch fixes."
+}

--- a/library/marketing/google-analytics/.printing-press.json
+++ b/library/marketing/google-analytics/.printing-press.json
@@ -2,7 +2,7 @@
   "api_name": "google-analytics",
   "cli_name": "google-analytics-pp-cli",
   "category": "marketing",
-  "description": "Agent-first Google Analytics 4 CLI with typed Data/Admin/Funnel API coverage and one-call reports for channels, pages, funnels, anomalies, revenue, and health.",
+  "description": "Agent-first Google Analytics 4 CLI with typed Data/Admin/Funnel API coverage, one-call reports for channels, pages, funnels, anomalies, revenue, and health, plus a gated GA4 Admin write surface for key events, custom dimensions/metrics, and data streams.",
   "spec_format": "openapi3-curated",
   "spec_source": "curated-ga4-data-admin-apis",
   "spec_checksum": "sha256:2dfe6cb7ef79f217ae73793eda907af9aa0f5368f4fa9a41ed16a89e62089da0",
@@ -21,6 +21,7 @@
   ],
   "auth_env_vars": [
     "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_ANALYTICS_ADC",
     "GA4_PROPERTY_ID",
     "GA4_PROPERTY_IDS"
   ],
@@ -54,6 +55,36 @@
       "name": "Agent-Context",
       "command": "agent-context",
       "description": "agent-context emits structured tool metadata for agents"
+    },
+    {
+      "name": "Key-Events",
+      "command": "key-events",
+      "description": "key-events lists, creates, patches, and deletes GA4 key events (conversions) through the Admin API"
+    },
+    {
+      "name": "Custom-Dimensions",
+      "command": "custom-dimensions",
+      "description": "custom-dimensions lists, creates, and archives GA4 custom dimensions"
+    },
+    {
+      "name": "Custom-Metrics",
+      "command": "custom-metrics",
+      "description": "custom-metrics lists, creates, and archives GA4 custom metrics"
+    },
+    {
+      "name": "Data-Streams",
+      "command": "data-streams",
+      "description": "data-streams manages the full data stream lifecycle with an updateMask built only from the flags actually passed"
+    },
+    {
+      "name": "Admin",
+      "command": "admin",
+      "description": "admin is a generic Admin API escape hatch over any method/path with --body, --update-mask, and --api v1beta|v1alpha for resources such as accessBindings that exist only in v1alpha"
+    },
+    {
+      "name": "Destructive-Write-Gate",
+      "command": "key-events delete",
+      "description": "destructive writes require --yes to appear on the command line; --agent implies --yes for prompts but deliberately does not authorize destruction"
     }
   ],
   "mcp": false,
@@ -63,8 +94,8 @@
   "printer_name": "Cathryn Lavery",
   "owner": "cathrynlavery",
   "owner_name": "Cathryn Lavery",
-  "auth_type": "service_account_jwt",
+  "auth_type": "service_account_jwt_or_authorized_user",
   "spec_url": "https://developers.google.com/analytics/devguides/reporting/data/v1",
-  "version": "1.1.0",
-  "catalog_description": "Agent-first Google Analytics 4 CLI with typed Data/Admin/Funnel API coverage and one-call reports for channels, pages, funnels, anomalies, revenue, and health."
+  "version": "1.2.0",
+  "catalog_description": "Agent-first Google Analytics 4 CLI with typed Data/Admin/Funnel API coverage, one-call reports for channels, pages, funnels, anomalies, revenue, and health, plus a gated GA4 Admin write surface for key events, custom dimensions/metrics, and data streams."
 }

--- a/library/marketing/google-analytics/AGENTS.md
+++ b/library/marketing/google-analytics/AGENTS.md
@@ -4,13 +4,33 @@ This CLI is GA4-only. Do not add Search Console endpoints here; use `google-sear
 
 ## Auth
 
-Use a Google service account JSON key with `https://www.googleapis.com/auth/analytics.readonly`. Resolution order:
+Two credential shapes are supported and detected by `ga4.Credentials.Kind()`:
+
+- `service_account` — `client_email` + `private_key`; mints an RS256 JWT for the requested scope.
+- `authorized_user` — `client_id` + `client_secret` + `refresh_token` (ADC); exchanges the refresh token. **Do not send a scope on that request** — the original grant fixes it, and the CLI must not imply otherwise.
+
+Resolution order:
 
 1. `--credentials`
-2. `GOOGLE_APPLICATION_CREDENTIALS`
-3. No implicit local fallback. Pass `--credentials` or set `GOOGLE_APPLICATION_CREDENTIALS`.
+2. `GOOGLE_ANALYTICS_ADC`
+3. `GOOGLE_APPLICATION_CREDENTIALS`
+4. No implicit local fallback. Never hard-code a credential path — in particular, do not port the developer-local ADC path from any scratch script.
+
+Scopes: reads use `ga4.AnalyticsReadonlyScope` via `flags.newClient()`; writes use `ga4.AnalyticsEditScope` via `flags.newWriteClient()`. Clients are cached per scope.
 
 Property resolution for data commands is `--property`, then `GA4_PROPERTY_ID`. Do not hard-code brand property IDs in command implementations. Fleet checks can pass `health --properties <comma-list>` or set `GA4_PROPERTY_IDS`.
+
+## Destructive-write gate
+
+Every `delete` and both `archive` subcommands must call `requireExplicitYes(cmd, action)` before doing anything else.
+
+That helper checks `cmd.Flags().Changed("yes")` and **must never be rewritten to read `rootFlags.yes`**: `--agent` sets that field to true, so reading it would let agent mode authorize destruction on its own. New destructive commands must reuse the helper rather than rolling their own check.
+
+## Admin API versions
+
+`Client.AdminBase` is v1beta and `Client.AdminAlphaBase` is v1alpha. `Client.AlphaBase` is the **Data** API alpha host used by `funnel` — do not reuse it for Admin calls.
+
+`accessBindings` exists only in v1alpha; v1beta answers 404 with an HTML page, not JSON. That is why `admin` exposes `--api`.
 
 ## Required validation
 
@@ -19,3 +39,8 @@ Property resolution for data commands is `--property`, then `GA4_PROPERTY_ID`. D
 - `google-analytics-pp-cli agent-context --agent`
 - `google-analytics-pp-cli health --properties $GA4_PROPERTY_IDS --agent` when credentials/property grants are available
 - Live the first authorized property smoke: `channels`, `compare`, `whats-changed`, `funnel`
+- Gate smoke (no credentials needed, must exit non-zero without touching the network):
+  `google-analytics-pp-cli key-events delete --name properties/1/keyEvents/x --agent`
+- Live write smoke when an `analytics.edit` grant is available: `key-events list`, then
+  `key-events create` against an event that already exists and confirm `409 ALREADY_EXISTS`
+  rather than creating a new resource

--- a/library/marketing/google-analytics/CHANGELOG.md
+++ b/library/marketing/google-analytics/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.2.0 - 2026-08-06
+
+- Adds a GA4 Admin API write surface: `key-events` (list/create/patch/delete), `custom-dimensions` and `custom-metrics` (list/create/archive), and `data-streams` (list/get/create/patch/delete).
+- Adds `admin <GET|POST|PATCH|PUT|DELETE> <path>` as a generic Admin escape hatch with `--body` (inline or `@file`), `--update-mask`, `--api v1beta|v1alpha`, and `--no-paginate`. `--api v1alpha` reaches resources such as `accessBindings` that v1beta answers with a 404 HTML page.
+- Accepts ADC `authorized_user` credentials (`client_id` + `client_secret` + `refresh_token`) alongside service-account JSON keys, and adds `GOOGLE_ANALYTICS_ADC` to the resolution order. Previously `--credentials` assumed a service account, which blocked the whole write path.
+- Requests `analytics.edit` for writes while reads keep `analytics.readonly`, caching one client per scope.
+- Gates every destructive mutation behind a typed `--yes`. The check inspects whether the flag appeared on the command line, so `--agent` (which implies `--yes`) cannot authorize a delete or archive on its own.
+- Surfaces actionable hints on Admin failures: 403 distinguishes a missing Editor/Administrator role from a missing scope, and 404 suggests retrying with `--api v1alpha`.
+
 ## 2026.7.1 - 2026-07-08
 
 - fix(catalog): require Go 1.26.5 across published modules (#1467).

--- a/library/marketing/google-analytics/README.md
+++ b/library/marketing/google-analytics/README.md
@@ -1,6 +1,6 @@
 # Google Analytics 4 Printing Press CLI
 
-`google-analytics-pp-cli` is an agent-first GA4 CLI for live analytics work. It covers the GA4 Data API, the GA4 Admin API discovery calls, and curated novel commands that answer the questions agents actually ask without stitching multiple raw API calls together.
+`google-analytics-pp-cli` is an agent-first GA4 CLI for live analytics work. It covers the GA4 Data API, the GA4 Admin API — reads *and* writes — and curated novel commands that answer the questions agents actually ask without stitching multiple raw API calls together.
 
 Created by [@cathrynlavery](https://github.com/cathrynlavery) (Cathryn Lavery).
 Contributors: [@cathrynlavery](https://github.com/cathrynlavery) (Cathryn Lavery).
@@ -13,13 +13,20 @@ PP_LIBRARY_REPO=/path/to/printing-press-library pp-sync build google-analytics-p
 
 ## Auth
 
-Use a service-account JSON key with Analytics readonly scope. Set `GOOGLE_APPLICATION_CREDENTIALS` to your service-account JSON path, or pass `--credentials` explicitly.
+Two credential shapes are accepted, and the CLI detects which one you handed it:
 
-Resolution order: `--credentials`, then `GOOGLE_APPLICATION_CREDENTIALS`. There is no implicit developer-local credential fallback.
+- **Service-account JSON key** (`client_email` + `private_key`) — the classic path. Signs an RS256 JWT and requests the scope the command needs.
+- **ADC `authorized_user` JSON** (`client_id` + `client_secret` + `refresh_token`) — what `gcloud auth application-default login` writes. Exchanges the refresh token for an access token.
+
+Resolution order: `--credentials`, then `GOOGLE_ANALYTICS_ADC`, then `GOOGLE_APPLICATION_CREDENTIALS`. A leading `~/` is expanded. There is no implicit developer-local credential fallback.
+
+Scopes: reads request `analytics.readonly`; writes request `analytics.edit`. A service account that only holds readonly will mint fine for reads and fail at mint time for writes. An `authorized_user` token carries whatever the original grant allowed — the CLI cannot narrow it, so `health` reports `scope_requested`, not scope granted.
 
 GA4 property resolution for data commands: `--property`, then `GA4_PROPERTY_ID`. The CLI does not hard-code the first authorized property or the second authorized property property IDs. For fleet health checks, pass explicit properties or set `GA4_PROPERTY_IDS`.
 
 Important gotcha: Google Cloud API access is not GA4 property access. The service account must also be granted Viewer access inside each GA4 property. `health` / `doctor` distinguishes invalid credentials from property not shared / permission denied.
+
+Writes need more than the scope: the account must be **Editor or Administrator** on the property. A `403` on a write means the token carried the scope but the role was missing — the CLI says so in the error.
 
 ## Global agent flags
 
@@ -29,7 +36,7 @@ Every command inherits:
 - `--json`
 - `--compact`
 - `--no-input`
-- `--yes`
+- `--yes` — also the explicit authorization for destructive Admin writes (see below); `--agent` alone does not satisfy that gate
 - `--property`
 - `--credentials`
 - `--timeout`
@@ -45,6 +52,7 @@ Every command inherits:
 - `properties` — Admin API `accountSummaries.list`
 - `property` — Admin API `properties.get`
 - `streams` — Admin API `properties.dataStreams.list`
+- `admin` — escape hatch for any Admin API path/method (see Admin write surface)
 
 ## Novel commands
 
@@ -59,13 +67,94 @@ Every command inherits:
 - `audience` / `cohort` — cheap audience and retention snapshots.
 - `health` / `doctor` — token mint, Admin visibility, and per-property access grants.
 
+## Admin write surface
+
+Everything below mutates your GA4 configuration. Reads inside these groups (`list`, `get`) use the readonly scope; mutations use `analytics.edit`.
+
+### The destructive-action gate
+
+Destructive calls — every `delete`, plus `custom-dimensions archive` and `custom-metrics archive` — require a **typed** `--yes`:
+
+```bash
+# refused: --agent implies --yes, and that is deliberately not enough
+google-analytics-pp-cli key-events delete --name properties/123/keyEvents/abc --agent
+
+# allowed: --yes was actually typed
+google-analytics-pp-cli key-events delete --name properties/123/keyEvents/abc --agent --yes
+```
+
+The gate inspects whether the `--yes` flag was set on the command line, not the resolved value, so an agent running in `--agent` mode can read and create but cannot destroy without a human putting `--yes` in the invocation.
+
+### key-events
+
+```bash
+google-analytics-pp-cli key-events list --property "$GA4_PROPERTY_ID" --agent
+google-analytics-pp-cli key-events create --property "$GA4_PROPERTY_ID" --event generate_lead --agent
+google-analytics-pp-cli key-events create --property "$GA4_PROPERTY_ID" --event purchase --counting ONCE_PER_SESSION --agent
+google-analytics-pp-cli key-events patch --name properties/123/keyEvents/abc --counting ONCE_PER_EVENT --agent
+google-analytics-pp-cli key-events delete --name properties/123/keyEvents/abc --agent --yes
+```
+
+Creating a key event that already exists returns `409 ALREADY_EXISTS` — which is the cheapest way to prove your credential can write without actually changing anything.
+
+### custom-dimensions / custom-metrics
+
+```bash
+google-analytics-pp-cli custom-dimensions list --property "$GA4_PROPERTY_ID" --agent
+google-analytics-pp-cli custom-dimensions create --property "$GA4_PROPERTY_ID" \
+  --parameter plan --display-name Plan --scope EVENT --agent
+google-analytics-pp-cli custom-dimensions archive --name properties/123/customDimensions/456 --agent --yes
+
+google-analytics-pp-cli custom-metrics list --property "$GA4_PROPERTY_ID" --agent
+google-analytics-pp-cli custom-metrics create --property "$GA4_PROPERTY_ID" \
+  --parameter cart_value --display-name "Cart Value" --measurement-unit CURRENCY --agent
+```
+
+Archiving frees the parameter slot and is not reversible from the API, so it is gated like a delete.
+
+### data-streams
+
+`streams` remains the read shorthand; `data-streams` adds the full lifecycle.
+
+```bash
+google-analytics-pp-cli data-streams list --property "$GA4_PROPERTY_ID" --agent
+google-analytics-pp-cli data-streams create --property "$GA4_PROPERTY_ID" \
+  --display-name "Marketing site" --type WEB_DATA_STREAM --uri https://example.com --agent
+google-analytics-pp-cli data-streams patch --name properties/123/dataStreams/456 --display-name "Renamed" --agent
+google-analytics-pp-cli data-streams delete --name properties/123/dataStreams/456 --agent --yes
+```
+
+`patch` builds its `updateMask` from the flags you actually passed, so it never clobbers a field you did not mention.
+
+### admin — the escape hatch
+
+Not every Admin resource has a typed command, and some live only in `v1alpha`. `admin` reaches any of them:
+
+```bash
+google-analytics-pp-cli admin GET properties/123/customDimensions --agent
+google-analytics-pp-cli admin POST properties/123/keyEvents \
+  --body '{"eventName":"signup","countingMethod":"ONCE_PER_EVENT"}' --agent
+google-analytics-pp-cli admin PATCH properties/123/keyEvents/abc \
+  --update-mask countingMethod --body '{"countingMethod":"ONCE_PER_SESSION"}' --agent
+google-analytics-pp-cli admin POST properties/123/customDimensions --body @dimension.json --agent
+google-analytics-pp-cli admin DELETE properties/123/customDimensions/456 --agent --yes
+```
+
+**`accessBindings` only exists in `v1alpha`.** Ask `v1beta` for it and Google answers `404` with an HTML error page rather than JSON:
+
+```bash
+google-analytics-pp-cli admin GET properties/123/accessBindings --api v1alpha --agent
+```
+
+`GET` paginates and merges the repeated list field by default; pass `--no-paginate` for a single raw page. `--body` takes inline JSON or `@file.json`. A `404` reminds you to retry with `--api v1alpha`.
+
 ## Examples
 
 ```bash
 google-analytics-pp-cli agent-context --agent
-google-analytics-pp-cli health --properties $GA4_PROPERTY_IDS --agent
-google-analytics-pp-cli channels --property $GA4_PROPERTY_ID --start 28daysAgo --end yesterday --agent
-google-analytics-pp-cli compare --property $GA4_PROPERTY_ID --metric sessions,totalRevenue --period wow --agent
-google-analytics-pp-cli whats-changed --property $GA4_PROPERTY_ID --agent
-google-analytics-pp-cli funnel --property $GA4_PROPERTY_ID --steps view_item,add_to_cart,begin_checkout,purchase --agent
+google-analytics-pp-cli health --properties "$GA4_PROPERTY_IDS" --agent
+google-analytics-pp-cli channels --property "$GA4_PROPERTY_ID" --start 28daysAgo --end yesterday --agent
+google-analytics-pp-cli compare --property "$GA4_PROPERTY_ID" --metric sessions,totalRevenue --period wow --agent
+google-analytics-pp-cli whats-changed --property "$GA4_PROPERTY_ID" --agent
+google-analytics-pp-cli funnel --property "$GA4_PROPERTY_ID" --steps view_item,add_to_cart,begin_checkout,purchase --agent
 ```

--- a/library/marketing/google-analytics/SKILL.md
+++ b/library/marketing/google-analytics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-google-analytics
-description: Google Analytics 4 Printing Press CLI for GA4 raw reports, funnels, acquisition/revenue insights, period comparisons, anomaly scans, and property-access health checks.
+description: Google Analytics 4 Printing Press CLI for GA4 raw reports, funnels, acquisition/revenue insights, period comparisons, anomaly scans, property-access health checks, and gated GA4 Admin writes (key events, custom dimensions/metrics, data streams).
 tags: [printing-press, ga4, google-analytics, analytics, marketing]
 ---
 
@@ -27,25 +27,27 @@ If `--version` reports "command not found" after install, the runtime cannot see
 
 ## When to Use This CLI
 
-Use this CLI when an agent needs live GA4 property data, acquisition/revenue summaries, ecommerce diagnostics, funnels, period comparisons, anomaly scans, or property-access diagnostics. Use `google-search-console-pp-cli` for Search Console.
+Use this CLI when an agent needs live GA4 property data, acquisition/revenue summaries, ecommerce diagnostics, funnels, period comparisons, anomaly scans, or property-access diagnostics. It also administers GA4 configuration: key events, custom dimensions and metrics, and data streams. Use `google-search-console-pp-cli` for Search Console.
 
 
 Use `google-analytics-pp-cli` for GA4-only analytics work. Search Console is covered by `google-search-console-pp-cli`; do not use the legacy combined GSC/GA4 CLI for new work.
 
 ## Auth and property selection
 
-- Service account key: `--credentials`, else `GOOGLE_APPLICATION_CREDENTIALS`.
-- Scope: `https://www.googleapis.com/auth/analytics.readonly`.
+- Credentials: `--credentials`, else `GOOGLE_ANALYTICS_ADC`, else `GOOGLE_APPLICATION_CREDENTIALS`. Both a service-account JSON key and an ADC `authorized_user` JSON (`client_id` + `client_secret` + `refresh_token`, what `gcloud auth application-default login` writes) are accepted; the shape is detected automatically.
+- Scopes: reads request `analytics.readonly`, writes request `analytics.edit`. An `authorized_user` token carries whatever its original grant allowed, so `health` reports `scope_requested`, not scope granted.
 - Property: pass `--property`, or set `GA4_PROPERTY_ID`.
-- Fleet health checks: `health --properties $GA4_PROPERTY_IDS --agent` or set `GA4_PROPERTY_IDS`.
+- Fleet health checks: `health --properties "$GA4_PROPERTY_IDS" --agent` or set `GA4_PROPERTY_IDS`.
 
 Durable gotcha: Google Cloud API access is not GA4 property access. The service account must be granted Viewer access inside the GA4 property. If `health` shows token/admin OK but a property check is 403/404, fix the GA4 property grant rather than rotating credentials.
+
+Durable gotcha for writes: the scope is necessary but not sufficient — the account must also be **Editor or Administrator** on the property. A `403` on a write means the role is missing, not the scope.
 
 ## Best commands for agents
 
 ```bash
 google-analytics-pp-cli agent-context --agent
-google-analytics-pp-cli health --properties $GA4_PROPERTY_IDS --agent
+google-analytics-pp-cli health --properties "$GA4_PROPERTY_IDS" --agent
 google-analytics-pp-cli channels --property "$GA4_PROPERTY_ID" --start 28daysAgo --end yesterday --agent
 google-analytics-pp-cli sources --property "$GA4_PROPERTY_ID" --agent
 google-analytics-pp-cli top-pages --property "$GA4_PROPERTY_ID" --agent
@@ -54,6 +56,39 @@ google-analytics-pp-cli whats-changed --property "$GA4_PROPERTY_ID" --agent
 google-analytics-pp-cli revenue --property "$GA4_PROPERTY_ID" --by channel --agent
 google-analytics-pp-cli funnel --property "$GA4_PROPERTY_ID" --steps view_item,add_to_cart,begin_checkout,purchase --agent
 ```
+
+## Admin writes (gated)
+
+Destructive calls — every `delete`, plus `custom-dimensions archive` and `custom-metrics archive` — require a **typed** `--yes`. `--agent` expands to include `--yes`, and that deliberately does **not** satisfy the gate: the CLI checks whether `--yes` appeared on the command line. An agent can list and create on its own; destroying needs a human to add `--yes`.
+
+```bash
+google-analytics-pp-cli key-events list --property "$GA4_PROPERTY_ID" --agent
+google-analytics-pp-cli key-events create --property "$GA4_PROPERTY_ID" --event generate_lead --agent
+google-analytics-pp-cli key-events patch --name properties/123/keyEvents/abc --counting ONCE_PER_SESSION --agent
+google-analytics-pp-cli key-events delete --name properties/123/keyEvents/abc --agent --yes
+
+google-analytics-pp-cli custom-dimensions create --property "$GA4_PROPERTY_ID" --parameter plan --display-name Plan --scope EVENT --agent
+google-analytics-pp-cli custom-metrics create --property "$GA4_PROPERTY_ID" --parameter cart_value --display-name "Cart Value" --measurement-unit CURRENCY --agent
+google-analytics-pp-cli custom-dimensions archive --name properties/123/customDimensions/456 --agent --yes
+
+google-analytics-pp-cli data-streams list --property "$GA4_PROPERTY_ID" --agent
+google-analytics-pp-cli data-streams create --property "$GA4_PROPERTY_ID" --display-name "Marketing site" --type WEB_DATA_STREAM --uri https://example.com --agent
+```
+
+To prove a credential can write without changing anything, create a key event that already exists and expect `409 ALREADY_EXISTS`.
+
+## Admin escape hatch
+
+`admin <GET|POST|PATCH|PUT|DELETE> <path>` reaches any Admin API resource, including those without a typed command:
+
+```bash
+google-analytics-pp-cli admin GET properties/123/customDimensions --agent
+google-analytics-pp-cli admin PATCH properties/123/keyEvents/abc --update-mask countingMethod --body '{"countingMethod":"ONCE_PER_SESSION"}' --agent
+google-analytics-pp-cli admin POST properties/123/customDimensions --body @dimension.json --agent
+google-analytics-pp-cli admin GET properties/123/accessBindings --api v1alpha --agent
+```
+
+Durable gotcha: **`accessBindings` lives only in `v1alpha`.** Asking `v1beta` returns `404` with an HTML error page instead of JSON. `GET` paginates and merges the list field unless you pass `--no-paginate`; `DELETE` is gated by the typed `--yes` rule above.
 
 ## Raw wrappers
 

--- a/library/marketing/google-analytics/internal/cli/admin_write_commands.go
+++ b/library/marketing/google-analytics/internal/cli/admin_write_commands.go
@@ -1,0 +1,565 @@
+// Copyright 2026 Cathryn Lavery and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-analytics/internal/ga4"
+	"github.com/spf13/cobra"
+)
+
+// hintAdminError surfaces actionable guidance (in English) when an Admin call
+// fails with a role or version problem. The hint lives here, on the CLI side,
+// not baked into ga4.APIError.
+func hintAdminError(err error) error {
+	var ae ga4.APIError
+	if errors.As(err, &ae) {
+		switch ae.Status {
+		case 403:
+			return fmt.Errorf("%v\nhint: token carries the scope but the account lacks the required role (Editor or Administrator) on that property/account", err)
+		case 404:
+			return fmt.Errorf("%v\nhint: check the path, or the resource may only exist in v1alpha (retry with --api v1alpha)", err)
+		}
+	}
+	return err
+}
+
+func listRows(raw map[string]any, key string) []map[string]any {
+	rows := []map[string]any{}
+	if arr, ok := raw[key].([]any); ok {
+		for _, item := range arr {
+			if m, ok := item.(map[string]any); ok {
+				rows = append(rows, m)
+			}
+		}
+	}
+	return rows
+}
+func listTable(raw map[string]any, key string) string { return table(listRows(raw, key)) }
+
+func parseBody(s string) (any, error) {
+	var data []byte
+	if strings.HasPrefix(s, "@") {
+		b, err := os.ReadFile(strings.TrimPrefix(s, "@"))
+		if err != nil {
+			return nil, err
+		}
+		data = b
+	} else {
+		data = []byte(s)
+	}
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, fmt.Errorf("invalid --body JSON: %w", err)
+	}
+	return v, nil
+}
+
+// ---- key-events ----
+
+func newKeyEventsCmd(flags *rootFlags) *cobra.Command {
+	c := &cobra.Command{Use: "key-events", Short: "List, create, patch, and delete GA4 key events"}
+	c.AddCommand(newKeyEventsListCmd(flags), newKeyEventsCreateCmd(flags), newKeyEventsDeleteCmd(flags), newKeyEventsPatchCmd(flags))
+	return c
+}
+func newKeyEventsListCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{Use: "list", Short: "List key events for a property", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.KeyEvents(context.Background(), p)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, listTable(raw, "keyEvents"))
+	}}
+}
+func newKeyEventsCreateCmd(flags *rootFlags) *cobra.Command {
+	var event, counting string
+	c := &cobra.Command{Use: "create", Short: "Create a key event", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		if event == "" {
+			return fmt.Errorf("--event is required")
+		}
+		body := map[string]any{"eventName": event}
+		if counting != "" {
+			body["countingMethod"] = counting
+		}
+		cl, _, err := flags.newWriteClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.CreateKeyEvent(context.Background(), p, body)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "created key event")
+	}}
+	c.Flags().StringVar(&event, "event", "", "Event name to mark as a key event")
+	c.Flags().StringVar(&counting, "counting", "", "Counting method: ONCE_PER_EVENT|ONCE_PER_SESSION")
+	return c
+}
+func newKeyEventsDeleteCmd(flags *rootFlags) *cobra.Command {
+	var name string
+	c := &cobra.Command{Use: "delete", Short: "Delete a key event", RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireExplicitYes(cmd, "key-events delete"); err != nil {
+			return err
+		}
+		if name == "" {
+			return fmt.Errorf("--name is required")
+		}
+		cl, _, err := flags.newWriteClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.DeleteKeyEvent(context.Background(), name)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "deleted "+name)
+	}}
+	c.Flags().StringVar(&name, "name", "", "Key event resource name, e.g. properties/123/keyEvents/<name>")
+	return c
+}
+func newKeyEventsPatchCmd(flags *rootFlags) *cobra.Command {
+	var name, counting string
+	c := &cobra.Command{Use: "patch", Short: "Update a key event's counting method", RunE: func(cmd *cobra.Command, args []string) error {
+		if name == "" {
+			return fmt.Errorf("--name is required")
+		}
+		if counting == "" {
+			return fmt.Errorf("--counting is required")
+		}
+		body := map[string]any{"countingMethod": counting}
+		cl, _, err := flags.newWriteClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.PatchKeyEvent(context.Background(), name, body, "countingMethod")
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "patched "+name)
+	}}
+	c.Flags().StringVar(&name, "name", "", "Key event resource name, e.g. properties/123/keyEvents/<name>")
+	c.Flags().StringVar(&counting, "counting", "", "Counting method: ONCE_PER_EVENT|ONCE_PER_SESSION")
+	return c
+}
+
+// ---- custom-dimensions ----
+
+func newCustomDimensionsCmd(flags *rootFlags) *cobra.Command {
+	c := &cobra.Command{Use: "custom-dimensions", Short: "List, create, and archive GA4 custom dimensions"}
+	c.AddCommand(newCustomDimensionsListCmd(flags), newCustomDimensionsCreateCmd(flags), newCustomDimensionsArchiveCmd(flags))
+	return c
+}
+func newCustomDimensionsListCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{Use: "list", Short: "List custom dimensions for a property", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.CustomDimensions(context.Background(), p)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, listTable(raw, "customDimensions"))
+	}}
+}
+func newCustomDimensionsCreateCmd(flags *rootFlags) *cobra.Command {
+	var parameter, displayName, scope, description string
+	var disallowAds bool
+	c := &cobra.Command{Use: "create", Short: "Create a custom dimension", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		if parameter == "" {
+			return fmt.Errorf("--parameter is required")
+		}
+		if displayName == "" {
+			return fmt.Errorf("--display-name is required")
+		}
+		body := map[string]any{"parameterName": parameter, "displayName": displayName}
+		if scope != "" {
+			body["scope"] = scope
+		}
+		if description != "" {
+			body["description"] = description
+		}
+		if disallowAds {
+			body["disallowAdsPersonalization"] = true
+		}
+		cl, _, err := flags.newWriteClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.CreateCustomDimension(context.Background(), p, body)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "created custom dimension")
+	}}
+	c.Flags().StringVar(&parameter, "parameter", "", "Parameter name (without trailing _name)")
+	c.Flags().StringVar(&displayName, "display-name", "", "Display name")
+	c.Flags().StringVar(&scope, "scope", "", "Scope: EVENT|USER|ITEM")
+	c.Flags().StringVar(&description, "description", "", "Optional description")
+	c.Flags().BoolVar(&disallowAds, "disallow-ads-personalization", false, "Disallow ads personalization")
+	return c
+}
+func newCustomDimensionsArchiveCmd(flags *rootFlags) *cobra.Command {
+	var name string
+	c := &cobra.Command{Use: "archive", Short: "Archive a custom dimension (irreversible)", RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireExplicitYes(cmd, "custom-dimensions archive"); err != nil {
+			return err
+		}
+		if name == "" {
+			return fmt.Errorf("--name is required")
+		}
+		cl, _, err := flags.newWriteClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.ArchiveCustomDimension(context.Background(), name)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "archived "+name)
+	}}
+	c.Flags().StringVar(&name, "name", "", "Custom dimension resource name, e.g. properties/123/customDimensions/<name>")
+	return c
+}
+
+// ---- custom-metrics ----
+
+func newCustomMetricsCmd(flags *rootFlags) *cobra.Command {
+	c := &cobra.Command{Use: "custom-metrics", Short: "List, create, and archive GA4 custom metrics"}
+	c.AddCommand(newCustomMetricsListCmd(flags), newCustomMetricsCreateCmd(flags), newCustomMetricsArchiveCmd(flags))
+	return c
+}
+func newCustomMetricsListCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{Use: "list", Short: "List custom metrics for a property", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.CustomMetrics(context.Background(), p)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, listTable(raw, "customMetrics"))
+	}}
+}
+func newCustomMetricsCreateCmd(flags *rootFlags) *cobra.Command {
+	var parameter, displayName, unit, scope, description string
+	c := &cobra.Command{Use: "create", Short: "Create a custom metric", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		if parameter == "" {
+			return fmt.Errorf("--parameter is required")
+		}
+		if displayName == "" {
+			return fmt.Errorf("--display-name is required")
+		}
+		body := map[string]any{"parameterName": parameter, "displayName": displayName}
+		if unit != "" {
+			body["measurementUnit"] = unit
+		}
+		if scope != "" {
+			body["scope"] = scope
+		}
+		if description != "" {
+			body["description"] = description
+		}
+		cl, _, err := flags.newWriteClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.CreateCustomMetric(context.Background(), p, body)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "created custom metric")
+	}}
+	c.Flags().StringVar(&parameter, "parameter", "", "Parameter name (without trailing _sum/_count suffix)")
+	c.Flags().StringVar(&displayName, "display-name", "", "Display name")
+	c.Flags().StringVar(&unit, "measurement-unit", "", "STANDARD|CURRENCY|FEET|METERS|KILOMETERS|MILES|MILLISECONDS|SECONDS|MINUTES|HOURS")
+	c.Flags().StringVar(&scope, "scope", "", "Scope: EVENT")
+	c.Flags().StringVar(&description, "description", "", "Optional description")
+	return c
+}
+func newCustomMetricsArchiveCmd(flags *rootFlags) *cobra.Command {
+	var name string
+	c := &cobra.Command{Use: "archive", Short: "Archive a custom metric (irreversible)", RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireExplicitYes(cmd, "custom-metrics archive"); err != nil {
+			return err
+		}
+		if name == "" {
+			return fmt.Errorf("--name is required")
+		}
+		cl, _, err := flags.newWriteClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.ArchiveCustomMetric(context.Background(), name)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "archived "+name)
+	}}
+	c.Flags().StringVar(&name, "name", "", "Custom metric resource name, e.g. properties/123/customMetrics/<name>")
+	return c
+}
+
+// ---- data-streams ----
+
+func newDataStreamsCmd(flags *rootFlags) *cobra.Command {
+	c := &cobra.Command{Use: "data-streams", Short: "List, get, create, patch, and delete GA4 data streams"}
+	c.AddCommand(newDataStreamsListCmd(flags), newDataStreamsGetCmd(flags), newDataStreamsCreateCmd(flags), newDataStreamsPatchCmd(flags), newDataStreamsDeleteCmd(flags))
+	return c
+}
+func newDataStreamsListCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{Use: "list", Short: "List data streams for a property", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.AdminList(context.Background(), "v1beta", fmt.Sprintf("properties/%s/dataStreams", url.PathEscape(p)))
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, listTable(raw, "dataStreams"))
+	}}
+}
+func newDataStreamsGetCmd(flags *rootFlags) *cobra.Command {
+	var name string
+	c := &cobra.Command{Use: "get", Short: "Get a data stream by resource name", RunE: func(cmd *cobra.Command, args []string) error {
+		if name == "" {
+			return fmt.Errorf("--name is required")
+		}
+		cl, _, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.AdminCall(context.Background(), "v1beta", "GET", name, nil, "")
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "")
+	}}
+	c.Flags().StringVar(&name, "name", "", "Data stream resource name, e.g. properties/123/dataStreams/<id>")
+	return c
+}
+func newDataStreamsCreateCmd(flags *rootFlags) *cobra.Command {
+	var displayName, typ, uri, packageName, bundleID string
+	c := &cobra.Command{Use: "create", Short: "Create a data stream", RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := requireProperty(flags)
+		if err != nil {
+			return err
+		}
+		if displayName == "" {
+			return fmt.Errorf("--display-name is required")
+		}
+		if typ == "" {
+			return fmt.Errorf("--type is required: WEB_DATA_STREAM|ANDROID_APP_DATA_STREAM|IOS_APP_DATA_STREAM")
+		}
+		body := map[string]any{"displayName": displayName, "type": typ}
+		switch typ {
+		case "WEB_DATA_STREAM":
+			if uri != "" {
+				body["webStreamData"] = map[string]any{"defaultUri": uri}
+			}
+		case "ANDROID_APP_DATA_STREAM":
+			if packageName != "" {
+				body["androidAppStreamData"] = map[string]any{"packageName": packageName}
+			}
+		case "IOS_APP_DATA_STREAM":
+			if bundleID != "" {
+				body["iosAppStreamData"] = map[string]any{"bundleId": bundleID}
+			}
+		}
+		cl, _, err := flags.newWriteClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.CreateDataStream(context.Background(), p, body)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "created data stream")
+	}}
+	c.Flags().StringVar(&displayName, "display-name", "", "Display name")
+	c.Flags().StringVar(&typ, "type", "", "WEB_DATA_STREAM|ANDROID_APP_DATA_STREAM|IOS_APP_DATA_STREAM")
+	c.Flags().StringVar(&uri, "uri", "", "Web stream default URI")
+	c.Flags().StringVar(&packageName, "package-name", "", "Android app package name")
+	c.Flags().StringVar(&bundleID, "bundle-id", "", "iOS app bundle id")
+	return c
+}
+func newDataStreamsPatchCmd(flags *rootFlags) *cobra.Command {
+	var name, displayName, uri string
+	c := &cobra.Command{Use: "patch", Short: "Update a data stream's display name or web URI", RunE: func(cmd *cobra.Command, args []string) error {
+		if name == "" {
+			return fmt.Errorf("--name is required")
+		}
+		body := map[string]any{}
+		mask := []string{}
+		if cmd.Flags().Changed("display-name") {
+			body["displayName"] = displayName
+			mask = append(mask, "displayName")
+		}
+		if cmd.Flags().Changed("uri") {
+			body["webStreamData"] = map[string]any{"defaultUri": uri}
+			mask = append(mask, "webStreamData.defaultUri")
+		}
+		if len(mask) == 0 {
+			return fmt.Errorf("nothing to patch: pass at least one of --display-name, --uri")
+		}
+		cl, _, err := flags.newWriteClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.PatchDataStream(context.Background(), name, body, strings.Join(mask, ","))
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "patched "+name)
+	}}
+	c.Flags().StringVar(&name, "name", "", "Data stream resource name, e.g. properties/123/dataStreams/<id>")
+	c.Flags().StringVar(&displayName, "display-name", "", "New display name")
+	c.Flags().StringVar(&uri, "uri", "", "New web stream default URI")
+	return c
+}
+func newDataStreamsDeleteCmd(flags *rootFlags) *cobra.Command {
+	var name string
+	c := &cobra.Command{Use: "delete", Short: "Delete a data stream", RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireExplicitYes(cmd, "data-streams delete"); err != nil {
+			return err
+		}
+		if name == "" {
+			return fmt.Errorf("--name is required")
+		}
+		cl, _, err := flags.newWriteClient()
+		if err != nil {
+			return err
+		}
+		raw, _, err := cl.DeleteDataStream(context.Background(), name)
+		if err != nil {
+			return hintAdminError(err)
+		}
+		return output(cmd, flags, raw, "deleted "+name)
+	}}
+	c.Flags().StringVar(&name, "name", "", "Data stream resource name, e.g. properties/123/dataStreams/<id>")
+	return c
+}
+
+// ---- admin escape hatch ----
+
+func adminListHuman(raw map[string]any) string {
+	for _, k := range ga4.AdminListKeys {
+		if arr, ok := raw[k].([]any); ok {
+			rows := []map[string]any{}
+			for _, item := range arr {
+				if m, ok := item.(map[string]any); ok {
+					rows = append(rows, m)
+				}
+			}
+			return table(rows)
+		}
+	}
+	return ""
+}
+
+func newAdminCmd(flags *rootFlags) *cobra.Command {
+	var body, updateMask, api string
+	var noPaginate bool
+	c := &cobra.Command{
+		Use:   "admin",
+		Short: "Escape-hatch Admin API call: admin <GET|POST|PATCH|PUT|DELETE> <path>",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			method := strings.ToUpper(args[0])
+			path := args[1]
+			switch method {
+			case "GET", "POST", "PATCH", "PUT", "DELETE":
+			default:
+				return fmt.Errorf("unknown method %q; expected GET|POST|PATCH|PUT|DELETE", args[0])
+			}
+			if !ga4.ValidAdminAPI(api) {
+				return fmt.Errorf("unknown --api %q; expected v1beta or v1alpha", api)
+			}
+			if method == "GET" {
+				cl, _, err := flags.newClient()
+				if err != nil {
+					return err
+				}
+				if !noPaginate {
+					raw, _, err := cl.AdminList(context.Background(), api, path)
+					if err != nil {
+						return hintAdminError(err)
+					}
+					return output(cmd, flags, raw, adminListHuman(raw))
+				}
+				raw, _, err := cl.AdminCall(context.Background(), api, "GET", path, nil, "")
+				if err != nil {
+					return hintAdminError(err)
+				}
+				return output(cmd, flags, raw, "")
+			}
+			if method == "DELETE" {
+				if err := requireExplicitYes(cmd, "admin DELETE "+path); err != nil {
+					return err
+				}
+			}
+			cl, _, err := flags.newWriteClient()
+			if err != nil {
+				return err
+			}
+			var bd any
+			if body != "" {
+				bd, err = parseBody(body)
+				if err != nil {
+					return err
+				}
+			}
+			raw, _, err := cl.AdminCall(context.Background(), api, method, path, bd, updateMask)
+			if err != nil {
+				return hintAdminError(err)
+			}
+			return output(cmd, flags, raw, "")
+		},
+	}
+	c.Flags().StringVar(&body, "body", "", "JSON body (inline string or @file.json)")
+	c.Flags().StringVar(&updateMask, "update-mask", "", "Comma-separated updateMask fields")
+	c.Flags().StringVar(&api, "api", "v1beta", "Admin API version: v1beta|v1alpha")
+	c.Flags().BoolVar(&noPaginate, "no-paginate", false, "Disable pagination for GET")
+	return c
+}

--- a/library/marketing/google-analytics/internal/cli/admin_write_commands_test.go
+++ b/library/marketing/google-analytics/internal/cli/admin_write_commands_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// requireExplicitYes is the security-critical gate on destructive writes. It must
+// inspect the flag's Changed state, not rootFlags.yes, so that --agent (which
+// implies --yes) can never authorize a mutation on its own.
+func TestRequireExplicitYes(t *testing.T) {
+	cases := []struct {
+		name        string
+		extra       []string
+		wantDestrue bool // expect the destructive-and-irreversible error
+	}{
+		{"explicit --yes authorizes", []string{"--yes"}, false},
+		{"--agent alone is not enough", []string{"--agent"}, true},
+		{"neither flag", []string{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear every credential source so the --yes case can never mint a
+			// token and issue a live DELETE from `go test`. It must fail at
+			// credential resolution, well before any network call.
+			t.Setenv("GOOGLE_ANALYTICS_ADC", "")
+			t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+			var f rootFlags
+			root := newRootCmd(&f)
+			root.SetOut(io.Discard)
+			root.SetErr(io.Discard)
+			args := append([]string{"data-streams", "delete", "--name", "properties/1/dataStreams/2"}, tc.extra...)
+			root.SetArgs(args)
+			err := root.Execute()
+			if tc.wantDestrue {
+				if err == nil || !strings.Contains(err.Error(), "destructive") {
+					t.Fatalf("expected destructive gate error, got %v", err)
+				}
+				return
+			}
+			// Explicit --yes must sail past requireExplicitYes; any later failure is
+			// downstream (e.g. missing credentials), never the destructive gate.
+			if err != nil && strings.Contains(err.Error(), "destructive") {
+				t.Fatalf("unexpected destructive gate error despite --yes: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseBody(t *testing.T) {
+	// Inline JSON parses.
+	v, err := parseBody(`{"a":1,"b":"two"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := v.(map[string]any)
+	if !ok || m["a"] != float64(1) || m["b"] != "two" {
+		t.Fatalf("inline parse produced %#v", v)
+	}
+
+	// @file reads from disk.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "body.json")
+	if err := os.WriteFile(path, []byte(`{"x":[1,2]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	v, err = parseBody("@" + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok = v.(map[string]any)
+	if !ok || m["x"] == nil {
+		t.Fatalf("@file parse produced %#v", v)
+	}
+
+	// Invalid JSON mentions --body.
+	if _, err := parseBody(`{not json`); err == nil || !strings.Contains(err.Error(), "--body") {
+		t.Fatalf("expected invalid-json error mentioning --body, got %v", err)
+	}
+}
+
+func TestCredentialPathResolutionOrder(t *testing.T) {
+	t.Setenv("GOOGLE_ANALYTICS_ADC", "/adc.json")
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/app.json")
+
+	// --credentials beats GOOGLE_ANALYTICS_ADC beats GOOGLE_APPLICATION_CREDENTIALS.
+	if got := credentialPath(&rootFlags{credentials: "/flag.json"}); got != "/flag.json" {
+		t.Fatalf("--credentials should win, got %q", got)
+	}
+	if got := credentialPath(&rootFlags{}); got != "/adc.json" {
+		t.Fatalf("GOOGLE_ANALYTICS_ADC should beat GOOGLE_APPLICATION_CREDENTIALS, got %q", got)
+	}
+
+	// GAC-only fallback.
+	t.Setenv("GOOGLE_ANALYTICS_ADC", "")
+	if got := credentialPath(&rootFlags{}); got != "/app.json" {
+		t.Fatalf("GOOGLE_APPLICATION_CREDENTIALS fallback failed, got %q", got)
+	}
+
+	// ~/ is expanded against the home dir.
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "~/keys/ga.json")
+	got := credentialPath(&rootFlags{})
+	if !strings.HasPrefix(got, string(os.PathSeparator)) || !strings.HasSuffix(got, "keys/ga.json") || strings.HasPrefix(got, "~/") {
+		t.Fatalf("~ expansion produced %q", got)
+	}
+
+	// Nothing set -> empty.
+	t.Setenv("GOOGLE_ANALYTICS_ADC", "")
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	if got := credentialPath(&rootFlags{}); got != "" {
+		t.Fatalf("expected empty credential path, got %q", got)
+	}
+}

--- a/library/marketing/google-analytics/internal/cli/agent_context.go
+++ b/library/marketing/google-analytics/internal/cli/agent_context.go
@@ -4,6 +4,36 @@ import "github.com/spf13/cobra"
 
 func newAgentContextCmd() *cobra.Command {
 	return &cobra.Command{Use: "agent-context", Short: "Emit structured tool description for agents", RunE: func(cmd *cobra.Command, args []string) error {
-		return printJSON(cmd.OutOrStdout(), map[string]any{"name": "google-analytics-pp-cli", "binary": "google-analytics-pp-cli", "purpose": "GA4-only analytics CLI with raw API wrappers and one-call novel reports", "auth": "Google service account JSON via --credentials or GOOGLE_APPLICATION_CREDENTIALS; analytics.readonly scope", "property_resolution": "--property, else GA4_PROPERTY_ID; health can accept --properties for fleet checks", "global_flags": []string{"--agent", "--json", "--compact", "--no-input", "--yes", "--property", "--credentials", "--timeout"}, "raw_commands": []string{"report", "pivot", "batch", "realtime", "metadata", "compatibility", "properties", "property", "streams"}, "novel_commands": []string{"channels", "sources", "top-pages", "events", "conversions", "funnel", "compare", "whats-changed", "revenue", "audience", "cohort", "health", "doctor"}, "examples": []string{"google-analytics-pp-cli health --properties $GA4_PROPERTY_IDS --agent", "google-analytics-pp-cli channels --property $GA4_PROPERTY_ID --start 28daysAgo --end yesterday --agent", "google-analytics-pp-cli compare --property $GA4_PROPERTY_ID --metrics sessions,totalRevenue --period wow --agent", "google-analytics-pp-cli funnel --property $GA4_PROPERTY_ID --steps view_item,add_to_cart,begin_checkout,purchase --agent"}})
+		return printJSON(cmd.OutOrStdout(), map[string]any{
+			"name":                "google-analytics-pp-cli",
+			"binary":              "google-analytics-pp-cli",
+			"purpose":             "GA4-only analytics CLI with raw API wrappers, one-call novel reports, and a gated GA4 Admin write surface",
+			"auth":                "Google service-account JSON key or ADC authorized_user JSON (client_id + client_secret + refresh_token); resolution is --credentials, then GOOGLE_ANALYTICS_ADC, then GOOGLE_APPLICATION_CREDENTIALS",
+			"scopes":              map[string]string{"read": "analytics.readonly", "write": "analytics.edit (also requires Editor or Administrator on the property)"},
+			"property_resolution": "--property, else GA4_PROPERTY_ID; health can accept --properties for fleet checks",
+			"global_flags":        []string{"--agent", "--json", "--compact", "--no-input", "--yes", "--property", "--credentials", "--timeout"},
+			"raw_commands":        []string{"report", "pivot", "batch", "realtime", "metadata", "compatibility", "properties", "property", "streams"},
+			"novel_commands":      []string{"channels", "sources", "top-pages", "events", "conversions", "funnel", "compare", "whats-changed", "revenue", "audience", "cohort", "health", "doctor"},
+			"write_commands":      []string{"key-events create|patch|delete", "custom-dimensions create|archive", "custom-metrics create|archive", "data-streams create|patch|delete", "admin POST|PATCH|PUT|DELETE"},
+			"destructive_gate":    "Every delete, plus custom-dimensions archive and custom-metrics archive, requires --yes to appear on the command line. --agent expands to include --yes but does NOT satisfy this gate; a human must add --yes explicitly.",
+			"gotchas": []string{
+				"accessBindings exists only in Admin API v1alpha; v1beta returns 404 with an HTML page instead of JSON. Use: admin GET properties/<id>/accessBindings --api v1alpha",
+				"A 403 on a write means the token carried the scope but the account lacks Editor/Administrator on the property.",
+				"To prove write access without mutating anything, create a key event that already exists and expect 409 ALREADY_EXISTS.",
+				"An authorized_user token carries whatever its original grant allowed; health reports scope_requested, not scope granted.",
+			},
+			"examples": []string{
+				"google-analytics-pp-cli health --properties $GA4_PROPERTY_IDS --agent",
+				"google-analytics-pp-cli channels --property $GA4_PROPERTY_ID --start 28daysAgo --end yesterday --agent",
+				"google-analytics-pp-cli compare --property $GA4_PROPERTY_ID --metrics sessions,totalRevenue --period wow --agent",
+				"google-analytics-pp-cli funnel --property $GA4_PROPERTY_ID --steps view_item,add_to_cart,begin_checkout,purchase --agent",
+				"google-analytics-pp-cli key-events list --property $GA4_PROPERTY_ID --agent",
+				"google-analytics-pp-cli key-events create --property $GA4_PROPERTY_ID --event generate_lead --agent",
+				"google-analytics-pp-cli key-events delete --name properties/123/keyEvents/abc --agent --yes",
+				"google-analytics-pp-cli custom-dimensions create --property $GA4_PROPERTY_ID --parameter plan --display-name Plan --scope EVENT --agent",
+				"google-analytics-pp-cli admin GET properties/123/accessBindings --api v1alpha --agent",
+				"google-analytics-pp-cli admin PATCH properties/123/keyEvents/abc --update-mask countingMethod --body '{\"countingMethod\":\"ONCE_PER_SESSION\"}' --agent",
+			},
+		})
 	}}
 }

--- a/library/marketing/google-analytics/internal/cli/confirm.go
+++ b/library/marketing/google-analytics/internal/cli/confirm.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Cathryn Lavery and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// requireExplicitYes gates destructive mutations. It inspects the flag's
+// Changed state rather than rootFlags.yes on purpose: --agent implies --yes,
+// and agent mode alone must never authorize a destructive call.
+func requireExplicitYes(cmd *cobra.Command, action string) error {
+	if cmd.Flags().Changed("yes") {
+		return nil
+	}
+	return fmt.Errorf("%s is destructive and irreversible: re-run with an explicit --yes (--agent alone does not authorize it)", action)
+}

--- a/library/marketing/google-analytics/internal/cli/health.go
+++ b/library/marketing/google-analytics/internal/cli/health.go
@@ -23,10 +23,16 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 }
 func runHealth(cmd *cobra.Command, flags *rootFlags, props string) error {
 	cl, key, err := flags.newClient()
-	res := map[string]any{"credential_path": credentialPath(flags), "scope": ga4.AnalyticsReadonlyScope}
+	res := map[string]any{"credential_path": credentialPath(flags), "scope_requested": ga4.AnalyticsReadonlyScope}
+	if kind := key.Kind(); kind != "" {
+		res["credential_kind"] = kind
+	}
 	if key.ClientEmail != "" {
 		res["service_account"] = key.ClientEmail
 		res["project_id"] = key.ProjectID
+	}
+	if kind := key.Kind(); kind == "authorized_user" && key.ClientID != "" {
+		res["client_id"] = key.ClientID
 	}
 	if err != nil {
 		res["ok"] = false

--- a/library/marketing/google-analytics/internal/cli/root.go
+++ b/library/marketing/google-analytics/internal/cli/root.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -25,8 +26,8 @@ type rootFlags struct {
 	propertyID  string
 	credentials string
 	timeout     time.Duration
-	client      *ga4.Client
-	key         ga4.ServiceAccountKey
+	clients     map[string]*ga4.Client
+	key         ga4.Credentials
 }
 
 func RootCmd() *cobra.Command { var f rootFlags; return newRootCmd(&f) }
@@ -37,8 +38,16 @@ func newRootCmd(flags *rootFlags) *cobra.Command {
 
 Raw wrappers: report, pivot, batch, realtime, metadata, compatibility, properties, property, streams.
 Novel commands: health/doctor, channels, sources, top-pages, events, conversions, funnel, compare, whats-changed, revenue, audience, cohort.
+Admin writes: key-events, custom-dimensions, custom-metrics, data-streams, plus the admin escape hatch.
 
-Auth: uses a Google service-account JSON key. Set GOOGLE_APPLICATION_CREDENTIALS, or pass --credentials. Scope: analytics.readonly.
+Auth: accepts either a Google service-account JSON key or an ADC authorized_user JSON
+(client_id + client_secret + refresh_token). Resolution: --credentials, then GOOGLE_ANALYTICS_ADC,
+then GOOGLE_APPLICATION_CREDENTIALS. Reads request analytics.readonly; writes request analytics.edit
+and additionally need Editor or Administrator on the property.
+
+Destructive writes (every delete, and custom-dimension/custom-metric archive) require a typed --yes.
+--agent implies --yes for prompts but deliberately does not authorize destruction on its own.
+
 Property resolution for data commands: --property, then GA4_PROPERTY_ID. The CLI never hard-codes a brand property for reads.`, SilenceUsage: true, Version: version}
 	cmd.SetVersionTemplate("google-analytics-pp-cli {{ .Version }}\n")
 	cmd.PersistentFlags().BoolVar(&flags.asJSON, "json", false, "Output JSON")
@@ -59,19 +68,27 @@ Property resolution for data commands: --property, then GA4_PROPERTY_ID. The CLI
 	cmd.AddCommand(newHealthCmd(flags), newDoctorCmd(flags))
 	cmd.AddCommand(newReportCmd(flags), newPivotCmd(flags), newBatchCmd(flags), newRealtimeCmd(flags), newMetadataCmd(flags), newCompatibilityCmd(flags))
 	cmd.AddCommand(newPropertiesCmd(flags), newPropertyCmd(flags), newStreamsCmd(flags))
+	cmd.AddCommand(newKeyEventsCmd(flags), newCustomDimensionsCmd(flags), newCustomMetricsCmd(flags), newDataStreamsCmd(flags), newAdminCmd(flags))
 	cmd.AddCommand(newChannelsCmd(flags), newSourcesCmd(flags), newTopPagesCmd(flags), newEventsCmd(flags), newConversionsCmd(flags))
 	cmd.AddCommand(newFunnelCmd(flags), newCompareCmd(flags), newWhatsChangedCmd(flags), newRevenueCmd(flags), newAudienceCmd(flags), newCohortCmd(flags))
 	return cmd
 }
 
-func (f *rootFlags) newClient() (*ga4.Client, ga4.ServiceAccountKey, error) {
-	if f.client != nil {
-		return f.client, f.key, nil
+// mint loads credentials and returns a per-scope cached client. Read and write
+// commands in one process therefore keep distinct clients so they never clobber
+// each other. For authorized_user both scope keys resolve to the same token,
+// which is correct: the grant, not the request, decides the scope.
+func (f *rootFlags) mint(scope string) (*ga4.Client, ga4.Credentials, error) {
+	if f.clients == nil {
+		f.clients = map[string]*ga4.Client{}
 	}
-	var key ga4.ServiceAccountKey
+	if c, ok := f.clients[scope]; ok {
+		return c, f.key, nil
+	}
+	var key ga4.Credentials
 	path := credentialPath(f)
 	if path == "" {
-		return nil, key, fmt.Errorf("missing credentials: set GOOGLE_APPLICATION_CREDENTIALS or pass --credentials")
+		return nil, key, fmt.Errorf("missing credentials: set GOOGLE_APPLICATION_CREDENTIALS (or GOOGLE_ANALYTICS_ADC) or pass --credentials")
 	}
 	b, err := os.ReadFile(path)
 	if err != nil {
@@ -80,13 +97,21 @@ func (f *rootFlags) newClient() (*ga4.Client, ga4.ServiceAccountKey, error) {
 	if err := jsonDecode(b, &key); err != nil {
 		return nil, key, err
 	}
-	tok, err := ga4.MintToken(key)
+	tok, err := ga4.MintToken(key, scope)
 	if err != nil {
 		return nil, key, err
 	}
-	f.client = ga4.NewClient(tok, f.timeout)
+	f.clients[scope] = ga4.NewClient(tok, f.timeout)
 	f.key = key
-	return f.client, key, nil
+	return f.clients[scope], key, nil
+}
+
+func (f *rootFlags) newClient() (*ga4.Client, ga4.ServiceAccountKey, error) {
+	c, k, err := f.mint(ga4.AnalyticsReadonlyScope)
+	return c, k, err
+}
+func (f *rootFlags) newWriteClient() (*ga4.Client, ga4.Credentials, error) {
+	return f.mint(ga4.AnalyticsEditScope)
 }
 
 func output(cmd *cobra.Command, f *rootFlags, v any, human string) error {
@@ -115,11 +140,16 @@ func requireProperty(f *rootFlags) (string, error) {
 }
 func cleanProperty(p string) string { return strings.TrimSpace(strings.TrimPrefix(p, "properties/")) }
 func credentialPath(f *rootFlags) string {
+	var p string
 	if f.credentials != "" {
-		return f.credentials
+		p = f.credentials
+	} else if p = os.Getenv("GOOGLE_ANALYTICS_ADC"); p == "" {
+		p = os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 	}
-	if p := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); p != "" {
-		return p
+	if strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			p = filepath.Join(home, strings.TrimPrefix(p, "~/"))
+		}
 	}
-	return ""
+	return p
 }

--- a/library/marketing/google-analytics/internal/ga4/admin.go
+++ b/library/marketing/google-analytics/internal/ga4/admin.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Cathryn Lavery and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package ga4
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// AdminListKeys enumerates the repeated list fields AdminList knows how to merge
+// across pages, mirroring the live Python reference used to validate this surface.
+var AdminListKeys = []string{"accountSummaries", "accounts", "properties", "keyEvents", "customDimensions", "customMetrics", "dataStreams", "audiences", "conversionEvents", "firebaseLinks", "googleAdsLinks", "accessBindings"}
+
+// ValidAdminAPI reports whether api names an Admin API version this client can
+// address. Callers validate up front so an unknown selector cannot silently
+// fall back to v1beta.
+func ValidAdminAPI(api string) bool { return api == "v1beta" || api == "v1alpha" }
+
+// adminBase resolves the Admin API root for a version selector ("v1beta" or
+// "v1alpha"). v1alpha is the Admin alpha host, NOT the Data API alpha host.
+func (c *Client) adminBase(api string) string {
+	if api == "v1alpha" {
+		return c.AdminAlphaBase
+	}
+	return c.AdminBase
+}
+
+// adminURL joins an API-relative path onto the selected Admin root and appends
+// updateMask as a query parameter, respecting an existing "?" in the path.
+func (c *Client) adminURL(api, path, updateMask string) string {
+	base := strings.TrimRight(c.adminBase(api), "/")
+	target := base + "/" + strings.TrimLeft(path, "/")
+	if updateMask != "" {
+		sep := "?"
+		if strings.Contains(target, "?") {
+			sep = "&"
+		}
+		target += sep + "updateMask=" + url.QueryEscape(updateMask)
+	}
+	return target
+}
+
+// adminDo performs an arbitrary Admin HTTP method, optionally with a JSON body,
+// reusing the shared do() auth header / error handling.
+func (c *Client) adminDo(ctx context.Context, method, target string, body any, out any) (int, error) {
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return 0, err
+		}
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, target, reader)
+	if err != nil {
+		return 0, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return c.do(req, out)
+}
+
+// AdminCall performs a single Admin API call. method is an uppercase HTTP verb;
+// path is relative to the Admin API root (leading slash tolerated).
+func (c *Client) AdminCall(ctx context.Context, api, method, path string, body any, updateMask string) (map[string]any, int, error) {
+	out := map[string]any{}
+	st, err := c.adminDo(ctx, method, c.adminURL(api, path, updateMask), body, &out)
+	return out, st, err
+}
+
+// AdminList fetches and merges a paginated Admin list endpoint. It follows
+// nextPageToken with pageSize=200 and merges the single repeated list key it
+// finds from adminListKeys. If no known list key is present, the raw (last)
+// page is returned unchanged rather than guessing.
+func (c *Client) AdminList(ctx context.Context, api, path string) (map[string]any, int, error) {
+	listKey := ""
+	merged := []any{}
+	lastStatus := 0
+	var lastRaw map[string]any
+	pageToken := ""
+	for {
+		target := c.adminURL(api, path, "")
+		sep := "?"
+		if strings.Contains(target, "?") {
+			sep = "&"
+		}
+		target += sep + "pageSize=200"
+		if pageToken != "" {
+			target += "&pageToken=" + url.QueryEscape(pageToken)
+		}
+		page := map[string]any{}
+		st, err := c.get(ctx, target, &page)
+		lastStatus = st
+		lastRaw = page
+		if err != nil {
+			if lastRaw == nil {
+				lastRaw = map[string]any{}
+			}
+			return lastRaw, st, err
+		}
+		if listKey == "" {
+			for _, k := range AdminListKeys {
+				if _, ok := page[k]; ok {
+					listKey = k
+					break
+				}
+			}
+		}
+		if listKey != "" {
+			if arr, ok := page[listKey].([]any); ok {
+				merged = append(merged, arr...)
+			}
+		}
+		next, _ := page["nextPageToken"].(string)
+		if next == "" {
+			break
+		}
+		pageToken = next
+	}
+	if lastStatus == 0 {
+		lastStatus = 200
+	}
+	if listKey != "" {
+		return map[string]any{listKey: merged}, lastStatus, nil
+	}
+	if lastRaw == nil {
+		lastRaw = map[string]any{}
+	}
+	return lastRaw, lastStatus, nil
+}
+
+func (c *Client) KeyEvents(ctx context.Context, property string) (map[string]any, int, error) {
+	return c.AdminList(ctx, "v1beta", fmt.Sprintf("properties/%s/keyEvents", url.PathEscape(property)))
+}
+func (c *Client) CreateKeyEvent(ctx context.Context, property string, body map[string]any) (map[string]any, int, error) {
+	return c.AdminCall(ctx, "v1beta", http.MethodPost, fmt.Sprintf("properties/%s/keyEvents", url.PathEscape(property)), body, "")
+}
+func (c *Client) PatchKeyEvent(ctx context.Context, name string, body map[string]any, updateMask string) (map[string]any, int, error) {
+	return c.AdminCall(ctx, "v1beta", http.MethodPatch, name, body, updateMask)
+}
+func (c *Client) DeleteKeyEvent(ctx context.Context, name string) (map[string]any, int, error) {
+	return c.AdminCall(ctx, "v1beta", http.MethodDelete, name, nil, "")
+}
+
+func (c *Client) CustomDimensions(ctx context.Context, property string) (map[string]any, int, error) {
+	return c.AdminList(ctx, "v1beta", fmt.Sprintf("properties/%s/customDimensions", url.PathEscape(property)))
+}
+func (c *Client) CreateCustomDimension(ctx context.Context, property string, body map[string]any) (map[string]any, int, error) {
+	return c.AdminCall(ctx, "v1beta", http.MethodPost, fmt.Sprintf("properties/%s/customDimensions", url.PathEscape(property)), body, "")
+}
+func (c *Client) ArchiveCustomDimension(ctx context.Context, name string) (map[string]any, int, error) {
+	return c.AdminCall(ctx, "v1beta", http.MethodPost, name+":archive", nil, "")
+}
+
+func (c *Client) CustomMetrics(ctx context.Context, property string) (map[string]any, int, error) {
+	return c.AdminList(ctx, "v1beta", fmt.Sprintf("properties/%s/customMetrics", url.PathEscape(property)))
+}
+func (c *Client) CreateCustomMetric(ctx context.Context, property string, body map[string]any) (map[string]any, int, error) {
+	return c.AdminCall(ctx, "v1beta", http.MethodPost, fmt.Sprintf("properties/%s/customMetrics", url.PathEscape(property)), body, "")
+}
+func (c *Client) ArchiveCustomMetric(ctx context.Context, name string) (map[string]any, int, error) {
+	return c.AdminCall(ctx, "v1beta", http.MethodPost, name+":archive", nil, "")
+}
+
+func (c *Client) CreateDataStream(ctx context.Context, property string, body map[string]any) (map[string]any, int, error) {
+	return c.AdminCall(ctx, "v1beta", http.MethodPost, fmt.Sprintf("properties/%s/dataStreams", url.PathEscape(property)), body, "")
+}
+func (c *Client) PatchDataStream(ctx context.Context, name string, body map[string]any, updateMask string) (map[string]any, int, error) {
+	return c.AdminCall(ctx, "v1beta", http.MethodPatch, name, body, updateMask)
+}
+func (c *Client) DeleteDataStream(ctx context.Context, name string) (map[string]any, int, error) {
+	return c.AdminCall(ctx, "v1beta", http.MethodDelete, name, nil, "")
+}

--- a/library/marketing/google-analytics/internal/ga4/admin_test.go
+++ b/library/marketing/google-analytics/internal/ga4/admin_test.go
@@ -1,0 +1,176 @@
+package ga4
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestCredentialsKind(t *testing.T) {
+	cases := []struct {
+		name string
+		c    Credentials
+		want string
+	}{
+		{"service_account by key fields", Credentials{PrivateKey: "pk", ClientEmail: "e@x.com"}, "service_account"},
+		{"authorized_user by fields", Credentials{ClientID: "c", ClientSecret: "s", RefreshToken: "r"}, "authorized_user"},
+		{"empty", Credentials{}, ""},
+		{"malformed (client id only)", Credentials{ClientID: "c"}, ""},
+		{"malformed (refresh only)", Credentials{RefreshToken: "r"}, ""},
+		{"explicit service_account wins", Credentials{Type: "service_account"}, "service_account"},
+		{"explicit authorized_user wins", Credentials{Type: "authorized_user"}, "authorized_user"},
+		{"unknown type with no fields", Credentials{Type: "weird"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.c.Kind(); got != tc.want {
+				t.Fatalf("Kind()=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCredentialsUnmarshalRealisticJSON(t *testing.T) {
+	// Service-account key payload. The private key is deliberately fake, not a real PEM.
+	sa := `{"type":"service_account","project_id":"analytics-123","private_key":"-----BEGIN PRIVATE KEY-----\nFAKE_KEY_MATERIAL_NOT_A_REAL_KEY\n-----END PRIVATE KEY-----\n","client_email":"svc@analytics-123.iam.gserviceaccount.com","token_uri":"https://oauth2.googleapis.com/token"}`
+	var a Credentials
+	if err := json.Unmarshal([]byte(sa), &a); err != nil {
+		t.Fatal(err)
+	}
+	if a.Kind() != "service_account" {
+		t.Fatalf("service_account Kind()=%q", a.Kind())
+	}
+	if a.ClientEmail == "" || a.PrivateKey == "" {
+		t.Fatalf("service_account fields not decoded: %#v", a)
+	}
+
+	// ADC authorized_user payload.
+	au := `{"type":"authorized_user","client_id":"123.apps.googleusercontent.com","client_secret":"d-very_secret","refresh_token":"1//fake_refresh_token","quota_project_id":"analytics-123"}`
+	var b Credentials
+	if err := json.Unmarshal([]byte(au), &b); err != nil {
+		t.Fatal(err)
+	}
+	if b.Kind() != "authorized_user" {
+		t.Fatalf("authorized_user Kind()=%q", b.Kind())
+	}
+	if b.ClientSecret == "" || b.RefreshToken == "" {
+		t.Fatalf("authorized_user fields not decoded: %#v", b)
+	}
+}
+
+func TestAdminURLUpdateMask(t *testing.T) {
+	c := NewClient("tok", time.Second)
+	c.AdminBase = "https://analyticsadmin.googleapis.com/v1beta"
+	c.AdminAlphaBase = "https://analyticsadmin.googleapis.com/v1alpha"
+
+	// No query on the path -> "?" separator.
+	if got := c.adminURL("v1beta", "properties/123/keyEvents", "countingMethod"); got != "https://analyticsadmin.googleapis.com/v1beta/properties/123/keyEvents?updateMask=countingMethod" {
+		t.Fatalf("no-query case: %q", got)
+	}
+	// Path already contains "?" -> "&" separator.
+	if got := c.adminURL("v1beta", "properties/123/keyEvents?foo=bar", "countingMethod"); got != "https://analyticsadmin.googleapis.com/v1beta/properties/123/keyEvents?foo=bar&updateMask=countingMethod" {
+		t.Fatalf("existing-query case: %q", got)
+	}
+	// Mask is URL-escaped.
+	if got := c.adminURL("v1beta", "x", "a.b,c"); got != "https://analyticsadmin.googleapis.com/v1beta/x?updateMask="+url.QueryEscape("a.b,c") {
+		t.Fatalf("escape case: %q", got)
+	}
+	// Empty mask -> omitted entirely.
+	if got := c.adminURL("v1beta", "x", ""); got != "https://analyticsadmin.googleapis.com/v1beta/x" {
+		t.Fatalf("empty-mask case: %q", got)
+	}
+	// Leading slash tolerated.
+	if got := c.adminURL("v1beta", "/properties/123", ""); got != "https://analyticsadmin.googleapis.com/v1beta/properties/123" {
+		t.Fatalf("leading-slash case: %q", got)
+	}
+	// v1alpha selects the alpha host.
+	if got := c.adminURL("v1alpha", "properties/123/accessBindings", ""); got != "https://analyticsadmin.googleapis.com/v1alpha/properties/123/accessBindings" {
+		t.Fatalf("v1alpha case: %q", got)
+	}
+	// Any non-v1alpha value resolves to the beta host via adminBase.
+	if got := c.adminURL("v1gamma", "properties/123", ""); got != "https://analyticsadmin.googleapis.com/v1beta/properties/123" {
+		t.Fatalf("fallback case: %q", got)
+	}
+}
+
+func TestValidAdminAPI(t *testing.T) {
+	for _, api := range []string{"v1beta", "v1alpha"} {
+		if !ValidAdminAPI(api) {
+			t.Fatalf("ValidAdminAPI(%q)=false", api)
+		}
+	}
+	for _, api := range []string{"", "v1", "v2beta", "V1BETA", "v1alpha2"} {
+		if ValidAdminAPI(api) {
+			t.Fatalf("ValidAdminAPI(%q)=true", api)
+		}
+	}
+}
+
+func TestAdminListMergesPages(t *testing.T) {
+	seenTokens := []string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenTokens = append(seenTokens, r.URL.Query().Get("pageToken"))
+		if r.URL.Query().Get("pageToken") == "next" {
+			_, _ = w.Write([]byte(`{"keyEvents":[{"name":"properties/1/keyEvents/ke2"}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"keyEvents":[{"name":"properties/1/keyEvents/ke1"}],"nextPageToken":"next"}`))
+	}))
+	defer srv.Close()
+	c := NewClient("tok", time.Second)
+	c.AdminBase = srv.URL
+	out, st, err := c.AdminList(context.Background(), "v1beta", "properties/1/keyEvents")
+	if err != nil || st != 200 {
+		t.Fatalf("%d %v", st, err)
+	}
+	arr, ok := out["keyEvents"].([]any)
+	if !ok || len(arr) != 2 {
+		t.Fatalf("merged keyEvents=%#v", out["keyEvents"])
+	}
+	if len(seenTokens) != 2 || seenTokens[1] != "next" {
+		t.Fatalf("pagination tokens=%#v", seenTokens)
+	}
+}
+
+func TestAdminListReturnsEmptyNonNilList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"dataStreams":[]}`))
+	}))
+	defer srv.Close()
+	c := NewClient("tok", time.Second)
+	c.AdminBase = srv.URL
+	out, _, err := c.AdminList(context.Background(), "v1beta", "properties/1/dataStreams")
+	if err != nil {
+		t.Fatal(err)
+	}
+	arr, ok := out["dataStreams"].([]any)
+	if !ok || arr == nil || len(arr) != 0 {
+		t.Fatalf("expected non-nil empty list, got %#v (ok=%v)", out["dataStreams"], ok)
+	}
+}
+
+func TestAdminListPassesThroughRawPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"weirdField":"value","nested":{"k":1}}`))
+	}))
+	defer srv.Close()
+	c := NewClient("tok", time.Second)
+	c.AdminBase = srv.URL
+	out, _, err := c.AdminList(context.Background(), "v1beta", "properties/1/somethingUnknown")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out["weirdField"] != "value" {
+		t.Fatalf("raw page not passed through: %#v", out)
+	}
+	// No list key should have been synthesized.
+	for _, k := range AdminListKeys {
+		if _, ok := out[k]; ok {
+			t.Fatalf("unexpected synthesized list key %q in %#v", k, out)
+		}
+	}
+}

--- a/library/marketing/google-analytics/internal/ga4/auth.go
+++ b/library/marketing/google-analytics/internal/ga4/auth.go
@@ -18,7 +18,18 @@ import (
 	"time"
 )
 
-func MintToken(key ServiceAccountKey) (string, error) {
+func MintToken(creds Credentials, scope string) (string, error) {
+	switch creds.Kind() {
+	case "service_account":
+		return mintServiceAccountToken(creds, scope)
+	case "authorized_user":
+		return mintRefreshToken(creds)
+	default:
+		return "", fmt.Errorf("unsupported credential shape: provide a service_account (client_email + private_key) or an authorized_user (client_id + client_secret + refresh_token) JSON")
+	}
+}
+
+func mintServiceAccountToken(key Credentials, scope string) (string, error) {
 	if key.TokenURI == "" {
 		key.TokenURI = "https://oauth2.googleapis.com/token"
 	}
@@ -36,7 +47,7 @@ func MintToken(key ServiceAccountKey) (string, error) {
 	}
 	now := time.Now().Unix()
 	header := b64json(map[string]string{"alg": "RS256", "typ": "JWT"})
-	claims := b64json(map[string]any{"iss": key.ClientEmail, "scope": AnalyticsReadonlyScope, "aud": key.TokenURI, "iat": now, "exp": now + 3600})
+	claims := b64json(map[string]any{"iss": key.ClientEmail, "scope": scope, "aud": key.TokenURI, "iat": now, "exp": now + 3600})
 	unsigned := header + "." + claims
 	h := sha256.Sum256([]byte(unsigned))
 	sig, err := rsa.SignPKCS1v15(rand.Reader, pk, crypto.SHA256, h[:])
@@ -45,6 +56,44 @@ func MintToken(key ServiceAccountKey) (string, error) {
 	}
 	form := url.Values{"grant_type": {"urn:ietf:params:oauth:grant-type:jwt-bearer"}, "assertion": {unsigned + "." + base64.RawURLEncoding.EncodeToString(sig)}}
 	resp, err := http.PostForm(key.TokenURI, form)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", APIError{Status: resp.StatusCode, Body: string(body)}
+	}
+	var out struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", err
+	}
+	if out.AccessToken == "" {
+		return "", fmt.Errorf("token response missing access_token")
+	}
+	return out.AccessToken, nil
+}
+
+// mintRefreshToken exchanges an authorized_user refresh token for an access
+// token. Scope is intentionally not sent: the original grant already fixes it,
+// and callers must not assume the result is narrowed to any requested scope.
+func mintRefreshToken(creds Credentials) (string, error) {
+	uri := creds.TokenURI
+	if uri == "" {
+		uri = "https://oauth2.googleapis.com/token"
+	}
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {creds.ClientID},
+		"client_secret": {creds.ClientSecret},
+		"refresh_token": {creds.RefreshToken},
+	}
+	resp, err := http.PostForm(uri, form)
 	if err != nil {
 		return "", err
 	}

--- a/library/marketing/google-analytics/internal/ga4/client.go
+++ b/library/marketing/google-analytics/internal/ga4/client.go
@@ -15,11 +15,12 @@ import (
 )
 
 type Client struct {
-	HTTPClient *http.Client
-	Token      string
-	DataBase   string
-	AdminBase  string
-	AlphaBase  string
+	HTTPClient     *http.Client
+	Token          string
+	DataBase       string
+	AdminBase      string
+	AdminAlphaBase string // Admin API v1alpha (accessBindings et al. live only here)
+	AlphaBase      string // Data API alpha (analyticsdata) used by funnel
 }
 
 type APIError struct {
@@ -30,7 +31,7 @@ type APIError struct {
 func (e APIError) Error() string { return fmt.Sprintf("google api status %d: %s", e.Status, e.Body) }
 
 func NewClient(token string, timeout time.Duration) *Client {
-	return &Client{HTTPClient: &http.Client{Timeout: timeout}, Token: token, DataBase: "https://analyticsdata.googleapis.com/v1beta", AdminBase: "https://analyticsadmin.googleapis.com/v1beta", AlphaBase: "https://analyticsdata.googleapis.com/v1alpha"}
+	return &Client{HTTPClient: &http.Client{Timeout: timeout}, Token: token, DataBase: "https://analyticsdata.googleapis.com/v1beta", AdminBase: "https://analyticsadmin.googleapis.com/v1beta", AdminAlphaBase: "https://analyticsadmin.googleapis.com/v1alpha", AlphaBase: "https://analyticsdata.googleapis.com/v1alpha"}
 }
 
 func (c *Client) RunReport(ctx context.Context, property string, req RunReportRequest) (ReportResponse, int, error) {

--- a/library/marketing/google-analytics/internal/ga4/types.go
+++ b/library/marketing/google-analytics/internal/ga4/types.go
@@ -4,13 +4,42 @@ package ga4
 
 import "encoding/json"
 
-const AnalyticsReadonlyScope = "https://www.googleapis.com/auth/analytics.readonly"
+const (
+	AnalyticsReadonlyScope = "https://www.googleapis.com/auth/analytics.readonly"
+	AnalyticsEditScope     = "https://www.googleapis.com/auth/analytics.edit"
+)
 
-type ServiceAccountKey struct {
-	ClientEmail string `json:"client_email"`
-	PrivateKey  string `json:"private_key"`
-	TokenURI    string `json:"token_uri"`
-	ProjectID   string `json:"project_id"`
+// Credentials holds either a Google service-account JSON key
+// (client_email + private_key) or an ADC authorized_user payload
+// (client_id + client_secret + refresh_token).
+type Credentials struct {
+	Type         string `json:"type"` // "service_account" | "authorized_user"
+	ClientEmail  string `json:"client_email"`
+	PrivateKey   string `json:"private_key"`
+	TokenURI     string `json:"token_uri"`
+	ProjectID    string `json:"project_id"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+// ServiceAccountKey is a compatibility alias for the pre-rename name.
+type ServiceAccountKey = Credentials
+
+// Kind reports the credential shape: "service_account" when a private key is
+// present, "authorized_user" when a refresh token + client id are present, ""
+// otherwise. Type wins when set and recognized.
+func (c Credentials) Kind() string {
+	if c.Type == "service_account" || c.Type == "authorized_user" {
+		return c.Type
+	}
+	if c.PrivateKey != "" {
+		return "service_account"
+	}
+	if c.RefreshToken != "" && c.ClientID != "" {
+		return "authorized_user"
+	}
+	return ""
 }
 
 type DateRange struct {


### PR DESCRIPTION
## What

`google-analytics-pp-cli` was read-only by construction: every command wrapped the Data API, auth assumed a service-account key, and the help text pinned `analytics.readonly`. There was no way to create a key event, a custom dimension, or a data stream — the GA4 Admin API surface was simply absent.

This adds a **gated** Admin API write surface.

## Changes

**Auth** — `ServiceAccountKey` becomes `Credentials` (type alias keeps the old name working). `Kind()` auto-detects service-account vs ADC `authorized_user`, and `MintToken` grew a refresh-token path. Resolution order: `--credentials` → `GOOGLE_ANALYTICS_ADC` → `GOOGLE_APPLICATION_CREDENTIALS`, with `~/` expansion. No credential path is hard-coded.

**Commands** — `key-events`, `custom-dimensions`, `custom-metrics`, `data-streams`, all with `--agent` JSON. Reads use `analytics.readonly`; writes use `analytics.edit`; clients are cached per scope.

**Escape hatch** — `admin <GET|POST|PATCH|PUT|DELETE> <path>` with `--body`/`@file`, `--update-mask`, `--api v1beta|v1alpha`, `--no-paginate`. `--api` is validated up front so a typo cannot silently fall back to v1beta.

**Write gate** — `requireExplicitYes` checks `cmd.Flags().Changed("yes")`, not the struct field, so `--agent` alone never authorizes a destructive call. Same pattern as `linear-pp-cli`.

```
$ google-analytics-pp-cli key-events delete --property N --name ... --agent
Error: key-events delete is destructive and irreversible: re-run with an explicit --yes (--agent alone does not authorize it)
```

## Two traps encoded in the docs

- **`accessBindings` lives in `v1alpha`, not `v1beta`.** v1beta returns a 404 *HTML* page, not JSON — easy to misread as a bad path.
- **Probing write permission must collide, never invent.** A `create` with a fresh name succeeds and leaves real data behind. Send a `create` that duplicates an existing resource and expect `409 ALREADY_EXISTS`. Found the hard way: a probe with a novel name created three stray key events on live properties.

## Verification

`go build`, `go vet`, `go test` (37 pass), `govulncheck`, `go mod tidy` all green. Admin commands verified live against a real GA4 property: `keyEvents` create/delete, `customDimensions` list, `accessBindings` via v1alpha. The write gate was smoke-tested against the built binary in both directions.

One defect fixed in the new tests: the gate test would have attempted a live DELETE if credentials happened to be exported, so it now clears the credential env vars first.

Docs were also quoted correctly, which takes the repo's own verifier from 6 errors on `main` to all checks passing.

## Not included

`publish validate` has three pre-existing failures — manifest `schema_version` 1-vs-2, a `phase5` marker at schema_version 0, and SKILL.md install-section drift. All three reproduce identically on a pristine `upstream/main`; they are artifacts of the original 4.20.1 print, and the verifier states the install text is generator-owned and must not be hand-edited. The fix is a reprint, which should run after this merges so the write surface isn't overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
