### PR TITLE
feat(linear): issue relations and an unblocked query

### DIFF
--- a/library/project-management/linear/.printing-press-patches/relation-reads-are-complete-or-they-fail.json
+++ b/library/project-management/linear/.printing-press-patches/relation-reads-are-complete-or-they-fail.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "relation-reads-are-complete-or-they-fail",
+  "applied_at": "2026-08-12",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "An issue's relation set is read from both the outgoing and the inverse connection, and it is either complete or an error: a paging bound reached is never returned as a short read.",
+  "reason": "Linear exposes a relation from both ends, so reading one connection misses half the graph, and every consumer treats an absent relation as no relation. A silently truncated set drops links from the listing, makes idempotent creation duplicate an existing relation, and lets the unblocked query call an issue actionable while an unseen blocker is still open.",
+  "files": [
+    "internal/client/relations_queries.go",
+    "internal/cli/relations.go",
+    "internal/cli/unblocked.go"
+  ],
+  "validated_outcome": "An issue whose relation connection never reports exhaustion fails the read with a message naming the partial set, instead of answering from the pages it managed to fetch."
+}

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -100,6 +100,7 @@ parent and sub-issue links.`,
 	cmd.AddCommand(newIssuesCreateCmd(flags))
 	cmd.AddCommand(newIssuesEditCmd(flags, &dbPath))
 	cmd.AddCommand(newIssuesReadAliasCmd(flags, &dbPath))
+	cmd.AddCommand(newIssuesCloseDuplicateCmd(flags))
 	return cmd
 }
 

--- a/library/project-management/linear/internal/cli/relations.go
+++ b/library/project-management/linear/internal/cli/relations.go
@@ -1,0 +1,938 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+// Issue relations.
+//
+// Linear models every issue-to-issue link as one IssueRelation carrying an
+// IssueRelationType. The enum has exactly four values (blocks, duplicate,
+// related, similar) and they are schema values, not workspace vocabulary, so
+// naming them here is API data rather than a compiled-in workspace literal.
+//
+// "blocked by" is NOT a fifth type. A single IssueRelation{type: blocks,
+// issue: A, relatedIssue: B} is outgoing on A and incoming on B. The incoming
+// direction over a `blocks` relation is what a human calls "blocked by".
+// Every row this file emits carries `type` (the enum, verbatim) and
+// `direction` (outgoing or incoming) as separate fields, and no code path
+// ever writes "blocked_by" into a type.
+
+const (
+	relationDirectionOutgoing = "outgoing"
+	relationDirectionIncoming = "incoming"
+	relationDirectionBoth     = "both"
+)
+
+// issueRelationTypes are the IssueRelationType enum values, verified against
+// the introspected schema. Order is the enum's own order.
+var issueRelationTypes = []string{"blocks", "duplicate", "related", "similar"}
+
+// symmetricRelationTypes are the types whose meaning does not depend on which
+// side of the pair the relation was created from. `blocks` is directional (A
+// blocks B is not B blocks A) and `duplicate` is directional (A is a
+// duplicate of B), so both are excluded. Used only by the --idempotent
+// existing-relation check.
+var symmetricRelationTypes = map[string]bool{"related": true, "similar": true}
+
+func normalizeIssueRelationType(value string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	for _, t := range issueRelationTypes {
+		if normalized == t {
+			return normalized, nil
+		}
+	}
+	return "", usageErr(fmt.Errorf("--type %q is not a valid IssueRelationType. Valid types: %s", value, strings.Join(issueRelationTypes, ", ")))
+}
+
+// relationIssueRef is the flattened issue projection used on both sides of a
+// relation row. State is flattened to state_name / state_type so a consumer
+// can evaluate a state group without walking a nested object.
+type relationIssueRef struct {
+	ID         string `json:"id"`
+	Identifier string `json:"identifier"`
+	Title      string `json:"title"`
+	URL        string `json:"url,omitempty"`
+	ArchivedAt string `json:"archived_at,omitempty"`
+	StateName  string `json:"state_name,omitempty"`
+	StateType  string `json:"state_type,omitempty"`
+}
+
+func relationIssueRefOf(src client.IssueRelationIssue) relationIssueRef {
+	return relationIssueRef{
+		ID:         src.ID,
+		Identifier: src.Identifier,
+		Title:      src.Title,
+		URL:        src.URL,
+		ArchivedAt: src.ArchivedAt,
+		StateName:  src.State.Name,
+		StateType:  src.State.Type,
+	}
+}
+
+// relationRow is one rendered relation. Direction is relative to the issue
+// the command was asked about, never a property of the relation itself.
+type relationRow struct {
+	ID           string           `json:"id"`
+	Type         string           `json:"type"`
+	Direction    string           `json:"direction"`
+	Issue        relationIssueRef `json:"issue"`
+	RelatedIssue relationIssueRef `json:"related_issue"`
+	CreatedAt    string           `json:"created_at,omitempty"`
+	// ArchivedAt is the relation's own archivedAt, empty for a live relation.
+	// It is populated only when the read asked for archived rows.
+	ArchivedAt string `json:"archived_at,omitempty"`
+}
+
+// counterpart returns the issue on the far side of the relation from the
+// subject, which is the one worth showing in a table.
+func (r relationRow) counterpart() relationIssueRef {
+	if r.Direction == relationDirectionIncoming {
+		return r.Issue
+	}
+	return r.RelatedIssue
+}
+
+// relationLabel renders type plus direction as the phrase a human uses. This
+// is a presentation-layer string only: `blocked by` never appears in the
+// `type` field of any payload.
+func relationLabel(relType, direction string) string {
+	incoming := direction == relationDirectionIncoming
+	switch relType {
+	case "blocks":
+		if incoming {
+			return "blocked by"
+		}
+		return "blocks"
+	case "duplicate":
+		if incoming {
+			return "duplicated by"
+		}
+		return "duplicate of"
+	case "related":
+		return "related to"
+	case "similar":
+		return "similar to"
+	}
+	if incoming {
+		return relType + " (incoming)"
+	}
+	return relType
+}
+
+func relationRowsFrom(res client.IssueRelationsResult) []relationRow {
+	rows := make([]relationRow, 0, len(res.Relations)+len(res.InverseRelations))
+	for _, n := range res.Relations {
+		rows = append(rows, relationRowOf(n, relationDirectionOutgoing))
+	}
+	for _, n := range res.InverseRelations {
+		rows = append(rows, relationRowOf(n, relationDirectionIncoming))
+	}
+	sortRelationRows(rows)
+	return rows
+}
+
+func relationRowOf(n client.IssueRelationNode, direction string) relationRow {
+	return relationRow{
+		ID:           n.ID,
+		Type:         n.Type,
+		Direction:    direction,
+		Issue:        relationIssueRefOf(n.Issue),
+		RelatedIssue: relationIssueRefOf(n.RelatedIssue),
+		CreatedAt:    n.CreatedAt,
+		ArchivedAt:   n.ArchivedAt,
+	}
+}
+
+func sortRelationRows(rows []relationRow) {
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Type != rows[j].Type {
+			return rows[i].Type < rows[j].Type
+		}
+		if rows[i].Direction != rows[j].Direction {
+			return rows[i].Direction < rows[j].Direction
+		}
+		return rows[i].counterpart().Identifier < rows[j].counterpart().Identifier
+	})
+}
+
+func newRelationsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "relations",
+		Aliases: []string{"links"},
+		Short:   "Read and manage issue relations (blocks, duplicate, related, similar)",
+		Long: `Manage the IssueRelation graph.
+
+Linear has exactly four relation types: blocks, duplicate, related and
+similar. "blocked by" is not one of them. It is the incoming direction over a
+blocks relation, so every row carries a separate 'direction' field
+(outgoing or incoming) alongside the verbatim 'type'.`,
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,2,3,4,5,6,7"},
+		RunE:        parentNoSubcommandRunE(flags),
+	}
+	cmd.AddCommand(newRelationsListCmd(flags))
+	cmd.AddCommand(newRelationsCreateCmd(flags))
+	cmd.AddCommand(newRelationsDeleteCmd(flags))
+	return cmd
+}
+
+func newRelationsListCmd(flags *rootFlags) *cobra.Command {
+	var typeFilter, direction, dbPath string
+	var includeArchived bool
+	cmd := &cobra.Command{
+		Use:         "list <issue>",
+		Aliases:     []string{"ls"},
+		Short:       "List every relation touching one issue, in both directions",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		Long: `List an issue's relations.
+
+Reads Issue.relations (outgoing) and Issue.inverseRelations (incoming) and
+renders them as one list. Query.issueRelations takes no filter argument, so a
+relation read is always per-issue: there is no server-side way to ask for
+"every blocks relation in the workspace".
+
+Rows carry 'type' (the IssueRelationType enum value) and 'direction'
+(outgoing or incoming) as separate fields. An incoming blocks relation is
+what a human calls "blocked by". It is a direction, never a type.
+
+With --data-source live (the default via auto) relations are fetched from the
+API and written through to the local issue_relations table, so a later
+--data-source local read of the same issue works offline.
+
+--include-archived passes includeArchived: true to both relation connections,
+so relations that were archived alongside their issues come back too. Archived
+rows carry archived_at, and the issue projections on either side carry their
+own archived_at when the issue itself is archived. Without the flag an
+archived relation is invisible on both the live and the local path, even if a
+previous --include-archived read cached one.`,
+		Example: `  linear-pp-cli relations list ESP-1155
+  linear-pp-cli relations list ESP-1155 --type blocks --direction incoming --agent
+  linear-pp-cli relations list ESP-1155 --data-source local --json
+  linear-pp-cli relations list ESP-1155 --include-archived --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if typeFilter != "" {
+				normalized, err := normalizeIssueRelationType(typeFilter)
+				if err != nil {
+					return err
+				}
+				typeFilter = normalized
+			}
+			switch direction {
+			case relationDirectionBoth, relationDirectionOutgoing, relationDirectionIncoming:
+			default:
+				return usageErr(fmt.Errorf("--direction %q is invalid. Valid values: %s, %s, %s", direction, relationDirectionBoth, relationDirectionOutgoing, relationDirectionIncoming))
+			}
+			return runRelationsList(cmd, flags, resolveDBPath(dbPath), args[0], typeFilter, direction, includeArchived)
+		},
+	}
+	cmd.Flags().StringVar(&typeFilter, "type", "", "Only show relations of this IssueRelationType ("+strings.Join(issueRelationTypes, ", ")+")")
+	cmd.Flags().StringVar(&direction, "direction", relationDirectionBoth, "Which side to show: both, outgoing, or incoming (incoming blocks == blocked by)")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
+	cmd.Flags().BoolVar(&includeArchived, "include-archived", false, "Include archived relations (maps to the includeArchived connection argument)")
+	return cmd
+}
+
+func runRelationsList(cmd *cobra.Command, flags *rootFlags, dbPath, issueRef, typeFilter, direction string, includeArchived bool) error {
+	db, openErr := openStoreAt(dbPath)
+	if db != nil {
+		defer db.Close()
+	}
+
+	var rows []relationRow
+	var prov DataProvenance
+
+	fetchLocal := func(reason string) ([]relationRow, DataProvenance, error) {
+		if openErr != nil {
+			return nil, DataProvenance{}, fmt.Errorf("opening local database: %w\nRun 'linear-pp-cli relations list %s' with --data-source live first", openErr, issueRef)
+		}
+		if db == nil {
+			return nil, DataProvenance{}, notFoundErr(fmt.Errorf("no local relation snapshot. Relations are not part of 'sync', so run 'linear-pp-cli relations list %s --data-source live' once to populate it", issueRef))
+		}
+		subjectID, err := resolveIssueIDLocal(db, issueRef)
+		if err != nil {
+			return nil, DataProvenance{}, err
+		}
+		raw, err := db.ListIssueRelationsForIssue(subjectID)
+		if err != nil {
+			return nil, DataProvenance{}, err
+		}
+		local := make([]relationRow, 0, len(raw))
+		for _, r := range raw {
+			var node client.IssueRelationNode
+			if err := json.Unmarshal(r, &node); err != nil || node.ID == "" {
+				continue
+			}
+			dir := relationDirectionIncoming
+			if node.Issue.ID == subjectID {
+				dir = relationDirectionOutgoing
+			}
+			local = append(local, relationRowOf(node, dir))
+		}
+		sortRelationRows(local)
+		return local, localProvenance(db, "issue_relations", reason), nil
+	}
+
+	switch flags.dataSource {
+	case "local":
+		var err error
+		rows, prov, err = fetchLocal("user_requested")
+		if err != nil {
+			return err
+		}
+	default:
+		c, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		issueID, err := resolveIssueID(c, issueRef)
+		if err != nil {
+			if flags.dataSource == "live" || !isNetworkError(err) {
+				return classifyLiveReadError(err, flags)
+			}
+			rows, prov, err = fetchLocal("api_unreachable")
+			if err != nil {
+				return err
+			}
+			break
+		}
+		res, err := c.FetchIssueRelationsWith(issueID, 0, includeArchived)
+		if err != nil {
+			if flags.dataSource == "live" || !isNetworkError(err) {
+				return classifyLiveReadError(err, flags)
+			}
+			var fallbackErr error
+			rows, prov, fallbackErr = fetchLocal("api_unreachable")
+			if fallbackErr != nil {
+				return fmt.Errorf("API unreachable and no local relation snapshot for %s.\n\nOriginal error: %w", issueRef, err)
+			}
+			break
+		}
+		rows = relationRowsFrom(res)
+		prov = DataProvenance{Source: "live", ResourceType: "issue_relations", Reason: "user_requested"}
+		if db != nil {
+			writeThroughRelations(db, issueID, res)
+		}
+	}
+
+	filtered := make([]relationRow, 0, len(rows))
+	for _, r := range rows {
+		if typeFilter != "" && r.Type != typeFilter {
+			continue
+		}
+		if direction != relationDirectionBoth && r.Direction != direction {
+			continue
+		}
+		// The live path already excluded archived relations server-side, but
+		// the local snapshot may hold rows cached by an earlier
+		// --include-archived read. Re-applying the predicate here keeps the
+		// two paths answering the same question.
+		if !includeArchived && r.ArchivedAt != "" {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+
+	prov = attachFreshness(prov, flags)
+	printProvenance(cmd, len(filtered), prov)
+	if wantsHumanTable(cmd.OutOrStdout(), flags) {
+		return printRelationTable(cmd, filtered, includeArchived)
+	}
+	payload, err := json.Marshal(filtered)
+	if err != nil {
+		return err
+	}
+	return renderPayloadWithProvenance(cmd, flags, payload, prov, false)
+}
+
+func printRelationTable(cmd *cobra.Command, rows []relationRow, showArchived bool) error {
+	if len(rows) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No relations.")
+		return nil
+	}
+	tw := newTabWriter(cmd.OutOrStdout())
+	if showArchived {
+		fmt.Fprintln(tw, "RELATION\tISSUE\tSTATE\tARCHIVED\tTITLE\tRELATION-ID")
+	} else {
+		fmt.Fprintln(tw, "RELATION\tISSUE\tSTATE\tTITLE\tRELATION-ID")
+	}
+	for _, r := range rows {
+		other := r.counterpart()
+		if showArchived {
+			// A relation can be archived on its own, and either endpoint can
+			// be archived independently. Show whichever stamp exists, relation
+			// first, so the column is never silently empty for an archived row.
+			stamp := r.ArchivedAt
+			if stamp == "" {
+				stamp = other.ArchivedAt
+			}
+			if stamp == "" {
+				stamp = "-"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				relationLabel(r.Type, r.Direction),
+				other.Identifier,
+				other.StateName,
+				stamp,
+				truncate(other.Title, 48),
+				r.ID,
+			)
+			continue
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			relationLabel(r.Type, r.Direction),
+			other.Identifier,
+			other.StateName,
+			truncate(other.Title, 48),
+			r.ID,
+		)
+	}
+	return tw.Flush()
+}
+
+// writeThroughRelations mirrors a live relation read into the local snapshot.
+// Failures are advisory: a read must not fail because the cache write did.
+func writeThroughRelations(db *store.Store, issueID string, res client.IssueRelationsResult) {
+	records := make([]store.IssueRelationRecord, 0, len(res.Relations)+len(res.InverseRelations))
+	appendRecord := func(n client.IssueRelationNode) {
+		data, err := json.Marshal(n)
+		if err != nil {
+			return
+		}
+		records = append(records, store.IssueRelationRecord{
+			ID:             n.ID,
+			IssueID:        n.Issue.ID,
+			RelatedIssueID: n.RelatedIssue.ID,
+			Type:           n.Type,
+			Data:           data,
+		})
+	}
+	for _, n := range res.Relations {
+		appendRecord(n)
+	}
+	for _, n := range res.InverseRelations {
+		appendRecord(n)
+	}
+	if err := db.ReplaceIssueRelationsForIssue(issueID, records); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: local relation write-through failed: %v\n", err)
+	}
+}
+
+// resolveIssueIDLocal maps an identifier to a UUID using the local snapshot,
+// so a --data-source local relation read never touches the network.
+func resolveIssueIDLocal(db *store.Store, issueRef string) (string, error) {
+	if store.IsUUID(issueRef) {
+		return issueRef, nil
+	}
+	rows, err := db.ListIssues(map[string]string{"identifier": issueRef}, 1)
+	if err != nil {
+		return "", err
+	}
+	if len(rows) == 0 {
+		return "", notFoundErr(fmt.Errorf("issue %q not found in the local store. Run 'linear-pp-cli sync' or use --data-source live", issueRef))
+	}
+	var row struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rows[0], &row); err != nil || row.ID == "" {
+		return "", notFoundErr(fmt.Errorf("issue %q has no id in the local store. Run 'linear-pp-cli sync'", issueRef))
+	}
+	return row.ID, nil
+}
+
+func newRelationsCreateCmd(flags *rootFlags) *cobra.Command {
+	var relType, to, dbPath string
+	cmd := &cobra.Command{
+		Use:   "create <issue> --type <type> --to <issue>",
+		Short: "Create an issue relation (blocks, duplicate, related, similar)",
+		Long: `Create one IssueRelation from <issue> to --to.
+
+Direction matters for the two directional types. 'create A --type blocks --to
+B' means A blocks B, which makes B blocked by A. 'create A --type duplicate
+--to B' means A is a duplicate of B, so B is the canonical issue. 'related'
+and 'similar' are symmetric.
+
+To close A as a duplicate of B, prefer 'issues close-duplicate A --of B',
+which creates the relation and then sets the duplicate state in that order.
+
+--idempotent turns an already-existing identical relation into a successful
+no-op. For blocks and duplicate the existing-relation check is
+direction-sensitive. For the symmetric types related and similar it matches
+in either direction.`,
+		Example: `  linear-pp-cli relations create ESP-1155 --type blocks --to ESP-1160
+  linear-pp-cli relations create ESP-1155 --type related --to ESP-1161 --idempotent --agent
+  linear-pp-cli relations create ESP-1155 --type blocks --to ESP-1160 --dry-run --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if to == "" {
+				return usageErr(fmt.Errorf("--to is required (the issue on the other side of the relation)"))
+			}
+			if relType == "" {
+				return usageErr(fmt.Errorf("--type is required. Valid types: %s", strings.Join(issueRelationTypes, ", ")))
+			}
+			normalizedType, err := normalizeIssueRelationType(relType)
+			if err != nil {
+				return err
+			}
+			if flags.dryRun {
+				return renderMutationDryRun(cmd, flags, "would_create_relation", "issueRelationCreate", map[string]any{
+					"input": map[string]any{
+						"type":           normalizedType,
+						"issueId":        args[0],
+						"relatedIssueId": to,
+					},
+				})
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			issueID, err := resolveIssueID(c, args[0])
+			if err != nil {
+				return classifyLiveReadError(err, flags)
+			}
+			relatedID, err := resolveIssueID(c, to)
+			if err != nil {
+				return classifyLiveReadError(err, flags)
+			}
+			if issueID == relatedID {
+				return usageErr(fmt.Errorf("cannot relate %s to itself", args[0]))
+			}
+			if err := enforceIssueTrustMode(flags, resolveDBPath(dbPath), issueID, args[0]); err != nil {
+				return err
+			}
+
+			if flags.idempotent {
+				existing, err := findExistingRelation(c, issueID, relatedID, normalizedType)
+				if err != nil {
+					return classifyLiveReadError(err, flags)
+				}
+				if existing != nil {
+					return writeNoop(flags, "already_exists", fmt.Sprintf("relation already exists (%s, id %s)", relationLabel(existing.Type, existing.Direction), existing.ID))
+				}
+			}
+
+			node, err := createIssueRelation(c, issueID, relatedID, normalizedType)
+			if err != nil {
+				return classifyMutationError("issueRelationCreate", err, flags, nil)
+			}
+
+			row := relationRowOf(node, relationDirectionOutgoing)
+			if db, dbErr := store.Open(resolveDBPath(dbPath)); dbErr == nil {
+				defer db.Close()
+				if data, mErr := json.Marshal(node); mErr == nil {
+					_ = db.UpsertIssueRelation(store.IssueRelationRecord{
+						ID:             node.ID,
+						IssueID:        node.Issue.ID,
+						RelatedIssueID: node.RelatedIssue.ID,
+						Type:           node.Type,
+						Data:           data,
+					})
+				}
+			}
+
+			if flags.asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(map[string]any{
+					"event":         "relation_created",
+					"id":            row.ID,
+					"type":          row.Type,
+					"direction":     row.Direction,
+					"issue":         row.Issue,
+					"related_issue": row.RelatedIssue,
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s %s %s\n", row.Issue.Identifier, relationLabel(row.Type, row.Direction), row.RelatedIssue.Identifier)
+			fmt.Fprintf(cmd.OutOrStdout(), "  relation id: %s\n", row.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&relType, "type", "", "Relation type: "+strings.Join(issueRelationTypes, ", ")+" (required)")
+	cmd.Flags().StringVar(&to, "to", "", "The issue on the other side of the relation, identifier or UUID (required)")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path for the trust-mode ledger and relation write-through")
+	return cmd
+}
+
+// createIssueRelation issues the mutation and returns the created node.
+func createIssueRelation(c *client.Client, issueID, relatedID, relType string) (client.IssueRelationNode, error) {
+	resp, err := c.Mutate(client.IssueRelationCreateMutation, map[string]any{
+		"input": map[string]any{
+			"type":           relType,
+			"issueId":        issueID,
+			"relatedIssueId": relatedID,
+		},
+	})
+	if err != nil {
+		return client.IssueRelationNode{}, err
+	}
+	node, ok, err := client.DecodeIssueRelationCreate(resp)
+	if err != nil {
+		return client.IssueRelationNode{}, err
+	}
+	if !ok {
+		return client.IssueRelationNode{}, apiErr(fmt.Errorf("Linear reported issueRelationCreate success=false"))
+	}
+	return node, nil
+}
+
+// findExistingRelation looks for a relation of relType between the two
+// issues. Direction-sensitive for blocks and duplicate, direction-insensitive
+// for the symmetric types. Returns nil when there is no match.
+func findExistingRelation(c *client.Client, issueID, relatedID, relType string) (*relationRow, error) {
+	res, err := c.FetchIssueRelations(issueID, 0)
+	if err != nil {
+		return nil, err
+	}
+	for _, n := range res.Relations {
+		if n.Type == relType && n.RelatedIssue.ID == relatedID {
+			row := relationRowOf(n, relationDirectionOutgoing)
+			return &row, nil
+		}
+	}
+	if !symmetricRelationTypes[relType] {
+		return nil, nil
+	}
+	for _, n := range res.InverseRelations {
+		if n.Type == relType && n.Issue.ID == relatedID {
+			row := relationRowOf(n, relationDirectionIncoming)
+			return &row, nil
+		}
+	}
+	return nil, nil
+}
+
+func newRelationsDeleteCmd(flags *rootFlags) *cobra.Command {
+	var dbPath string
+	cmd := &cobra.Command{
+		Use:     "delete <relation-id>",
+		Aliases: []string{"rm"},
+		Short:   "Delete an issue relation by its relation UUID",
+		Long: `Delete one IssueRelation.
+
+The argument is the relation's own UUID, not an issue identifier. Get it from
+the RELATION-ID column of 'relations list <issue>'.
+
+Deleting is confirmed interactively unless --yes is passed. With
+--ignore-missing an already-deleted relation is a successful no-op.`,
+		Example: `  linear-pp-cli relations delete 9f1c2a5e-2b1d-4d2f-9a44-1f0c3f6a77aa --yes
+  linear-pp-cli relations delete 9f1c... --ignore-missing --agent`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			relationID := strings.TrimSpace(args[0])
+			if !store.IsUUID(relationID) {
+				return usageErr(fmt.Errorf("expected a relation UUID (got %q). Run 'linear-pp-cli relations list <issue>' and use the RELATION-ID column", args[0]))
+			}
+			if flags.dryRun {
+				return renderMutationDryRun(cmd, flags, "would_delete_relation", "issueRelationDelete", map[string]any{
+					"id": relationID,
+				})
+			}
+			if err := confirmRelationMutation(cmd, flags, fmt.Sprintf("Delete issue relation %s?", relationID)); err != nil {
+				return err
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			resp, err := c.Mutate(client.IssueRelationDeleteMutation, map[string]any{"id": relationID})
+			if err != nil {
+				if flags.ignoreMissing && isMissingEntityError(err) {
+					deleteRelationLocally(resolveDBPath(dbPath), relationID)
+					return writeNoop(flags, "already_deleted", "relation already deleted (no-op)")
+				}
+				return classifyDeleteError(err, flags)
+			}
+			entityID, ok, err := client.DecodeIssueRelationDelete(resp)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return apiErr(fmt.Errorf("Linear reported issueRelationDelete success=false for %s", relationID))
+			}
+			deleteRelationLocally(resolveDBPath(dbPath), relationID)
+			if flags.asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(map[string]any{
+					"event": "relation_deleted",
+					"id":    firstNonEmpty(entityID, relationID),
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted relation %s\n", firstNonEmpty(entityID, relationID))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path for the local relation snapshot")
+	return cmd
+}
+
+func deleteRelationLocally(dbPath, relationID string) {
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	_, _ = db.DeleteIssueRelation(relationID)
+}
+
+// isMissingEntityError reports whether a GraphQL failure means the target no
+// longer exists. Linear answers a delete of an unknown id with a 200 plus an
+// errors array, so the HTTP-404 branch in classifyDeleteError never fires for
+// the GraphQL transport and --ignore-missing needs this shape check too.
+func isMissingEntityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "could not find") ||
+		strings.Contains(msg, "does not exist") ||
+		strings.Contains(msg, "entity not found")
+}
+
+// confirmRelationMutation is the shared confirmation gate for the destructive
+// relation paths. --yes skips it, --no-input without --yes is a usage error
+// rather than a hang.
+func confirmRelationMutation(cmd *cobra.Command, flags *rootFlags, prompt string) error {
+	if flags.yes {
+		return nil
+	}
+	if flags.noInput {
+		return usageErr(fmt.Errorf("%s this needs explicit confirmation: pass --yes (or drop --no-input)", prompt))
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "%s [y/N] ", prompt)
+	var resp string
+	fmt.Fscanln(cmd.InOrStdin(), &resp)
+	if !strings.EqualFold(resp, "y") && !strings.EqualFold(resp, "yes") {
+		return usageErr(fmt.Errorf("aborted"))
+	}
+	return nil
+}
+
+// newIssuesCloseDuplicateCmd closes an issue as a duplicate of another, in
+// the only order that does not lose information.
+//
+// Linear removed the per-team markedAsDuplicateWorkflowStateId model
+// (deprecated on Team, TeamCreateInput and TeamUpdateInput, "Duplicates are
+// now system-managed via the native duplicate state"), so duplication is
+// carried by the IssueRelation graph. Setting a duplicate-typed state without
+// first creating the duplicate relation produces an orphaned close: the issue
+// reads as closed-as-duplicate with nothing recording what it duplicates.
+//
+// The ordering is therefore fixed and not configurable:
+//
+//	step 1  issueRelationCreate{type: duplicate, issue: <issue>, relatedIssue: <canonical>}
+//	step 2  issueUpdate{stateId: <the team's duplicate-typed state>}
+//
+// Step 1 failing leaves nothing done. Step 1 succeeding and step 2 failing
+// leaves the relation recorded and the issue open, which is recoverable and
+// exits 6 (partial) naming the step that failed. The reverse order has no
+// recoverable failure mode, which is why it is not offered.
+func newIssuesCloseDuplicateCmd(flags *rootFlags) *cobra.Command {
+	var canonical, duplicateState, dbPath string
+	cmd := &cobra.Command{
+		Use:     "close-duplicate <issue> --of <canonical-issue>",
+		Aliases: []string{"dupe"},
+		Short:   "Close an issue as a duplicate: create the duplicate relation, then set the duplicate state",
+		Long: `Close <issue> as a duplicate of --of.
+
+Two steps, in this order and no other:
+
+  1. issueRelationCreate with type duplicate, from <issue> to the canonical
+     issue. This is what records WHAT the issue duplicates.
+  2. issueUpdate setting <issue> to its team's duplicate-typed workflow state.
+
+Doing step 2 first (which 'issues edit --state-type duplicate' does on its
+own) produces an orphaned close. If step 1 fails nothing is changed. If step 2
+fails the relation still stands and the command exits 6 (partial) telling you
+which step failed and how to finish.
+
+The duplicate state is resolved at runtime from the issue's own team, by
+querying workflowStates filtered on type eq duplicate. A team with no
+duplicate-typed state is exit 3: nothing is guessed and no state name is
+compiled into this binary. Pass --duplicate-state when a team has more than
+one duplicate-typed state.`,
+		Example: `  linear-pp-cli issues close-duplicate ESP-1160 --of ESP-1155 --yes
+  linear-pp-cli issues close-duplicate ESP-1160 --of ESP-1155 --dry-run --json
+  linear-pp-cli issues close-duplicate ESP-1160 --of ESP-1155 --idempotent --agent`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if canonical == "" {
+				return usageErr(fmt.Errorf("--of is required (the canonical issue this one duplicates)"))
+			}
+			if flags.dryRun {
+				return renderMutationDryRun(cmd, flags, "would_close_duplicate", "issueRelationCreate+issueUpdate", map[string]any{
+					"steps": []map[string]any{
+						{
+							"step":     1,
+							"mutation": "issueRelationCreate",
+							"input": map[string]any{
+								"type":           "duplicate",
+								"issueId":        args[0],
+								"relatedIssueId": canonical,
+							},
+						},
+						{
+							"step":       2,
+							"mutation":   "issueUpdate",
+							"issue":      args[0],
+							"state_type": "duplicate",
+						},
+					},
+				})
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			raw, err := fetchIssueLive(c, args[0])
+			if err != nil {
+				return classifyLiveReadError(err, flags)
+			}
+			var subject struct {
+				ID         string `json:"id"`
+				Identifier string `json:"identifier"`
+				Title      string `json:"title"`
+				Team       struct {
+					ID  string `json:"id"`
+					Key string `json:"key"`
+				} `json:"team"`
+			}
+			if err := json.Unmarshal(raw, &subject); err != nil || subject.ID == "" {
+				return notFoundErr(fmt.Errorf("issue %q not found", args[0]))
+			}
+			canonicalID, err := resolveIssueID(c, canonical)
+			if err != nil {
+				return classifyLiveReadError(err, flags)
+			}
+			if canonicalID == subject.ID {
+				return usageErr(fmt.Errorf("cannot close %s as a duplicate of itself", args[0]))
+			}
+			if err := enforceIssueTrustMode(flags, resolveDBPath(dbPath), subject.ID, args[0]); err != nil {
+				return err
+			}
+
+			// Resolve the duplicate-typed state BEFORE the relation is
+			// created. A team with no duplicate state must fail before any
+			// mutation goes out, otherwise step 1 lands and step 2 can never
+			// succeed, turning a plain exit 3 into a pointless partial.
+			team := issueTeamInfo{ID: subject.Team.ID, Key: subject.Team.Key}
+			stateID, err := resolveDuplicateStateID(c, team, duplicateState)
+			if err != nil {
+				return err
+			}
+
+			if err := confirmRelationMutation(cmd, flags, fmt.Sprintf("Close %s as a duplicate of %s?", firstNonEmpty(subject.Identifier, args[0]), canonical)); err != nil {
+				return err
+			}
+
+			// Step 1: the relation. Always first.
+			relationID := ""
+			relationStatus := "created"
+			if flags.idempotent {
+				existing, findErr := findExistingRelation(c, subject.ID, canonicalID, "duplicate")
+				if findErr != nil {
+					return classifyLiveReadError(findErr, flags)
+				}
+				if existing != nil {
+					relationID = existing.ID
+					relationStatus = "already_existed"
+				}
+			}
+			if relationID == "" {
+				node, createErr := createIssueRelation(c, subject.ID, canonicalID, "duplicate")
+				if createErr != nil {
+					return classifyMutationError("issueRelationCreate", createErr, flags, nil)
+				}
+				relationID = node.ID
+			}
+
+			// Step 2: the state. A failure here is partial, not total: the
+			// relation from step 1 stands and the issue is still open.
+			if err := setIssueState(c, subject.ID, stateID); err != nil {
+				return partialFailureErr(fmt.Errorf(
+					"step 1 (issueRelationCreate) succeeded, relation %s records %s as a duplicate of %s, but step 2 (issueUpdate to the duplicate state) failed: %v\n%s is still OPEN. Finish with 'linear-pp-cli issues edit %s --state %s'",
+					relationID, firstNonEmpty(subject.Identifier, args[0]), canonical, err,
+					firstNonEmpty(subject.Identifier, args[0]), firstNonEmpty(subject.Identifier, args[0]), stateID,
+				))
+			}
+
+			if flags.asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(map[string]any{
+					"event":        "issue_closed_as_duplicate",
+					"identifier":   subject.Identifier,
+					"id":           subject.ID,
+					"canonical":    canonical,
+					"canonical_id": canonicalID,
+					"relation_id":  relationID,
+					"relation":     relationStatus,
+					"state_id":     stateID,
+					"steps":        []string{"issueRelationCreate", "issueUpdate"},
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s closed as a duplicate of %s\n", firstNonEmpty(subject.Identifier, args[0]), canonical)
+			fmt.Fprintf(cmd.OutOrStdout(), "  relation %s (%s), then duplicate state %s\n", relationID, relationStatus, stateID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&canonical, "of", "", "The canonical issue this one duplicates, identifier or UUID (required)")
+	cmd.Flags().StringVar(&duplicateState, "duplicate-state", "", "Disambiguate when the team has several duplicate-typed states: pass the state UUID or its exact name")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path for the trust-mode ledger")
+	return cmd
+}
+
+// resolveDuplicateStateID finds the team's duplicate-typed workflow state.
+// The state's NAME is workspace vocabulary and is never assumed: resolution
+// goes through WorkflowState.type, which is API-documented schema data.
+// override accepts a UUID or an exact state name for teams carrying more
+// than one duplicate-typed state.
+func resolveDuplicateStateID(c graphqlQueryer, team issueTeamInfo, override string) (string, error) {
+	if override != "" {
+		if store.IsUUID(override) {
+			return override, nil
+		}
+		return resolveWorkflowState(c, team, override, "")
+	}
+	stateID, err := resolveWorkflowState(c, team, "", "duplicate")
+	if err != nil {
+		return "", fmt.Errorf("%w\nA duplicate-typed state cannot be created by mutation (WorkflowStateCreateInput does not accept the duplicate type), so it has to already exist in Linear for this team", err)
+	}
+	return stateID, nil
+}
+
+// setIssueState is step 2 of the duplicate close.
+func setIssueState(c *client.Client, issueID, stateID string) error {
+	resp, err := c.Mutate(client.IssueUpdateMutation, map[string]any{
+		"id":    issueID,
+		"input": map[string]any{"stateId": stateID},
+	})
+	if err != nil {
+		return err
+	}
+	var parsed struct {
+		IssueUpdate struct {
+			Success bool `json:"success"`
+		} `json:"issueUpdate"`
+	}
+	if err := json.Unmarshal(resp, &parsed); err != nil {
+		return fmt.Errorf("parsing issueUpdate response: %w", err)
+	}
+	if !parsed.IssueUpdate.Success {
+		return fmt.Errorf("Linear reported issueUpdate success=false")
+	}
+	return nil
+}

--- a/library/project-management/linear/internal/cli/root.go
+++ b/library/project-management/linear/internal/cli/root.go
@@ -318,6 +318,8 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newTodayCmd(flags))
 	rootCmd.AddCommand(newBottleneckCmd(flags))
 	rootCmd.AddCommand(newBlockingCmd(flags))
+	rootCmd.AddCommand(newRelationsCmd(flags))
+	rootCmd.AddCommand(newUnblockedCmd(flags))
 	rootCmd.AddCommand(newSimilarCmd(flags))
 	rootCmd.AddCommand(newVelocityCmd(flags))
 	rootCmd.AddCommand(newSlippedCmd(flags))

--- a/library/project-management/linear/internal/cli/trust_gate.go
+++ b/library/project-management/linear/internal/cli/trust_gate.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+)
+
+// enforceIssueTrustMode is the mutation guard behind --trust-mode strict.
+//
+// The flag has always been documented as "refuses to mutate Linear issues not
+// in the local pp_created table", but store.IsPPCreated had no callers, so the
+// only thing strict mode actually did was demand a session tag on create. This
+// helper closes that hole: every issue-mutating path calls it with the
+// resolved issue UUID before the mutation goes out, and a target that is not
+// an unarchived row in the pp_created ledger is refused with exit code 2.
+//
+// The gate fails closed. A missing or unreadable ledger means the caller
+// cannot prove the issue is a fixture, so the mutation is refused rather than
+// waved through.
+//
+// pp-cleanup is deliberately exempt: it enumerates its targets from the ledger
+// itself, so re-checking membership there would be circular.
+func enforceIssueTrustMode(flags *rootFlags, dbPath, issueID, issueRef string) error {
+	if flags == nil || flags.trustMode != "strict" {
+		return nil
+	}
+	if issueRef == "" {
+		issueRef = issueID
+	}
+	if issueID == "" {
+		return usageErr(fmt.Errorf("trust-mode=strict: cannot verify %q against the local pp_created ledger without a resolved issue id", issueRef))
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return usageErr(fmt.Errorf("trust-mode=strict: cannot read the local pp_created ledger at %s: %w\nRun 'linear-pp-cli sync' to create the store, or drop --trust-mode strict to mutate pre-existing issues", dbPath, err))
+	}
+	defer db.Close()
+
+	created, err := db.IsPPCreated(issueID)
+	if err != nil {
+		return usageErr(fmt.Errorf("trust-mode=strict: reading the local pp_created ledger failed: %w", err))
+	}
+	if !created {
+		return usageErr(fmt.Errorf("trust-mode=strict: %s is not in the local pp_created ledger, so this CLI did not create it and refuses to mutate it.\nRun 'linear-pp-cli pp-test list' to see the fixtures this CLI owns, or drop --trust-mode strict to mutate pre-existing workspace issues", issueRef))
+	}
+	return nil
+}

--- a/library/project-management/linear/internal/cli/unblocked.go
+++ b/library/project-management/linear/internal/cli/unblocked.go
@@ -1,0 +1,345 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/groups"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+// `unblocked`: which blocked issues are now actionable.
+//
+// One paged query, filtered client-side. IssueFilter.hasBlockedByRelations
+// looks like the server-side shortcut for "is this blocked" and is a trap:
+// Linear stops matching it once every blocker of an issue has closed, which
+// is exactly the state this command exists to report. Filtering the crawl on
+// it made the command structurally incapable of returning a row. Proven live
+// on 2026-08-11: completing blocker ACC-256 made blocked ACC-257 disappear
+// from the candidate set entirely, even under --show-blocked, while `relations
+// list` still showed the relation and `issues get` still showed ACC-257 open.
+//
+// So the query asks only for the open group (plus --team) and selects each
+// issue's inverseRelations inline:
+//
+//	issues(filter: {state: <open group>, team: ...}) {
+//	  nodes { ... inverseRelations(first: $relFirst) { nodes { type issue { state } } } }
+//	}
+//
+// "Blocked by something" is then a local test: keep an issue only when at
+// least one inverse relation carries type `blocks`. The blockers' own states
+// ride along in the same selection set, so the verdict costs no extra round
+// trip. When an issue's inline relation page is truncated the rest is paged
+// before any verdict, because a partial blocker set yields a confident wrong
+// answer.
+//
+// Closed is defined as the complement of the open group, not as its own list.
+// An issue counts as closed when the resolved open group does NOT match its
+// state. Under the shipped default `active` group (types triage, backlog,
+// unstarted, started) the complement is exactly completed, canceled and
+// duplicate. A workspace that redefines `active` in groups.toml moves both
+// sides of the test together, which is the point: there is no second,
+// hand-written "closed" predicate that could drift out of agreement.
+//
+// Scope: this answers which BLOCKED items became actionable. An open issue
+// with no blockers at all was never blocked, so it is dropped by the local
+// `blocks` test. Without a server-side relation predicate the query walks
+// every open issue in scope, so --team is the way to keep the crawl small.
+//
+// Live only. Relations are not part of `sync`, so meta.source is always
+// "live" and there is no local fallback to fall back to.
+
+// unblockedBlocker is one blocker of a candidate issue.
+type unblockedBlocker struct {
+	Identifier string `json:"identifier"`
+	Title      string `json:"title,omitempty"`
+	StateName  string `json:"state_name"`
+	StateType  string `json:"state_type"`
+	Closed     bool   `json:"closed"`
+}
+
+// unblockedRow is one issue whose blockers are all closed.
+type unblockedRow struct {
+	Identifier        string             `json:"identifier"`
+	ID                string             `json:"id"`
+	Title             string             `json:"title"`
+	URL               string             `json:"url,omitempty"`
+	Priority          string             `json:"priority"`
+	StateName         string             `json:"state_name"`
+	StateType         string             `json:"state_type"`
+	Team              string             `json:"team,omitempty"`
+	Blockers          []unblockedBlocker `json:"blockers"`
+	AllBlockersClosed bool               `json:"all_blockers_closed"`
+}
+
+func newUnblockedCmd(flags *rootFlags) *cobra.Command {
+	var teamFlag, stateFlag string
+	var limit, relLimit int
+	var includeStillBlocked bool
+	cmd := &cobra.Command{
+		Use:   "unblocked",
+		Short: "Show blocked issues whose blockers are now all closed",
+		Long: `Answer "what became actionable?".
+
+Lists open issues that HAVE blocking relations and whose every blocker sits in
+a closed state. An issue with no blockers is not a result: it was never
+blocked, so it never became unblocked.
+
+One query, filtered locally. IssueFilter's hasBlockedByRelations comparator
+looks like the server-side way to ask "is this blocked" and cannot be used:
+Linear stops matching it once every blocker of an issue closes, so filtering
+on it hid precisely the issues this command exists to surface. Instead the
+query asks for open issues and selects each one's inverseRelations inline,
+then keeps the issues carrying at least one incoming 'blocks' relation and
+tests every blocker's state locally.
+
+Without a server-side relation filter the crawl covers every open issue in
+scope, so pass --team to keep it small. --relation-limit sets how many blocker
+relations come back inline per issue, and anything past that is paged before
+the verdict rather than guessed.
+
+Closed is the complement of the open group, never a second hand-written list.
+An issue is closed when the group passed to --state does not match it. With
+the default 'active' group that is exactly the completed, canceled and
+duplicate state types. Redefine 'active' in groups.toml and both sides of the
+test move together.
+
+Relations are not synced, so this command is live only.`,
+		Example: `  linear-pp-cli unblocked
+  linear-pp-cli unblocked --team ESP --agent
+  linear-pp-cli unblocked --state active --show-blocked --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if limit <= 0 {
+				return usageErr(fmt.Errorf("--limit must be positive"))
+			}
+			if relLimit <= 0 {
+				return usageErr(fmt.Errorf("--relation-limit must be positive"))
+			}
+			return runUnblocked(cmd, flags, teamFlag, stateFlag, limit, relLimit, includeStillBlocked)
+		},
+	}
+	cmd.Flags().StringVar(&teamFlag, "team", "", "Filter to one team key or team UUID")
+	cmd.Flags().StringVar(&stateFlag, "state", "active", stateGroupFlagUsage)
+	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum candidate issues to examine per page")
+	cmd.Flags().IntVar(&relLimit, "relation-limit", 50, "Blocker relations to pull inline per candidate before paging the rest")
+	cmd.Flags().BoolVar(&includeStillBlocked, "show-blocked", false, "Also emit candidates that still have at least one open blocker (all_blockers_closed=false)")
+	return cmd
+}
+
+func runUnblocked(cmd *cobra.Command, flags *rootFlags, teamFlag, stateToken string, limit, relLimit int, includeStillBlocked bool) error {
+	if flags.dataSource == "local" {
+		return usageErr(fmt.Errorf("unblocked is live only: issue relations are not part of 'sync', so there is no local snapshot to compute blocker states from. Drop --data-source local"))
+	}
+	c, err := flags.newClient()
+	if err != nil {
+		return err
+	}
+
+	// One resolved predicate drives both sides of the answer: the server-side
+	// state filter on the crawl and the client-side blocker test. Closed is
+	// its complement.
+	set, err := resolveStateSet(flags, teamKeyForGroups(nil, teamFlag), stateToken)
+	if err != nil {
+		return err
+	}
+
+	// The crawl asks for the open group and nothing about relations.
+	// hasBlockedByRelations is the only relation predicate the server offers
+	// and it stops matching an issue once all of its blockers close, so it
+	// cannot appear here: it would filter out every row worth reporting.
+	filter := map[string]any{}
+	if stateFilter := groups.LiveFilter(set); stateFilter != nil {
+		filter["state"] = stateFilter
+	}
+	if teamFlag != "" {
+		filter["team"] = unblockedTeamFilter(teamFlag)
+	}
+
+	candidates, err := fetchUnblockedCandidates(c, filter, limit, relLimit)
+	if err != nil {
+		return classifyLiveReadError(err, flags)
+	}
+
+	// Local pass: a crawled issue is a candidate only if something blocks it,
+	// and then every blocker's state is resolved against the same predicate.
+	// Not matched by the open group == closed.
+	rows := make([]unblockedRow, 0, len(candidates))
+	for _, cand := range candidates {
+		inverse := cand.InverseRelations
+		if cand.RelationsTruncated {
+			// The inline page was capped. Computing "all blockers closed"
+			// from a partial blocker set would produce a confident wrong
+			// answer, so page the rest before deciding.
+			full, err := c.FetchIssueInverseRelations(cand.ID, relLimit)
+			if err != nil {
+				return classifyLiveReadError(err, flags)
+			}
+			inverse = full
+		}
+		blockers := make([]unblockedBlocker, 0, len(inverse))
+		allClosed := true
+		for _, rel := range inverse {
+			if rel.Type != "blocks" {
+				continue
+			}
+			blocker := rel.Issue
+			closed := !set.Match(blocker.State.Type, blocker.State.Name)
+			if !closed {
+				allClosed = false
+			}
+			blockers = append(blockers, unblockedBlocker{
+				Identifier: blocker.Identifier,
+				Title:      blocker.Title,
+				StateName:  blocker.State.Name,
+				StateType:  blocker.State.Type,
+				Closed:     closed,
+			})
+		}
+		if len(blockers) == 0 {
+			// Nothing blocks this issue: either it carries no inverse
+			// relations at all, or the ones it carries are `related`,
+			// `similar` or `duplicate`. It was never blocked, so it never
+			// became unblocked. This local test is what replaces the
+			// unusable hasBlockedByRelations server filter.
+			continue
+		}
+		if !allClosed && !includeStillBlocked {
+			continue
+		}
+		sort.Slice(blockers, func(i, j int) bool { return blockers[i].Identifier < blockers[j].Identifier })
+		rows = append(rows, unblockedRow{
+			Identifier:        cand.Identifier,
+			ID:                cand.ID,
+			Title:             cand.Title,
+			URL:               cand.URL,
+			Priority:          priorityLabel(cand.Priority),
+			StateName:         cand.State.Name,
+			StateType:         cand.State.Type,
+			Team:              cand.Team.Key,
+			Blockers:          blockers,
+			AllBlockersClosed: allClosed,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].AllBlockersClosed != rows[j].AllBlockersClosed {
+			return rows[i].AllBlockersClosed
+		}
+		return rows[i].Identifier < rows[j].Identifier
+	})
+
+	prov := attachFreshness(DataProvenance{
+		Source:       "live",
+		ResourceType: "issues",
+		Reason:       "relations_not_synced",
+	}, flags)
+	printProvenance(cmd, len(rows), prov)
+
+	if wantsHumanTable(cmd.OutOrStdout(), flags) {
+		if len(rows) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "Nothing became unblocked.")
+			return nil
+		}
+		tw := newTabWriter(cmd.OutOrStdout())
+		fmt.Fprintln(tw, "ID\tPRI\tBLOCKERS\tSTATE\tTITLE")
+		for _, r := range rows {
+			fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n", r.Identifier, r.Priority, len(r.Blockers), r.StateName, truncate(r.Title, 48))
+		}
+		return tw.Flush()
+	}
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return err
+	}
+	return renderPayloadWithProvenance(cmd, flags, payload, prov, false)
+}
+
+// unblockedCandidate is one crawled issue plus its inline blocker page.
+type unblockedCandidate struct {
+	ID         string
+	Identifier string
+	Title      string
+	URL        string
+	Priority   int
+	State      client.IssueRelationState
+	Team       struct {
+		ID  string
+		Key string
+	}
+	InverseRelations   []client.IssueRelationNode
+	RelationsTruncated bool
+}
+
+// fetchUnblockedCandidates walks the crawl to exhaustion. Every open issue in
+// scope comes back, blocked or not, because the server has no usable "is
+// blocked" predicate. The blocks test happens in the caller.
+func fetchUnblockedCandidates(c *client.Client, filter map[string]any, limit, relLimit int) ([]unblockedCandidate, error) {
+	var out []unblockedCandidate
+	cursor := ""
+	for {
+		vars := map[string]any{"first": limit, "filter": filter, "relFirst": relLimit}
+		if cursor != "" {
+			vars["after"] = cursor
+		}
+		var resp struct {
+			Issues struct {
+				Nodes []struct {
+					ID         string                    `json:"id"`
+					Identifier string                    `json:"identifier"`
+					Title      string                    `json:"title"`
+					URL        string                    `json:"url"`
+					Priority   int                       `json:"priority"`
+					State      client.IssueRelationState `json:"state"`
+					Team       struct {
+						ID  string `json:"id"`
+						Key string `json:"key"`
+					} `json:"team"`
+					InverseRelations struct {
+						Nodes    []client.IssueRelationNode `json:"nodes"`
+						PageInfo struct {
+							HasNextPage bool `json:"hasNextPage"`
+						} `json:"pageInfo"`
+					} `json:"inverseRelations"`
+				} `json:"nodes"`
+				PageInfo struct {
+					HasNextPage bool   `json:"hasNextPage"`
+					EndCursor   string `json:"endCursor"`
+				} `json:"pageInfo"`
+			} `json:"issues"`
+		}
+		if err := c.QueryInto(client.UnblockedCandidatesQuery, vars, &resp); err != nil {
+			return nil, err
+		}
+		for _, n := range resp.Issues.Nodes {
+			cand := unblockedCandidate{
+				ID:                 n.ID,
+				Identifier:         n.Identifier,
+				Title:              n.Title,
+				URL:                n.URL,
+				Priority:           n.Priority,
+				State:              n.State,
+				InverseRelations:   n.InverseRelations.Nodes,
+				RelationsTruncated: n.InverseRelations.PageInfo.HasNextPage,
+			}
+			cand.Team.ID = n.Team.ID
+			cand.Team.Key = n.Team.Key
+			out = append(out, cand)
+		}
+		if !resp.Issues.PageInfo.HasNextPage || resp.Issues.PageInfo.EndCursor == "" {
+			return out, nil
+		}
+		cursor = resp.Issues.PageInfo.EndCursor
+	}
+}
+
+// unblockedTeamFilter builds the TeamFilter fragment for a key or a UUID.
+func unblockedTeamFilter(team string) map[string]any {
+	if store.IsUUID(team) {
+		return map[string]any{"id": map[string]any{"eq": team}}
+	}
+	return map[string]any{"key": map[string]any{"eqIgnoreCase": team}}
+}

--- a/library/project-management/linear/internal/client/relations_paging_test.go
+++ b/library/project-management/linear/internal/client/relations_paging_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/config"
+)
+
+// A relation set that never exhausts must not come back as a short read: the
+// callers read "absent" as "no such relation", so a partial set silently drops
+// links from `relations list`, duplicates an existing relation on idempotent
+// create, and lets `unblocked` clear an issue whose blocker was never seen.
+func TestFetchIssueRelationsRefusesToTruncate(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requests.Add(1)
+		// Every page claims another page after it, so the loop can only end
+		// at the page bound.
+		fmt.Fprintf(w, `{"data":{"issue":{
+			"id":"11111111-1111-1111-1111-111111111111",
+			"identifier":"ENG-1",
+			"team":{"id":"team-1","key":"ENG"},
+			"relations":{"nodes":[{"id":"rel-%d","type":"blocks"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-%d"}},
+			"inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}
+		}}}`, n, n)
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{BaseURL: srv.URL}, 0, 0)
+	_, err := c.FetchIssueRelations("11111111-1111-1111-1111-111111111111", 50)
+	if err == nil {
+		t.Fatal("a relation set that never exhausted must be an error, not a partial result")
+	}
+	if !strings.Contains(err.Error(), "partial relation set") {
+		t.Fatalf("error does not name the cause: %v", err)
+	}
+	if got := requests.Load(); got != int64(maxRelationPages) {
+		t.Fatalf("paged %d times, want the %d page bound", got, maxRelationPages)
+	}
+}
+
+// The ordinary case still returns on exhaustion, with both sides collected.
+func TestFetchIssueRelationsReturnsOnExhaustion(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"issue":{
+			"id":"11111111-1111-1111-1111-111111111111",
+			"identifier":"ENG-1",
+			"team":{"id":"team-1","key":"ENG"},
+			"relations":{"nodes":[{"id":"rel-1","type":"blocks"}],"pageInfo":{"hasNextPage":false,"endCursor":""}},
+			"inverseRelations":{"nodes":[{"id":"rel-2","type":"blocks"}],"pageInfo":{"hasNextPage":false,"endCursor":""}}
+		}}}`)
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{BaseURL: srv.URL}, 0, 0)
+	res, err := c.FetchIssueRelations("11111111-1111-1111-1111-111111111111", 50)
+	if err != nil {
+		t.Fatalf("FetchIssueRelations: %v", err)
+	}
+	if len(res.Relations) != 1 || len(res.InverseRelations) != 1 {
+		t.Fatalf("collected %d outgoing and %d incoming relations, want 1 and 1", len(res.Relations), len(res.InverseRelations))
+	}
+	if res.TeamKey != "ENG" {
+		t.Fatalf("TeamKey = %q, want ENG", res.TeamKey)
+	}
+}

--- a/library/project-management/linear/internal/client/relations_queries.go
+++ b/library/project-management/linear/internal/client/relations_queries.go
@@ -1,0 +1,315 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GraphQL documents for the issue-relation surface (IssueRelationType:
+// blocks, duplicate, related, similar).
+//
+// Direction, not a fifth type. Linear stores "A blocks B" as a single
+// IssueRelation{type: blocks, issue: A, relatedIssue: B}. It appears in
+// A.relations (outgoing) and in B.inverseRelations (incoming). "blocked by"
+// is therefore the incoming direction over a `blocks` relation and is never
+// a value of IssueRelation.type. Every consumer of these documents must
+// render it as a direction.
+
+// IssueRelationsQuery reads both relation connections of one issue in a
+// single document. $id is the issue UUID: the top-level issue(id:) argument
+// behaves inconsistently with TEAM-NUMBER identifiers across workspaces, so
+// callers resolve the identifier first.
+//
+// Both connections select the same node shape so consumers never have to
+// branch on which connection a node came from. IssueRelation exposes both
+// `issue` (the relation source) and `relatedIssue` (the relation target),
+// verified against the introspected schema.
+//
+// $includeArchived maps to the includeArchived Boolean argument carried by
+// both Issue.relations and Issue.inverseRelations, verified live in
+// api-inventory.json. Declaring the variable changes nothing for a caller who
+// does not pass it: an unprovided variable makes the argument absent rather
+// than null, so the server default (exclude archived) still applies.
+//
+// archivedAt is selected on the relation itself (IssueRelation.archivedAt:
+// DateTime) and on both issue projections (Issue.archivedAt: DateTime), both
+// verified live in api-inventory.json. It is null on everything live, so it is
+// free on the default path and is the only thing that tells an archived row
+// apart once includeArchived is on.
+const IssueRelationsQuery = `query($id: String!, $first: Int!, $after: String, $inverseAfter: String, $includeArchived: Boolean) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+    url
+    state { id name type }
+    team { id key }
+    relations(first: $first, after: $after, includeArchived: $includeArchived) {
+      nodes {
+        id
+        type
+        createdAt
+        archivedAt
+        issue { id identifier title url archivedAt state { id name type } }
+        relatedIssue { id identifier title url archivedAt state { id name type } }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+    inverseRelations(first: $first, after: $inverseAfter, includeArchived: $includeArchived) {
+      nodes {
+        id
+        type
+        createdAt
+        archivedAt
+        issue { id identifier title url archivedAt state { id name type } }
+        relatedIssue { id identifier title url archivedAt state { id name type } }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}`
+
+// IssueRelationCreateMutation creates one relation. IssueRelationCreateInput
+// requires type, issueId and relatedIssueId.
+const IssueRelationCreateMutation = `mutation($input: IssueRelationCreateInput!) {
+  issueRelationCreate(input: $input) {
+    success
+    issueRelation {
+      id
+      type
+      createdAt
+      issue { id identifier title url state { id name type } }
+      relatedIssue { id identifier title url state { id name type } }
+    }
+  }
+}`
+
+// IssueRelationDeleteMutation deletes one relation by its UUID and returns
+// the DeletePayload, whose entityId echoes the deleted relation.
+const IssueRelationDeleteMutation = `mutation($id: String!) {
+  issueRelationDelete(id: $id) {
+    success
+    entityId
+  }
+}`
+
+// UnblockedCandidatesQuery is the single crawl behind `unblocked`.
+//
+// $filter carries the open-group state predicate and the optional team, and
+// deliberately carries nothing about relations. IssueFilter's
+// hasBlockedByRelations is a bare RelationExistsComparator, and worse than
+// merely coarse: Linear stops matching an issue once all of its blockers
+// close, so filtering on it drops exactly the issues `unblocked` reports.
+// "Blocked by something" and "are all its blockers closed" are both decided
+// client-side over the inverseRelations this document selects inline, which
+// is why each relation node carries the blocking issue's own state.
+const UnblockedCandidatesQuery = `query($first: Int!, $after: String, $filter: IssueFilter, $relFirst: Int!) {
+  issues(first: $first, after: $after, filter: $filter) {
+    nodes {
+      id
+      identifier
+      title
+      url
+      priority
+      state { id name type }
+      team { id key }
+      inverseRelations(first: $relFirst) {
+        nodes {
+          id
+          type
+          createdAt
+          issue { id identifier title url state { id name type } }
+          relatedIssue { id identifier title url state { id name type } }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}`
+
+// IssueRelationState is the workflow state carried on either side of a
+// relation. Type is one of the seven API-documented WorkflowState.type
+// values and is what group predicates are evaluated against.
+type IssueRelationState struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// IssueRelationIssue is the issue projection carried on both sides of a
+// relation node.
+type IssueRelationIssue struct {
+	ID         string             `json:"id"`
+	Identifier string             `json:"identifier"`
+	Title      string             `json:"title"`
+	URL        string             `json:"url,omitempty"`
+	ArchivedAt string             `json:"archivedAt,omitempty"`
+	State      IssueRelationState `json:"state"`
+}
+
+// IssueRelationNode is one IssueRelation. Type is the IssueRelationType enum
+// value as returned by the API. Issue is the relation source, RelatedIssue is
+// the relation target, both always populated by the documents above.
+type IssueRelationNode struct {
+	ID           string             `json:"id"`
+	Type         string             `json:"type"`
+	CreatedAt    string             `json:"createdAt,omitempty"`
+	ArchivedAt   string             `json:"archivedAt,omitempty"`
+	Issue        IssueRelationIssue `json:"issue"`
+	RelatedIssue IssueRelationIssue `json:"relatedIssue"`
+}
+
+// IssueRelationsResult is the fully paged result of IssueRelationsQuery for
+// one issue. Relations are the outgoing side, InverseRelations the incoming
+// side. Subject is the issue the two connections hang off.
+type IssueRelationsResult struct {
+	Subject          IssueRelationIssue  `json:"issue"`
+	TeamID           string              `json:"team_id,omitempty"`
+	TeamKey          string              `json:"team_key,omitempty"`
+	Relations        []IssueRelationNode `json:"relations"`
+	InverseRelations []IssueRelationNode `json:"inverse_relations"`
+}
+
+// relationConnection is the wire shape of either connection.
+type relationConnection struct {
+	Nodes    []IssueRelationNode `json:"nodes"`
+	PageInfo struct {
+		HasNextPage bool   `json:"hasNextPage"`
+		EndCursor   string `json:"endCursor"`
+	} `json:"pageInfo"`
+}
+
+// defaultRelationPageSize is the per-connection page size. Relation counts
+// per issue are small in practice, so one page usually exhausts both sides.
+const defaultRelationPageSize = 50
+
+// maxRelationPages bounds the paging loop so a pathological issue cannot
+// spin forever against the rate-limit budget.
+const maxRelationPages = 20
+
+// FetchIssueRelations reads both relation connections of one issue to
+// exhaustion, excluding archived relations. issueID must be a UUID.
+// pageSize <= 0 uses the default.
+func (c *Client) FetchIssueRelations(issueID string, pageSize int) (IssueRelationsResult, error) {
+	return c.FetchIssueRelationsWith(issueID, pageSize, false)
+}
+
+// FetchIssueRelationsWith is FetchIssueRelations with the includeArchived
+// connection argument exposed. includeArchived is only sent when true, so the
+// default path emits exactly the variable set it always emitted.
+//
+// Nodes are deduplicated by relation id, which keeps the loop safe when a
+// finished connection is re-requested with its last cursor while the other
+// side is still paging.
+func (c *Client) FetchIssueRelationsWith(issueID string, pageSize int, includeArchived bool) (IssueRelationsResult, error) {
+	var out IssueRelationsResult
+	if issueID == "" {
+		return out, fmt.Errorf("fetching issue relations: empty issue id")
+	}
+	if pageSize <= 0 {
+		pageSize = defaultRelationPageSize
+	}
+	seenOutgoing := map[string]bool{}
+	seenIncoming := map[string]bool{}
+	var after, inverseAfter string
+	for range maxRelationPages {
+		vars := map[string]any{"id": issueID, "first": pageSize}
+		if includeArchived {
+			vars["includeArchived"] = true
+		}
+		if after != "" {
+			vars["after"] = after
+		}
+		if inverseAfter != "" {
+			vars["inverseAfter"] = inverseAfter
+		}
+		var resp struct {
+			Issue *struct {
+				IssueRelationIssue
+				Team struct {
+					ID  string `json:"id"`
+					Key string `json:"key"`
+				} `json:"team"`
+				Relations        relationConnection `json:"relations"`
+				InverseRelations relationConnection `json:"inverseRelations"`
+			} `json:"issue"`
+		}
+		if err := c.QueryInto(IssueRelationsQuery, vars, &resp); err != nil {
+			return out, err
+		}
+		if resp.Issue == nil || resp.Issue.ID == "" {
+			return out, fmt.Errorf("issue %q not found", issueID)
+		}
+		out.Subject = resp.Issue.IssueRelationIssue
+		out.TeamID = resp.Issue.Team.ID
+		out.TeamKey = resp.Issue.Team.Key
+		for _, n := range resp.Issue.Relations.Nodes {
+			if n.ID == "" || seenOutgoing[n.ID] {
+				continue
+			}
+			seenOutgoing[n.ID] = true
+			out.Relations = append(out.Relations, n)
+		}
+		for _, n := range resp.Issue.InverseRelations.Nodes {
+			if n.ID == "" || seenIncoming[n.ID] {
+				continue
+			}
+			seenIncoming[n.ID] = true
+			out.InverseRelations = append(out.InverseRelations, n)
+		}
+		moreOutgoing := resp.Issue.Relations.PageInfo.HasNextPage && resp.Issue.Relations.PageInfo.EndCursor != ""
+		moreIncoming := resp.Issue.InverseRelations.PageInfo.HasNextPage && resp.Issue.InverseRelations.PageInfo.EndCursor != ""
+		if !moreOutgoing && !moreIncoming {
+			return out, nil
+		}
+		if moreOutgoing {
+			after = resp.Issue.Relations.PageInfo.EndCursor
+		}
+		if moreIncoming {
+			inverseAfter = resp.Issue.InverseRelations.PageInfo.EndCursor
+		}
+	}
+	return out, nil
+}
+
+// FetchIssueInverseRelations pages only the incoming side of one issue. Used
+// by the unblocked traversal when a candidate's first inline page of
+// inverseRelations was truncated, so the "all blockers closed" verdict is
+// never computed from a partial blocker set.
+func (c *Client) FetchIssueInverseRelations(issueID string, pageSize int) ([]IssueRelationNode, error) {
+	res, err := c.FetchIssueRelations(issueID, pageSize)
+	if err != nil {
+		return nil, err
+	}
+	return res.InverseRelations, nil
+}
+
+// DecodeIssueRelationCreate parses an issueRelationCreate response.
+func DecodeIssueRelationCreate(raw json.RawMessage) (IssueRelationNode, bool, error) {
+	var parsed struct {
+		IssueRelationCreate struct {
+			Success       bool              `json:"success"`
+			IssueRelation IssueRelationNode `json:"issueRelation"`
+		} `json:"issueRelationCreate"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return IssueRelationNode{}, false, fmt.Errorf("parsing issueRelationCreate response: %w", err)
+	}
+	return parsed.IssueRelationCreate.IssueRelation, parsed.IssueRelationCreate.Success, nil
+}
+
+// DecodeIssueRelationDelete parses an issueRelationDelete response and
+// returns the echoed entity id.
+func DecodeIssueRelationDelete(raw json.RawMessage) (string, bool, error) {
+	var parsed struct {
+		IssueRelationDelete struct {
+			Success  bool   `json:"success"`
+			EntityID string `json:"entityId"`
+		} `json:"issueRelationDelete"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return "", false, fmt.Errorf("parsing issueRelationDelete response: %w", err)
+	}
+	return parsed.IssueRelationDelete.EntityID, parsed.IssueRelationDelete.Success, nil
+}

--- a/library/project-management/linear/internal/client/relations_queries.go
+++ b/library/project-management/linear/internal/client/relations_queries.go
@@ -185,7 +185,11 @@ type relationConnection struct {
 const defaultRelationPageSize = 50
 
 // maxRelationPages bounds the paging loop so a pathological issue cannot
-// spin forever against the rate-limit budget.
+// spin forever against the rate-limit budget. Hitting the bound is an error,
+// never a short read: every consumer of this result treats "absent" as
+// "no such relation", so a silently truncated set makes `relations list` drop
+// links, makes idempotent creation duplicate an existing relation, and lets
+// `unblocked` call an issue actionable while an unseen blocker is still open.
 const maxRelationPages = 20
 
 // FetchIssueRelations reads both relation connections of one issue to
@@ -270,7 +274,10 @@ func (c *Client) FetchIssueRelationsWith(issueID string, pageSize int, includeAr
 			inverseAfter = resp.Issue.InverseRelations.PageInfo.EndCursor
 		}
 	}
-	return out, nil
+	return out, fmt.Errorf(
+		"issue %s has more relations than %d pages of %d can read: refusing to answer from a partial relation set, retry with a larger page size",
+		issueID, maxRelationPages, pageSize,
+	)
 }
 
 // FetchIssueInverseRelations pages only the incoming side of one issue. Used


### PR DESCRIPTION
## Gaps closed

- **GAP-002** No relations command at all: cannot create, read, update or delete an issue relation of any of the four `IssueRelationType` values. (MUST-SHIP 3)
- **GAP-004** No unblocked query: cannot ask which open issues have all of their blockers closed. (MUST-SHIP 4)
- **GAP-010** Issue relations are never synced, so every relation-aware command must go live.

## Design

All four relation types come from one enum, so create is one command with a type argument rather than four commands. `blocked_by` is rendered as a direction over `Issue.inverseRelations` and never as a fifth type, because the enum has four members and the inverse is a traversal, not a kind. The read side is the harder half: `Query.issueRelations` takes only pagination arguments and has no filter, so a per-issue read has to traverse `Issue.relations` and `Issue.inverseRelations` instead of querying the root connection.

`unblocked` cannot be one server-side query. `IssueFilter.hasBlockedByRelations` is a bare `RelationExistsComparator` with no nested filter on the blocking issue, so it can only answer "is this blocked by anything at all". The first implementation used it as phase 1 and was dead on arrival in a real workspace, which the probe proved by isolation: the predicate goes false the instant every blocker closes, which is exactly the state the command exists to report, so phase 2 never ran and the command could never return a result. The shipped version asks for open issues in scope, selects `inverseRelations` inline, and decides locally, testing each blocker's `state.type` against the resolved closed group from the state-group layer rather than against a literal.

## Verification (MUST-SHIP 3 and 4 proofs)

Setup, all live against a real workspace:

```
$ linear-pp-cli issues create --title "A2 blocker" --team ACC --trust-mode strict --agent   -> ACC-261
$ linear-pp-cli issues create --title "B2 blocked" --team ACC --trust-mode strict --agent   -> ACC-262
$ linear-pp-cli relations create ACC-261 --type blocks --to ACC-262 --agent                 -> relation 69d6e439
```

Phase 1, blocker still open:

```json
{
  "meta": { "reason": "relations_not_synced", "resource_type": "issues", "source": "live" },
  "results": [
    { "identifier": "ACC-262", "state_type": "triage",
      "blockers": [ { "identifier": "ACC-261", "state_type": "triage", "closed": false } ],
      "all_blockers_closed": false }
  ]
}
```

Same moment without `--show-blocked`, B2 is correctly absent because it is still blocked:

```
$ linear-pp-cli unblocked --team ACC --agent   ->   {"meta":{...},"results":[]}
```

Close the blocker, then re-run the exact call that returned an empty list before:

```
$ linear-pp-cli issues edit ACC-261 --state-type completed --trust-mode strict --agent
state: { "name": "Done", "type": "completed" }

$ linear-pp-cli unblocked --team ACC --agent
```
```json
{
  "results": [
    { "identifier": "ACC-262", "state_type": "triage",
      "blockers": [ { "identifier": "ACC-261", "state_name": "Done", "state_type": "completed", "closed": true } ],
      "all_blockers_closed": true }
  ]
}
```

Closing the blocker now moves the issue **into** the result set instead of out of it. That inversion is the whole defect and the whole fix.

Relation round trip, both directions readable:

```
$ linear-pp-cli relations list ACC-258 --no-cache      -> duplicate outgoing ACC-258 -> ACC-257
$ linear-pp-cli sql "SELECT * FROM issue_relations WHERE issue_id='c844f546-...' OR related_issue_id='c844f546-...'"
id 69d6e439-..., type blocks, ACC-261 -> ACC-262, synced_at 2026-08-11T19:52:38Z
```

Build, vet and the full test suite are green.

---

Stacked on #1693. Review the diff against `feat/linear-sync-prune-incremental`.
