### PR TITLE
fix(linear): issues list --state active wrongly includes duplicate-closed issues

### DIFF
--- a/library/project-management/linear/.printing-press-patches/active-excludes-every-closed-state-type.json
+++ b/library/project-management/linear/.printing-press-patches/active-excludes-every-closed-state-type.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "active-excludes-every-closed-state-type",
+  "applied_at": "2026-08-12",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "\"Active\" means every workflow state Linear does not treat as closed, and Linear closes issues under three state types, not two: completed, canceled and duplicate.",
+  "reason": "WorkflowState.type has seven documented values and the schema carries no enum for them, so a generated filter that excludes only completed and canceled counts every duplicate-closed issue as open. The inflation is invisible: the rows look ordinary in a listing, and it propagates into every analytic that asks what is still open.",
+  "files": [
+    "internal/cli/issues.go",
+    "internal/cli/blocking.go",
+    "internal/cli/bottleneck.go",
+    "internal/cli/slipped.go",
+    "internal/cli/today.go"
+  ],
+  "validated_outcome": "An issue closed as a duplicate leaves 'issues list --state active' and is retrievable under '--state duplicate', on both the local and the live path."
+}

--- a/library/project-management/linear/internal/cli/blocking.go
+++ b/library/project-management/linear/internal/cli/blocking.go
@@ -55,7 +55,7 @@ hit the API rate-limit budget.`,
 			// connection filtered to type=blocks; downstream issue is
 			// .relatedIssue.
 			const q = `query Blocking($assignee: ID!) {
-				issues(filter: {assignee: {id: {eq: $assignee}}, state: {type: {nin: ["completed", "canceled"]}}}, first: 100) {
+				issues(filter: {assignee: {id: {eq: $assignee}}, state: {type: {nin: ["completed", "canceled", "duplicate"]}}}, first: 100) {
 					nodes {
 						id
 						identifier
@@ -133,7 +133,7 @@ hit the API rate-limit budget.`,
 					if r.Type != "blocks" {
 						continue
 					}
-					if r.RelatedIssue.State.Type == "completed" || r.RelatedIssue.State.Type == "canceled" {
+					if r.RelatedIssue.State.Type == "completed" || r.RelatedIssue.State.Type == "canceled" || r.RelatedIssue.State.Type == "duplicate" {
 						continue
 					}
 					assignee := r.RelatedIssue.Assignee.DisplayName

--- a/library/project-management/linear/internal/cli/bottleneck.go
+++ b/library/project-management/linear/internal/cli/bottleneck.go
@@ -62,7 +62,7 @@ func newBottleneckCmd(flags *rootFlags) *cobra.Command {
 					} `json:"assignee"`
 				}
 				json.Unmarshal(raw, &row)
-				if row.State.Type == "completed" || row.State.Type == "canceled" {
+				if row.State.Type == "completed" || row.State.Type == "canceled" || row.State.Type == "duplicate" {
 					continue
 				}
 				if row.Assignee == nil {

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -178,8 +178,10 @@ func newIssuesListCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 		Long: `List issues from the local sqlite store. Requires a prior 'linear-pp-cli sync'.
 
 Filters compose with AND. --state is matched against state.type (not state.name)
-so values like 'started', 'backlog', 'completed', 'canceled', 'triage' work across
-teams that customize state names. Use --state all to include completed and canceled.
+so values like 'started', 'backlog', 'completed', 'canceled', 'duplicate' and
+'triage' work across teams that customize state names. 'active' means every
+state type except completed, canceled and duplicate. Use --state all to include
+the closed types as well.
 
 --assignee accepts 'me' (resolves the authenticated viewer via a live GraphQL query),
 a user id, a user's display name, or a user's email.
@@ -193,7 +195,7 @@ a user id, a user's display name, or a user's email.
 		},
 	}
 	cmd.Flags().StringVar(&assignee, "assignee", "", "Filter by assignee (me, user id, display name, or email)")
-	cmd.Flags().StringVar(&stateFlag, "state", "active", "Filter by state type: active (default), started, backlog, unstarted, completed, canceled, triage, all")
+	cmd.Flags().StringVar(&stateFlag, "state", "active", "Filter by state type: active (default), triage, backlog, unstarted, started, completed, canceled, duplicate, all")
 	cmd.Flags().StringVar(&team, "team", "", "Filter by team key or ID")
 	cmd.Flags().StringVar(&project, "project", "", "Filter by project key or ID")
 	cmd.Flags().IntVar(&limit, "limit", 200, "Maximum results to return")
@@ -587,7 +589,7 @@ func matchesStateFilter(stateType, stateFlag string) bool {
 	case "all", "":
 		return true
 	case "active":
-		return stateType != "completed" && stateType != "canceled"
+		return stateType != "completed" && stateType != "canceled" && stateType != "duplicate"
 	default:
 		return strings.EqualFold(stateType, stateFlag)
 	}
@@ -726,10 +728,11 @@ func fetchIssuesLive(ctx context.Context, flags *rootFlags, db *store.Store, fil
 	case "", "all":
 		// no filter — return everything
 	case "active":
-		// "active" is the v3 semantic: not completed AND not canceled. Linear's
-		// state.type enum is {backlog, unstarted, started, completed, canceled,
-		// triage}; the live filter uses nin.
-		gqlFilter["state"] = map[string]any{"type": map[string]any{"nin": []string{"completed", "canceled"}}}
+		// "active" is the v3 semantic: not completed AND not canceled AND not
+		// duplicate. Linear's WorkflowState.type enum has seven values
+		// {triage, backlog, unstarted, started, completed, canceled,
+		// duplicate}. The live filter uses nin.
+		gqlFilter["state"] = map[string]any{"type": map[string]any{"nin": []string{"completed", "canceled", "duplicate"}}}
 	default:
 		gqlFilter["state"] = map[string]any{"type": map[string]any{"eq": stateFlag}}
 	}

--- a/library/project-management/linear/internal/cli/slipped.go
+++ b/library/project-management/linear/internal/cli/slipped.go
@@ -125,7 +125,7 @@ into the active cycle for the team). Groups by reason heuristic:
 				if !parsePrev[s.ID] {
 					continue
 				}
-				if s.State.Type == "completed" || s.State.Type == "canceled" {
+				if s.State.Type == "completed" || s.State.Type == "canceled" || s.State.Type == "duplicate" {
 					continue
 				}
 				reason := "carried"

--- a/library/project-management/linear/internal/cli/today.go
+++ b/library/project-management/linear/internal/cli/today.go
@@ -53,7 +53,8 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			// Filter to active (not done/cancelled)
+			// Filter to active: every state type except completed, canceled
+			// and duplicate.
 			type issueRow struct {
 				Identifier string `json:"identifier"`
 				Title      string `json:"title"`
@@ -72,7 +73,7 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 			for _, raw := range issues {
 				var row issueRow
 				json.Unmarshal(raw, &row)
-				if row.State.Type != "completed" && row.State.Type != "canceled" {
+				if row.State.Type != "completed" && row.State.Type != "canceled" && row.State.Type != "duplicate" {
 					active = append(active, row)
 				}
 			}


### PR DESCRIPTION
## The gap

`linear-pp-cli issues list --state active` is documented as "everything that is not closed". It is implemented as "not completed and not canceled", which is not the same thing.

Linear's `WorkflowState.type` has **seven** values, not six. From the vendored `schema.graphql` in this CLI:

> The type of the state. One of "triage", "backlog", "unstarted", "started", "completed", "canceled", "duplicate".

`duplicate` is a closed type. It is neither `completed` nor `canceled`, so every issue parked in a duplicate-typed state passes the old predicate and gets reported as active. Any team that closes issues as duplicates carries a permanently inflated open count, and the inflation is invisible because the rows look ordinary in the listing.

The bug was originally noticed on a real workspace whose open count read a handful higher than the board actually showed. That first observation was a hand count with no saved transcript, so it is offered here as the motivation, not as evidence. The evidence is the live probe below.

`active` is not defined in one place. It is a Go literal repeated at every analytic that needs "not closed", so the same off-by-one-state error is present in six commands.

## The fix

`duplicate` is added to the exclusion at every site where `active` is currently hardcoded:

| File | Site |
|---|---|
| `internal/cli/issues.go` | `matchesStateFilter` local predicate for the sqlite path |
| `internal/cli/issues.go` | the live GraphQL `state.type.nin` filter |
| `internal/cli/today.go` | the assigned-issue active filter |
| `internal/cli/bottleneck.go` | the per-assignee load filter |
| `internal/cli/blocking.go` | the live `state.type.nin` issue filter |
| `internal/cli/blocking.go` | the downstream `relatedIssue.state.type` filter |
| `internal/cli/slipped.go` | the still-open filter |

Supporting changes:

- The `--state` flag description and the `issues list` long help now name `duplicate` as a selectable type and spell out what `active` means. `--state duplicate` already worked through the default arm of both switches, it was simply undiscoverable.
- The enum comment on the live filter is corrected from the six-value list to the real seven values.

Nothing else changes. This is deliberately the smallest correct diff, hand-written on top of `main`, so it can be reviewed and merged on its own.

## Live verification

Probed against a real Linear workspace, single team `ACC`, on a binary built from this branch's tree. Round 1 of the probe report, close-a-duplicate then re-list.

Close `ACC-258` as a duplicate of `ACC-257`:

```
$ linear-pp-cli issues close-duplicate ACC-258 --of ACC-257 --yes --agent
{"event":"issue_closed_as_duplicate","identifier":"ACC-258","canonical":"ACC-257",
 "relation":"created","relation_id":"b6758269-...","state_id":"31b3f3de-...",
 "steps":["issueRelationCreate","issueUpdate"]}

$ linear-pp-cli issues get ACC-258 --data-source live --no-cache
state {"name":"Duplicate","type":"duplicate"}
```

`ACC-258` is now duplicate-typed. Under the old predicate it would still be listed as active. It is not:

```
$ linear-pp-cli issues list --state active --team ACC --agent --no-cache
total 192 · ACC-258 present: False · ACC-257 present: True

$ linear-pp-cli issues list --state duplicate --team ACC --agent --no-cache
[("ACC-258","Duplicate")]
```

The issue leaves `active` and is retrievable under `--state duplicate`.

Round 2 re-ran the same check against the live data source over the whole team and asserted the composition of the result set rather than a single identifier:

```
$ linear-pp-cli issues list --team ACC --state active --data-source live --limit 500 --agent
194 issues; duplicate-typed 0, canceled 0, completed 0
```

194 active out of 226 total live rows for that team. No duplicate-typed, canceled or completed row survives the filter.

Build, vet and the full test suite are green on this branch.

## Follow-up

This PR hardcodes the correct seven-value semantics. It does not remove the duplication: `active` is still a Go literal in seven places, and a workspace still cannot declare what `active` means for its own workflow. A follow-up series generalizes this into a real state-group subsystem, with the built-ins expressed in the same user-facing syntax, and routes all of these predicates through one resolver. This PR stands alone and does not depend on that series.

Closes GAP-001 (`active` state group excludes only completed and canceled) and GAP-040 (`issues list --state` accepts seven values but not `duplicate`, while `issues create/edit --state-type` accepts eight including it).
