### PR TITLE
feat(linear): user-definable state groups with a single resolver

### DIFF
--- a/library/project-management/linear/.printing-press-patches/state-predicates-resolve-through-one-declarable-group.json
+++ b/library/project-management/linear/.printing-press-patches/state-predicates-resolve-through-one-declarable-group.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 2,
+  "id": "state-predicates-resolve-through-one-declarable-group",
+  "applied_at": "2026-08-12",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "Every workflow-state predicate in this CLI resolves through one user-declarable group registry, and a project-level calculation resolves it at the project's own team scope.",
+  "reason": "Linear lets a workspace name its own workflow states, so a hardcoded state comparison is wrong for any team that ships out of a custom column, and a team may redeclare a group that the workspace already defines. Reintroducing per-command state literals silently returns wrong open counts, velocity and landing dates; resolving a project's group at workspace scope silently ignores that project's team override.",
+  "files": [
+    "internal/groups/groups.go",
+    "internal/groups/defaults.toml",
+    "internal/cli/groups_cmd.go",
+    "internal/cli/issues.go",
+    "internal/cli/blocking.go",
+    "internal/cli/bottleneck.go",
+    "internal/cli/slipped.go",
+    "internal/cli/today.go",
+    "internal/cli/cycles_compare.go",
+    "internal/cli/projects_burndown.go",
+    "internal/cli/milestones_at_risk.go"
+  ],
+  "validated_outcome": "A group declared under [team_state_groups.<KEY>] governs that team's issue listings and its projects' burndown and at-risk arithmetic, while a project spanning several teams falls back to the workspace declaration."
+}

--- a/library/project-management/linear/internal/cli/blocking.go
+++ b/library/project-management/linear/internal/cli/blocking.go
@@ -10,12 +10,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// pp:data-source live
 // newBlockingCmd shows issues you (or a named user) are blocking — i.e.,
 // issues whose `inverseRelations` chain to another open issue assigned
 // to someone else. Sorted by downstream impact.
 func newBlockingCmd(flags *rootFlags) *cobra.Command {
 	var jsonOut bool
 	var assigneeFlag string
+	var stateFlag string
 	cmd := &cobra.Command{
 		Use:   "blocking",
 		Short: "Show issues you are blocking — sorted by downstream impact",
@@ -50,12 +52,28 @@ hit the API rate-limit budget.`,
 				userID = viewer.Viewer.ID
 			}
 
+			// The blocker set and the downstream re-check both resolve
+			// through internal/groups, so the server-side filter and the
+			// in-memory relation walk cannot disagree about what "open"
+			// means. The document below binds the resolved predicate as a
+			// WorkflowStateFilter variable rather than hardcoding one.
+			set, err := resolveStateSet(flags, "", stateFlag)
+			if err != nil {
+				return err
+			}
+			stateFilter := set.GraphQLFilter()
+			if stateFilter == nil {
+				// An empty WorkflowStateFilter constrains nothing, which is
+				// what an unfiltered group means.
+				stateFilter = map[string]any{}
+			}
+
 			// Query issues assigned to the user with their outbound
 			// "blocks" relations expanded. We use the issue.relations
 			// connection filtered to type=blocks; downstream issue is
 			// .relatedIssue.
-			const q = `query Blocking($assignee: ID!) {
-				issues(filter: {assignee: {id: {eq: $assignee}}, state: {type: {nin: ["completed", "canceled", "duplicate"]}}}, first: 100) {
+			const q = `query Blocking($assignee: ID!, $stateFilter: WorkflowStateFilter) {
+				issues(filter: {assignee: {id: {eq: $assignee}}, state: $stateFilter}, first: 100) {
 					nodes {
 						id
 						identifier
@@ -112,7 +130,7 @@ hit the API rate-limit budget.`,
 					} `json:"nodes"`
 				} `json:"issues"`
 			}
-			if err := c.QueryInto(q, map[string]any{"assignee": userID}, &resp); err != nil {
+			if err := c.QueryInto(q, map[string]any{"assignee": userID, "stateFilter": stateFilter}, &resp); err != nil {
 				return fmt.Errorf("blocking query: %w", err)
 			}
 
@@ -133,7 +151,7 @@ hit the API rate-limit budget.`,
 					if r.Type != "blocks" {
 						continue
 					}
-					if r.RelatedIssue.State.Type == "completed" || r.RelatedIssue.State.Type == "canceled" || r.RelatedIssue.State.Type == "duplicate" {
+					if !set.Matches(r.RelatedIssue.State.Type, r.RelatedIssue.State.Name) {
 						continue
 					}
 					assignee := r.RelatedIssue.Assignee.DisplayName
@@ -218,5 +236,6 @@ hit the API rate-limit budget.`,
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json-out", false, "Force JSON output (alias for --json)")
 	cmd.Flags().StringVar(&assigneeFlag, "assignee", "me", "User UUID or 'me' to target a specific user's blocking queue")
+	cmd.Flags().StringVar(&stateFlag, "state", "active", stateGroupFlagUsage)
 	return cmd
 }

--- a/library/project-management/linear/internal/cli/bottleneck.go
+++ b/library/project-management/linear/internal/cli/bottleneck.go
@@ -12,18 +12,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// pp:data-source computed
+// bottleneck never calls the API: it aggregates the locally synced issue rows
+// into per-assignee load counts and an overload alert, so what it emits is
+// derived arithmetic rather than the stored rows themselves.
 func newBottleneckCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	var jsonOut bool
 	var teamFilter string
+	var stateFlag string
 	cmd := &cobra.Command{
 		Use:         "bottleneck",
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:       "Find overloaded team members and blocked issues",
-		Long:        "Analyze issue distribution per assignee to find bottlenecks. Shows who has too many active issues and which issues are blocking others.",
+		Long: `Analyze issue distribution per assignee to find bottlenecks. Shows who has too
+many open issues and which issues are blocking others.
+
+What counts as open is the 'active' state group by default. Redefine it in
+groups.toml, or pass --state to count a different group for this run.`,
 		Example: `  linear-pp-cli bottleneck
   linear-pp-cli bottleneck --team ENG
-  linear-pp-cli bottleneck --json`,
+  linear-pp-cli bottleneck --state started --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dbPath == "" {
 				dbPath = defaultDBPath("linear-pp-cli")
@@ -33,6 +42,16 @@ func newBottleneckCmd(flags *rootFlags) *cobra.Command {
 				return fmt.Errorf("opening database: %w\nRun 'linear-pp-cli sync' first.", err)
 			}
 			defer db.Close()
+
+			// The local --json flag shadows the root persistent one, so a
+			// caller who passes --json ahead of the subcommand, or who uses
+			// --agent, sets flags.asJSON and never sets jsonOut. Honor both.
+			wantJSON := jsonOut || flags.asJSON
+
+			set, err := resolveStateSet(flags, teamKeyForGroups(db, teamFilter), stateFlag)
+			if err != nil {
+				return err
+			}
 
 			filter := map[string]string{}
 			if teamFilter != "" {
@@ -54,15 +73,18 @@ func newBottleneckCmd(flags *rootFlags) *cobra.Command {
 			loads := map[string]*assigneeLoad{}
 			for _, raw := range issues {
 				var row struct {
-					Priority int                   `json:"priority"`
-					State    struct{ Type string } `json:"state"`
+					Priority int `json:"priority"`
+					State    struct {
+						Name string `json:"name"`
+						Type string `json:"type"`
+					} `json:"state"`
 					Assignee *struct {
 						ID   string `json:"id"`
 						Name string `json:"name"`
 					} `json:"assignee"`
 				}
 				json.Unmarshal(raw, &row)
-				if row.State.Type == "completed" || row.State.Type == "canceled" || row.State.Type == "duplicate" {
+				if !set.Matches(row.State.Type, row.State.Name) {
 					continue
 				}
 				if row.Assignee == nil {
@@ -95,14 +117,14 @@ func newBottleneckCmd(flags *rootFlags) *cobra.Command {
 				hintIfStale(cmd, db, "issues", flags.maxAge)
 			}
 
-			if jsonOut {
+			if wantJSON {
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
 				return enc.Encode(sorted)
 			}
 
 			if len(sorted) == 0 {
-				fmt.Println("No active issues with assignees found.")
+				fmt.Printf("No issues with assignees in state group %q.\n", set.Group.Name)
 				return nil
 			}
 
@@ -121,7 +143,8 @@ func newBottleneckCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&teamFilter, "team", "", "Filter by team key or ID")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	cmd.Flags().StringVar(&stateFlag, "state", "active", stateGroupFlagUsage)
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON (alias for the root --json flag)")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
 	return cmd
 }

--- a/library/project-management/linear/internal/cli/cycles_compare.go
+++ b/library/project-management/linear/internal/cli/cycles_compare.go
@@ -9,11 +9,13 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/groups"
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
 
 	"github.com/spf13/cobra"
 )
 
+// pp:data-source computed
 // newCyclesCompareCmd implements the prior `cycles compare` transcendence
 // feature that shipped deferred under v1's ship-with-gaps verdict. Diffs two
 // cycles by number, name, or "current"/"previous" alias and reports
@@ -21,6 +23,7 @@ import (
 func newCyclesCompareCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	var teamFilter string
+	var completedGroup string
 	cmd := &cobra.Command{
 		Use:   "compare <cycle-a> <cycle-b>",
 		Short: "Compare two cycles side-by-side: completion %, scope added/cut, carryover",
@@ -88,7 +91,15 @@ Outputs scope_count, completed_scope_count, completion_pct, plus diff metrics:
 				issuesB = filterIssuesByTeam(issuesB, teamID)
 			}
 
-			diff := diffCycleIssues(issuesA, issuesB)
+			// Completion is a declared group, so a workspace whose "shipped"
+			// column is not typed completed can say so once in groups.toml
+			// instead of being miscounted here.
+			completedSet, err := resolveStateSet(flags, teamKeyForGroups(db, teamFilter), completedGroup)
+			if err != nil {
+				return err
+			}
+
+			diff := diffCycleIssues(issuesA, issuesB, completedSet)
 			summary := map[string]any{
 				"cycle_a": map[string]any{
 					"id":             cyA.ID,
@@ -138,6 +149,7 @@ Outputs scope_count, completed_scope_count, completion_pct, plus diff metrics:
 	}
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
 	cmd.Flags().StringVar(&teamFilter, "team", "", "Filter both cycles to a team (key or UUID)")
+	cmd.Flags().StringVar(&completedGroup, "completed-group", "completed", completedGroupFlagUsage)
 	return cmd
 }
 
@@ -216,7 +228,7 @@ type cycleDiff struct {
 	BStates   map[string]int
 }
 
-func diffCycleIssues(a, b []json.RawMessage) cycleDiff {
+func diffCycleIssues(a, b []json.RawMessage, completed groups.Set) cycleDiff {
 	type slim struct {
 		ID    string `json:"id"`
 		State struct {
@@ -234,7 +246,7 @@ func diffCycleIssues(a, b []json.RawMessage) cycleDiff {
 				if s.State.Name != "" {
 					states[s.State.Name]++
 				}
-				if s.State.Type == "completed" {
+				if completed.Matches(s.State.Type, s.State.Name) {
 					closed++
 				}
 			}

--- a/library/project-management/linear/internal/cli/groups_cmd.go
+++ b/library/project-management/linear/internal/cli/groups_cmd.go
@@ -1,0 +1,386 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/groups"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+// resourceTypeStateGroups labels the provenance envelope of the groups
+// commands. The answer comes from disk, never from the API.
+const resourceTypeStateGroups = "state_groups"
+
+// resourceTypeWorkflowStates is the store resource `groups check` reads to
+// show which concrete states a group actually hits.
+const resourceTypeWorkflowStates = "workflow_states"
+
+// stateGroupFlagUsage is the shared help text for every --state flag that
+// takes a group token. Kept in one place so the nine former hand-written
+// predicates cannot drift apart again.
+const stateGroupFlagUsage = "State group or type to include: a group name from 'groups list' (active, all, ...), " +
+	"a raw type (" + validLinearWorkflowStateTypeList + "), type:<type> to bypass a shadowing group, or name:<state name>"
+
+// completedGroupFlagUsage is the help text for the completed-side group used
+// by burndown-style arithmetic, where "done" means "counted as delivered".
+const completedGroupFlagUsage = "State group or type that counts as delivered for this calculation (see 'groups list')"
+
+// loadStateGroups resolves the group registry for this invocation and returns
+// the config path it was anchored to. Loading is lazy and memoized, so a
+// malformed groups.toml never breaks commands that take no state filter.
+func loadStateGroups(flags *rootFlags) (*groups.Registry, string, error) {
+	cfg, err := config.Load(flags.configPath)
+	if err != nil {
+		return nil, "", configErr(err)
+	}
+	reg, err := groups.Load(cfg.Path)
+	if err != nil {
+		return nil, cfg.Path, configErr(err)
+	}
+	return reg, cfg.Path, nil
+}
+
+// resolveStateSet turns a --state token into the single predicate every state
+// filter in this CLI is allowed to use. A broken file is a config problem the
+// user fixes once (exit 10). A bad token is a usage problem on this
+// invocation (exit 2).
+func resolveStateSet(flags *rootFlags, teamKey, token string) (groups.Set, error) {
+	reg, _, err := loadStateGroups(flags)
+	if err != nil {
+		return groups.Set{}, err
+	}
+	set, err := reg.Resolve(teamKey, token)
+	if err != nil {
+		if errors.Is(err, groups.ErrUnknownToken) {
+			return groups.Set{}, usageErr(err)
+		}
+		return groups.Set{}, configErr(err)
+	}
+	return set, nil
+}
+
+// teamKeyForGroups maps whatever the user passed to --team (a key or a UUID)
+// to the team key that team-scoped group tables are keyed by. Team scope only
+// applies when a team is unambiguously in scope, so an empty input stays
+// empty and the workspace group applies.
+func teamKeyForGroups(db *store.Store, input string) string {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return ""
+	}
+	if db != nil {
+		if team, ok := resolveTeam(db, trimmed); ok && team.Key != "" {
+			return team.Key
+		}
+	}
+	return trimmed
+}
+
+func newGroupsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "groups",
+		Short: "Inspect the workflow-state groups that --state resolves against",
+		Long: `Show and test the state groups every --state flag resolves through.
+
+A group names a set of workflow states. Built-in groups ship with the binary.
+You can add or override any of them by declaring them in groups.toml next to
+your config file (the path is printed by 'groups list'). Declarations there
+survive token rotation, which is why they do not live in config.toml.
+
+Grammar:
+
+  schema_version = 1
+
+  [state_groups.wip]
+  description = "Actually being worked, plus our review column"
+  types = ["started"]
+  names = ["In Review"]
+
+  [team_state_groups.ENG.wip]
+  types = ["started"]
+  names = ["In Review", "QA"]
+
+Membership is the union of the two keys: a state belongs to the group when its
+type is listed in types OR its name matches one of names case-insensitively.
+There is no negation and no nesting, on purpose.`,
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,2,10"},
+		RunE:        parentNoSubcommandRunE(flags),
+	}
+	cmd.AddCommand(newGroupsListCmd(flags))
+	cmd.AddCommand(newGroupsCheckCmd(flags))
+	return cmd
+}
+
+func newGroupsListCmd(flags *rootFlags) *cobra.Command {
+	var team string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List every effective state group and where it is declared",
+		Long: `List every state group visible right now, including shadowed ones, so you can
+see why a token resolves the way it does.
+
+source is one of:
+  builtin            shipped with this binary
+  config:workspace   declared in [state_groups.<name>] in your groups.toml
+  config:team:<KEY>  declared in [team_state_groups.<KEY>.<name>]
+
+Precedence is team, then workspace, then builtin. A shadowed row names the
+higher-precedence entries that win over it in shadowed_by. Use
+'--state type:<type>' when you have shadowed a raw type and still need it.`,
+		Example: `  linear-pp-cli groups list
+  linear-pp-cli groups list --team ENG --json`,
+		Annotations: map[string]string{
+			"mcp:read-only":       "true",
+			"pp:typed-exit-codes": "0,2,10",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, cfgPath, err := loadStateGroups(flags)
+			if err != nil {
+				return err
+			}
+			warnMisplacedGroups(cmd, reg, cfgPath)
+
+			rows := reg.Effective(team)
+			var teamScope any
+			if scope := strings.ToUpper(strings.TrimSpace(team)); scope != "" {
+				teamScope = scope
+			}
+			envelope := map[string]any{
+				"results": rows,
+				"meta": map[string]any{
+					"source":              "local",
+					"resource_type":       resourceTypeStateGroups,
+					"reason":              "user_requested",
+					"groups_path":         reg.Path(),
+					"groups_file_present": reg.Present(),
+					"team_scope":          teamScope,
+				},
+			}
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				return printJSONFiltered(cmd.OutOrStdout(), envelope, flags)
+			}
+			table := make([][]string, 0, len(rows))
+			for _, g := range rows {
+				table = append(table, []string{
+					g.Name,
+					g.Source,
+					strings.Join(g.Types, ","),
+					strings.Join(g.Names, ","),
+					g.Description,
+				})
+			}
+			if err := flags.printTable(cmd, []string{"NAME", "SOURCE", "TYPES", "NAMES", "DESCRIPTION"}, table); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "\ndeclarations: %s (present: %t)\n", reg.Path(), reg.Present())
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&team, "team", "", "Team key whose team-scoped groups to include (e.g. ENG)")
+	return cmd
+}
+
+func newGroupsCheckCmd(flags *rootFlags) *cobra.Command {
+	var team, dbPath string
+	cmd := &cobra.Command{
+		Use:   "check <group-or-type>",
+		Short: "Resolve one state token and show exactly what it matches",
+		Long: `Resolve a --state token through the full resolution order and print the
+membership predicate it produces, the live WorkflowStateFilter it emits, and,
+when workflow states have been synced, the concrete states in your workspace
+that it actually hits.
+
+unmatched_names is the payoff: it is how you discover that you wrote
+names = ["Staging"] but your column is called "On Staging". Group names are
+never validated at load time precisely because they are validated here,
+against live data.
+
+The command never fails just because the local store is cold. It drops
+matching_states and tells you to sync.`,
+		Example: `  linear-pp-cli groups check active
+  linear-pp-cli groups check wip --team ENG --json
+  linear-pp-cli groups check type:duplicate`,
+		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			"mcp:read-only":       "true",
+			"pp:typed-exit-codes": "0,2,10",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, cfgPath, err := loadStateGroups(flags)
+			if err != nil {
+				return err
+			}
+			warnMisplacedGroups(cmd, reg, cfgPath)
+
+			set, resolveErr := reg.Resolve(team, args[0])
+			if resolveErr != nil {
+				if errors.Is(resolveErr, groups.ErrUnknownToken) {
+					return usageErr(resolveErr)
+				}
+				return configErr(resolveErr)
+			}
+
+			result := map[string]any{
+				"token":       set.Token,
+				"resolved_as": set.ResolvedAs,
+				"source":      set.Group.Source,
+				"scope":       set.Group.Scope,
+				"types":       set.Group.Types,
+				"names":       set.Group.Names,
+			}
+			liveFilter := set.GraphQLFilter()
+			if liveFilter == nil {
+				result["live_filter"] = nil
+			} else {
+				result["live_filter"] = map[string]any{"state": liveFilter}
+			}
+
+			meta := map[string]any{
+				"source":        "local",
+				"resource_type": resourceTypeStateGroups,
+				"reason":        "user_requested",
+			}
+
+			db, _ := openStoreAt(resolveDBPath(dbPath))
+			if db != nil {
+				defer db.Close()
+				prov := localProvenance(db, resourceTypeWorkflowStates, "user_requested")
+				if prov.SyncedAt != nil {
+					meta["synced_at"] = prov.SyncedAt.UTC().Format(time.RFC3339)
+				}
+				matching, unmatched, ok := matchStatesForGroup(db, set, team)
+				if ok {
+					result["matching_states"] = matching
+					result["unmatched_names"] = unmatched
+				} else {
+					hintIfUnsynced(cmd, db, resourceTypeWorkflowStates)
+				}
+			}
+
+			envelope := map[string]any{"results": result, "meta": meta}
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				return printJSONFiltered(cmd.OutOrStdout(), envelope, flags)
+			}
+			return renderGroupCheck(cmd, result)
+		},
+	}
+	cmd.Flags().StringVar(&team, "team", "", "Team key to resolve team-scoped groups against (e.g. ENG)")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path used to list the concrete states the group hits")
+	return cmd
+}
+
+// warnMisplacedGroups points at the one file the declarations must live in.
+// config.save rewrites config.toml wholesale from a fixed struct, so group
+// tables left there are deleted the first time the user rotates a token.
+func warnMisplacedGroups(cmd *cobra.Command, reg *groups.Registry, cfgPath string) {
+	if !groups.MisplacedInConfig(cfgPath) {
+		return
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"warning: %s declares state_groups or team_state_groups. Those keys are ignored there and any 'auth' write will delete them. Move them to %s\n",
+		cfgPath, reg.Path())
+}
+
+// matchStatesForGroup lists the concrete workflow states in the local
+// snapshot that the resolved set matches. The third return is false when the
+// store holds no workflow states at all, which is a cold cache and not an
+// error.
+func matchStatesForGroup(db *store.Store, set groups.Set, teamKey string) ([]map[string]any, []string, bool) {
+	teamID := ""
+	if trimmed := strings.TrimSpace(teamKey); trimmed != "" {
+		if team, ok := resolveTeam(db, trimmed); ok {
+			teamID = team.ID
+		}
+	}
+	raw, err := db.ListWorkflowStates(teamID)
+	if err != nil || len(raw) == 0 {
+		return nil, nil, false
+	}
+
+	matched := make([]map[string]any, 0, len(raw))
+	hit := map[string]bool{}
+	for _, item := range raw {
+		var ws workflowStateRow
+		if err := json.Unmarshal(item, &ws); err != nil || ws.ID == "" {
+			continue
+		}
+		byType := set.MatchesType(ws.Type)
+		byName := set.MatchesName(ws.Name)
+		if !byType && !byName {
+			continue
+		}
+		matchedBy := "name"
+		if byType {
+			matchedBy = "type"
+		}
+		for _, want := range set.Group.Names {
+			if strings.EqualFold(strings.TrimSpace(want), strings.TrimSpace(ws.Name)) {
+				hit[want] = true
+			}
+		}
+		matched = append(matched, map[string]any{
+			"id":         ws.ID,
+			"name":       ws.Name,
+			"type":       ws.Type,
+			"team_key":   ws.Team.Key,
+			"matched_by": matchedBy,
+		})
+	}
+	sort.Slice(matched, func(i, j int) bool {
+		a, _ := matched[i]["team_key"].(string)
+		b, _ := matched[j]["team_key"].(string)
+		if a != b {
+			return a < b
+		}
+		an, _ := matched[i]["name"].(string)
+		bn, _ := matched[j]["name"].(string)
+		return an < bn
+	})
+
+	unmatched := []string{}
+	for _, want := range set.Group.Names {
+		if !hit[want] {
+			unmatched = append(unmatched, want)
+		}
+	}
+	return matched, unmatched, true
+}
+
+func renderGroupCheck(cmd *cobra.Command, result map[string]any) error {
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "%-14s %v\n", "TOKEN", result["token"])
+	fmt.Fprintf(out, "%-14s %v\n", "RESOLVED AS", result["resolved_as"])
+	fmt.Fprintf(out, "%-14s %v\n", "SOURCE", result["source"])
+	fmt.Fprintf(out, "%-14s %v\n", "SCOPE", result["scope"])
+	if types, ok := result["types"].([]string); ok {
+		fmt.Fprintf(out, "%-14s %s\n", "TYPES", strings.Join(types, ", "))
+	}
+	if names, ok := result["names"].([]string); ok {
+		fmt.Fprintf(out, "%-14s %s\n", "NAMES", strings.Join(names, ", "))
+	}
+	if filter, err := json.Marshal(result["live_filter"]); err == nil {
+		fmt.Fprintf(out, "%-14s %s\n", "LIVE FILTER", string(filter))
+	}
+	states, ok := result["matching_states"].([]map[string]any)
+	if !ok {
+		fmt.Fprintln(cmd.ErrOrStderr(), "no synced workflow states. Run 'linear-pp-cli sync' to see which states this group hits")
+		return nil
+	}
+	fmt.Fprintf(out, "\n%-10s %-24s %-12s %s\n", "TEAM", "STATE", "TYPE", "MATCHED BY")
+	fmt.Fprintln(out, strings.Repeat("-", 62))
+	for _, s := range states {
+		fmt.Fprintf(out, "%-10v %-24v %-12v %v\n", s["team_key"], s["name"], s["type"], s["matched_by"])
+	}
+	if unmatched, ok := result["unmatched_names"].([]string); ok && len(unmatched) > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(), "\nnames matching no synced state: %s\n", strings.Join(unmatched, ", "))
+	}
+	return nil
+}

--- a/library/project-management/linear/internal/cli/groups_cmd.go
+++ b/library/project-management/linear/internal/cli/groups_cmd.go
@@ -84,6 +84,29 @@ func teamKeyForGroups(db *store.Store, input string) string {
 	return trimmed
 }
 
+// projectTeamKeyForGroups reports the team key a project's state predicates
+// must resolve against, given the project's stored payload. A Linear project
+// can span several teams, so a team-scoped override is only unambiguous when
+// the project belongs to exactly one team: anything else (no teams recorded,
+// or more than one) resolves at workspace scope, which is what the empty key
+// selects.
+func projectTeamKeyForGroups(raw json.RawMessage) string {
+	var payload struct {
+		Teams struct {
+			Nodes []struct {
+				Key string `json:"key"`
+			} `json:"nodes"`
+		} `json:"teams"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return ""
+	}
+	if len(payload.Teams.Nodes) != 1 {
+		return ""
+	}
+	return strings.TrimSpace(payload.Teams.Nodes[0].Key)
+}
+
 func newGroupsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "groups",

--- a/library/project-management/linear/internal/cli/groups_scope_test.go
+++ b/library/project-management/linear/internal/cli/groups_scope_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Project-level arithmetic (projects burndown, milestones at-risk) resolves
+// its "delivered" group at the project's own team scope. A project belongs to
+// exactly one team in the common case, and only that case may pick up a
+// team_state_groups override: a project spanning teams has no single correct
+// override, so it must fall back to workspace scope.
+func TestProjectTeamKeyForGroups(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "single team yields its key",
+			raw:  `{"id":"p1","name":"Migration","teams":{"nodes":[{"id":"t1","key":"ENG","name":"Engineering"}]}}`,
+			want: "ENG",
+		},
+		{
+			name: "two teams are ambiguous, workspace scope wins",
+			raw:  `{"id":"p1","teams":{"nodes":[{"key":"ENG"},{"key":"OPS"}]}}`,
+			want: "",
+		},
+		{
+			name: "no teams recorded",
+			raw:  `{"id":"p1","teams":{"nodes":[]}}`,
+			want: "",
+		},
+		{
+			name: "teams key absent entirely",
+			raw:  `{"id":"p1","name":"Legacy row synced before teams were selected"}`,
+			want: "",
+		},
+		{
+			name: "blank key is not a team scope",
+			raw:  `{"id":"p1","teams":{"nodes":[{"key":"   "}]}}`,
+			want: "",
+		},
+		{
+			name: "malformed payload never panics",
+			raw:  `{"teams":"not-an-object"}`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := projectTeamKeyForGroups(json.RawMessage(tc.raw)); got != tc.want {
+				t.Fatalf("projectTeamKeyForGroups() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/cliutil"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/groups"
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
 
 	"github.com/spf13/cobra"
@@ -47,12 +48,23 @@ type issueRow struct {
 	} `json:"assignee,omitempty"`
 	UpdatedAt string `json:"updatedAt"`
 	URL       string `json:"url,omitempty"`
+	// ArchivedAt is Issue.archivedAt, null on a live issue. It is the only
+	// thing that distinguishes an archived row once --include-archived is on.
+	ArchivedAt string `json:"archivedAt,omitempty"`
 }
 
+// pp:data-source auto
+// The identifier read goes through the shared resolver, so --data-source
+// picks the leg: local sqlite first, then the live GraphQL query, with the
+// store miss returned as not found when live fails on a fresh store.
 func newIssuesCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	cmd := &cobra.Command{
-		Use:   "issues [ID]",
+		// Use carries no positional placeholder on purpose. The read form
+		// (`issues ESP-1155`) shares its slot with every subcommand, so a
+		// placeholder here reads as though `issues create` were an ID.
+		// The read form is documented in Long and leads the Example block.
+		Use:   "issues",
 		Short: "Get, list, or create Linear issues",
 		Long: `Get a single issue by identifier (e.g. ESP-1155), or list issues with filters.
 
@@ -97,8 +109,10 @@ func newIssuesReadAliasCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 		Aliases: []string{"view", "show"},
 		Short:   "Get Linear issues by identifier",
 		Long:    `Compatibility aliases for the canonical positional form: linear-pp-cli issues ID.`,
-		Hidden:  true,
-		Args:    cobra.ExactArgs(1),
+		Example: `  linear-pp-cli issues get ESP-1155
+  linear-pp-cli issues get ESP-1155,ESP-1156 --agent`,
+		Hidden: true,
+		Args:   cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runIssuesRead(cmd, flags, *dbPath, args[0])
 		},
@@ -170,6 +184,8 @@ func newIssuesListCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 		team      string
 		project   string
 		limit     int
+
+		includeArchived bool
 	)
 	cmd := &cobra.Command{
 		Use:         "list",
@@ -177,28 +193,38 @@ func newIssuesListCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 		Short:       "List issues from the local sqlite store with filters",
 		Long: `List issues from the local sqlite store. Requires a prior 'linear-pp-cli sync'.
 
-Filters compose with AND. --state is matched against state.type (not state.name)
-so values like 'started', 'backlog', 'completed', 'canceled', 'duplicate' and
-'triage' work across teams that customize state names. 'active' means every
-state type except completed, canceled and duplicate. Use --state all to include
-the closed types as well.
+Filters compose with AND. --state takes a state group or a raw state type: any
+group from 'groups list' (active, all, and one trivial group per raw type),
+a raw type (triage, backlog, unstarted, started, completed, canceled,
+duplicate), 'type:<type>' to bypass a group that shadows a raw type, or
+'name:<state name>' for one literal state name. Declare your own groups in
+groups.toml next to your config file. Use --state all to drop the filter.
 
 --assignee accepts 'me' (resolves the authenticated viewer via a live GraphQL query),
 a user id, a user's display name, or a user's email.
 
---team and --project accept either a team/project key or a UUID.`,
+--team and --project accept either a team/project key or a UUID.
+
+--include-archived passes includeArchived: true to the issues connection, so
+archived issues come back alongside live ones and carry archivedAt. Archived
+issues keep the workflow state they were archived in, which is usually a
+completed or canceled one, so pair the flag with --state all to actually see
+them. Note that sync prunes archived issues out of the local store, so the
+flag only reaches archived rows on a live read.`,
 		Example: `  linear-pp-cli issues list --assignee me
   linear-pp-cli issues list --assignee me --state started --json
-  linear-pp-cli issues list --team ESP --state all --limit 500`,
+  linear-pp-cli issues list --team ESP --state all --limit 500
+  linear-pp-cli issues list --team ESP --state all --include-archived --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runIssuesList(cmd, flags, resolveDBPath(*dbPath), assignee, stateFlag, team, project, limit)
+			return runIssuesList(cmd, flags, resolveDBPath(*dbPath), assignee, stateFlag, team, project, limit, includeArchived)
 		},
 	}
 	cmd.Flags().StringVar(&assignee, "assignee", "", "Filter by assignee (me, user id, display name, or email)")
-	cmd.Flags().StringVar(&stateFlag, "state", "active", "Filter by state type: active (default), triage, backlog, unstarted, started, completed, canceled, duplicate, all")
+	cmd.Flags().StringVar(&stateFlag, "state", "active", stateGroupFlagUsage)
 	cmd.Flags().StringVar(&team, "team", "", "Filter by team key or ID")
 	cmd.Flags().StringVar(&project, "project", "", "Filter by project key or ID")
 	cmd.Flags().IntVar(&limit, "limit", 200, "Maximum results to return")
+	cmd.Flags().BoolVar(&includeArchived, "include-archived", false, "Include archived issues, mapping to the issues connection includeArchived argument. Live reads only")
 	return cmd
 }
 
@@ -361,6 +387,22 @@ func fetchIssueByIDLive(c graphqlQueryer, id string) (json.RawMessage, error) {
 }
 
 func resolveIssueID(c graphqlQueryer, identifier string) (string, error) {
+	return resolveIssueIDWith(c, identifier, false)
+}
+
+// resolveIssueIDWith is resolveIssueID with the issues connection's
+// includeArchived argument exposed.
+//
+// The default false is the right answer for every read and almost every
+// write: an archived issue is not a live target and resolving one silently
+// would be worse than exit 3. `issues unarchive` is the exception, because its
+// subject is archived by definition, and excluding archived rows here made
+// TEAM-NUMBER unresolvable for it while the UUID path worked. Rather than
+// widen the default for everyone, callers who need archived rows ask.
+//
+// includeArchived is only sent when true, so the default path emits exactly
+// the variable set it always emitted and the server default keeps applying.
+func resolveIssueIDWith(c graphqlQueryer, identifier string, includeArchived bool) (string, error) {
 	if store.IsUUID(identifier) {
 		return identifier, nil
 	}
@@ -368,8 +410,8 @@ func resolveIssueID(c graphqlQueryer, identifier string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("invalid issue identifier %q (expected TEAM-NUMBER, e.g. ESP-1155)", identifier)
 	}
-	query := `query($teamKey: String!, $number: Float!) {
-		issues(filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }, first: 1) {
+	query := `query($teamKey: String!, $number: Float!, $includeArchived: Boolean) {
+		issues(filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }, first: 1, includeArchived: $includeArchived) {
 			nodes { id }
 		}
 	}`
@@ -380,7 +422,11 @@ func resolveIssueID(c graphqlQueryer, identifier string) (string, error) {
 			} `json:"nodes"`
 		} `json:"issues"`
 	}
-	if err := c.QueryInto(query, map[string]any{"teamKey": teamKey, "number": number}, &resp); err != nil {
+	vars := map[string]any{"teamKey": teamKey, "number": number}
+	if includeArchived {
+		vars["includeArchived"] = true
+	}
+	if err := c.QueryInto(query, vars, &resp); err != nil {
 		return "", err
 	}
 	if len(resp.Issues.Nodes) == 0 || resp.Issues.Nodes[0].ID == "" {
@@ -427,7 +473,7 @@ func parseIssueIdentifier(identifier string) (string, float64, bool) {
 	return teamKey, float64(number), true
 }
 
-func runIssuesList(cmd *cobra.Command, flags *rootFlags, dbPath, assignee, stateFlag, team, project string, limit int) error {
+func runIssuesList(cmd *cobra.Command, flags *rootFlags, dbPath, assignee, stateFlag, team, project string, limit int, includeArchived bool) error {
 	db, err := openStoreAt(dbPath)
 	if err != nil {
 		return fmt.Errorf("opening database: %w\nRun 'linear-pp-cli sync' first", err)
@@ -469,6 +515,15 @@ func runIssuesList(cmd *cobra.Command, flags *rootFlags, dbPath, assignee, state
 		filter["project_id"] = projectID
 	}
 
+	// One resolver, one predicate. Every state filter in this CLI resolves
+	// through internal/groups so the live query and the local re-check
+	// cannot disagree on normalization, and so the user can redeclare what
+	// a token means without a rebuild.
+	set, err := resolveStateSet(flags, teamKeyForGroups(db, team), stateFlag)
+	if err != nil {
+		return err
+	}
+
 	// Honor --data-source for the actual issue fetch. `auto` (default)
 	// tries live-first per the framework's resolveRead pattern; `local`
 	// pins to the store (budget-conscious); `live` errors instead of
@@ -480,7 +535,7 @@ func runIssuesList(cmd *cobra.Command, flags *rootFlags, dbPath, assignee, state
 	servedFromLive := false
 	fellBackOnNetErr := false
 	if useLive {
-		raw, err = fetchIssuesLive(cmd.Context(), flags, db, filter, stateFlag, limit)
+		raw, err = fetchIssuesLive(cmd.Context(), flags, db, filter, set, limit, includeArchived)
 		if err != nil {
 			if flags.dataSource == "live" {
 				return err
@@ -511,7 +566,14 @@ func runIssuesList(cmd *cobra.Command, flags *rootFlags, dbPath, assignee, state
 		if err := json.Unmarshal(r, &row); err != nil {
 			continue
 		}
-		if !matchesStateFilter(row.State.Type, stateFlag) {
+		// The live path already excluded archived issues server-side unless
+		// asked otherwise, but the store can hold archived rows written
+		// through by an earlier --include-archived read. Re-applying the
+		// predicate keeps the local path answering the same question.
+		if !includeArchived && row.ArchivedAt != "" {
+			continue
+		}
+		if !set.Matches(row.State.Type, row.State.Name) {
 			continue
 		}
 		rows = append(rows, row)
@@ -571,6 +633,29 @@ func runIssuesList(cmd *cobra.Command, flags *rootFlags, dbPath, assignee, state
 		return nil
 	}
 
+	if includeArchived {
+		// Only widen the table when the caller asked for archived rows. The
+		// stamp is trimmed to the date: the time of day is never the reason
+		// anyone is reading this column.
+		fmt.Fprintf(cmd.OutOrStdout(), "%-12s %-4s %-16s %-10s %-12s %s\n", "ID", "PRI", "STATE", "TEAM", "ARCHIVED", "TITLE")
+		fmt.Fprintln(cmd.OutOrStdout(), strings.Repeat("-", 92))
+		for _, row := range rows {
+			title := row.Title
+			if len(title) > 40 {
+				title = title[:37] + "..."
+			}
+			archived := "-"
+			if len(row.ArchivedAt) >= 10 {
+				archived = row.ArchivedAt[:10]
+			} else if row.ArchivedAt != "" {
+				archived = row.ArchivedAt
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%-12s %-4s %-16s %-10s %-12s %s\n",
+				row.Identifier, priorityLabel(row.Priority), row.State.Name, row.Team.Key, archived, title)
+		}
+		return nil
+	}
+
 	fmt.Fprintf(cmd.OutOrStdout(), "%-12s %-4s %-16s %-10s %s\n", "ID", "PRI", "STATE", "TEAM", "TITLE")
 	fmt.Fprintln(cmd.OutOrStdout(), strings.Repeat("-", 80))
 	for _, row := range rows {
@@ -582,17 +667,6 @@ func runIssuesList(cmd *cobra.Command, flags *rootFlags, dbPath, assignee, state
 			row.Identifier, priorityLabel(row.Priority), row.State.Name, row.Team.Key, title)
 	}
 	return nil
-}
-
-func matchesStateFilter(stateType, stateFlag string) bool {
-	switch strings.ToLower(strings.TrimSpace(stateFlag)) {
-	case "all", "":
-		return true
-	case "active":
-		return stateType != "completed" && stateType != "canceled" && stateType != "duplicate"
-	default:
-		return strings.EqualFold(stateType, stateFlag)
-	}
 }
 
 // resolveAssigneeFilter maps --assignee input to a user UUID.
@@ -709,7 +783,11 @@ func renderIssues(cmd *cobra.Command, flags *rootFlags, issues []json.RawMessage
 // write-throughs the response into the local store via UpsertIssue so the
 // next --data-source local read sees fresh data. The cliutil/store imports
 // already in this file's import block cover the helpers used here.
-func fetchIssuesLive(ctx context.Context, flags *rootFlags, db *store.Store, filter map[string]string, stateFlag string, limit int) ([]json.RawMessage, error) {
+//
+// includeArchived maps to the issues connection's includeArchived argument.
+// It is only sent when true, so the default path emits exactly the variable
+// set it always emitted and the server default keeps applying.
+func fetchIssuesLive(ctx context.Context, flags *rootFlags, db *store.Store, filter map[string]string, set groups.Set, limit int, includeArchived bool) ([]json.RawMessage, error) {
 	c, err := flags.newClient()
 	if err != nil {
 		return nil, err
@@ -724,17 +802,8 @@ func fetchIssuesLive(ctx context.Context, flags *rootFlags, db *store.Store, fil
 	if v, ok := filter["project_id"]; ok && v != "" {
 		gqlFilter["project"] = map[string]any{"id": map[string]any{"eq": v}}
 	}
-	switch stateFlag {
-	case "", "all":
-		// no filter — return everything
-	case "active":
-		// "active" is the v3 semantic: not completed AND not canceled AND not
-		// duplicate. Linear's WorkflowState.type enum has seven values
-		// {triage, backlog, unstarted, started, completed, canceled,
-		// duplicate}. The live filter uses nin.
-		gqlFilter["state"] = map[string]any{"type": map[string]any{"nin": []string{"completed", "canceled", "duplicate"}}}
-	default:
-		gqlFilter["state"] = map[string]any{"type": map[string]any{"eq": stateFlag}}
+	if stateFilter := set.GraphQLFilter(); stateFilter != nil {
+		gqlFilter["state"] = stateFilter
 	}
 	// Linear's GraphQL `issues` query caps `first` at 100 per page. To
 	// honor a user-supplied --limit greater than 100, paginate via
@@ -760,6 +829,9 @@ func fetchIssuesLive(ctx context.Context, flags *rootFlags, db *store.Store, fil
 			}
 		}
 		vars := map[string]any{"first": first, "filter": gqlFilter}
+		if includeArchived {
+			vars["includeArchived"] = true
+		}
 		if cursor != "" {
 			vars["after"] = cursor
 		}

--- a/library/project-management/linear/internal/cli/milestones_at_risk.go
+++ b/library/project-management/linear/internal/cli/milestones_at_risk.go
@@ -24,8 +24,13 @@ func newMilestonesCmd(flags *rootFlags) *cobra.Command {
 	return cmd
 }
 
+// pp:data-source computed
+// milestones at-risk never calls the API: it reuses computeBurndownStats over
+// the locally synced project and issue rows to project a landing date, then
+// ranks milestones by the slip that projection implies.
 func newMilestonesAtRiskCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
+	var completedGroup string
 	var limit int
 	cmd := &cobra.Command{
 		Use:     "at-risk",
@@ -59,6 +64,13 @@ slipDays descending. Only milestones with slipDays > 0 are returned.`,
 				return configErr(fmt.Errorf("opening database: %w", err))
 			}
 			defer db.Close()
+
+			// Inherits the burndown arithmetic, so it must inherit the
+			// same declared notion of "delivered".
+			completedSet, err := resolveStateSet(flags, "", completedGroup)
+			if err != nil {
+				return err
+			}
 
 			projects, err := db.ListProjects(map[string]string{})
 			if err != nil {
@@ -106,7 +118,7 @@ slipDays descending. Only milestones with slipDays > 0 are returned.`,
 				projectedSource := ""
 				if prj.ID != "" {
 					if issues, ierr := db.ListIssues(map[string]string{"project_id": prj.ID}, 1000); ierr == nil && len(issues) > 0 {
-						stats := computeBurndownStats(issues, 4)
+						stats := computeBurndownStats(issues, 4, completedSet)
 						if stats.WeeklyVelocity > 0 {
 							weeksToLand := stats.RemainingEstimate / stats.WeeklyVelocity
 							landing := time.Now().UTC().AddDate(0, 0, int(math.Ceil(weeksToLand*7)))
@@ -186,6 +198,7 @@ slipDays descending. Only milestones with slipDays > 0 are returned.`,
 	}
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/linear-pp-cli/data.db)")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum at-risk milestones to return")
+	cmd.Flags().StringVar(&completedGroup, "completed-group", "completed", completedGroupFlagUsage)
 	return cmd
 }
 

--- a/library/project-management/linear/internal/cli/milestones_at_risk.go
+++ b/library/project-management/linear/internal/cli/milestones_at_risk.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/groups"
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -66,9 +67,25 @@ slipDays descending. Only milestones with slipDays > 0 are returned.`,
 			defer db.Close()
 
 			// Inherits the burndown arithmetic, so it must inherit the
-			// same declared notion of "delivered".
-			completedSet, err := resolveStateSet(flags, "", completedGroup)
-			if err != nil {
+			// same declared notion of "delivered". The token is resolved
+			// once per team scope rather than once for the whole run: a
+			// project whose team redeclares the group is counted by its
+			// own definition, and the workspace definition still covers
+			// projects that span teams. Resolution is memoized because a
+			// portfolio commonly holds many projects per team.
+			completedSets := map[string]groups.Set{}
+			completedSetFor := func(teamKey string) (groups.Set, error) {
+				if set, ok := completedSets[teamKey]; ok {
+					return set, nil
+				}
+				set, err := resolveStateSet(flags, teamKey, completedGroup)
+				if err != nil {
+					return groups.Set{}, err
+				}
+				completedSets[teamKey] = set
+				return set, nil
+			}
+			if _, err := completedSetFor(""); err != nil {
 				return err
 			}
 
@@ -117,6 +134,10 @@ slipDays descending. Only milestones with slipDays > 0 are returned.`,
 				projectLanding := ""
 				projectedSource := ""
 				if prj.ID != "" {
+					completedSet, cerr := completedSetFor(projectTeamKeyForGroups(prjRaw))
+					if cerr != nil {
+						return cerr
+					}
 					if issues, ierr := db.ListIssues(map[string]string{"project_id": prj.ID}, 1000); ierr == nil && len(issues) > 0 {
 						stats := computeBurndownStats(issues, 4, completedSet)
 						if stats.WeeklyVelocity > 0 {

--- a/library/project-management/linear/internal/cli/projects_burndown.go
+++ b/library/project-management/linear/internal/cli/projects_burndown.go
@@ -79,8 +79,10 @@ What counts as delivered is the 'completed' state group by default. Run
 
 			// "Delivered" is a declared group, not a hardcoded type
 			// comparison, so a workspace that ships out of a custom column
-			// can say so once in groups.toml.
-			completedSet, err := resolveStateSet(flags, "", completedGroup)
+			// can say so once in groups.toml. It resolves at the project's
+			// own team scope, so a team that redeclares "completed" gets
+			// its own definition here rather than the workspace one.
+			completedSet, err := resolveStateSet(flags, proj.TeamKey, completedGroup)
 			if err != nil {
 				return err
 			}
@@ -162,6 +164,10 @@ type projectRef struct {
 	Name       string `json:"name"`
 	State      string `json:"state"`
 	TargetDate string `json:"targetDate"`
+	// TeamKey is the project's sole team, or empty when the project spans
+	// several teams or records none. It is the scope every state group in
+	// this project's arithmetic resolves at.
+	TeamKey string `json:"-"`
 }
 
 func resolveProjectByNameOrID(db *store.Store, q string) (*projectRef, error) {
@@ -174,6 +180,7 @@ func resolveProjectByNameOrID(db *store.Store, q string) (*projectRef, error) {
 		Name       string `json:"name"`
 		State      string `json:"state"`
 		TargetDate string `json:"targetDate"`
+		TeamKey    string `json:"-"`
 	}
 	var matches []proj
 	qLower := strings.ToLower(q)
@@ -182,6 +189,7 @@ func resolveProjectByNameOrID(db *store.Store, q string) (*projectRef, error) {
 		if err := json.Unmarshal(raw, &p); err != nil {
 			continue
 		}
+		p.TeamKey = projectTeamKeyForGroups(raw)
 		if p.ID == q || p.Name == q {
 			matches = append(matches, p)
 			continue
@@ -198,10 +206,10 @@ func resolveProjectByNameOrID(db *store.Store, q string) (*projectRef, error) {
 		for _, p := range matches {
 			names = append(names, p.Name)
 		}
-		return nil, fmt.Errorf("project %q matched %d projects: %s — be more specific", q, len(matches), strings.Join(names, ", "))
+		return nil, fmt.Errorf("project %q matched %d projects: %s — be more specific.", q, len(matches), strings.Join(names, ", "))
 	}
 	m := matches[0]
-	return &projectRef{ID: m.ID, Name: m.Name, State: m.State, TargetDate: m.TargetDate}, nil
+	return &projectRef{ID: m.ID, Name: m.Name, State: m.State, TargetDate: m.TargetDate, TeamKey: m.TeamKey}, nil
 }
 
 type burndownStats struct {

--- a/library/project-management/linear/internal/cli/projects_burndown.go
+++ b/library/project-management/linear/internal/cli/projects_burndown.go
@@ -9,11 +9,13 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/groups"
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
 
 	"github.com/spf13/cobra"
 )
 
+// pp:data-source computed
 // newProjectsBurndownCmd implements the prior `projects burndown` transcendence
 // feature that shipped deferred under v1's ship-with-gaps verdict. Linear
 // regresses remaining estimate against measured velocity to project a project
@@ -21,6 +23,7 @@ import (
 func newProjectsBurndownCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	var weeks int
+	var completedGroup string
 	cmd := &cobra.Command{
 		Use:   "burndown <project>",
 		Short: "Project a project's landing date from estimate vs measured velocity",
@@ -31,16 +34,21 @@ recent N-week velocity (default 4 weeks).
 
 Output:
   scope                total issues attached to the project
-  completed            issues whose state.type == "completed"
-  remaining_estimate   sum of estimate field across non-completed issues
+  completed            issues in the --completed-group state group
+  remaining_estimate   sum of estimate field across every other issue
   weekly_velocity      avg estimate-points completed per week over last N weeks
   projected_landing    the calendar date when remaining_estimate hits zero
                        at the measured velocity (with confidence band)
   target_date          the project's static target_date (for comparison)
-  delta_days           projected_landing - target_date (negative = early)`,
+  delta_days           projected_landing - target_date (negative = early)
+
+What counts as delivered is the 'completed' state group by default. Run
+'groups list' to see it, redeclare it in groups.toml, or pass
+--completed-group for one run.`,
 		Example: `  linear-pp-cli projects burndown PROJ-42
   linear-pp-cli projects burndown "Q3 Migration" --weeks 8
-  linear-pp-cli projects burndown PROJ-42 --json`,
+  linear-pp-cli projects burndown PROJ-42 --json
+  linear-pp-cli projects burndown PROJ-42 --completed-group shipped`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,7 +77,15 @@ Output:
 				return fmt.Errorf("no issues attached to project %q in local store; sync may be incomplete", proj.Name)
 			}
 
-			stats := computeBurndownStats(issues, weeks)
+			// "Delivered" is a declared group, not a hardcoded type
+			// comparison, so a workspace that ships out of a custom column
+			// can say so once in groups.toml.
+			completedSet, err := resolveStateSet(flags, "", completedGroup)
+			if err != nil {
+				return err
+			}
+
+			stats := computeBurndownStats(issues, weeks, completedSet)
 			summary := map[string]any{
 				"project": map[string]any{
 					"id":          proj.ID,
@@ -137,6 +153,7 @@ Output:
 	}
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
 	cmd.Flags().IntVar(&weeks, "weeks", 4, "Velocity window: number of recent weeks to average completed estimate-points across")
+	cmd.Flags().StringVar(&completedGroup, "completed-group", "completed", completedGroupFlagUsage)
 	return cmd
 }
 
@@ -195,10 +212,11 @@ type burndownStats struct {
 	WeeklyVelocity    float64
 }
 
-func computeBurndownStats(issues []json.RawMessage, weeks int) burndownStats {
+func computeBurndownStats(issues []json.RawMessage, weeks int, completed groups.Set) burndownStats {
 	type issueSlim struct {
 		Estimate float64 `json:"estimate"`
 		State    struct {
+			Name string `json:"name"`
 			Type string `json:"type"`
 		} `json:"state"`
 		CompletedAt string `json:"completedAt"`
@@ -211,7 +229,7 @@ func computeBurndownStats(issues []json.RawMessage, weeks int) burndownStats {
 			continue
 		}
 		s.Scope++
-		if i.State.Type == "completed" {
+		if completed.Matches(i.State.Type, i.State.Name) {
 			s.Completed++
 			s.CompletedEstimate += i.Estimate
 			if i.CompletedAt != "" {

--- a/library/project-management/linear/internal/cli/root.go
+++ b/library/project-management/linear/internal/cli/root.go
@@ -159,24 +159,19 @@ Highlights (not in the official API docs):
   • today   See all of your assigned issues across every team for today, ranked by priority and cycle deadline.
   • bottleneck   See which team members are overloaded and which issues are blocked before sprint planning.
   • projects burndown   Project a project's landing date by linear-regressing remaining estimate against the team's measured velocity.
-  • projects list   List Linear projects live, optionally scoped by team, before attaching or auditing portfolio work.
-  • projects search   Search Linear projects live by name with an optional team filter.
-  • projects resolve   Resolve one Linear project name to a UUID, preferring exact matches and supporting team scoping.
   • cycles compare   Side-by-side metrics between any two cycles: completion %, scope added, scope cut, carryover, average cycle time.
   • stale   Find issues that haven't been touched in N days, grouped by team and project.
   • slipped   Show what carried over from last cycle into this cycle, grouped by team and reason heuristic.
   • blocking   Show issues you are blocking — sorted by downstream impact (downstream count × downstream priority).
-  • issues search   Search synced Linear issues by text before creating a new ticket; team-scoped alias for similar duplicate checks.
   • similar   Find issues that look like duplicates of a query string using offline FTS5 fuzzy matching.
   • velocity   Track sprint completion rates over the last N cycles to spot productivity trends.
   • initiatives health   Rolled-up portfolio view per initiative: child project progress, milestone target-vs-projected dates, slippage flags.
-  • initiatives list   List Linear initiatives live with their current status and URL.
-  • initiatives search   Search Linear initiatives live by name.
-  • initiatives resolve   Resolve one Linear initiative name to a UUID, preferring exact matches.
   • milestones at-risk   List portfolio milestones whose projected landing date has slipped past their target, ranked by slip magnitude.
   • pp-test list   List Linear issues this CLI created in the current or named session, then archive them with pp-cleanup.
   • issues create --trust-mode strict   Refuse mutations on Linear issues not in the local pp_created ledger when --trust-mode strict is set; works on create and any future mutation surface.
-  • issues create/edit --parent   Create, set, change, or clear Linear parent/sub-issue links without raw GraphQL.
+  • projects list   List Linear projects live, optionally scoped by team, before attaching or auditing portfolio work.
+  • projects search   Search Linear projects live by name with an optional team filter.
+  …and 10 more — see README.md for the full list
 
 Agent mode: add --agent to any command for JSON output + non-interactive mode.
 Health check: run 'linear-pp-cli doctor' to verify auth and connectivity.
@@ -314,6 +309,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	// v3-ported top-level commands
 	rootCmd.AddCommand(newIssuesCmd(flags))
 	rootCmd.AddCommand(newWorkflowStatesCmd(flags))
+	rootCmd.AddCommand(newGroupsCmd(flags))
 	rootCmd.AddCommand(newCommentsCmd(flags))
 	rootCmd.AddCommand(newProjectUpdatesCmd(flags))
 	rootCmd.AddCommand(newDocumentsCmd(flags))
@@ -331,7 +327,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newExportCmd(flags))
 
 	// v3-ported persistent flags
-	rootCmd.PersistentFlags().StringVar(&flags.trustMode, "trust-mode", "", "Mutation guard: 'strict' refuses to mutate Linear issues not in the local pp_created table.")
+	rootCmd.PersistentFlags().StringVar(&flags.trustMode, "trust-mode", "", "Mutation guard: 'strict' refuses to mutate Linear issues absent from the local pp_created ledger. Enforced on 'issues create' (requires a session tag) and on 'issues edit' (refuses with exit 2 when the target was not created by this CLI). 'pp-cleanup' is exempt because it only touches ledger rows.")
 	rootCmd.PersistentFlags().StringVar(&flags.ppSession, "pp-session", "", "Session tag for issues this CLI creates (defaults to PP_SESSION env or run timestamp)")
 
 	return rootCmd

--- a/library/project-management/linear/internal/cli/slipped.go
+++ b/library/project-management/linear/internal/cli/slipped.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// pp:data-source computed
 // newSlippedCmd shows what carried over from the previous cycle into the
 // current cycle. Defined as: issues that were in the prior cycle, did not
 // complete, and are now in the active cycle (or unscheduled). Maya's
@@ -20,6 +21,7 @@ import (
 func newSlippedCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	var teamFilter string
+	var stateFlag string
 	cmd := &cobra.Command{
 		Use:   "slipped",
 		Short: "Show issues that slipped from the previous cycle into the current cycle",
@@ -82,6 +84,15 @@ into the active cycle for the team). Groups by reason heuristic:
 				previousIssues = filterIssuesByTeam(previousIssues, teamID)
 			}
 
+			// What counts as "did not land" is the resolved state group,
+			// not a hardcoded completed-or-canceled pair, so a workspace
+			// that treats duplicate or a custom column as closed can say so
+			// once in groups.toml instead of nine times in this binary.
+			set, err := resolveStateSet(flags, teamKeyForGroups(db, teamFilter), stateFlag)
+			if err != nil {
+				return err
+			}
+
 			// "Slipped" = in current cycle but state is not completed AND issue
 			// also appeared in the previous cycle. We approximate the second
 			// condition by intersecting on identifier (which is stable across
@@ -125,7 +136,7 @@ into the active cycle for the team). Groups by reason heuristic:
 				if !parsePrev[s.ID] {
 					continue
 				}
-				if s.State.Type == "completed" || s.State.Type == "canceled" || s.State.Type == "duplicate" {
+				if !set.Matches(s.State.Type, s.State.Name) {
 					continue
 				}
 				reason := "carried"
@@ -188,6 +199,7 @@ into the active cycle for the team). Groups by reason heuristic:
 	}
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
 	cmd.Flags().StringVar(&teamFilter, "team", "", "Filter to a team key (ENG) or UUID")
+	cmd.Flags().StringVar(&stateFlag, "state", "active", stateGroupFlagUsage)
 	_ = strings.Join // keep imports lean
 	return cmd
 }

--- a/library/project-management/linear/internal/cli/today.go
+++ b/library/project-management/linear/internal/cli/today.go
@@ -12,16 +12,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// pp:data-source live
+// today resolves the viewer through a live GraphQL query on every run, then
+// filters the locally synced issue rows for that assignee. It cannot run
+// without credentials, so it is not a local-only surface.
 func newTodayCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	var jsonOut bool
+	var stateFlag string
 	cmd := &cobra.Command{
 		Use:         "today",
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:       "Show your issues for today across all teams",
-		Long:        "Display all issues assigned to you in active cycles, sorted by priority. Requires a prior sync.",
+		Long: `Display all issues assigned to you, sorted by priority. Requires a prior sync.
+
+--state resolves through the same state groups as 'issues list' and defaults to
+the 'active' group. Run 'groups list' to see how active is defined here, or
+'groups check active' to see exactly which of your workflow states it hits.`,
 		Example: `  linear-pp-cli today
-  linear-pp-cli today --json`,
+  linear-pp-cli today --json
+  linear-pp-cli today --state started`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dbPath == "" {
 				dbPath = defaultDBPath("linear-pp-cli")
@@ -31,6 +41,16 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 				return fmt.Errorf("opening database: %w\nRun 'linear-pp-cli sync' first.", err)
 			}
 			defer db.Close()
+
+			// The local --json flag shadows the root persistent one, so a
+			// caller who passes --json ahead of the subcommand, or who uses
+			// --agent, sets flags.asJSON and never sets jsonOut. Honor both.
+			wantJSON := jsonOut || flags.asJSON
+
+			set, err := resolveStateSet(flags, "", stateFlag)
+			if err != nil {
+				return err
+			}
 
 			// Get viewer ID from config
 			c, err := flags.newClient()
@@ -53,8 +73,6 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			// Filter to active: every state type except completed, canceled
-			// and duplicate.
 			type issueRow struct {
 				Identifier string `json:"identifier"`
 				Title      string `json:"title"`
@@ -73,7 +91,7 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 			for _, raw := range issues {
 				var row issueRow
 				json.Unmarshal(raw, &row)
-				if row.State.Type != "completed" && row.State.Type != "canceled" && row.State.Type != "duplicate" {
+				if set.Matches(row.State.Type, row.State.Name) {
 					active = append(active, row)
 				}
 			}
@@ -88,13 +106,13 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 			if len(active) == 0 {
 				if !hintIfUnsynced(cmd, db, "issues") {
 					hintIfStale(cmd, db, "issues", flags.maxAge)
-					if jsonOut {
+					if wantJSON {
 						enc := json.NewEncoder(os.Stdout)
 						enc.SetIndent("", "  ")
 						return enc.Encode(active)
 					}
-					fmt.Println("No active issues assigned to you. Nice!")
-				} else if jsonOut {
+					fmt.Printf("No issues assigned to you in state group %q. Nice!\n", set.Group.Name)
+				} else if wantJSON {
 					enc := json.NewEncoder(os.Stdout)
 					enc.SetIndent("", "  ")
 					return enc.Encode(active)
@@ -103,7 +121,7 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 			}
 			hintIfStale(cmd, db, "issues", flags.maxAge)
 
-			if jsonOut {
+			if wantJSON {
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
 				return enc.Encode(active)
@@ -119,11 +137,12 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 				}
 				fmt.Printf("%-12s %-4s %-15s %-10s %s\n", row.Identifier, pri, row.State.Name, row.Team.Key, title)
 			}
-			fmt.Fprintf(os.Stderr, "\n%d active issues\n", len(active))
+			fmt.Fprintf(os.Stderr, "\n%d issues in state group %q\n", len(active), set.Group.Name)
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON (alias for the root --json flag)")
+	cmd.Flags().StringVar(&stateFlag, "state", "active", stateGroupFlagUsage)
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
 	return cmd
 }

--- a/library/project-management/linear/internal/groups/defaults.toml
+++ b/library/project-management/linear/internal/groups/defaults.toml
@@ -1,0 +1,30 @@
+# internal/groups/defaults.toml
+# Every value below is a Linear API-documented WorkflowState.type string
+# (WorkflowState.type / WorkflowStateFilter.type field descriptions).
+# TIER 2 API data, not a house convention. See contract section 3.
+schema_version = 1
+
+[state_groups.active]
+description = "Not completed, not canceled, not duplicate"
+types = ["triage", "backlog", "unstarted", "started"]
+
+[state_groups.triage]
+types = ["triage"]
+
+[state_groups.backlog]
+types = ["backlog"]
+
+[state_groups.unstarted]
+types = ["unstarted"]
+
+[state_groups.started]
+types = ["started"]
+
+[state_groups.completed]
+types = ["completed"]
+
+[state_groups.canceled]
+types = ["canceled"]
+
+[state_groups.duplicate]
+types = ["duplicate"]

--- a/library/project-management/linear/internal/groups/groups.go
+++ b/library/project-management/linear/internal/groups/groups.go
@@ -1,0 +1,733 @@
+// Package groups resolves user-declarable workflow-state groups.
+//
+// A group names a set of Linear workflow states. It is the single place in
+// this CLI that is allowed to express a state predicate: every --state token,
+// every "is this issue still open" check and every live WorkflowStateFilter
+// is produced here. Nothing else may hand-write a state comparison.
+//
+// Declarations live in a groups.toml sibling of the CLI config file, never in
+// config.toml itself (config.save rewrites that file wholesale from a fixed
+// struct and would silently delete them). Built-in defaults are embedded from
+// defaults.toml and parsed by the same code path as the user file, so there is
+// exactly one representation of a group in the binary.
+//
+// The only Linear vocabulary compiled in here is the seven API-documented
+// WorkflowState.type values. Workspace-specific state names, team keys and
+// project names never appear: they belong in the user's own groups.toml.
+package groups
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/config"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+//go:embed defaults.toml
+var defaultsTOML []byte
+
+// FileName is the sibling file the declarations are read from.
+const FileName = "groups.toml"
+
+// EnvGroupsPath overrides the resolved groups file path verbatim.
+const EnvGroupsPath = "LINEAR_GROUPS"
+
+// ReservedAll is the token that means "no state predicate at all". It is not
+// a set, so it is never encoded as a list of types: if Linear ever adds an
+// eighth WorkflowState.type, an enumerated "all" would start silently
+// excluding it while an absent predicate cannot.
+const ReservedAll = "all"
+
+// Group source discriminators, reported by `groups list` and by Set.Source.
+const (
+	SourceBuiltin   = "builtin"
+	SourceWorkspace = "config:workspace"
+	sourceTeamPfx   = "config:team:"
+)
+
+// Scope labels paired with the sources above.
+const (
+	scopeWorkspace = "workspace"
+	scopeTeamPfx   = "team:"
+)
+
+// How a token was resolved, reported by `groups check`.
+const (
+	ResolvedGroup       = "group"
+	ResolvedRawType     = "raw_type"
+	ResolvedLiteralName = "literal_name"
+	ResolvedUnfiltered  = "unfiltered"
+)
+
+// Escape-hatch prefixes that bypass group lookup entirely, so a user who
+// shadows a raw type with a group of the same name can still reach the type.
+const (
+	prefixType = "type:"
+	prefixName = "name:"
+)
+
+// GraphQL field and comparator names on WorkflowStateFilter / StringComparator.
+// StringComparator has no inIgnoreCase, which is why names are emitted as an
+// or-list of eqIgnoreCase rather than a single in: an in would be
+// case-sensitive live while the local path compares case-insensitively, which
+// is exactly the live-versus-local divergence this package exists to remove.
+const (
+	fieldType       = "type"
+	fieldName       = "name"
+	fieldOr         = "or"
+	cmpIn           = "in"
+	cmpEqIgnoreCase = "eqIgnoreCase"
+)
+
+// apiStateTypes is the complete read/filter vocabulary of
+// WorkflowState.type. There is no WorkflowStateType enum in the live schema.
+// The field is a bare String and these seven values come from its own
+// description. TIER 2 API data, identical for every Linear workspace.
+var apiStateTypes = []string{
+	"triage",
+	"backlog",
+	"unstarted",
+	"started",
+	"completed",
+	"canceled",
+	"duplicate",
+}
+
+var apiStateTypeSet = func() map[string]struct{} {
+	m := make(map[string]struct{}, len(apiStateTypes))
+	for _, t := range apiStateTypes {
+		m[t] = struct{}{}
+	}
+	return m
+}()
+
+// APITypeList renders the seven valid types for error messages.
+var APITypeList = strings.Join(apiStateTypes, ", ")
+
+// IsAPIType reports whether s is one of the seven documented type values.
+// The input is trimmed and lowercased first.
+func IsAPIType(s string) bool {
+	_, ok := apiStateTypeSet[strings.ToLower(strings.TrimSpace(s))]
+	return ok
+}
+
+// APITypes returns a copy of the seven documented type values.
+func APITypes() []string { return append([]string(nil), apiStateTypes...) }
+
+var groupNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+
+// ErrUnknownToken marks a resolution failure caused by this invocation's
+// token rather than by the file on disk. Callers map it to a usage error
+// (exit 2). Every other error from this package is a config error (exit 10).
+var ErrUnknownToken = errors.New("unknown state group or type")
+
+// Group is one declared set of workflow states.
+type Group struct {
+	Name        string   `json:"name"`
+	Source      string   `json:"source"`
+	Scope       string   `json:"scope"`
+	Reserved    bool     `json:"reserved"`
+	ShadowedBy  []string `json:"shadowed_by"`
+	Description string   `json:"description"`
+	Types       []string `json:"types"`
+	Names       []string `json:"names"`
+}
+
+// GroupInfo is the name the cross-package implementation contract uses for
+// the rows `groups list` returns.
+type GroupInfo = Group
+
+// Set is a resolved predicate. Unfiltered means "no state predicate at all",
+// which is what the empty token and the reserved "all" produce.
+type Set struct {
+	Group      Group  `json:"group"`
+	Unfiltered bool   `json:"unfiltered"`
+	ResolvedAs string `json:"resolved_as"`
+	Token      string `json:"token"`
+}
+
+// Predicate is the cross-package name for a resolved Set. It is a concrete
+// value type, not an interface, so callers can declare and copy it freely.
+type Predicate = Set
+
+// Source reports where the resolved group came from: builtin,
+// config:workspace, or config:team:<KEY>.
+func (s Set) Source() string { return s.Group.Source }
+
+// MatchesType reports whether a WorkflowState.type belongs to the set.
+func (s Set) MatchesType(stateType string) bool {
+	if s.Unfiltered {
+		return true
+	}
+	t := strings.ToLower(strings.TrimSpace(stateType))
+	if t == "" {
+		return false
+	}
+	for _, want := range s.Group.Types {
+		if want == t {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesName reports whether a WorkflowState.name belongs to the set.
+// Comparison is case-insensitive after trimming, matching the live path's
+// eqIgnoreCase emission.
+func (s Set) MatchesName(stateName string) bool {
+	if s.Unfiltered {
+		return true
+	}
+	n := strings.TrimSpace(stateName)
+	if n == "" {
+		return false
+	}
+	for _, want := range s.Group.Names {
+		if strings.EqualFold(strings.TrimSpace(want), n) {
+			return true
+		}
+	}
+	return false
+}
+
+// Matches is the local-path predicate: membership is the union of the type
+// set and the name set, evaluated against the same state.
+func (s Set) Matches(stateType, stateName string) bool {
+	if s.Unfiltered {
+		return true
+	}
+	return s.MatchesType(stateType) || s.MatchesName(stateName)
+}
+
+// Match is the cross-package alias of Matches.
+func (s Set) Match(stateType, stateName string) bool { return s.Matches(stateType, stateName) }
+
+// GraphQLFilter is the live-path predicate. It returns the value for the
+// "state" key of an IssueFilter (a WorkflowStateFilter), or nil when the set
+// is unfiltered and the key must be omitted entirely.
+func (s Set) GraphQLFilter() map[string]any {
+	if s.Unfiltered {
+		return nil
+	}
+	typeClause := func() map[string]any {
+		return map[string]any{fieldType: map[string]any{cmpIn: append([]string(nil), s.Group.Types...)}}
+	}
+	nameClause := func(n string) map[string]any {
+		return map[string]any{fieldName: map[string]any{cmpEqIgnoreCase: n}}
+	}
+	hasTypes := len(s.Group.Types) > 0
+	hasNames := len(s.Group.Names) > 0
+	switch {
+	case hasTypes && !hasNames:
+		return typeClause()
+	case !hasTypes && len(s.Group.Names) == 1:
+		return nameClause(s.Group.Names[0])
+	case !hasTypes && hasNames:
+		or := make([]any, 0, len(s.Group.Names))
+		for _, n := range s.Group.Names {
+			or = append(or, nameClause(n))
+		}
+		return map[string]any{fieldOr: or}
+	case hasTypes && hasNames:
+		or := make([]any, 0, len(s.Group.Names)+1)
+		or = append(or, typeClause())
+		for _, n := range s.Group.Names {
+			or = append(or, nameClause(n))
+		}
+		return map[string]any{fieldOr: or}
+	}
+	return nil
+}
+
+// LiveFilter is the package-level form of Set.GraphQLFilter, named by the
+// cross-package implementation contract.
+func LiveFilter(p Predicate) map[string]any { return p.GraphQLFilter() }
+
+// fileDoc is the on-disk grammar, shared by defaults.toml and the user file.
+type fileDoc struct {
+	SchemaVersion   int                              `toml:"schema_version"`
+	StateGroups     map[string]groupTable            `toml:"state_groups"`
+	TeamStateGroups map[string]map[string]groupTable `toml:"team_state_groups"`
+}
+
+type groupTable struct {
+	Types       []string `toml:"types"`
+	Names       []string `toml:"names"`
+	Description string   `toml:"description"`
+}
+
+const supportedSchemaVersion = 1
+
+// Registry holds the merged built-in and user-declared groups.
+type Registry struct {
+	path      string
+	present   bool
+	builtin   map[string]Group
+	workspace map[string]Group
+	team      map[string]map[string]Group // upper-cased team key -> group name -> group
+}
+
+// Path reports where the user file was looked for, for meta.groups_path.
+func (r *Registry) Path() string { return r.path }
+
+// Present reports whether that file exists. A missing file is not an error.
+func (r *Registry) Present() bool { return r.present }
+
+// DirForConfigPath maps a config FILE path to the directory the groups file
+// lives in. An empty configPath resolves through the normal config chain, so
+// callers can pass the raw --config flag value straight through.
+func DirForConfigPath(configPath string) string {
+	cfg, err := config.Load(configPath)
+	if err != nil || cfg == nil || cfg.Path == "" {
+		return ""
+	}
+	return filepath.Dir(cfg.Path)
+}
+
+// PathForDir resolves the groups file inside a directory. $LINEAR_GROUPS
+// wins verbatim. An empty directory with no override means built-ins only.
+func PathForDir(dir string) string {
+	if v := strings.TrimSpace(os.Getenv(EnvGroupsPath)); v != "" {
+		return v
+	}
+	if strings.TrimSpace(dir) == "" {
+		return ""
+	}
+	return filepath.Join(dir, FileName)
+}
+
+// PathForConfig resolves the groups file that sits next to a config file.
+func PathForConfig(configPath string) string {
+	if v := strings.TrimSpace(os.Getenv(EnvGroupsPath)); v != "" {
+		return v
+	}
+	if strings.TrimSpace(configPath) == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(configPath), FileName)
+}
+
+type memo struct {
+	reg *Registry
+	err error
+}
+
+var (
+	memoMu sync.Mutex
+	memos  = map[string]memo{}
+)
+
+// Load parses defaults.toml plus the user file that sits next to configPath.
+// Memoized per resolved path so a malformed file is reported once and a valid
+// one is parsed once per process.
+func Load(configPath string) (*Registry, error) { return loadPath(PathForConfig(configPath)) }
+
+// LoadDir parses defaults.toml plus the user file inside dir.
+func LoadDir(dir string) (*Registry, error) { return loadPath(PathForDir(dir)) }
+
+func loadPath(path string) (*Registry, error) {
+	memoMu.Lock()
+	defer memoMu.Unlock()
+	if m, ok := memos[path]; ok {
+		return m.reg, m.err
+	}
+	reg, err := build(path)
+	memos[path] = memo{reg: reg, err: err}
+	return reg, err
+}
+
+func build(path string) (*Registry, error) {
+	r := &Registry{
+		path:      path,
+		builtin:   map[string]Group{},
+		workspace: map[string]Group{},
+		team:      map[string]map[string]Group{},
+	}
+
+	var defaults fileDoc
+	if err := toml.Unmarshal(defaultsTOML, &defaults); err != nil {
+		return nil, fmt.Errorf("parsing embedded %s: %w", FileName, err)
+	}
+	if err := r.absorb(defaults, "", SourceBuiltin); err != nil {
+		return nil, err
+	}
+
+	if path == "" {
+		return r, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return r, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	r.present = true
+
+	var user fileDoc
+	if err := toml.Unmarshal(data, &user); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if user.SchemaVersion != 0 && user.SchemaVersion != supportedSchemaVersion {
+		return nil, fmt.Errorf("%s: unsupported groups schema_version %d", path, user.SchemaVersion)
+	}
+	if err := r.absorb(user, path, SourceWorkspace); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// absorb validates and installs one parsed document. origin is "" for the
+// embedded defaults, which are correct by construction but validated anyway
+// so a defaults typo fails loudly at load rather than silently at use.
+func (r *Registry) absorb(doc fileDoc, origin, workspaceSource string) error {
+	dest := r.builtin
+	if workspaceSource == SourceWorkspace {
+		dest = r.workspace
+	}
+	names := make([]string, 0, len(doc.StateGroups))
+	for name := range doc.StateGroups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		g, err := normalizeGroup(origin, name, doc.StateGroups[name], workspaceSource, scopeWorkspace)
+		if err != nil {
+			return err
+		}
+		dest[g.Name] = g
+	}
+
+	teamKeys := make([]string, 0, len(doc.TeamStateGroups))
+	for key := range doc.TeamStateGroups {
+		teamKeys = append(teamKeys, key)
+	}
+	sort.Strings(teamKeys)
+	for _, key := range teamKeys {
+		upper := strings.ToUpper(strings.TrimSpace(key))
+		if upper == "" {
+			return fmt.Errorf("%s: team_state_groups has an empty team key", describeOrigin(origin))
+		}
+		tableNames := make([]string, 0, len(doc.TeamStateGroups[key]))
+		for name := range doc.TeamStateGroups[key] {
+			tableNames = append(tableNames, name)
+		}
+		sort.Strings(tableNames)
+		for _, name := range tableNames {
+			g, err := normalizeGroup(origin, name, doc.TeamStateGroups[key][name], sourceTeamPfx+upper, scopeTeamPfx+upper)
+			if err != nil {
+				return err
+			}
+			if r.team[upper] == nil {
+				r.team[upper] = map[string]Group{}
+			}
+			r.team[upper][g.Name] = g
+		}
+	}
+	return nil
+}
+
+func describeOrigin(origin string) string {
+	if origin == "" {
+		return FileName
+	}
+	return origin
+}
+
+func normalizeGroup(origin, rawName string, t groupTable, source, scope string) (Group, error) {
+	where := describeOrigin(origin)
+	name := strings.TrimSpace(rawName)
+	if !groupNamePattern.MatchString(name) {
+		return Group{}, fmt.Errorf("%s: group name %q must match %s", where, rawName, groupNamePattern.String())
+	}
+	if name == ReservedAll {
+		return Group{}, fmt.Errorf("%s: %q is reserved and always means no state filter", where, ReservedAll)
+	}
+	types := make([]string, 0, len(t.Types))
+	for _, raw := range t.Types {
+		v := strings.ToLower(strings.TrimSpace(raw))
+		if v == "" {
+			continue
+		}
+		if !IsAPIType(v) {
+			return Group{}, fmt.Errorf("%s: group %q lists %q, which is not a valid Linear workflow state type. Valid types: %s", where, name, raw, APITypeList)
+		}
+		types = append(types, v)
+	}
+	names := make([]string, 0, len(t.Names))
+	for _, raw := range t.Names {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		names = append(names, v)
+	}
+	if len(types) == 0 && len(names) == 0 {
+		return Group{}, fmt.Errorf("%s: group %q declares no types and no names", where, name)
+	}
+	return Group{
+		Name:        name,
+		Source:      source,
+		Scope:       scope,
+		ShadowedBy:  []string{},
+		Description: strings.TrimSpace(t.Description),
+		Types:       types,
+		Names:       names,
+	}, nil
+}
+
+func reservedAllGroup() Group {
+	return Group{
+		Name:        ReservedAll,
+		Source:      SourceBuiltin,
+		Scope:       scopeWorkspace,
+		Reserved:    true,
+		ShadowedBy:  []string{},
+		Description: "No state predicate. Matches every workflow state.",
+		Types:       []string{},
+		Names:       []string{},
+	}
+}
+
+func unfilteredSet(token, resolvedAs string) Set {
+	return Set{Group: reservedAllGroup(), Unfiltered: true, ResolvedAs: resolvedAs, Token: token}
+}
+
+// Resolve is THE entry point. Every state filter in the CLI goes through it.
+// teamKey may be "". Resolution order, first match wins, after an
+// unconditional trim-plus-lowercase of the token:
+//
+//	1 empty token          no predicate
+//	2 "all"                no predicate, reserved
+//	3 "type:<t>"           the raw API type, bypassing every group
+//	4 "name:<n>"           one literal state name, bypassing every group
+//	5 team-scoped group    replaces, never merges with, the workspace group
+//	6 workspace group      user config beats built-in of the same name
+//	7 built-in group       covers "active" and the seven trivial type groups
+//	8 raw API type         redundancy guard, unreachable in a correct build
+//	9 otherwise            ErrUnknownToken, listing everything available
+func (r *Registry) Resolve(teamKey, token string) (Set, error) {
+	trimmed := strings.TrimSpace(token)
+	lower := strings.ToLower(trimmed)
+
+	if lower == "" {
+		return unfilteredSet(lower, ResolvedUnfiltered), nil
+	}
+	if lower == ReservedAll {
+		return unfilteredSet(lower, ResolvedUnfiltered), nil
+	}
+
+	if strings.HasPrefix(lower, prefixType) {
+		want := strings.ToLower(strings.TrimSpace(trimmed[len(prefixType):]))
+		if !IsAPIType(want) {
+			return Set{}, fmt.Errorf("%w: %q is not a valid Linear workflow state type. Valid types: %s", ErrUnknownToken, want, APITypeList)
+		}
+		return Set{
+			Group: Group{
+				Name:       want,
+				Source:     SourceBuiltin,
+				Scope:      scopeWorkspace,
+				ShadowedBy: []string{},
+				Types:      []string{want},
+				Names:      []string{},
+			},
+			ResolvedAs: ResolvedRawType,
+			Token:      lower,
+		}, nil
+	}
+
+	if strings.HasPrefix(lower, prefixName) {
+		want := strings.TrimSpace(trimmed[len(prefixName):])
+		if want == "" {
+			return Set{}, fmt.Errorf("%w: %q names no state", ErrUnknownToken, trimmed)
+		}
+		return Set{
+			Group: Group{
+				Name:       want,
+				Source:     SourceBuiltin,
+				Scope:      scopeWorkspace,
+				ShadowedBy: []string{},
+				Types:      []string{},
+				Names:      []string{want},
+			},
+			ResolvedAs: ResolvedLiteralName,
+			Token:      lower,
+		}, nil
+	}
+
+	if key := strings.ToUpper(strings.TrimSpace(teamKey)); key != "" {
+		if g, ok := r.team[key][lower]; ok {
+			return Set{Group: g, ResolvedAs: ResolvedGroup, Token: lower}, nil
+		}
+	}
+	if g, ok := r.workspace[lower]; ok {
+		return Set{Group: g, ResolvedAs: ResolvedGroup, Token: lower}, nil
+	}
+	if g, ok := r.builtin[lower]; ok {
+		return Set{Group: g, ResolvedAs: ResolvedGroup, Token: lower}, nil
+	}
+	if IsAPIType(lower) {
+		return Set{
+			Group: Group{
+				Name:       lower,
+				Source:     SourceBuiltin,
+				Scope:      scopeWorkspace,
+				ShadowedBy: []string{},
+				Types:      []string{lower},
+				Names:      []string{},
+			},
+			ResolvedAs: ResolvedRawType,
+			Token:      lower,
+		}, nil
+	}
+	return Set{}, fmt.Errorf("%w: %q. Available groups: %s. Raw types: %s. Run 'groups list' to see where each one is declared",
+		ErrUnknownToken, trimmed, strings.Join(r.availableNames(teamKey), ", "), APITypeList)
+}
+
+func (r *Registry) availableNames(teamKey string) []string {
+	seen := map[string]struct{}{ReservedAll: {}}
+	for name := range r.builtin {
+		seen[name] = struct{}{}
+	}
+	for name := range r.workspace {
+		seen[name] = struct{}{}
+	}
+	if key := strings.ToUpper(strings.TrimSpace(teamKey)); key != "" {
+		for name := range r.team[key] {
+			seen[name] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Effective enumerates every group visible at a scope, for `groups list`.
+// Shadowed entries are listed too, each naming the higher-precedence entries
+// that win over it, so the user can see why a token resolves the way it does.
+// An empty teamKey lists every team's declarations. A non-empty one lists
+// only that team's.
+func (r *Registry) Effective(teamKey string) []Group {
+	want := strings.ToUpper(strings.TrimSpace(teamKey))
+	teamKeys := make([]string, 0, len(r.team))
+	for key := range r.team {
+		if want != "" && key != want {
+			continue
+		}
+		teamKeys = append(teamKeys, key)
+	}
+	sort.Strings(teamKeys)
+
+	shadowsOf := func(name string, includeWorkspace bool) []string {
+		out := []string{}
+		if includeWorkspace {
+			if _, ok := r.workspace[name]; ok {
+				out = append(out, SourceWorkspace)
+			}
+		}
+		for _, key := range teamKeys {
+			if _, ok := r.team[key][name]; ok {
+				out = append(out, sourceTeamPfx+key)
+			}
+		}
+		return out
+	}
+
+	out := make([]Group, 0, len(r.builtin)+len(r.workspace)+1)
+	all := reservedAllGroup()
+	out = append(out, all)
+	for _, g := range r.builtin {
+		g.ShadowedBy = shadowsOf(g.Name, true)
+		out = append(out, g)
+	}
+	for _, g := range r.workspace {
+		g.ShadowedBy = shadowsOf(g.Name, false)
+		out = append(out, g)
+	}
+	for _, key := range teamKeys {
+		for _, g := range r.team[key] {
+			g.ShadowedBy = []string{}
+			out = append(out, g)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return sourceRank(out[i].Source) < sourceRank(out[j].Source)
+	})
+	return out
+}
+
+func sourceRank(source string) int {
+	switch {
+	case source == SourceBuiltin:
+		return 0
+	case source == SourceWorkspace:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// Resolve is the package-level form named by the cross-package implementation
+// contract. cfgDir is a DIRECTORY. Passing "" uses the default config chain,
+// which honors $LINEAR_CONFIG. $LINEAR_GROUPS still overrides the resolved
+// file either way.
+func Resolve(cfgDir, teamKey, name string) (Predicate, error) {
+	reg, err := LoadDir(resolveDir(cfgDir))
+	if err != nil {
+		return Predicate{}, err
+	}
+	return reg.Resolve(teamKey, name)
+}
+
+// List is the package-level form of Registry.Effective.
+func List(cfgDir, teamKey string) ([]GroupInfo, error) {
+	reg, err := LoadDir(resolveDir(cfgDir))
+	if err != nil {
+		return nil, err
+	}
+	return reg.Effective(teamKey), nil
+}
+
+func resolveDir(cfgDir string) string {
+	if strings.TrimSpace(cfgDir) != "" {
+		return cfgDir
+	}
+	return DirForConfigPath("")
+}
+
+// MisplacedInConfig reports whether the config file carries group tables that
+// this package deliberately does not honor. Callers warn about it: config.save
+// rewrites config.toml wholesale from a fixed struct, so declarations left
+// there are deleted the first time the user rotates a token.
+func MisplacedInConfig(configPath string) bool {
+	path := strings.TrimSpace(configPath)
+	if path == "" {
+		return false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var doc map[string]any
+	if err := toml.Unmarshal(data, &doc); err != nil {
+		return false
+	}
+	_, hasWorkspace := doc["state_groups"]
+	_, hasTeam := doc["team_state_groups"]
+	return hasWorkspace || hasTeam
+}

--- a/library/project-management/linear/internal/groups/groups_test.go
+++ b/library/project-management/linear/internal/groups/groups_test.go
@@ -1,0 +1,739 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package groups
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// fixtureTOML is the user file the resolution tests load. It is deliberately
+// adversarial: it shadows a builtin group (active), shadows a builtin raw type
+// with a name-only group of the same name (started), declares a names-only
+// group and a mixed group, and gives one team its own active plus a team-only
+// group. Every precedence rule in Registry.Resolve is observable against it.
+const fixtureTOML = `
+schema_version = 1
+
+[state_groups.active]
+description = "only what is genuinely in flight"
+types = ["started"]
+
+[state_groups.started]
+names = ["Doing"]
+
+[state_groups.review]
+names = ["In Review", "Code Review"]
+
+[state_groups.mixed]
+types = ["started"]
+names = ["Needs QA"]
+
+[team_state_groups.ENG.active]
+names = ["ENG Doing"]
+
+[team_state_groups.ENG.shipped]
+types = ["completed"]
+`
+
+// newRegistry writes contents as the groups file in a fresh temp dir and loads
+// it through the public loader, returning the registry and the directory. A
+// fresh directory per call gives every test its own key in the load memo, and
+// clearing LINEAR_GROUPS stops an override in the developer's shell from
+// redirecting the load somewhere else.
+func newRegistry(t *testing.T, contents string) (*Registry, string) {
+	t.Helper()
+	t.Setenv(EnvGroupsPath, "")
+	dir := t.TempDir()
+	if contents != "" {
+		if err := os.WriteFile(filepath.Join(dir, FileName), []byte(contents), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", FileName, err)
+		}
+	}
+	reg, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir(%s): %v", dir, err)
+	}
+	return reg, dir
+}
+
+// Resolution precedence is the whole point of this package: every --state,
+// --completed-group and --candidate-group token lands here, so a regression in
+// the order below silently changes what "open" means across the binary.
+func TestRegistryResolve_PrecedenceAndNormalization(t *testing.T) {
+	reg, _ := newRegistry(t, fixtureTOML)
+
+	tests := []struct {
+		name       string
+		teamKey    string
+		token      string
+		wantGroup  string
+		wantSource string
+		wantAs     string
+		wantToken  string
+		wantTypes  []string
+		wantNames  []string
+		unfiltered bool
+	}{
+		{
+			name: "empty token carries no predicate", token: "",
+			wantGroup: ReservedAll, wantSource: SourceBuiltin, wantAs: ResolvedUnfiltered,
+			wantToken: "", wantTypes: []string{}, wantNames: []string{}, unfiltered: true,
+		},
+		{
+			name: "all is reserved and carries no predicate", token: "all",
+			wantGroup: ReservedAll, wantSource: SourceBuiltin, wantAs: ResolvedUnfiltered,
+			wantToken: "all", wantTypes: []string{}, wantNames: []string{}, unfiltered: true,
+		},
+		{
+			name: "all is trimmed and lowercased", token: "  ALL  ",
+			wantGroup: ReservedAll, wantSource: SourceBuiltin, wantAs: ResolvedUnfiltered,
+			wantToken: "all", wantTypes: []string{}, wantNames: []string{}, unfiltered: true,
+		},
+		{
+			name: "workspace group beats the builtin of the same name", token: "active",
+			wantGroup: "active", wantSource: SourceWorkspace, wantAs: ResolvedGroup,
+			wantToken: "active", wantTypes: []string{"started"}, wantNames: []string{},
+		},
+		{
+			name: "token is trimmed and lowercased before lookup", token: "  ACTIVE  ",
+			wantGroup: "active", wantSource: SourceWorkspace, wantAs: ResolvedGroup,
+			wantToken: "active", wantTypes: []string{"started"}, wantNames: []string{},
+		},
+		{
+			// The team declaration carries no types. If team ever merged
+			// into workspace instead of replacing it, "started" would leak
+			// back in here.
+			name:    "team group replaces the workspace group instead of merging",
+			teamKey: "ENG", token: "active",
+			wantGroup: "active", wantSource: sourceTeamPfx + "ENG", wantAs: ResolvedGroup,
+			wantToken: "active", wantTypes: []string{}, wantNames: []string{"ENG Doing"},
+		},
+		{
+			name: "team key is case-insensitive", teamKey: "eng", token: "active",
+			wantGroup: "active", wantSource: sourceTeamPfx + "ENG", wantAs: ResolvedGroup,
+			wantToken: "active", wantTypes: []string{}, wantNames: []string{"ENG Doing"},
+		},
+		{
+			name: "another team does not see ENG's declaration", teamKey: "OPS", token: "active",
+			wantGroup: "active", wantSource: SourceWorkspace, wantAs: ResolvedGroup,
+			wantToken: "active", wantTypes: []string{"started"}, wantNames: []string{},
+		},
+		{
+			name:    "team scope falls through to workspace for names it does not declare",
+			teamKey: "ENG", token: "review",
+			wantGroup: "review", wantSource: SourceWorkspace, wantAs: ResolvedGroup,
+			wantToken: "review", wantTypes: []string{}, wantNames: []string{"In Review", "Code Review"},
+		},
+		{
+			name: "team-only group resolves with the team key", teamKey: "ENG", token: "shipped",
+			wantGroup: "shipped", wantSource: sourceTeamPfx + "ENG", wantAs: ResolvedGroup,
+			wantToken: "shipped", wantTypes: []string{"completed"}, wantNames: []string{},
+		},
+		{
+			name: "unshadowed builtin still resolves", token: "backlog",
+			wantGroup: "backlog", wantSource: SourceBuiltin, wantAs: ResolvedGroup,
+			wantToken: "backlog", wantTypes: []string{"backlog"}, wantNames: []string{},
+		},
+		{
+			// The fixture redefines "started" as a name-only group, so a
+			// bare token must return the group and the escape hatch must
+			// still reach the raw API type.
+			name: "a group shadows the raw type of the same name", token: "started",
+			wantGroup: "started", wantSource: SourceWorkspace, wantAs: ResolvedGroup,
+			wantToken: "started", wantTypes: []string{}, wantNames: []string{"Doing"},
+		},
+		{
+			name: "type: prefix bypasses the shadowing group", token: "type:started",
+			wantGroup: "started", wantSource: SourceBuiltin, wantAs: ResolvedRawType,
+			wantToken: "type:started", wantTypes: []string{"started"}, wantNames: []string{},
+		},
+		{
+			name: "type: prefix and its value are case-insensitive", token: " TYPE:Started ",
+			wantGroup: "started", wantSource: SourceBuiltin, wantAs: ResolvedRawType,
+			wantToken: "type:started", wantTypes: []string{"started"}, wantNames: []string{},
+		},
+		{
+			// The token is lowercased for lookup, but a workflow state name
+			// is workspace data and must survive verbatim.
+			name: "name: prefix keeps the literal state name", token: "name:In Review",
+			wantGroup: "In Review", wantSource: SourceBuiltin, wantAs: ResolvedLiteralName,
+			wantToken: "name:in review", wantTypes: []string{}, wantNames: []string{"In Review"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := reg.Resolve(tc.teamKey, tc.token)
+			if err != nil {
+				t.Fatalf("Resolve(%q, %q) returned error: %v", tc.teamKey, tc.token, err)
+			}
+			if got.Group.Name != tc.wantGroup {
+				t.Errorf("group name = %q, want %q", got.Group.Name, tc.wantGroup)
+			}
+			if got.Source() != tc.wantSource {
+				t.Errorf("source = %q, want %q", got.Source(), tc.wantSource)
+			}
+			if got.ResolvedAs != tc.wantAs {
+				t.Errorf("resolved_as = %q, want %q", got.ResolvedAs, tc.wantAs)
+			}
+			if got.Token != tc.wantToken {
+				t.Errorf("token = %q, want %q", got.Token, tc.wantToken)
+			}
+			if got.Unfiltered != tc.unfiltered {
+				t.Errorf("unfiltered = %v, want %v", got.Unfiltered, tc.unfiltered)
+			}
+			if !slices.Equal(got.Group.Types, tc.wantTypes) {
+				t.Errorf("types = %v, want %v", got.Group.Types, tc.wantTypes)
+			}
+			if !slices.Equal(got.Group.Names, tc.wantNames) {
+				t.Errorf("names = %v, want %v", got.Group.Names, tc.wantNames)
+			}
+			if tc.unfiltered && !got.Group.Reserved {
+				t.Errorf("unfiltered set should carry the reserved %q group", ReservedAll)
+			}
+		})
+	}
+}
+
+// Unknown tokens are the user's typo, not a broken config file, so they must
+// come back as ErrUnknownToken (exit 2) and name what was available instead.
+func TestRegistryResolve_UnknownTokens(t *testing.T) {
+	reg, _ := newRegistry(t, fixtureTOML)
+
+	tests := []struct {
+		name     string
+		teamKey  string
+		token    string
+		contains []string
+	}{
+		{
+			name: "unknown group lists the alternatives", token: "nope",
+			contains: []string{`"nope"`, "active", "review", "started"},
+		},
+		{
+			name: "team-only group is invisible without the team key", token: "shipped",
+			contains: []string{`"shipped"`},
+		},
+		{
+			name: "type: prefix rejects a non-API type", token: "type:done",
+			contains: []string{"not a valid Linear workflow state type", "triage"},
+		},
+		{
+			name: "name: prefix rejects an empty name", token: "name:   ",
+			contains: []string{"names no state"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := reg.Resolve(tc.teamKey, tc.token)
+			if err == nil {
+				t.Fatalf("Resolve(%q, %q) = nil error, want ErrUnknownToken", tc.teamKey, tc.token)
+			}
+			if !errors.Is(err, ErrUnknownToken) {
+				t.Errorf("error %v is not ErrUnknownToken; callers would map it to exit 10 instead of exit 2", err)
+			}
+			for _, want := range tc.contains {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not mention %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+// The shipped defaults decide what "open" means for a workspace that never
+// writes a groups.toml, which is most of them.
+func TestLoadDir_BuiltinDefaults(t *testing.T) {
+	reg, dir := newRegistry(t, "")
+
+	if reg.Present() {
+		t.Errorf("Present() = true with no %s on disk", FileName)
+	}
+	if want := filepath.Join(dir, FileName); reg.Path() != want {
+		t.Errorf("Path() = %q, want %q", reg.Path(), want)
+	}
+
+	active, err := reg.Resolve("", "active")
+	if err != nil {
+		t.Fatalf("resolving builtin active: %v", err)
+	}
+	if active.Source() != SourceBuiltin {
+		t.Errorf("builtin active source = %q, want %q", active.Source(), SourceBuiltin)
+	}
+	wantActive := []string{"triage", "backlog", "unstarted", "started"}
+	if !slices.Equal(active.Group.Types, wantActive) {
+		t.Errorf("builtin active types = %v, want %v", active.Group.Types, wantActive)
+	}
+	for _, closed := range []string{"completed", "canceled", "duplicate"} {
+		if active.MatchesType(closed) {
+			t.Errorf("builtin active must not count %q as active", closed)
+		}
+	}
+
+	// Every documented API type is reachable as a group of the same name,
+	// which is what makes the raw-type fallback in Resolve unreachable.
+	for _, ty := range APITypes() {
+		set, err := reg.Resolve("", ty)
+		if err != nil {
+			t.Fatalf("resolving builtin type group %q: %v", ty, err)
+		}
+		if set.ResolvedAs != ResolvedGroup {
+			t.Errorf("%q resolved_as = %q, want %q", ty, set.ResolvedAs, ResolvedGroup)
+		}
+		if !slices.Equal(set.Group.Types, []string{ty}) {
+			t.Errorf("%q types = %v, want [%s]", ty, set.Group.Types, ty)
+		}
+	}
+}
+
+// A malformed or dishonest declaration must fail at load, loudly, rather than
+// resolving to a predicate that quietly matches the wrong states.
+func TestLoadDir_RejectsInvalidDeclarations(t *testing.T) {
+	t.Setenv(EnvGroupsPath, "")
+
+	tests := []struct {
+		name     string
+		contents string
+		wantErr  string
+	}{
+		{
+			name:     "all is reserved",
+			contents: "[state_groups.all]\ntypes = [\"started\"]\n",
+			wantErr:  "reserved",
+		},
+		{
+			name:     "group name must be lowercase",
+			contents: "[state_groups.Active]\ntypes = [\"started\"]\n",
+			wantErr:  "must match",
+		},
+		{
+			name:     "group name must not start with a dash",
+			contents: "[state_groups.\"-x\"]\ntypes = [\"started\"]\n",
+			wantErr:  "must match",
+		},
+		{
+			name:     "types must be documented API types",
+			contents: "[state_groups.shipped]\ntypes = [\"done\"]\n",
+			wantErr:  "not a valid Linear workflow state type",
+		},
+		{
+			name:     "a group must declare something",
+			contents: "[state_groups.empty]\ndescription = \"nothing at all\"\n",
+			wantErr:  "declares no types and no names",
+		},
+		{
+			name:     "unsupported schema version",
+			contents: "schema_version = 2\n[state_groups.shipped]\ntypes = [\"completed\"]\n",
+			wantErr:  "unsupported groups schema_version",
+		},
+		{
+			name:     "malformed toml",
+			contents: "[state_groups.shipped\ntypes = [\"completed\"]\n",
+			wantErr:  "parsing",
+		},
+		{
+			name:     "team key must not be blank",
+			contents: "[team_state_groups.\"  \".shipped]\ntypes = [\"completed\"]\n",
+			wantErr:  "empty team key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, FileName), []byte(tc.contents), 0o600); err != nil {
+				t.Fatalf("writing %s: %v", FileName, err)
+			}
+			_, err := LoadDir(dir)
+			if err == nil {
+				t.Fatalf("LoadDir accepted an invalid %s", FileName)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not mention %q", err.Error(), tc.wantErr)
+			}
+			if errors.Is(err, ErrUnknownToken) {
+				t.Errorf("a bad file is a config error, not a bad token: %v", err)
+			}
+		})
+	}
+}
+
+// schema_version is optional. A user file that omits it must still load, or
+// every hand-written groups.toml in the wild breaks.
+func TestLoadDir_SchemaVersionIsOptional(t *testing.T) {
+	reg, _ := newRegistry(t, "[state_groups.shipped]\ntypes = [\"completed\"]\n")
+	if !reg.Present() {
+		t.Errorf("Present() = false after writing %s", FileName)
+	}
+	set, err := reg.Resolve("", "shipped")
+	if err != nil {
+		t.Fatalf("resolving shipped: %v", err)
+	}
+	if set.Source() != SourceWorkspace {
+		t.Errorf("source = %q, want %q", set.Source(), SourceWorkspace)
+	}
+}
+
+// `groups list` renders Effective, and its whole job is explaining why a token
+// resolves the way it does. Shadowed rows must stay visible and must name the
+// declarations that outrank them.
+func TestRegistryEffective_ShadowingAndOrder(t *testing.T) {
+	reg, _ := newRegistry(t, fixtureTOML)
+
+	rows := reg.Effective("")
+	bySourceForName := func(rows []Group, name string) []string {
+		var out []string
+		for _, g := range rows {
+			if g.Name == name {
+				out = append(out, g.Source)
+			}
+		}
+		return out
+	}
+
+	wantOrder := []string{SourceBuiltin, SourceWorkspace, sourceTeamPfx + "ENG"}
+	if got := bySourceForName(rows, "active"); !slices.Equal(got, wantOrder) {
+		t.Errorf("active rows = %v, want %v (builtin, then workspace, then team)", got, wantOrder)
+	}
+
+	// A lowercase team key must select the same scope Resolve selects.
+	if got := bySourceForName(reg.Effective("eng"), "shipped"); !slices.Equal(got, []string{sourceTeamPfx + "ENG"}) {
+		t.Errorf("Effective(eng) shipped rows = %v, want the ENG declaration", got)
+	}
+
+	var reserved int
+	for _, g := range rows {
+		switch {
+		case g.Name == ReservedAll:
+			reserved++
+			if !g.Reserved {
+				t.Errorf("%q row is not marked reserved", ReservedAll)
+			}
+		case g.Name == "active" && g.Source == SourceBuiltin:
+			want := []string{SourceWorkspace, sourceTeamPfx + "ENG"}
+			if !slices.Equal(g.ShadowedBy, want) {
+				t.Errorf("builtin active shadowed_by = %v, want %v", g.ShadowedBy, want)
+			}
+		case g.Name == "active" && g.Source == SourceWorkspace:
+			want := []string{sourceTeamPfx + "ENG"}
+			if !slices.Equal(g.ShadowedBy, want) {
+				t.Errorf("workspace active shadowed_by = %v, want %v", g.ShadowedBy, want)
+			}
+		case g.Name == "review" && g.Source == SourceWorkspace:
+			if len(g.ShadowedBy) != 0 {
+				t.Errorf("unshadowed review reports shadowed_by = %v", g.ShadowedBy)
+			}
+		}
+	}
+	if reserved != 1 {
+		t.Errorf("%q appears %d times, want exactly once", ReservedAll, reserved)
+	}
+
+	// A team scope must only report its own declarations plus the shared
+	// ones, never another team's.
+	for _, g := range reg.Effective("OPS") {
+		if strings.HasPrefix(g.Source, sourceTeamPfx) {
+			t.Errorf("Effective(OPS) leaked %s row %q", g.Source, g.Name)
+		}
+		if g.Name == "active" && g.Source == SourceBuiltin {
+			want := []string{SourceWorkspace}
+			if !slices.Equal(g.ShadowedBy, want) {
+				t.Errorf("Effective(OPS) builtin active shadowed_by = %v, want %v", g.ShadowedBy, want)
+			}
+		}
+	}
+}
+
+// Set is the predicate every local (non-GraphQL) filter evaluates, so its
+// matching rules are the offline half of this package's contract.
+func TestSetMatches(t *testing.T) {
+	t.Parallel()
+
+	set := Set{Group: Group{
+		Name:  "mixed",
+		Types: []string{"started"},
+		Names: []string{"In Review"},
+	}}
+
+	tests := []struct {
+		name      string
+		stateType string
+		stateName string
+		wantType  bool
+		wantName  bool
+	}{
+		{name: "exact type", stateType: "started", stateName: "Doing", wantType: true},
+		{name: "type comparison ignores case", stateType: "STARTED", stateName: "Doing", wantType: true},
+		{name: "type comparison trims", stateType: "  started  ", stateName: "Doing", wantType: true},
+		{name: "unlisted type", stateType: "completed", stateName: "Done"},
+		{name: "empty type matches nothing", stateName: "Done"},
+		{name: "exact name", stateType: "completed", stateName: "In Review", wantName: true},
+		{name: "name comparison ignores case", stateType: "completed", stateName: "in review", wantName: true},
+		{name: "name comparison trims", stateType: "completed", stateName: "  In Review  ", wantName: true},
+		{name: "empty name matches nothing", stateType: "completed"},
+		{name: "a name is not a type", stateType: "In Review", stateName: "Done"},
+		{name: "a type is not a name", stateType: "completed", stateName: "started"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := set.MatchesType(tc.stateType); got != tc.wantType {
+				t.Errorf("MatchesType(%q) = %v, want %v", tc.stateType, got, tc.wantType)
+			}
+			if got := set.MatchesName(tc.stateName); got != tc.wantName {
+				t.Errorf("MatchesName(%q) = %v, want %v", tc.stateName, got, tc.wantName)
+			}
+			wantUnion := tc.wantType || tc.wantName
+			if got := set.Matches(tc.stateType, tc.stateName); got != wantUnion {
+				t.Errorf("Matches(%q, %q) = %v, want %v", tc.stateType, tc.stateName, got, wantUnion)
+			}
+			// Match is the cross-package alias other packages call.
+			if got := set.Match(tc.stateType, tc.stateName); got != wantUnion {
+				t.Errorf("Match(%q, %q) = %v, want %v", tc.stateType, tc.stateName, got, wantUnion)
+			}
+		})
+	}
+}
+
+// "all" means no predicate at all, not "every type I happen to know about".
+func TestSetUnfiltered_MatchesEverythingAndEmitsNoFilter(t *testing.T) {
+	t.Parallel()
+
+	set := Set{Unfiltered: true}
+	for _, tc := range [][2]string{{"started", "Doing"}, {"anything", "at all"}, {"", ""}} {
+		if !set.Matches(tc[0], tc[1]) {
+			t.Errorf("unfiltered Matches(%q, %q) = false", tc[0], tc[1])
+		}
+	}
+	if !set.MatchesType("") || !set.MatchesName("") {
+		t.Errorf("unfiltered set rejected an empty state")
+	}
+	if got := set.GraphQLFilter(); got != nil {
+		t.Errorf("GraphQLFilter() = %v, want nil so the state key is omitted entirely", got)
+	}
+}
+
+// The live half of the contract. These shapes are handed straight to Linear as
+// a WorkflowStateFilter, and they must agree with what Matches does locally.
+func TestSetGraphQLFilter_Shapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		group Group
+		want  map[string]any
+	}{
+		{
+			name:  "types only use a single in comparator",
+			group: Group{Types: []string{"triage", "started"}, Names: []string{}},
+			want:  map[string]any{"type": map[string]any{"in": []string{"triage", "started"}}},
+		},
+		{
+			// StringComparator has no inIgnoreCase, so a lone name is an
+			// eqIgnoreCase rather than a case-sensitive in.
+			name:  "a single name uses eqIgnoreCase",
+			group: Group{Types: []string{}, Names: []string{"In Review"}},
+			want:  map[string]any{"name": map[string]any{"eqIgnoreCase": "In Review"}},
+		},
+		{
+			name:  "several names become an or of eqIgnoreCase clauses",
+			group: Group{Types: []string{}, Names: []string{"In Review", "Code Review"}},
+			want: map[string]any{"or": []any{
+				map[string]any{"name": map[string]any{"eqIgnoreCase": "In Review"}},
+				map[string]any{"name": map[string]any{"eqIgnoreCase": "Code Review"}},
+			}},
+		},
+		{
+			name:  "types and names or together with the type clause first",
+			group: Group{Types: []string{"started"}, Names: []string{"Needs QA"}},
+			want: map[string]any{"or": []any{
+				map[string]any{"type": map[string]any{"in": []string{"started"}}},
+				map[string]any{"name": map[string]any{"eqIgnoreCase": "Needs QA"}},
+			}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			set := Set{Group: tc.group}
+			got := set.GraphQLFilter()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("GraphQLFilter() = %#v, want %#v", got, tc.want)
+			}
+			// LiveFilter is the package-level form other packages call.
+			if other := LiveFilter(set); !reflect.DeepEqual(other, got) {
+				t.Errorf("LiveFilter() = %#v, want %#v", other, got)
+			}
+		})
+	}
+}
+
+// The emitted filter must not alias the group's own slice: a caller that sorts
+// or appends to the request payload would otherwise corrupt the registry entry
+// every later Matches call reads.
+func TestSetGraphQLFilter_DoesNotAliasGroupTypes(t *testing.T) {
+	t.Parallel()
+
+	set := Set{Group: Group{Types: []string{"started", "backlog"}, Names: []string{}}}
+	filter := set.GraphQLFilter()
+	emitted := filter["type"].(map[string]any)["in"].([]string)
+	emitted[0] = "canceled"
+
+	if !slices.Equal(set.Group.Types, []string{"started", "backlog"}) {
+		t.Errorf("mutating the emitted filter changed the group to %v", set.Group.Types)
+	}
+	if set.MatchesType("canceled") {
+		t.Errorf("group started matching canceled after the emitted filter was mutated")
+	}
+}
+
+func TestIsAPIType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{in: "started", want: true},
+		{in: "  STARTED  ", want: true},
+		{in: "triage", want: true},
+		{in: "duplicate", want: true},
+		{in: "done", want: false},
+		{in: "in progress", want: false},
+		{in: "", want: false},
+	}
+	for _, tc := range tests {
+		if got := IsAPIType(tc.in); got != tc.want {
+			t.Errorf("IsAPIType(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// APITypes hands out the filter vocabulary to error messages and to callers
+// that enumerate states. It must hand out a copy, not the package's own slice.
+func TestAPITypes_ReturnsACopy(t *testing.T) {
+	t.Parallel()
+
+	first := APITypes()
+	if len(first) != 7 {
+		t.Fatalf("APITypes() returned %d types, want the 7 documented values", len(first))
+	}
+	for _, ty := range first {
+		if !IsAPIType(ty) {
+			t.Errorf("APITypes() returned %q, which IsAPIType rejects", ty)
+		}
+		if !strings.Contains(APITypeList, ty) {
+			t.Errorf("APITypeList %q omits %q", APITypeList, ty)
+		}
+	}
+
+	first[0] = "clobbered"
+	if second := APITypes(); second[0] == "clobbered" {
+		t.Errorf("APITypes() aliases the package slice; a caller corrupted the vocabulary")
+	}
+}
+
+// Group declarations left in config.toml are silently deleted the next time
+// config.save rewrites that file, so detecting them is a real user warning.
+func TestMisplacedInConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	write := func(name, contents string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+		return path
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "workspace groups in config", path: write("a.toml", "[state_groups.active]\ntypes = [\"started\"]\n"), want: true},
+		{name: "team groups in config", path: write("b.toml", "[team_state_groups.ENG.active]\ntypes = [\"started\"]\n"), want: true},
+		{name: "ordinary config", path: write("c.toml", "api_key = \"secret\"\nbase_url = \"https://api.linear.app\"\n")},
+		{name: "malformed config is not a claim either way", path: write("d.toml", "[state_groups.active\n")},
+		{name: "missing file", path: filepath.Join(dir, "absent.toml")},
+		{name: "empty path"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MisplacedInConfig(tc.path); got != tc.want {
+				t.Errorf("MisplacedInConfig(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// PathForDir and PathForConfig decide which file the declarations come from.
+// $LINEAR_GROUPS is the documented escape hatch and must win verbatim.
+func TestPathResolution(t *testing.T) {
+	t.Setenv(EnvGroupsPath, "")
+
+	if got, want := PathForDir("/tmp/cfg"), filepath.Join("/tmp/cfg", FileName); got != want {
+		t.Errorf("PathForDir = %q, want %q", got, want)
+	}
+	if got := PathForDir("  "); got != "" {
+		t.Errorf("PathForDir(blank) = %q, want \"\" (builtins only)", got)
+	}
+	if got, want := PathForConfig("/tmp/cfg/config.toml"), filepath.Join("/tmp/cfg", FileName); got != want {
+		t.Errorf("PathForConfig = %q, want %q", got, want)
+	}
+	if got := PathForConfig(""); got != "" {
+		t.Errorf("PathForConfig(blank) = %q, want \"\"", got)
+	}
+
+	t.Setenv(EnvGroupsPath, "  /elsewhere/custom.toml  ")
+	for _, got := range []string{
+		PathForDir("/tmp/cfg"),
+		PathForDir(""),
+		PathForConfig("/tmp/cfg/config.toml"),
+		PathForConfig(""),
+	} {
+		if got != "/elsewhere/custom.toml" {
+			t.Errorf("path = %q, want the %s override", got, EnvGroupsPath)
+		}
+	}
+}
+
+// The package-level Resolve and List are what callers outside this package
+// actually import; they must agree with the Registry methods for the same dir.
+func TestPackageLevelResolveAndList(t *testing.T) {
+	reg, dir := newRegistry(t, fixtureTOML)
+
+	got, err := Resolve(dir, "ENG", "active")
+	if err != nil {
+		t.Fatalf("Resolve(%s, ENG, active): %v", dir, err)
+	}
+	want, err := reg.Resolve("ENG", "active")
+	if err != nil {
+		t.Fatalf("Registry.Resolve(ENG, active): %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Resolve = %#v, want %#v", got, want)
+	}
+
+	if _, err := Resolve(dir, "", "nope"); !errors.Is(err, ErrUnknownToken) {
+		t.Errorf("Resolve error = %v, want ErrUnknownToken", err)
+	}
+
+	list, err := List(dir, "ENG")
+	if err != nil {
+		t.Fatalf("List(%s, ENG): %v", dir, err)
+	}
+	if !reflect.DeepEqual(list, reg.Effective("ENG")) {
+		t.Errorf("List did not match Registry.Effective")
+	}
+}

--- a/library/project-management/linear/internal/store/store.go
+++ b/library/project-management/linear/internal/store/store.go
@@ -35,6 +35,7 @@ type relationRef struct {
 
 type issueState struct {
 	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 type issuePayload struct {
@@ -42,6 +43,7 @@ type issuePayload struct {
 	Title       string      `json:"title"`
 	Description string      `json:"description"`
 	StateName   string      `json:"stateName"`
+	StateType   string      `json:"stateType"`
 	State       issueState  `json:"state"`
 	Priority    int         `json:"priority"`
 	AssigneeID  string      `json:"assigneeId"`
@@ -215,6 +217,7 @@ func (s *Store) migrate() error {
 			title TEXT,
 			description TEXT,
 			state_name TEXT,
+			state_type TEXT,
 			priority INTEGER,
 			assignee_id TEXT,
 			team_id TEXT,
@@ -286,7 +289,7 @@ func (s *Store) migrate() error {
 	}
 	for table, cols := range map[string]map[string]string{
 		"issues": {
-			"identifier": "TEXT", "title": "TEXT", "description": "TEXT", "state_name": "TEXT", "priority": "INTEGER",
+			"identifier": "TEXT", "title": "TEXT", "description": "TEXT", "state_name": "TEXT", "state_type": "TEXT", "priority": "INTEGER",
 			"assignee_id": "TEXT", "team_id": "TEXT", "project_id": "TEXT", "cycle_id": "TEXT", "updated_at": "TEXT",
 			"created_at": "TEXT", "estimate": "REAL", "due_date": "TEXT",
 		},
@@ -448,6 +451,9 @@ func (s *Store) UpsertIssue(id, identifier, title string, data json.RawMessage) 
 	if payload.StateName == "" {
 		payload.StateName = payload.State.Name
 	}
+	if payload.StateType == "" {
+		payload.StateType = payload.State.Type
+	}
 	if payload.AssigneeID == "" {
 		payload.AssigneeID = payload.Assignee.ID
 	}
@@ -467,9 +473,9 @@ func (s *Store) UpsertIssue(id, identifier, title string, data json.RawMessage) 
 	defer tx.Rollback()
 	_, err = tx.Exec(
 		`INSERT OR REPLACE INTO issues
-		(id, data, identifier, title, description, state_name, priority, assignee_id, team_id, project_id, cycle_id, updated_at, created_at, estimate, due_date, synced_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
-		id, string(data), payload.Identifier, payload.Title, payload.Description, payload.StateName, payload.Priority,
+		(id, data, identifier, title, description, state_name, state_type, priority, assignee_id, team_id, project_id, cycle_id, updated_at, created_at, estimate, due_date, synced_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		id, string(data), payload.Identifier, payload.Title, payload.Description, payload.StateName, payload.StateType, payload.Priority,
 		payload.AssigneeID, payload.TeamID, payload.ProjectID, payload.CycleID, payload.UpdatedAt, payload.CreatedAt,
 		payload.Estimate, payload.DueDate,
 	)
@@ -625,7 +631,7 @@ func (s *Store) ListIssues(filter map[string]string, limit int) ([]json.RawMessa
 		limit = 200
 	}
 	where, args := buildFilters(filter, map[string]string{
-		"state_name": "state_name", "assignee_id": "assignee_id", "team_id": "team_id",
+		"state_name": "state_name", "state_type": "state_type", "assignee_id": "assignee_id", "team_id": "team_id",
 		"project_id": "project_id", "cycle_id": "cycle_id", "priority": "priority",
 		"identifier": "identifier",
 	})


### PR DESCRIPTION
## Gaps closed

- **GAP-005** State groups are compiled-in, not user-declared: the group vocabulary and the meaning of `active` are Go literals, so a workspace cannot declare its own groups and the built-ins are not expressed in the same syntax. (MUST-SHIP 5)
- **GAP-009** The store persists `issues.state_name` but not `state_type`, so no group can be evaluated against the local snapshot without `json_extract`.
- **GAP-039** Live and local state filters disagree on hygiene: the live switch is case-sensitive and untrimmed, so `--state Active` matches nothing server-side.
- **GAP-001 / GAP-040** carried forward from the standalone fix, now expressed as group definitions rather than repeated literals.

## Design

`internal/groups` is the single resolver, specified in `contract-state-groups.md`. Its central constraint is that the built-ins must be re-expressible in the same syntax a user writes, which forces the syntax to name `WorkflowState.type` values rather than state names: names are workspace literals and cannot live in the binary. The builtins therefore ship as a TOML document (`internal/groups/defaults.toml`) in exactly the shape a workspace would write, and a user file at `~/.config/linear-pp-cli/groups.toml` overlays it. Resolution accepts a group name or a raw `type:<value>` selector and reports which of the two it took, so a caller can always tell whether it matched a declared group or fell through to a bare type. The eight analytics that each re-implemented "not closed" in Go now call the resolver instead, which is what makes the `active` correction hold everywhere rather than in the one command someone remembered to patch. The store gains a real `state_type` column because a type-based group cannot be evaluated against the sqlite snapshot otherwise. One hard schema constraint shapes the whole layer: `WorkflowStateUpdateInput` has no `type` field and `WorkflowStateCreateInput` accepts only five of the seven types, so a mistyped state can never be repaired by mutation and the group layer has to tolerate whatever the workspace already has.

## Verification (MUST-SHIP 5 proof)

Live probe against a real workspace, single team `ACC`.

```
$ linear-pp-cli groups list --agent
```

Meta carries `groups_file_present: false` and `groups_path: ~/.config/linear-pp-cli/groups.toml`. Nine builtin groups, each with `source: builtin` and `scope: workspace`, `reserved` flag set on `all`. The builtins are reported through the same structure a user file would produce.

```
$ linear-pp-cli groups check active --agent
```

`duplicate` is absent from both the type list and the matched states.

```
$ linear-pp-cli groups check type:duplicate --agent
resolved_as: raw_type, matches state "Duplicate" id 31b3f3de-... on ACC
```

The raw-type escape hatch resolves, and it confirms this workspace actually has a duplicate-typed state, so the `active` exclusion has something real to exclude.

Unknown selectors fail usefully rather than silently matching nothing:

```
$ linear-pp-cli groups check parked --agent
{"code":2,"type":"usage","error":"unknown state group or type: \"parked\". Available groups: active, all,
 backlog, canceled, completed, duplicate, started, triage, unstarted. ... Run 'groups list' to see where
 each one is declared"}
```

The error names the recovery command and tells you where each group is declared.

Group-driven listing, local and live:

```
$ linear-pp-cli issues list --state duplicate --team ACC --agent   -> []   (pre-probe)
$ linear-pp-cli issues list --state active   --team ACC --agent    -> 190+ rows, all non-closed

$ linear-pp-cli issues list --team ACC --state active --data-source live --limit 500 --agent
194 issues; duplicate-typed 0, canceled 0, completed 0
```

Build, vet and the full test suite are green, including the new `internal/groups` suite.

---

Stacked on #1691. Review the diff against `pr/linear-active-duplicate-fix`.
