### PR TITLE
feat(linear): complete the issue write surface

### DIFF
--- a/library/project-management/linear/.printing-press-patches/active-excludes-every-closed-state-type.json
+++ b/library/project-management/linear/.printing-press-patches/active-excludes-every-closed-state-type.json
@@ -11,7 +11,8 @@
     "internal/cli/blocking.go",
     "internal/cli/bottleneck.go",
     "internal/cli/slipped.go",
-    "internal/cli/today.go"
+    "internal/cli/today.go",
+    "internal/cli/similar.go"
   ],
   "validated_outcome": "An issue closed as a duplicate leaves 'issues list --state active' and is retrievable under '--state duplicate', on both the local and the live path."
 }

--- a/library/project-management/linear/.printing-press-patches/issue-writes-never-lie-and-never-clobber.json
+++ b/library/project-management/linear/.printing-press-patches/issue-writes-never-lie-and-never-clobber.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 2,
+  "id": "issue-writes-never-lie-and-never-clobber",
+  "applied_at": "2026-08-12",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "A dry run predicts exactly what the real invocation would do, including the trust-mode verdict for a TEAM-NUMBER reference, and a description composed from a body this CLI read is re-checked against the live body before it is written.",
+  "reason": "Linear's issueUpdate replaces the whole description and takes no precondition, so a read-modify-write append silently deletes any edit that landed after the read, and the gap is wide when the same call also uploads media or resolves a team, parent, labels or state. Separately, a dry run that skips a guard the real call applies is worse than no dry run: it reports success for a target the real invocation refuses. The pp_created ledger records identifiers as well as UUIDs, which is what lets the strict-mode check stay offline.",
+  "files": [
+    "internal/cli/issues_edit.go",
+    "internal/cli/issues_edit_append.go",
+    "internal/cli/issues_lifecycle.go",
+    "internal/cli/issues_batch.go",
+    "internal/cli/trust_gate.go",
+    "internal/store/pp_fixtures.go"
+  ],
+  "validated_outcome": "Under --trust-mode strict, 'issues edit ENG-8 --dry-run' refuses a target absent from the ledger instead of reporting a would-update, and an append whose issue description changed since the read exits 5 naming the edit it would have deleted."
+}

--- a/library/project-management/linear/.printing-press-patches/issue-writes-never-lie-and-never-clobber.json
+++ b/library/project-management/linear/.printing-press-patches/issue-writes-never-lie-and-never-clobber.json
@@ -11,8 +11,11 @@
     "internal/cli/issues_edit_append.go",
     "internal/cli/issues_lifecycle.go",
     "internal/cli/issues_batch.go",
+    "internal/cli/issues_create.go",
     "internal/cli/trust_gate.go",
-    "internal/store/pp_fixtures.go"
+    "internal/cli/issues_write_guards_test.go",
+    "internal/store/pp_fixtures.go",
+    "internal/client/batch_queries.go"
   ],
   "validated_outcome": "Under --trust-mode strict, 'issues edit ENG-8 --dry-run' refuses a target absent from the ledger instead of reporting a would-update. 'issues edit ENG-7 --description-append note --dry-run' reports commentCreate. A media-derived description whose issue body changed since the read exits 5 naming the edit it would have deleted."
 }

--- a/library/project-management/linear/.printing-press-patches/issue-writes-never-lie-and-never-clobber.json
+++ b/library/project-management/linear/.printing-press-patches/issue-writes-never-lie-and-never-clobber.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 2,
   "id": "issue-writes-never-lie-and-never-clobber",
-  "applied_at": "2026-08-12",
+  "applied_at": "2026-08-13",
   "base_run_id": "20260518-232543",
   "base_printing_press_version": "4.9.0",
-  "summary": "A dry run predicts exactly what the real invocation would do, including the trust-mode verdict for a TEAM-NUMBER reference, and a description composed from a body this CLI read is re-checked against the live body before it is written.",
-  "reason": "Linear's issueUpdate replaces the whole description and takes no precondition, so a read-modify-write append silently deletes any edit that landed after the read, and the gap is wide when the same call also uploads media or resolves a team, parent, labels or state. Separately, a dry run that skips a guard the real call applies is worse than no dry run: it reports success for a target the real invocation refuses. The pp_created ledger records identifiers as well as UUIDs, which is what lets the strict-mode check stay offline.",
+  "summary": "A dry run predicts exactly what the real invocation would do, including the trust-mode verdict for a TEAM-NUMBER reference. --description-append posts a Linear comment instead of replacing the issue description. A description composed from a body this CLI read is re-checked against the live body before it is written.",
+  "reason": "Linear's issueUpdate replaces the whole description and takes no precondition, so a read-modify-write append silently deletes any edit that landed after the read. Comments are append-only, which is the concurrent-safe way to add a note. Media-without-description still rewrites the description, so that path keeps the live-body re-check. Separately, a dry run that skips a guard the real call applies is worse than no dry run: it reports success for a target the real invocation refuses. The pp_created ledger records identifiers as well as UUIDs, which is what lets the strict-mode check stay offline.",
   "files": [
     "internal/cli/issues_edit.go",
     "internal/cli/issues_edit_append.go",
@@ -14,5 +14,5 @@
     "internal/cli/trust_gate.go",
     "internal/store/pp_fixtures.go"
   ],
-  "validated_outcome": "Under --trust-mode strict, 'issues edit ENG-8 --dry-run' refuses a target absent from the ledger instead of reporting a would-update, and an append whose issue description changed since the read exits 5 naming the edit it would have deleted."
+  "validated_outcome": "Under --trust-mode strict, 'issues edit ENG-8 --dry-run' refuses a target absent from the ledger instead of reporting a would-update. 'issues edit ENG-7 --description-append note --dry-run' reports commentCreate. A media-derived description whose issue body changed since the read exits 5 naming the edit it would have deleted."
 }

--- a/library/project-management/linear/.printing-press-patches/relation-reads-are-complete-or-they-fail.json
+++ b/library/project-management/linear/.printing-press-patches/relation-reads-are-complete-or-they-fail.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "relation-reads-are-complete-or-they-fail",
+  "applied_at": "2026-08-12",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "An issue's relation set is read from both the outgoing and the inverse connection, and it is either complete or an error: a paging bound reached is never returned as a short read.",
+  "reason": "Linear exposes a relation from both ends, so reading one connection misses half the graph, and every consumer treats an absent relation as no relation. A silently truncated set drops links from the listing, makes idempotent creation duplicate an existing relation, and lets the unblocked query call an issue actionable while an unseen blocker is still open.",
+  "files": [
+    "internal/client/relations_queries.go",
+    "internal/cli/relations.go",
+    "internal/cli/unblocked.go"
+  ],
+  "validated_outcome": "An issue whose relation connection never reports exhaustion fails the read with a message naming the partial set, instead of answering from the pages it managed to fetch."
+}

--- a/library/project-management/linear/.printing-press-patches/relation-reads-are-complete-or-they-fail.json
+++ b/library/project-management/linear/.printing-press-patches/relation-reads-are-complete-or-they-fail.json
@@ -8,8 +8,10 @@
   "reason": "Linear exposes a relation from both ends, so reading one connection misses half the graph, and every consumer treats an absent relation as no relation. A silently truncated set drops links from the listing, makes idempotent creation duplicate an existing relation, and lets the unblocked query call an issue actionable while an unseen blocker is still open.",
   "files": [
     "internal/client/relations_queries.go",
+    "internal/client/relations_paging_test.go",
     "internal/cli/relations.go",
-    "internal/cli/unblocked.go"
+    "internal/cli/unblocked.go",
+    "internal/store/relations.go"
   ],
   "validated_outcome": "An issue whose relation connection never reports exhaustion fails the read with a message naming the partial set, instead of answering from the pages it managed to fetch."
 }

--- a/library/project-management/linear/.printing-press-patches/state-predicates-resolve-through-one-declarable-group.json
+++ b/library/project-management/linear/.printing-press-patches/state-predicates-resolve-through-one-declarable-group.json
@@ -8,8 +8,10 @@
   "reason": "Linear lets a workspace name its own workflow states, so a hardcoded state comparison is wrong for any team that ships out of a custom column, and a team may redeclare a group that the workspace already defines. Reintroducing per-command state literals silently returns wrong open counts, velocity and landing dates; resolving a project's group at workspace scope silently ignores that project's team override.",
   "files": [
     "internal/groups/groups.go",
+    "internal/groups/groups_test.go",
     "internal/groups/defaults.toml",
     "internal/cli/groups_cmd.go",
+    "internal/cli/groups_scope_test.go",
     "internal/cli/issues.go",
     "internal/cli/blocking.go",
     "internal/cli/bottleneck.go",

--- a/library/project-management/linear/.printing-press-patches/sync-reconciles-both-copies-of-a-resource.json
+++ b/library/project-management/linear/.printing-press-patches/sync-reconciles-both-copies-of-a-resource.json
@@ -8,9 +8,14 @@
   "reason": "Linear has no deletion feed, so an entity removed upstream is only detectable as an id absent from a complete enumeration. A generated write-through cache keeps a second copy of the shell resources, and reconciling only the typed table leaves the promoted local reads answering with deleted entities. The inverse failure is worse: reconciling against a partial live set, an incremental window or an empty response deletes live work, so those three cases must stay non-pruning.",
   "files": [
     "internal/store/prune.go",
+    "internal/store/prune_mirror_test.go",
     "internal/store/sync_cursors.go",
+    "internal/store/extended_sync.go",
     "internal/cli/sync.go",
-    "internal/cli/sync_extended.go"
+    "internal/cli/sync_extended.go",
+    "internal/cli/sync_test.go",
+    "internal/client/prune_queries.go",
+    "internal/client/extended_sync_queries.go"
   ],
   "validated_outcome": "After an entity is deleted upstream and a full sync runs, both 'sync --data-source local' reads of it (typed table and promoted cache) report it gone, and its resources_fts index row goes with it in the same commit; 'sync --incremental' and a --max-pages truncated crawl prune nothing."
 }

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -100,6 +100,7 @@ parent and sub-issue links.`,
 	cmd.AddCommand(newIssuesCreateCmd(flags))
 	cmd.AddCommand(newIssuesEditCmd(flags, &dbPath))
 	cmd.AddCommand(newIssuesReadAliasCmd(flags, &dbPath))
+	cmd.AddCommand(newIssuesCloseDuplicateCmd(flags))
 	return cmd
 }
 

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -100,6 +100,13 @@ parent and sub-issue links.`,
 	cmd.AddCommand(newIssuesCreateCmd(flags))
 	cmd.AddCommand(newIssuesEditCmd(flags, &dbPath))
 	cmd.AddCommand(newIssuesReadAliasCmd(flags, &dbPath))
+	cmd.AddCommand(newIssuesBatchCreateCmd(flags))
+	cmd.AddCommand(newIssuesBatchUpdateCmd(flags))
+	cmd.AddCommand(newIssuesArchiveCmd(flags))
+	cmd.AddCommand(newIssuesUnarchiveCmd(flags))
+	cmd.AddCommand(newIssuesDeleteCmd(flags))
+	cmd.AddCommand(newIssuesSubscribeCmd(flags))
+	cmd.AddCommand(newIssuesUnsubscribeCmd(flags))
 	cmd.AddCommand(newIssuesCloseDuplicateCmd(flags))
 	return cmd
 }

--- a/library/project-management/linear/internal/cli/issues_batch.go
+++ b/library/project-management/linear/internal/cli/issues_batch.go
@@ -711,9 +711,12 @@ fixture this CLI created.`,
 
 			dbPath := inheritedDBPath(cmd)
 
-			if flags.dryRun {
-				// Offline: identifiers stay unresolved and a state alias is
-				// shown as the alias, because resolving either needs the API.
+			if flags.dryRun && (flags == nil || flags.trustMode != "strict") {
+				// Offline when we are not proving fixture ownership.
+				// Strict mode must resolve each identifier first so a
+				// TEAM-NUMBER that the ledger still names cannot pass a dry
+				// run after Linear has reused that identifier for a different
+				// issue UUID.
 				fields := map[string]any{
 					"ids":   targets,
 					"input": input,
@@ -727,11 +730,6 @@ fixture this CLI created.`,
 				}
 				if teamFlag != "" {
 					fields["team"] = teamFlag
-				}
-				for _, target := range targets {
-					if err := trustModeDryRunGuard(flags, dbPath, target); err != nil {
-						return err
-					}
 				}
 				return renderMutationDryRun(cmd, flags, "would_batch_update_issues", "issueBatchUpdate", fields)
 			}
@@ -766,6 +764,24 @@ fixture this CLI created.`,
 					return err
 				}
 				uuids = append(uuids, issueID)
+			}
+
+			if flags.dryRun {
+				fields := map[string]any{
+					"ids":   uuids,
+					"input": input,
+					"count": len(uuids),
+				}
+				if stateNameFlag != "" {
+					fields["state_name"] = stateNameFlag
+				}
+				if stateTypeFlag != "" {
+					fields["state_type"] = stateTypeFlag
+				}
+				if teamFlag != "" {
+					fields["team"] = teamFlag
+				}
+				return renderMutationDryRun(cmd, flags, "would_batch_update_issues", "issueBatchUpdate", fields)
 			}
 
 			if err := confirmMutation(cmd, flags, fmt.Sprintf("Apply this change to %d issues in one transaction?", len(uuids))); err != nil {

--- a/library/project-management/linear/internal/cli/issues_batch.go
+++ b/library/project-management/linear/internal/cli/issues_batch.go
@@ -1,0 +1,860 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+// Issue batch mutations (GAP-034).
+//
+// Bulk triage against a rate-limited API was N round trips with no
+// backpressure signal. Linear ships two transactional batch mutations and
+// neither had a surface:
+//
+//	issueBatchCreate(input: IssueBatchCreateInput!)   input = { issues: [IssueCreateInput!]! }
+//	issueBatchUpdate(input: IssueUpdateInput!, ids: [UUID!]!)
+//
+// Both cap at 50 per call, both return IssueBatchPayload { issues, success }.
+// The two commands are registered on the issues parent in issues.go.
+
+// issueBatchMax is Linear's own ceiling, stated in both places:
+// IssueBatchCreateInput is documented "Up to 50 issues can be created in a
+// single batch" and issueBatchUpdate.ids is "Can't be more than 50 at a
+// time". Exceeding it is refused here rather than round-tripped, and the
+// batch is never silently split because the whole point of these mutations
+// is that they are one transaction.
+const issueBatchMax = 50
+
+// issueCreateInputFields is the IssueCreateInput field set, transcribed from
+// api-inventory.json. A record key outside this set (and outside the
+// resolution aliases below) is a usage error, so a typo like "titel" or
+// "team_id" fails loudly instead of being dropped on the floor by the API.
+//
+// boardOrder is deliberately absent: Linear marks it deprecated.
+var issueCreateInputFields = map[string]bool{
+	"id":                         true,
+	"title":                      true,
+	"description":                true,
+	"descriptionData":            true,
+	"assigneeId":                 true,
+	"delegateId":                 true,
+	"parentId":                   true,
+	"priority":                   true,
+	"estimate":                   true,
+	"subscriberIds":              true,
+	"labelIds":                   true,
+	"teamId":                     true,
+	"cycleId":                    true,
+	"projectId":                  true,
+	"projectMilestoneId":         true,
+	"lastAppliedTemplateId":      true,
+	"stateId":                    true,
+	"referenceCommentId":         true,
+	"sourceCommentId":            true,
+	"sourcePullRequestCommentId": true,
+	"sortOrder":                  true,
+	"prioritySortOrder":          true,
+	"subIssueSortOrder":          true,
+	"dueDate":                    true,
+	"createAsUser":               true,
+	"displayIconUrl":             true,
+	"preserveSortOrderOnCreate":  true,
+	"createdAt":                  true,
+	"slaBreachesAt":              true,
+	"slaStartedAt":               true,
+	"templateId":                 true,
+	"completedAt":                true,
+	"slaType":                    true,
+	"useDefaultTemplate":         true,
+	"releaseIds":                 true,
+	"inheritsSharedAccess":       true,
+}
+
+// issueUpdateInputFields is the IssueUpdateInput field set, same source and
+// same reason. Used to validate --set. boardOrder is deprecated and absent.
+var issueUpdateInputFields = map[string]bool{
+	"title":                     true,
+	"description":               true,
+	"descriptionData":           true,
+	"assigneeId":                true,
+	"delegateId":                true,
+	"parentId":                  true,
+	"priority":                  true,
+	"estimate":                  true,
+	"subscriberIds":             true,
+	"labelIds":                  true,
+	"addedLabelIds":             true,
+	"removedLabelIds":           true,
+	"releaseIds":                true,
+	"addedReleaseIds":           true,
+	"removedReleaseIds":         true,
+	"teamId":                    true,
+	"cycleId":                   true,
+	"projectId":                 true,
+	"projectMilestoneId":        true,
+	"lastAppliedTemplateId":     true,
+	"stateId":                   true,
+	"sortOrder":                 true,
+	"prioritySortOrder":         true,
+	"subIssueSortOrder":         true,
+	"dueDate":                   true,
+	"inheritsSharedAccess":      true,
+	"trusted":                   true,
+	"trashed":                   true,
+	"slaBreachesAt":             true,
+	"slaStartedAt":              true,
+	"snoozedUntilAt":            true,
+	"snoozedById":               true,
+	"slaType":                   true,
+	"autoClosedByParentClosing": true,
+}
+
+// Resolution aliases accepted in a batch-create record. None of them is an
+// IssueCreateInput field: each is resolved to a real one before the call, and
+// the alias key itself is never sent.
+const (
+	batchAliasTeam      = "team"      // team key, team name, or UUID  -> teamId
+	batchAliasStateName = "stateName" // workflow state name           -> stateId
+	batchAliasStateType = "stateType" // WorkflowState.type value      -> stateId
+)
+
+// batchIssue mirrors the batchIssueFields projection in
+// internal/client/batch_queries.go, which mirrors what issueCreate selects,
+// so a batch-created issue feeds the pp_created ledger and the local
+// write-back through the same shape a single create does.
+type batchIssue struct {
+	ID          string `json:"id"`
+	Identifier  string `json:"identifier"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	Priority    int    `json:"priority"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+	Team        struct {
+		ID  string `json:"id"`
+		Key string `json:"key"`
+	} `json:"team"`
+	State struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		Type string `json:"type"`
+	} `json:"state"`
+	Assignee *struct {
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		DisplayName string `json:"displayName"`
+	} `json:"assignee,omitempty"`
+	Project *struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"project,omitempty"`
+	Parent *struct {
+		ID         string `json:"id"`
+		Identifier string `json:"identifier"`
+		Title      string `json:"title"`
+	} `json:"parent,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// issues batch-create
+// ---------------------------------------------------------------------------
+
+func newIssuesBatchCreateCmd(flags *rootFlags) *cobra.Command {
+	var file string
+	var teamFlag, projectFlag string
+	var labelsFlag []string
+	var session string
+	cmd := &cobra.Command{
+		Use:   "batch-create --file <path>",
+		Short: "Create up to 50 issues in one transaction and record them in the pp_created ledger",
+		Long: `Create many issues in a single issueBatchCreate call.
+
+--file reads JSONL (one JSON object per line), a JSON array, or a single
+JSON object. Pass - to read stdin. Each record is an IssueCreateInput, so
+keys are Linear's own camelCase input field names (title, teamId,
+description, assigneeId, labelIds, priority, estimate, dueDate, parentId,
+projectId, cycleId, stateId, and the rest). An unknown key is refused by
+name rather than silently dropped.
+
+Three resolution aliases are accepted on top of those, and none of them is
+sent to the API:
+
+  team        a team key, team name, or UUID, resolved to teamId
+  stateName   a workflow state name, resolved to stateId within the record's team
+  stateType   a WorkflowState.type value, resolved to stateId within the record's team
+
+--team, --project and --label supply defaults for records that do not carry
+their own teamId, projectId or labelIds.
+
+Linear caps the batch at 50. A larger file is refused rather than split,
+because a split is no longer one transaction.
+
+Every created issue is written to the local pp_created ledger with a session
+tag, exactly like 'issues create', so pp-test list shows them and pp-cleanup
+can archive them without touching pre-existing tickets.`,
+		Example: `  linear-pp-cli issues batch-create --file /tmp/issues.jsonl --team ENG --agent
+  cat issues.json | linear-pp-cli issues batch-create --file - --agent
+  linear-pp-cli issues batch-create --file /tmp/issues.jsonl --team ENG --dry-run --agent`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(file) == "" {
+				return usageErr(fmt.Errorf("--file is required: a path to JSONL or JSON, or - for stdin"))
+			}
+			// trust-mode strict requires a session tag so every fixture this
+			// call creates is recoverable by pp-cleanup, matching what
+			// 'issues create' demands.
+			if flags.trustMode == "strict" && resolvePPSession(flags, session) == "" {
+				return usageErr(fmt.Errorf("trust-mode=strict: pass --session <tag> (or set PP_SESSION env) so these fixtures are recoverable by pp-cleanup"))
+			}
+
+			records, err := readIssueBatchRecords(cmd, file)
+			if err != nil {
+				return err
+			}
+			if len(records) == 0 {
+				return usageErr(fmt.Errorf("%s contained no issue records", file))
+			}
+			if len(records) > issueBatchMax {
+				return usageErr(fmt.Errorf("issueBatchCreate accepts at most %d issues per call, got %d. Split the file, because splitting it here would silently turn one transaction into several", issueBatchMax, len(records)))
+			}
+
+			dbPath := inheritedDBPath(cmd)
+
+			// The dry run stays offline: aliases are echoed back unresolved
+			// so the preview shows exactly what was asked for, with the
+			// resolution work named rather than faked.
+			if flags.dryRun {
+				preview := make([]map[string]any, 0, len(records))
+				pending := map[string]any{}
+				for index, record := range records {
+					input, unresolved, err := buildBatchCreateInput(nil, dbPath, index, record, teamFlag, projectFlag, labelsFlag)
+					if err != nil {
+						return err
+					}
+					preview = append(preview, input)
+					for key, value := range unresolved {
+						pending[fmt.Sprintf("%d.%s", index, key)] = value
+					}
+				}
+				fields := map[string]any{
+					"input": map[string]any{"issues": preview},
+					"count": len(preview),
+				}
+				if len(pending) > 0 {
+					fields["pending_resolution"] = pending
+				}
+				return renderMutationDryRun(cmd, flags, "would_batch_create_issues", "issueBatchCreate", fields)
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			inputs := make([]map[string]any, 0, len(records))
+			for index, record := range records {
+				input, _, err := buildBatchCreateInput(c, dbPath, index, record, teamFlag, projectFlag, labelsFlag)
+				if err != nil {
+					return err
+				}
+				inputs = append(inputs, input)
+			}
+
+			resp, err := c.Mutate(client.IssueBatchCreateMutation, map[string]any{
+				"input": map[string]any{"issues": inputs},
+			})
+			if err != nil {
+				return classifyGraphQLCreateError("issueBatchCreate", err, flags)
+			}
+			issues, err := decodeIssueBatchPayload(resp, "issueBatchCreate")
+			if err != nil {
+				return err
+			}
+
+			sess := resolvePPSession(flags, session)
+			if sess == "" || sess == "current" {
+				sess = ppCurrentSession()
+			}
+			recordBatchCreatedIssues(dbPath, issues, sess)
+
+			out, err := json.Marshal(map[string]any{
+				"issues":  issues,
+				"created": len(issues),
+				"session": sess,
+			})
+			if err != nil {
+				return err
+			}
+			return renderLivePayload(cmd, flags, out, "issues", true)
+		},
+	}
+	cmd.Flags().StringVar(&file, "file", "", "JSONL, JSON array, or single JSON object of IssueCreateInput records. - reads stdin (required)")
+	cmd.Flags().StringVar(&teamFlag, "team", "", "Default team key, name, or UUID for records without teamId or team")
+	cmd.Flags().StringVar(&projectFlag, "project", "", "Default project UUID for records without projectId")
+	cmd.Flags().StringSliceVar(&labelsFlag, "label", nil, "Default label UUIDs for records without labelIds (repeatable)")
+	cmd.Flags().StringVar(&session, "session", "", "Session tag for the pp_created ledger (defaults to PP_SESSION env or current run timestamp)")
+	return cmd
+}
+
+// readIssueBatchRecords loads a JSON array, a single JSON object, or JSONL.
+// The three are told apart by trying them in that order rather than by
+// extension, so a .json file holding JSONL still works.
+func readIssueBatchRecords(cmd *cobra.Command, path string) ([]map[string]any, error) {
+	var raw []byte
+	var err error
+	if path == "-" {
+		raw, err = io.ReadAll(cmd.InOrStdin())
+	} else {
+		raw, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, usageErr(fmt.Errorf("reading %s: %w", path, err))
+	}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return nil, usageErr(fmt.Errorf("%s is empty", path))
+	}
+
+	var asArray []map[string]any
+	if json.Unmarshal(raw, &asArray) == nil {
+		return asArray, nil
+	}
+	var asObject map[string]any
+	if json.Unmarshal(raw, &asObject) == nil {
+		return []map[string]any{asObject}, nil
+	}
+
+	records := make([]map[string]any, 0, 16)
+	for lineNumber, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(trimmed), &record); err != nil {
+			return nil, usageErr(fmt.Errorf("%s line %d is not a JSON object: %w", path, lineNumber+1, err))
+		}
+		records = append(records, record)
+	}
+	if len(records) == 0 {
+		return nil, usageErr(fmt.Errorf("%s parsed as neither a JSON array, a JSON object, nor JSONL", path))
+	}
+	return records, nil
+}
+
+// buildBatchCreateInput validates one record and turns it into an
+// IssueCreateInput. c may be nil on the --dry-run path, in which case the
+// aliases that need a lookup are left in place and returned in the second
+// value so the preview can name what it did not resolve.
+func buildBatchCreateInput(c graphqlQueryer, dbPath string, index int, record map[string]any, teamDefault, projectDefault string, labelDefaults []string) (map[string]any, map[string]any, error) {
+	if len(record) == 0 {
+		return nil, nil, usageErr(fmt.Errorf("record %d is empty. Every record must be a JSON object carrying at least a title and a team", index))
+	}
+	input := map[string]any{}
+	unresolved := map[string]any{}
+	var teamRef, stateName, stateType string
+
+	for _, key := range sortedKeys(record) {
+		value := record[key]
+		switch key {
+		case batchAliasTeam:
+			text, ok := value.(string)
+			if !ok {
+				return nil, nil, usageErr(fmt.Errorf("record %d: %q must be a string (team key, team name, or UUID)", index, batchAliasTeam))
+			}
+			teamRef = strings.TrimSpace(text)
+		case batchAliasStateName:
+			text, ok := value.(string)
+			if !ok {
+				return nil, nil, usageErr(fmt.Errorf("record %d: %q must be a string", index, batchAliasStateName))
+			}
+			stateName = strings.TrimSpace(text)
+		case batchAliasStateType:
+			text, ok := value.(string)
+			if !ok {
+				return nil, nil, usageErr(fmt.Errorf("record %d: %q must be a string", index, batchAliasStateType))
+			}
+			normalized, err := normalizeWorkflowStateType(text)
+			if err != nil {
+				return nil, nil, fmt.Errorf("record %d: %w", index, err)
+			}
+			stateType = normalized
+		default:
+			if !issueCreateInputFields[key] {
+				return nil, nil, usageErr(fmt.Errorf("record %d: %q is not an IssueCreateInput field and not one of the %s, %s, %s aliases. Run 'linear-pp-cli issues batch-create --help' for the accepted keys", index, key, batchAliasTeam, batchAliasStateName, batchAliasStateType))
+			}
+			input[key] = value
+		}
+	}
+
+	if projectDefault != "" {
+		if _, ok := input["projectId"]; !ok {
+			input["projectId"] = projectDefault
+		}
+	}
+	if len(labelDefaults) > 0 {
+		if _, ok := input["labelIds"]; !ok {
+			input["labelIds"] = labelDefaults
+		}
+	}
+	if teamRef == "" && teamDefault != "" {
+		if _, ok := input["teamId"]; !ok {
+			teamRef = teamDefault
+		}
+	}
+
+	if teamRef != "" {
+		if _, ok := input["teamId"]; ok {
+			return nil, nil, usageErr(fmt.Errorf("record %d: pass either teamId or the %s alias, not both", index, batchAliasTeam))
+		}
+		resolved, err := resolveWriteTeamID(c, dbPath, teamRef)
+		if err != nil {
+			return nil, nil, err
+		}
+		switch {
+		case store.IsUUID(resolved):
+			input["teamId"] = resolved
+		case c == nil:
+			// --dry-run stays offline, so an unresolvable key is reported
+			// as pending rather than guessed at.
+			unresolved["teamId"] = teamRef
+		default:
+			return nil, nil, notFoundErr(fmt.Errorf("record %d: team %q did not resolve to a team UUID", index, teamRef))
+		}
+	}
+	if _, ok := input["teamId"]; !ok && len(unresolved) == 0 {
+		return nil, nil, usageErr(fmt.Errorf("record %d: IssueCreateInput.teamId is required. Set teamId, set the %s alias, or pass --team", index, batchAliasTeam))
+	}
+
+	if stateName != "" && stateType != "" {
+		return nil, nil, usageErr(fmt.Errorf("record %d: pass either %s or %s, not both", index, batchAliasStateName, batchAliasStateType))
+	}
+	if stateName != "" || stateType != "" {
+		if _, ok := input["stateId"]; ok {
+			return nil, nil, usageErr(fmt.Errorf("record %d: pass either stateId or a state alias, not both", index))
+		}
+		teamID, _ := input["teamId"].(string)
+		if c == nil || teamID == "" {
+			unresolved["stateId"] = firstNonEmpty(stateName, stateType)
+		} else {
+			stateID, err := resolveWorkflowState(c, issueTeamInfo{ID: teamID}, stateName, stateType)
+			if err != nil {
+				return nil, nil, fmt.Errorf("record %d: %w", index, err)
+			}
+			input["stateId"] = stateID
+		}
+	}
+	return input, unresolved, nil
+}
+
+// sortedKeys keeps record iteration deterministic so an error names the same
+// offending key on every run and a dry-run preview is byte-stable.
+func sortedKeys(record map[string]any) []string {
+	keys := make([]string, 0, len(record))
+	for key := range record {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// decodeIssueBatchPayload unwraps IssueBatchPayload. success=false is an API
+// error, matching how every other mutation in this CLI treats it.
+func decodeIssueBatchPayload(resp json.RawMessage, mutationKey string) ([]batchIssue, error) {
+	var root map[string]struct {
+		Success bool         `json:"success"`
+		Issues  []batchIssue `json:"issues"`
+	}
+	if err := json.Unmarshal(resp, &root); err != nil {
+		return nil, fmt.Errorf("parsing %s response: %w", mutationKey, err)
+	}
+	payload, ok := root[mutationKey]
+	if !ok {
+		return nil, fmt.Errorf("%s response missing %q", mutationKey, mutationKey)
+	}
+	if !payload.Success {
+		return nil, apiErr(fmt.Errorf("Linear reported %s success=false", mutationKey))
+	}
+	return payload.Issues, nil
+}
+
+// recordBatchCreatedIssues writes every created issue into the pp_created
+// ledger and mirrors it into the local issues table, which is exactly what
+// 'issues create' does for its single issue. Without this a batch create
+// would be invisible to pp-test list and unreachable by pp-cleanup, and
+// --trust-mode strict would refuse to touch issues this CLI just made.
+//
+// Ledger failures are warnings on stderr, not command failures: the issues
+// exist upstream either way and reporting the create as failed would be a
+// lie.
+func recordBatchCreatedIssues(dbPath string, issues []batchIssue, session string) {
+	if len(issues) == 0 {
+		return
+	}
+	resolved := resolveDBPath(dbPath)
+	db, err := store.Open(resolved)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: cannot open ledger at %s: %v\n", resolved, err)
+		return
+	}
+	defer db.Close()
+	for _, issue := range issues {
+		if issue.ID == "" {
+			continue
+		}
+		if err := db.RecordPPFixture(issue.ID, issue.Identifier, issue.Title, session); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: pp_created ledger write failed for %s: %v\n", firstNonEmpty(issue.Identifier, issue.ID), err)
+		}
+		payload, err := json.Marshal(batchIssueWriteBack(issue))
+		if err != nil {
+			continue
+		}
+		if err := db.UpsertIssue(issue.ID, issue.Identifier, issue.Title, payload); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: local store write-back failed for %s: %v\n", firstNonEmpty(issue.Identifier, issue.ID), err)
+		}
+	}
+}
+
+// batchIssueWriteBack shapes one created issue the way sync writes the
+// issues.data column, so 'issues list' sees a batch-created ticket without
+// waiting for the next sync.
+func batchIssueWriteBack(issue batchIssue) map[string]any {
+	now := time.Now().UTC().Format(time.RFC3339)
+	wb := map[string]any{
+		"id":          issue.ID,
+		"identifier":  issue.Identifier,
+		"title":       issue.Title,
+		"description": issue.Description,
+		"url":         issue.URL,
+		"priority":    issue.Priority,
+		"team": map[string]any{
+			"id":  issue.Team.ID,
+			"key": issue.Team.Key,
+		},
+		"teamId": issue.Team.ID,
+		"state": map[string]any{
+			"id":   issue.State.ID,
+			"name": issue.State.Name,
+			"type": issue.State.Type,
+		},
+		"createdAt": firstNonEmpty(issue.CreatedAt, now),
+		"updatedAt": firstNonEmpty(issue.UpdatedAt, now),
+	}
+	if issue.Assignee != nil {
+		wb["assignee"] = map[string]any{
+			"id":          issue.Assignee.ID,
+			"name":        issue.Assignee.Name,
+			"displayName": issue.Assignee.DisplayName,
+		}
+		wb["assigneeId"] = issue.Assignee.ID
+	}
+	if issue.Project != nil {
+		wb["project"] = map[string]any{
+			"id":   issue.Project.ID,
+			"name": issue.Project.Name,
+		}
+		wb["projectId"] = issue.Project.ID
+	}
+	if issue.Parent != nil {
+		wb["parent"] = map[string]any{
+			"id":         issue.Parent.ID,
+			"identifier": issue.Parent.Identifier,
+			"title":      issue.Parent.Title,
+		}
+		wb["parentId"] = issue.Parent.ID
+	}
+	return wb
+}
+
+// ---------------------------------------------------------------------------
+// issues batch-update
+// ---------------------------------------------------------------------------
+
+func newIssuesBatchUpdateCmd(flags *rootFlags) *cobra.Command {
+	var ids []string
+	var setJSON string
+	var stateFlag, stateNameFlag, stateTypeFlag string
+	var assigneeFlag, cycleFlag, projectFlag, milestoneFlag, teamFlag, dueDateFlag string
+	var addLabels, removeLabels, replaceLabels []string
+	var priorityFlag, estimateFlag int
+	cmd := &cobra.Command{
+		Use:   "batch-update --ids <a,b,c>",
+		Short: "Apply one change to up to 50 issues in a single transaction",
+		Long: `Apply one IssueUpdateInput to many issues in a single issueBatchUpdate call.
+
+--ids takes issue identifiers (ENG-123) or UUIDs, comma-separated or
+repeated. Linear's mutation types the list as [UUID!]!, so identifiers are
+resolved before the call. Duplicates collapse, order is kept.
+
+The change itself comes from the flags, which mirror 'issues edit' where the
+field exists on IssueUpdateInput, and from --set, which takes a raw JSON
+IssueUpdateInput object. --set is the base and explicit flags override it,
+so a stored template can be reused with one field varied. Keys in --set are
+validated against IssueUpdateInput, and an unknown key is refused by name.
+
+--state-name and --state-type resolve to a stateId, and a workflow state
+UUID is per-team, so both require --team. --state takes an already-resolved
+UUID and does not.
+
+Linear caps the batch at 50. A larger list is refused rather than split.
+Confirmation is required unless --yes, because one call moves up to 50
+tickets. --trust-mode strict checks every resolved target against the local
+pp_created ledger and refuses the whole batch if any one of them is not a
+fixture this CLI created.`,
+		Example: `  linear-pp-cli issues batch-update --ids ENG-1,ENG-2,ENG-3 --state-type completed --team ENG --yes --agent
+  linear-pp-cli issues batch-update --ids ENG-1,ENG-2 --assignee <user-uuid> --priority 2 --yes --agent
+  linear-pp-cli issues batch-update --ids ENG-1,ENG-2 --add-label <label-uuid> --yes --agent
+  linear-pp-cli issues batch-update --ids ENG-1,ENG-2 --set '{"estimate":3}' --priority 1 --dry-run --agent`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			targets, err := parseBatchIssueRefs(ids)
+			if err != nil {
+				return err
+			}
+
+			input := map[string]any{}
+			if strings.TrimSpace(setJSON) != "" {
+				parsed, err := parseIssueUpdateSet(setJSON)
+				if err != nil {
+					return err
+				}
+				input = parsed
+			}
+
+			if stateFlag != "" {
+				if err := requireUUIDFlag("--state", "workflow state", stateFlag); err != nil {
+					return err
+				}
+				input["stateId"] = stateFlag
+			}
+			if stateNameFlag != "" && stateTypeFlag != "" {
+				return usageErr(fmt.Errorf("pass either --state-name or --state-type, not both"))
+			}
+			if (stateNameFlag != "" || stateTypeFlag != "") && stateFlag != "" {
+				return usageErr(fmt.Errorf("pass either --state, --state-name, or --state-type, not several"))
+			}
+			if stateTypeFlag != "" {
+				normalized, err := normalizeWorkflowStateType(stateTypeFlag)
+				if err != nil {
+					return err
+				}
+				stateTypeFlag = normalized
+			}
+			if (stateNameFlag != "" || stateTypeFlag != "") && teamFlag == "" {
+				return usageErr(fmt.Errorf("--state-name and --state-type need --team: a workflow state UUID belongs to one team, and a batch can span teams. Pass --team <key> to name the team to resolve against, or pass --state <uuid> directly"))
+			}
+			if assigneeFlag != "" {
+				if err := requireUUIDFlag("--assignee", "user", assigneeFlag); err != nil {
+					return err
+				}
+				input["assigneeId"] = assigneeFlag
+			}
+			if cycleFlag != "" {
+				if err := requireUUIDFlag("--cycle", "cycle", cycleFlag); err != nil {
+					return err
+				}
+				input["cycleId"] = cycleFlag
+			}
+			if projectFlag != "" {
+				if err := requireUUIDFlag("--project", "project", projectFlag); err != nil {
+					return err
+				}
+				input["projectId"] = projectFlag
+			}
+			if milestoneFlag != "" {
+				if err := requireUUIDFlag("--milestone", "project milestone", milestoneFlag); err != nil {
+					return err
+				}
+				input["projectMilestoneId"] = milestoneFlag
+			}
+			if len(replaceLabels) > 0 && (len(addLabels) > 0 || len(removeLabels) > 0) {
+				return usageErr(fmt.Errorf("--label replaces the whole label set, so it cannot be combined with --add-label or --remove-label"))
+			}
+			if len(replaceLabels) > 0 {
+				input["labelIds"] = replaceLabels
+			}
+			if len(addLabels) > 0 {
+				input["addedLabelIds"] = addLabels
+			}
+			if len(removeLabels) > 0 {
+				input["removedLabelIds"] = removeLabels
+			}
+			if cmd.Flags().Changed("priority") {
+				input["priority"] = priorityFlag
+			}
+			if cmd.Flags().Changed("estimate") {
+				if estimateFlag < 0 {
+					return usageErr(fmt.Errorf("--estimate expects a non-negative point value (got %d)", estimateFlag))
+				}
+				input["estimate"] = estimateFlag
+			}
+			if cmd.Flags().Changed("due-date") {
+				due, err := parseTimelessDate("--due-date", dueDateFlag)
+				if err != nil {
+					return err
+				}
+				input["dueDate"] = due
+			}
+
+			if len(input) == 0 && stateNameFlag == "" && stateTypeFlag == "" {
+				return usageErr(fmt.Errorf("nothing to update: pass at least one field flag or --set '<json>'"))
+			}
+
+			dbPath := inheritedDBPath(cmd)
+
+			if flags.dryRun {
+				// Offline: identifiers stay unresolved and a state alias is
+				// shown as the alias, because resolving either needs the API.
+				fields := map[string]any{
+					"ids":   targets,
+					"input": input,
+					"count": len(targets),
+				}
+				if stateNameFlag != "" {
+					fields["state_name"] = stateNameFlag
+				}
+				if stateTypeFlag != "" {
+					fields["state_type"] = stateTypeFlag
+				}
+				if teamFlag != "" {
+					fields["team"] = teamFlag
+				}
+				for _, target := range targets {
+					if err := trustModeDryRunGuard(flags, dbPath, target); err != nil {
+						return err
+					}
+				}
+				return renderMutationDryRun(cmd, flags, "would_batch_update_issues", "issueBatchUpdate", fields)
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			if stateNameFlag != "" || stateTypeFlag != "" {
+				teamID, err := resolveWriteTeamID(c, dbPath, teamFlag)
+				if err != nil {
+					return err
+				}
+				stateID, err := resolveWorkflowState(c, issueTeamInfo{ID: teamID}, stateNameFlag, stateTypeFlag)
+				if err != nil {
+					return classifyLiveReadError(err, flags)
+				}
+				input["stateId"] = stateID
+			}
+			if len(input) == 0 {
+				return usageErr(fmt.Errorf("nothing to update: pass at least one field flag or --set '<json>'"))
+			}
+
+			// Resolve every identifier and run the trust gate over the whole
+			// batch before mutating any of it, so strict mode cannot let a
+			// partial batch through.
+			uuids := make([]string, 0, len(targets))
+			for _, target := range targets {
+				issueID, err := resolveIssueTarget(c, flags, dbPath, target)
+				if err != nil {
+					return err
+				}
+				uuids = append(uuids, issueID)
+			}
+
+			if err := confirmMutation(cmd, flags, fmt.Sprintf("Apply this change to %d issues in one transaction?", len(uuids))); err != nil {
+				return err
+			}
+
+			resp, err := c.Mutate(client.IssueBatchUpdateMutation, map[string]any{
+				"input": input,
+				"ids":   uuids,
+			})
+			if err != nil {
+				return classifyGraphQLMutationError("issueBatchUpdate", err, flags)
+			}
+			issues, err := decodeIssueBatchPayload(resp, "issueBatchUpdate")
+			if err != nil {
+				return err
+			}
+			out, err := json.Marshal(map[string]any{
+				"issues":  issues,
+				"updated": len(issues),
+			})
+			if err != nil {
+				return err
+			}
+			return renderLivePayload(cmd, flags, out, "issues", true)
+		},
+	}
+	cmd.Flags().StringSliceVar(&ids, "ids", nil, "Issue identifiers or UUIDs, comma-separated or repeated (required, max 50)")
+	cmd.Flags().StringVar(&setJSON, "set", "", "Raw JSON IssueUpdateInput used as the base. Explicit flags override it")
+	cmd.Flags().StringVar(&stateFlag, "state", "", "Workflow state UUID")
+	cmd.Flags().StringVar(&stateNameFlag, "state-name", "", "Workflow state name, resolved against --team")
+	cmd.Flags().StringVar(&stateTypeFlag, "state-type", "", "Workflow state type (triage, backlog, unstarted, started, completed, canceled, duplicate), resolved against --team")
+	cmd.Flags().StringVar(&teamFlag, "team", "", "Team key, name, or UUID that --state-name and --state-type resolve against")
+	cmd.Flags().StringVar(&assigneeFlag, "assignee", "", "Assignee user UUID")
+	cmd.Flags().StringVar(&cycleFlag, "cycle", "", "Cycle UUID")
+	cmd.Flags().StringVar(&projectFlag, "project", "", "Project UUID")
+	cmd.Flags().StringVar(&milestoneFlag, "milestone", "", "Project milestone UUID")
+	cmd.Flags().StringVar(&dueDateFlag, "due-date", "", "Due date as YYYY-MM-DD (TimelessDate). A timestamp is rejected")
+	cmd.Flags().StringSliceVar(&addLabels, "add-label", nil, "Label UUIDs to add (repeatable, addedLabelIds)")
+	cmd.Flags().StringSliceVar(&removeLabels, "remove-label", nil, "Label UUIDs to remove (repeatable, removedLabelIds)")
+	cmd.Flags().StringSliceVar(&replaceLabels, "label", nil, "Label UUIDs replacing the whole set (repeatable, labelIds)")
+	cmd.Flags().IntVar(&priorityFlag, "priority", 0, "Priority: 1=Urgent, 2=High, 3=Medium, 4=Low (0=None). Only sent when the flag is passed, so --priority 0 is an explicit \"No priority\"")
+	cmd.Flags().IntVar(&estimateFlag, "estimate", 0, "Estimate points. Only sent when the flag is passed, so --estimate 0 is an explicit zero")
+	return cmd
+}
+
+// parseBatchIssueRefs normalises --ids into an ordered, deduplicated target
+// list and enforces Linear's ceiling before anything reaches the network.
+func parseBatchIssueRefs(ids []string) ([]string, error) {
+	targets := make([]string, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, raw := range ids {
+		for _, part := range strings.Split(raw, ",") {
+			ref := strings.TrimSpace(part)
+			if ref == "" {
+				continue
+			}
+			key := ref
+			if !store.IsUUID(ref) {
+				key = strings.ToUpper(ref)
+				ref = key
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			targets = append(targets, ref)
+		}
+	}
+	if len(targets) == 0 {
+		return nil, usageErr(fmt.Errorf("--ids is required: pass issue identifiers or UUIDs, comma-separated or repeated"))
+	}
+	if len(targets) > issueBatchMax {
+		return nil, usageErr(fmt.Errorf("issueBatchUpdate accepts at most %d ids per call, got %d. Split the list, because splitting it here would silently turn one transaction into several", issueBatchMax, len(targets)))
+	}
+	return targets, nil
+}
+
+// parseIssueUpdateSet validates --set against IssueUpdateInput so a typo is
+// named here instead of being accepted and ignored upstream.
+func parseIssueUpdateSet(raw string) (map[string]any, error) {
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, usageErr(fmt.Errorf("--set expects a JSON object of IssueUpdateInput fields: %w", err))
+	}
+	for _, key := range sortedKeys(parsed) {
+		if !issueUpdateInputFields[key] {
+			return nil, usageErr(fmt.Errorf("--set: %q is not an IssueUpdateInput field", key))
+		}
+	}
+	return parsed, nil
+}

--- a/library/project-management/linear/internal/cli/issues_batch.go
+++ b/library/project-management/linear/internal/cli/issues_batch.go
@@ -711,12 +711,12 @@ fixture this CLI created.`,
 
 			dbPath := inheritedDBPath(cmd)
 
-			if flags.dryRun && (flags == nil || flags.trustMode != "strict") {
-				// Offline when we are not proving fixture ownership.
-				// Strict mode must resolve each identifier first so a
-				// TEAM-NUMBER that the ledger still names cannot pass a dry
-				// run after Linear has reused that identifier for a different
-				// issue UUID.
+			if flags.dryRun {
+				// Offline: identifiers stay unresolved and a state alias is
+				// shown as the alias, because resolving either needs the API.
+				// Linear does not recycle TEAM-NUMBER identifiers, so the
+				// ledger's identifier column is the same identity the live
+				// path will resolve.
 				fields := map[string]any{
 					"ids":   targets,
 					"input": input,
@@ -730,6 +730,11 @@ fixture this CLI created.`,
 				}
 				if teamFlag != "" {
 					fields["team"] = teamFlag
+				}
+				for _, target := range targets {
+					if err := trustModeDryRunGuard(flags, dbPath, target); err != nil {
+						return err
+					}
 				}
 				return renderMutationDryRun(cmd, flags, "would_batch_update_issues", "issueBatchUpdate", fields)
 			}
@@ -764,24 +769,6 @@ fixture this CLI created.`,
 					return err
 				}
 				uuids = append(uuids, issueID)
-			}
-
-			if flags.dryRun {
-				fields := map[string]any{
-					"ids":   uuids,
-					"input": input,
-					"count": len(uuids),
-				}
-				if stateNameFlag != "" {
-					fields["state_name"] = stateNameFlag
-				}
-				if stateTypeFlag != "" {
-					fields["state_type"] = stateTypeFlag
-				}
-				if teamFlag != "" {
-					fields["team"] = teamFlag
-				}
-				return renderMutationDryRun(cmd, flags, "would_batch_update_issues", "issueBatchUpdate", fields)
 			}
 
 			if err := confirmMutation(cmd, flags, fmt.Sprintf("Apply this change to %d issues in one transaction?", len(uuids))); err != nil {

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
@@ -26,6 +27,10 @@ func newIssuesCreateCmd(flags *rootFlags) *cobra.Command {
 	var mediaPublic bool
 	var dbPath string
 	var session string
+	var dueDateFlag, cycleFlag, milestoneFlag, templateFlag string
+	var estimateFlag int
+	var useDefaultTemplateFlag bool
+	var subscribersFlag []string
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new Linear issue and record it in the pp_created ledger",
@@ -126,8 +131,56 @@ sub-issue under an existing parent.`,
 			if descSet {
 				input["description"] = descBody
 			}
-			if priorityFlag > 0 {
+			// priority is only sent when the flag was explicitly passed.
+			// IssueCreateInput.priority documents 0 as "No priority", so an
+			// unset flag and an explicit zero must stay distinguishable.
+			if cmd.Flags().Changed("priority") {
 				input["priority"] = priorityFlag
+			}
+			if cmd.Flags().Changed("estimate") {
+				if estimateFlag < 0 {
+					return usageErr(fmt.Errorf("--estimate expects a non-negative point value (got %d)", estimateFlag))
+				}
+				input["estimate"] = estimateFlag
+			}
+			if cmd.Flags().Changed("due-date") {
+				due, dueErr := parseTimelessDate("--due-date", dueDateFlag)
+				if dueErr != nil {
+					return dueErr
+				}
+				input["dueDate"] = due
+			}
+			if cycleFlag != "" {
+				if err := requireUUIDFlag("--cycle", "cycle", cycleFlag); err != nil {
+					return err
+				}
+				input["cycleId"] = cycleFlag
+			}
+			if milestoneFlag != "" {
+				if err := requireUUIDFlag("--milestone", "project milestone", milestoneFlag); err != nil {
+					return err
+				}
+				input["projectMilestoneId"] = milestoneFlag
+			}
+			if templateFlag != "" && useDefaultTemplateFlag {
+				return usageErr(fmt.Errorf("pass either --template <uuid> or --use-default-template, not both"))
+			}
+			if templateFlag != "" {
+				if err := requireUUIDFlag("--template", "template", templateFlag); err != nil {
+					return err
+				}
+				input["templateId"] = templateFlag
+			}
+			if cmd.Flags().Changed("use-default-template") {
+				input["useDefaultTemplate"] = useDefaultTemplateFlag
+			}
+			if len(subscribersFlag) > 0 {
+				for _, subscriber := range subscribersFlag {
+					if err := requireUUIDFlag("--subscriber", "user", subscriber); err != nil {
+						return err
+					}
+				}
+				input["subscriberIds"] = subscribersFlag
 			}
 			if assigneeFlag != "" {
 				input["assigneeId"] = assigneeFlag
@@ -388,7 +441,14 @@ sub-issue under an existing parent.`,
 	cmd.Flags().StringVar(&descFlag, "description", "", "Issue description (markdown)")
 	cmd.Flags().StringVar(&descFile, "description-file", "", "Read issue description markdown from file")
 	cmd.Flags().BoolVar(&descStdin, "description-stdin", false, "Read issue description markdown from stdin")
-	cmd.Flags().IntVar(&priorityFlag, "priority", 0, "Priority: 1=Urgent, 2=High, 3=Medium, 4=Low (0=None)")
+	cmd.Flags().IntVar(&priorityFlag, "priority", 0, "Priority: 1=Urgent, 2=High, 3=Medium, 4=Low (0=None). Only sent when the flag is passed, so --priority 0 is an explicit \"No priority\"")
+	cmd.Flags().IntVar(&estimateFlag, "estimate", 0, "Estimate points. Only sent when the flag is passed, so --estimate 0 is an explicit zero")
+	cmd.Flags().StringVar(&dueDateFlag, "due-date", "", "Due date as YYYY-MM-DD (TimelessDate). A timestamp is rejected")
+	cmd.Flags().StringVar(&cycleFlag, "cycle", "", "Cycle UUID to file the new issue into")
+	cmd.Flags().StringVar(&milestoneFlag, "milestone", "", "Project milestone UUID (projectMilestoneId)")
+	cmd.Flags().StringVar(&templateFlag, "template", "", "Template UUID to create from. Every other flag you pass explicitly overrides the matching template value")
+	cmd.Flags().BoolVar(&useDefaultTemplateFlag, "use-default-template", false, "Create from the team's default template. Every other flag you pass explicitly overrides the matching template value")
+	cmd.Flags().StringSliceVar(&subscribersFlag, "subscriber", nil, "Subscriber user UUIDs (repeatable)")
 	cmd.Flags().StringVar(&assigneeFlag, "assignee", "", "Assignee user UUID")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "Project UUID")
 	cmd.Flags().StringVar(&projectNameFlag, "project-name", "", "Resolve and attach project by exact name")
@@ -431,4 +491,30 @@ func resolveTeam(db *store.Store, keyOrID string) (issueTeamInfo, bool) {
 		}
 	}
 	return issueTeamInfo{}, false
+}
+
+// parseTimelessDate validates a TimelessDate flag value. Linear's
+// TimelessDate scalar is a calendar day with no clock component, so a
+// timestamp is rejected outright instead of being silently truncated.
+func parseTimelessDate(flagName, value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", usageErr(fmt.Errorf("%s expects a date in YYYY-MM-DD form (got an empty value)", flagName))
+	}
+	if len(trimmed) != len("2006-01-02") {
+		return "", usageErr(fmt.Errorf("%s expects a date-only value in YYYY-MM-DD form, not a timestamp (got %q)", flagName, value))
+	}
+	if _, err := time.Parse("2006-01-02", trimmed); err != nil {
+		return "", usageErr(fmt.Errorf("%s expects a date in YYYY-MM-DD form (got %q)", flagName, value))
+	}
+	return trimmed, nil
+}
+
+// requireUUIDFlag rejects a non-UUID value for a flag whose Linear input
+// field only accepts an object id.
+func requireUUIDFlag(flagName, subject, value string) error {
+	if store.IsUUID(value) {
+		return nil
+	}
+	return usageErr(fmt.Errorf("%s expects a %s UUID (got %q)", flagName, subject, value))
 }

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -20,6 +20,14 @@ func newIssuesEditCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 	var labelsFlag []string
 	var mediaFlag []string
 	var mediaPublic bool
+	var appendFlags descriptionAppendFlags
+	var dueDateFlag, cycleFlag, milestoneFlag, teamFlag string
+	var estimateFlag int
+	var subscribersFlag []string
+	var addLabelsFlag, removeLabelsFlag []string
+	var teamNeedsLiveResolve bool
+	var existingDescription string
+	var existingDescriptionLoaded bool
 	cmd := &cobra.Command{
 		Use:   "edit <issue-id>",
 		Short: "Edit a Linear issue",
@@ -36,7 +44,11 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
   linear-pp-cli issues edit ENG-123 --state-name "In Progress" --agent
   linear-pp-cli issues edit ENG-123 --state-type started --agent
   linear-pp-cli issues edit ENG-123 --parent ENG-100 --agent
-  linear-pp-cli issues edit ENG-123 --no-parent --agent`,
+  linear-pp-cli issues edit ENG-123 --no-parent --agent
+  linear-pp-cli issues edit ENG-123 --due-date 2026-09-30 --estimate 3 --agent
+  linear-pp-cli issues edit ENG-123 --add-label <label-uuid> --remove-label <label-uuid> --agent
+  linear-pp-cli issues edit ENG-123 --team OPS --agent
+  linear-pp-cli issues edit ENG-123 --description-append "Update: shipped behind a flag." --agent`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			input := map[string]any{}
@@ -48,6 +60,55 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 			}
 			if cmd.Flags().Changed("priority") {
 				input["priority"] = priorityFlag
+			}
+			if cmd.Flags().Changed("estimate") {
+				if estimateFlag < 0 {
+					return usageErr(fmt.Errorf("--estimate expects a non-negative point value (got %d)", estimateFlag))
+				}
+				input["estimate"] = estimateFlag
+			}
+			if cmd.Flags().Changed("due-date") {
+				due, dueErr := parseTimelessDate("--due-date", dueDateFlag)
+				if dueErr != nil {
+					return dueErr
+				}
+				input["dueDate"] = due
+			}
+			if cycleFlag != "" {
+				if err := requireUUIDFlag("--cycle", "cycle", cycleFlag); err != nil {
+					return err
+				}
+				input["cycleId"] = cycleFlag
+			}
+			if milestoneFlag != "" {
+				if err := requireUUIDFlag("--milestone", "project milestone", milestoneFlag); err != nil {
+					return err
+				}
+				input["projectMilestoneId"] = milestoneFlag
+			}
+			if len(subscribersFlag) > 0 {
+				for _, subscriber := range subscribersFlag {
+					if err := requireUUIDFlag("--subscriber", "user", subscriber); err != nil {
+						return err
+					}
+				}
+				input["subscriberIds"] = subscribersFlag
+			}
+			if teamFlag != "" {
+				// Same two-step team resolution as issues create: the local
+				// teams cache first, a live lookup once the client exists.
+				resolvedTeamID := teamFlag
+				if !store.IsUUID(teamFlag) {
+					teamNeedsLiveResolve = true
+					if db, dbErr := store.Open(resolveDBPath(*dbPath)); dbErr == nil {
+						if resolved, ok := resolveTeam(db, teamFlag); ok {
+							resolvedTeamID = resolved.ID
+							teamNeedsLiveResolve = false
+						}
+						db.Close()
+					}
+				}
+				input["teamId"] = resolvedTeamID
 			}
 			if assigneeFlag != "" {
 				input["assigneeId"] = assigneeFlag
@@ -89,8 +150,17 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 			if noParentFlag {
 				input["parentId"] = nil
 			}
+			if len(labelsFlag) > 0 && (len(addLabelsFlag) > 0 || len(removeLabelsFlag) > 0) {
+				return usageErr(fmt.Errorf("pass either --label (replaces the whole label set) or --add-label/--remove-label (incremental), not both"))
+			}
 			if len(labelsFlag) > 0 {
 				input["labelIds"] = labelsFlag
+			}
+			if len(addLabelsFlag) > 0 {
+				input["addedLabelIds"] = addLabelsFlag
+			}
+			if len(removeLabelsFlag) > 0 {
+				input["removedLabelIds"] = removeLabelsFlag
 			}
 
 			descBody, descSet, err := readMarkdownBody(cmd, markdownBodySpec{
@@ -107,6 +177,10 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 			}
 			if descSet {
 				input["description"] = descBody
+			}
+			appendBody, appendSet, err := appendFlags.resolve(cmd, descSet)
+			if err != nil {
+				return err
 			}
 			var c *client.Client
 			if projectFlag != "" || projectNameFlag != "" {
@@ -140,14 +214,17 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 					input["projectId"] = projectID
 				}
 			}
-			if len(input) == 0 && len(mediaFlag) == 0 && stateNameFlag == "" && stateTypeFlag == "" {
-				return usageErr(fmt.Errorf("no issue fields supplied; pass --title, --description-file, --media, --state, --state-name, --state-type, --project, --project-name, --assignee, --priority, --label, --parent, or --no-parent"))
+			if len(input) == 0 && len(mediaFlag) == 0 && stateNameFlag == "" && stateTypeFlag == "" && !appendSet {
+				return usageErr(fmt.Errorf("no issue fields supplied; pass --title, --description-file, --description-append, --media, --state, --state-name, --state-type, --team, --project, --project-name, --assignee, --priority, --estimate, --due-date, --cycle, --milestone, --subscriber, --label, --add-label, --remove-label, --parent, or --no-parent"))
 			}
 			if flags.dryRun {
 				out := map[string]any{"issue": args[0], "input": input}
 				if len(mediaFlag) > 0 {
 					out["media"] = mediaFlag
 					out["media_public"] = mediaPublic
+				}
+				if appendSet {
+					out["description_append"] = appendBody
 				}
 				if stateNameFlag != "" {
 					out["state_name"] = stateNameFlag
@@ -164,7 +241,7 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 					return err
 				}
 			}
-			if (len(mediaFlag) > 0 && !descSet) || len(labelsFlag) > 0 || stateNameFlag != "" || stateTypeFlag != "" {
+			if (len(mediaFlag) > 0 && !descSet) || appendSet || len(labelsFlag) > 0 || len(addLabelsFlag) > 0 || stateNameFlag != "" || stateTypeFlag != "" {
 				existing, err := fetchIssueLive(c, args[0])
 				if err != nil {
 					return classifyLiveReadError(err, flags)
@@ -186,6 +263,8 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				issueID = issue.ID
 				issueTeam = issueTeamInfo{ID: issue.Team.ID, Key: issue.Team.Key}
 				issueMetaLoaded = true
+				existingDescription = issue.Description
+				existingDescriptionLoaded = true
 				if len(mediaFlag) > 0 && !descSet {
 					descBody = issue.Description
 					descSet = true
@@ -197,6 +276,24 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 					return classifyLiveReadError(err, flags)
 				}
 			}
+			// --trust-mode strict: refuse to touch issues this CLI did not create.
+			if err := enforceIssueTrustMode(flags, resolveDBPath(*dbPath), issueID, args[0]); err != nil {
+				return err
+			}
+			if appendSet {
+				if !existingDescriptionLoaded {
+					return fmt.Errorf("internal error: description append requires the existing issue body")
+				}
+				descBody = appendedDescriptionBody(existingDescription, appendBody)
+				descSet = true
+			}
+			if teamNeedsLiveResolve {
+				resolvedTeamID, teamErr := resolveTeamIDLive(c, teamFlag)
+				if teamErr != nil {
+					return classifyLiveReadError(teamErr, flags)
+				}
+				input["teamId"] = resolvedTeamID
+			}
 			if parentFlag != "" {
 				parentID, err := resolveParentIssueID(c, parentRef)
 				if err != nil {
@@ -204,12 +301,25 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				}
 				input["parentId"] = parentID
 			}
-			if len(labelsFlag) > 0 {
+			if len(labelsFlag) > 0 || len(addLabelsFlag) > 0 {
 				if !issueMetaLoaded {
 					return fmt.Errorf("internal error: label validation requires issue metadata")
 				}
-				if err := validateIssueLabelTeams(c, labelsFlag, issueTeam); err != nil {
-					return classifyLiveReadError(err, flags)
+				labelTeam := issueTeam
+				if teamFlag != "" {
+					// A team move in the same call means the labels have to
+					// belong to the destination team, not the current one.
+					if movedTeamID, ok := input["teamId"].(string); ok && movedTeamID != "" {
+						labelTeam = issueTeamInfo{ID: movedTeamID}
+					}
+				}
+				for _, labelSet := range [][]string{labelsFlag, addLabelsFlag} {
+					if len(labelSet) == 0 {
+						continue
+					}
+					if err := validateIssueLabelTeams(c, labelSet, labelTeam); err != nil {
+						return classifyLiveReadError(err, flags)
+					}
 				}
 			}
 			if stateNameFlag != "" || stateTypeFlag != "" {
@@ -269,6 +379,12 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 	cmd.Flags().StringVar(&descFile, "description-file", "", "Read issue description markdown from file")
 	cmd.Flags().BoolVar(&descStdin, "description-stdin", false, "Read issue description markdown from stdin")
 	cmd.Flags().IntVar(&priorityFlag, "priority", 0, "Priority: 1=Urgent, 2=High, 3=Medium, 4=Low")
+	cmd.Flags().IntVar(&estimateFlag, "estimate", 0, "Estimate points. Only sent when the flag is passed, so --estimate 0 is an explicit zero")
+	cmd.Flags().StringVar(&dueDateFlag, "due-date", "", "Due date as YYYY-MM-DD (TimelessDate). A timestamp is rejected")
+	cmd.Flags().StringVar(&teamFlag, "team", "", "Move the issue to this team: team key (e.g. ENG) or team UUID")
+	cmd.Flags().StringVar(&cycleFlag, "cycle", "", "Cycle UUID to file the issue into")
+	cmd.Flags().StringVar(&milestoneFlag, "milestone", "", "Project milestone UUID (projectMilestoneId)")
+	cmd.Flags().StringSliceVar(&subscribersFlag, "subscriber", nil, "Subscriber user UUIDs, replacing the current set (repeatable)")
 	cmd.Flags().StringVar(&assigneeFlag, "assignee", "", "Assignee user UUID")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "Project UUID")
 	cmd.Flags().StringVar(&projectNameFlag, "project-name", "", "Resolve and attach project by exact name")
@@ -278,8 +394,11 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 	cmd.Flags().StringVar(&parentFlag, "parent", "", "Parent issue identifier or UUID")
 	cmd.Flags().BoolVar(&noParentFlag, "no-parent", false, "Clear issue parentage")
 	cmd.Flags().StringSliceVar(&labelsFlag, "label", nil, "Replacement label UUIDs (repeatable)")
+	cmd.Flags().StringSliceVar(&addLabelsFlag, "add-label", nil, "Label UUIDs to add without touching the rest (repeatable). Cannot be combined with --label")
+	cmd.Flags().StringSliceVar(&removeLabelsFlag, "remove-label", nil, "Label UUIDs to remove without touching the rest (repeatable). Cannot be combined with --label")
 	cmd.Flags().StringSliceVar(&mediaFlag, "media", nil, "Upload file and append it to the description markdown (repeatable)")
 	cmd.Flags().BoolVar(&mediaPublic, "media-public", false, "Request public Linear asset URLs for uploaded media")
+	appendFlags.register(cmd)
 	return cmd
 }
 

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -27,7 +27,13 @@ func newIssuesEditCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 	var addLabelsFlag, removeLabelsFlag []string
 	var teamNeedsLiveResolve bool
 	var existingDescription string
+	var existingDescriptionUpdatedAt string
 	var existingDescriptionLoaded bool
+	// descBodyDerivedFromRead marks a description composed from the body this
+	// command read, rather than one the caller supplied whole. Only the
+	// derived case can silently delete a concurrent edit, and only it is
+	// guarded before the write.
+	var descBodyDerivedFromRead bool
 	cmd := &cobra.Command{
 		Use:   "edit <issue-id>",
 		Short: "Edit a Linear issue",
@@ -249,6 +255,7 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				var issue struct {
 					ID          string `json:"id"`
 					Description string `json:"description"`
+					UpdatedAt   string `json:"updatedAt"`
 					Team        struct {
 						ID  string `json:"id"`
 						Key string `json:"key"`
@@ -264,10 +271,12 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				issueTeam = issueTeamInfo{ID: issue.Team.ID, Key: issue.Team.Key}
 				issueMetaLoaded = true
 				existingDescription = issue.Description
+				existingDescriptionUpdatedAt = issue.UpdatedAt
 				existingDescriptionLoaded = true
 				if len(mediaFlag) > 0 && !descSet {
 					descBody = issue.Description
 					descSet = true
+					descBodyDerivedFromRead = true
 				}
 			} else {
 				var err error
@@ -286,6 +295,7 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				}
 				descBody = appendedDescriptionBody(existingDescription, appendBody)
 				descSet = true
+				descBodyDerivedFromRead = true
 			}
 			if teamNeedsLiveResolve {
 				resolvedTeamID, teamErr := resolveTeamIDLive(c, teamFlag)
@@ -338,6 +348,14 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 			}
 			if descSet {
 				input["description"] = descBody
+			}
+			if descSet && descBodyDerivedFromRead {
+				// The body was composed from the copy read above, and
+				// resolution plus media upload may have taken a while since.
+				// Refuse rather than overwrite an edit that landed meanwhile.
+				if err := guardStaleDescription(c, issueID, existingDescriptionUpdatedAt, existingDescription); err != nil {
+					return err
+				}
 			}
 
 			const mutation = `mutation($id: String!, $input: IssueUpdateInput!) {

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -28,7 +28,6 @@ func newIssuesEditCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 	var teamNeedsLiveResolve bool
 	var existingDescription string
 	var existingDescriptionUpdatedAt string
-	var existingDescriptionLoaded bool
 	// descBodyDerivedFromRead marks a description composed from the body this
 	// command read, rather than one the caller supplied whole. Only the
 	// derived case can silently delete a concurrent edit, and only it is
@@ -41,6 +40,11 @@ func newIssuesEditCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 descriptions so shell commands, backticks, and GraphQL snippets are preserved
 literally. If --media is supplied without a description source, the existing
 description is fetched live and the uploaded media links are appended.
+
+--description-append posts a new Linear comment instead of rewriting the
+issue description. Comments are append-only, so a concurrent description
+edit cannot be overwritten. To replace the description, use --description
+or --description-file.
 
 Use --parent with an issue identifier or UUID to set/change parentage. Use
 --no-parent to clear parentage.`,
@@ -224,13 +228,19 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				return usageErr(fmt.Errorf("no issue fields supplied; pass --title, --description-file, --description-append, --media, --state, --state-name, --state-type, --team, --project, --project-name, --assignee, --priority, --estimate, --due-date, --cycle, --milestone, --subscriber, --label, --add-label, --remove-label, --parent, or --no-parent"))
 			}
 			if flags.dryRun {
+				if appendSet && len(input) == 0 && len(mediaFlag) == 0 && stateNameFlag == "" && stateTypeFlag == "" {
+					return renderMutationDryRun(cmd, flags, "would_create_comment", "commentCreate", map[string]any{
+						"issue": args[0],
+						"body":  appendBody,
+					})
+				}
 				out := map[string]any{"issue": args[0], "input": input}
 				if len(mediaFlag) > 0 {
 					out["media"] = mediaFlag
 					out["media_public"] = mediaPublic
 				}
 				if appendSet {
-					out["description_append"] = appendBody
+					out["comment_body"] = appendBody
 				}
 				if stateNameFlag != "" {
 					out["state_name"] = stateNameFlag
@@ -272,7 +282,6 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				issueMetaLoaded = true
 				existingDescription = issue.Description
 				existingDescriptionUpdatedAt = issue.UpdatedAt
-				existingDescriptionLoaded = true
 				if len(mediaFlag) > 0 && !descSet {
 					descBody = issue.Description
 					descSet = true
@@ -289,13 +298,12 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 			if err := enforceIssueTrustMode(flags, resolveDBPath(*dbPath), issueID, args[0]); err != nil {
 				return err
 			}
-			if appendSet {
-				if !existingDescriptionLoaded {
-					return fmt.Errorf("internal error: description append requires the existing issue body")
+			if appendSet && issueID == "" {
+				resolvedID, resolveErr := resolveIssueID(c, args[0])
+				if resolveErr != nil {
+					return classifyLiveReadError(resolveErr, flags)
 				}
-				descBody = appendedDescriptionBody(existingDescription, appendBody)
-				descSet = true
-				descBodyDerivedFromRead = true
+				issueID = resolvedID
 			}
 			if teamNeedsLiveResolve {
 				resolvedTeamID, teamErr := resolveTeamIDLive(c, teamFlag)
@@ -358,7 +366,13 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 				}
 			}
 
-			const mutation = `mutation($id: String!, $input: IssueUpdateInput!) {
+			if len(input) == 0 && !appendSet {
+				return usageErr(fmt.Errorf("no issue fields supplied after resolution"))
+			}
+
+			var updatedIssue json.RawMessage
+			if len(input) > 0 {
+				const mutation = `mutation($id: String!, $input: IssueUpdateInput!) {
 				issueUpdate(id: $id, input: $input) {
 					success
 					issue {
@@ -372,24 +386,40 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 					}
 				}
 			}`
-			resp, err := c.Mutate(mutation, map[string]any{"id": issueID, "input": input})
-			if err != nil {
-				return classifyMutationError("issueUpdate", err, flags, uploaded)
+				resp, err := c.Mutate(mutation, map[string]any{"id": issueID, "input": input})
+				if err != nil {
+					return classifyMutationError("issueUpdate", err, flags, uploaded)
+				}
+				var parsed struct {
+					IssueUpdate struct {
+						Success bool            `json:"success"`
+						Issue   json.RawMessage `json:"issue"`
+					} `json:"issueUpdate"`
+				}
+				if err := json.Unmarshal(resp, &parsed); err != nil {
+					return fmt.Errorf("parsing issueUpdate response: %w", err)
+				}
+				if !parsed.IssueUpdate.Success {
+					return apiErr(fmt.Errorf("Linear reported issueUpdate success=false"))
+				}
+				updatedIssue = parsed.IssueUpdate.Issue
+				writeIssueBack(resolveDBPath(*dbPath), updatedIssue)
 			}
-			var parsed struct {
-				IssueUpdate struct {
-					Success bool            `json:"success"`
-					Issue   json.RawMessage `json:"issue"`
-				} `json:"issueUpdate"`
+
+			if appendSet {
+				comment, commentErr := createIssueComment(c, issueID, appendBody)
+				if commentErr != nil {
+					return classifyMutationError("commentCreate", commentErr, flags, uploaded)
+				}
+				if updatedIssue == nil {
+					raw, marshalErr := json.Marshal(comment)
+					if marshalErr != nil {
+						return fmt.Errorf("encoding commentCreate result: %w", marshalErr)
+					}
+					return renderLiveObject(cmd, flags, raw, "comments")
+				}
 			}
-			if err := json.Unmarshal(resp, &parsed); err != nil {
-				return fmt.Errorf("parsing issueUpdate response: %w", err)
-			}
-			if !parsed.IssueUpdate.Success {
-				return apiErr(fmt.Errorf("Linear reported issueUpdate success=false"))
-			}
-			writeIssueBack(resolveDBPath(*dbPath), parsed.IssueUpdate.Issue)
-			return renderLiveObject(cmd, flags, parsed.IssueUpdate.Issue, "issues")
+			return renderLiveObject(cmd, flags, updatedIssue, "issues")
 		},
 	}
 	cmd.Flags().StringVar(&titleFlag, "title", "", "Issue title")

--- a/library/project-management/linear/internal/cli/issues_edit_append.go
+++ b/library/project-management/linear/internal/cli/issues_edit_append.go
@@ -39,9 +39,9 @@ type descriptionAppendFlags struct {
 
 // register adds the append flag family to the given command.
 func (d *descriptionAppendFlags) register(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&d.text, "description-append", "", "Append this markdown to the existing description instead of replacing it (read-modify-write, joined with a blank line)")
-	cmd.Flags().StringVar(&d.file, "description-append-file", "", "Append markdown read from this file to the existing description")
-	cmd.Flags().BoolVar(&d.stdin, "description-append-stdin", false, "Append markdown read from stdin to the existing description")
+	cmd.Flags().StringVar(&d.text, "description-append", "", "Post this markdown as a new comment on the issue (append-only, so a concurrent description edit cannot be overwritten)")
+	cmd.Flags().StringVar(&d.file, "description-append-file", "", "Post markdown read from this file as a new comment on the issue")
+	cmd.Flags().BoolVar(&d.stdin, "description-append-stdin", false, "Post markdown read from stdin as a new comment on the issue")
 }
 
 // resolve returns the append body and whether any append source was given.
@@ -104,12 +104,12 @@ func appendedDescriptionBodyWith(existing, addition, separator string) string {
 // guardStaleDescription refuses a description write whose body was composed
 // from a copy of the issue that is no longer current.
 //
-// Every append is a read-modify-write, and Linear's issueUpdate takes no
-// precondition: the mutation carries a whole description, so a concurrent edit
-// landing after the read is overwritten with a body that never contained it.
-// The window is not theoretical on this path. `issues edit` may resolve a
-// team, a parent, labels and a workflow state, and may upload media, between
-// reading the body and writing it back.
+// Linear's issueUpdate takes no precondition: the mutation carries a whole
+// description, so a concurrent edit landing after the read is overwritten
+// with a body that never contained it. The remaining callers are media
+// uploads that rewrite the description, and reconcile's hash-guarded
+// append. `--description-append` no longer uses this path. It posts a
+// comment instead.
 //
 // The guard re-reads the issue immediately before the write and compares both
 // the timestamp and the body. It shrinks the window to that final round trip
@@ -204,19 +204,49 @@ func appendIssueDescriptionFrom(c *client.Client, issueID string, existing strin
 	return existing, after, nil
 }
 
-// appendIssueDescription performs a standalone read-modify-write append on a
-// single issue description: it reads the current body with the same live
-// issue read the edit command uses, joins the addition after a blank line,
-// and commits the result through issueUpdate.
-//
-// Exact signature, relied on by the reconcile command:
+// createIssueComment posts a new comment on an issue. Comments are
+// append-only, so two callers can add notes at the same time without
+// either one deleting the other's description edit.
+func createIssueComment(c *client.Client, issueID, body string) (map[string]any, error) {
+	if c == nil {
+		return nil, fmt.Errorf("createIssueComment: nil Linear client")
+	}
+	if strings.TrimSpace(issueID) == "" {
+		return nil, usageErr(fmt.Errorf("createIssueComment: empty issue id"))
+	}
+	if strings.TrimSpace(body) == "" {
+		return nil, usageErr(fmt.Errorf("createIssueComment: empty comment body"))
+	}
+	resp, err := c.Mutate(client.CommentCreateMutation, map[string]any{
+		"input": map[string]any{
+			"issueId": issueID,
+			"body":    body,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var parsed struct {
+		CommentCreate struct {
+			Success bool           `json:"success"`
+			Comment map[string]any `json:"comment"`
+		} `json:"commentCreate"`
+	}
+	if err := json.Unmarshal(resp, &parsed); err != nil {
+		return nil, fmt.Errorf("parsing commentCreate response: %w", err)
+	}
+	if !parsed.CommentCreate.Success {
+		return nil, apiErr(fmt.Errorf("Linear reported commentCreate success=false for issue %q", issueID))
+	}
+	return parsed.CommentCreate.Comment, nil
+}
+
+// appendIssueDescription posts text as a new comment on the issue.
 //
 //	func appendIssueDescription(c *client.Client, issueID string, text string) (map[string]any, error)
 //
-// c is the *client.Client that issues_edit.go builds via flags.newClient().
 // issueID may be an issue UUID or a TEAM-NUMBER identifier. The returned map
-// is the decoded issueUpdate.issue payload. A caller that already hydrated
-// the issue should use appendIssueDescriptionFrom instead and skip the read.
+// is the decoded commentCreate.comment payload.
 func appendIssueDescription(c *client.Client, issueID string, text string) (map[string]any, error) {
 	if c == nil {
 		return nil, fmt.Errorf("appendIssueDescription: nil Linear client")
@@ -233,9 +263,7 @@ func appendIssueDescription(c *client.Client, issueID string, text string) (map[
 		return nil, err
 	}
 	var existing struct {
-		ID          string `json:"id"`
-		Description string `json:"description"`
-		UpdatedAt   string `json:"updatedAt"`
+		ID string `json:"id"`
 	}
 	if err := json.Unmarshal(raw, &existing); err != nil {
 		return nil, fmt.Errorf("parsing existing issue %q: %w", issueID, err)
@@ -243,8 +271,5 @@ func appendIssueDescription(c *client.Client, issueID string, text string) (map[
 	if existing.ID == "" {
 		return nil, notFoundErr(fmt.Errorf("issue %q did not include an id", issueID))
 	}
-	if err := guardStaleDescription(c, existing.ID, existing.UpdatedAt, existing.Description); err != nil {
-		return nil, err
-	}
-	return setIssueDescription(c, existing.ID, appendedDescriptionBody(existing.Description, text))
+	return createIssueComment(c, existing.ID, text)
 }

--- a/library/project-management/linear/internal/cli/issues_edit_append.go
+++ b/library/project-management/linear/internal/cli/issues_edit_append.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// issueDescriptionAppendMutation is the issueUpdate document used by the
+// append primitive. It selects the same issue fields as the main
+// "issues edit" mutation so callers can render the result identically.
+const issueDescriptionAppendMutation = `mutation($id: String!, $input: IssueUpdateInput!) {
+	issueUpdate(id: $id, input: $input) {
+		success
+		issue {
+			id identifier title description url priority estimate dueDate createdAt updatedAt
+			state { id name type }
+			team { id key name }
+			project { id name }
+			assignee { id name displayName email }
+			parent { id identifier title }
+			children { nodes { id identifier title } }
+		}
+	}
+}`
+
+// descriptionAppendFlags carries the --description-append flag family for
+// "issues edit". The flags are registered from issues_edit.go so the whole
+// append path lives in one file.
+type descriptionAppendFlags struct {
+	text  string
+	file  string
+	stdin bool
+}
+
+// register adds the append flag family to the given command.
+func (d *descriptionAppendFlags) register(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&d.text, "description-append", "", "Append this markdown to the existing description instead of replacing it (read-modify-write, joined with a blank line)")
+	cmd.Flags().StringVar(&d.file, "description-append-file", "", "Append markdown read from this file to the existing description")
+	cmd.Flags().BoolVar(&d.stdin, "description-append-stdin", false, "Append markdown read from stdin to the existing description")
+}
+
+// resolve returns the append body and whether any append source was given.
+// It rejects a combination with the replace-mode --description flags at exit
+// code 2, because appending and replacing the same field in one call is
+// always a mistake rather than a merge. The rejection happens before any
+// body is read, so --description-stdin and --description-append-stdin in the
+// same call fail with the conflict rather than with a drained stdin.
+func (d *descriptionAppendFlags) resolve(cmd *cobra.Command, descriptionReplaceSet bool) (string, bool, error) {
+	requested := cmd.Flags().Changed("description-append") ||
+		cmd.Flags().Changed("description-append-file") ||
+		d.stdin
+	if !requested {
+		return "", false, nil
+	}
+	if descriptionReplaceSet {
+		return "", false, usageErr(fmt.Errorf("pass either a --description* replace flag or a --description-append* flag, not both"))
+	}
+	body, set, err := readMarkdownBody(cmd, markdownBodySpec{
+		InlineFlag: "description-append",
+		Inline:     d.text,
+		FileFlag:   "description-append-file",
+		File:       d.file,
+		StdinFlag:  "description-append-stdin",
+		Stdin:      d.stdin,
+		Label:      "description append",
+	})
+	if err != nil {
+		return "", false, err
+	}
+	if !set || strings.TrimSpace(body) == "" {
+		return "", false, usageErr(fmt.Errorf("--description-append needs a non-empty body"))
+	}
+	return body, true, nil
+}
+
+// defaultDescriptionAppendSeparator is the blank line placed between an
+// existing description and an appended block.
+const defaultDescriptionAppendSeparator = "\n\n"
+
+// appendedDescriptionBody joins an addition onto an existing description with
+// exactly one blank line between them. An empty existing body yields the
+// addition alone, so the first append never leaves leading whitespace.
+func appendedDescriptionBody(existing, addition string) string {
+	return appendedDescriptionBodyWith(existing, addition, defaultDescriptionAppendSeparator)
+}
+
+// appendedDescriptionBodyWith is the pure composer behind every append path.
+// A caller that needs its own separator or its own header block calls this
+// directly and then commits the result with setIssueDescription.
+func appendedDescriptionBodyWith(existing, addition, separator string) string {
+	trimmedExisting := strings.TrimRight(existing, "\n")
+	trimmedAddition := strings.TrimLeft(addition, "\n")
+	if strings.TrimSpace(trimmedExisting) == "" {
+		return trimmedAddition
+	}
+	return trimmedExisting + separator + trimmedAddition
+}
+
+// setIssueDescription writes a fully composed description onto one issue and
+// returns the decoded issueUpdate.issue payload. It performs no read, so the
+// caller owns both the composition and any before/after hashing.
+//
+//	func setIssueDescription(c *client.Client, issueID string, body string) (map[string]any, error)
+//
+// issueID must be the issue UUID, because nothing here resolves identifiers.
+func setIssueDescription(c *client.Client, issueID string, body string) (map[string]any, error) {
+	if c == nil {
+		return nil, fmt.Errorf("setIssueDescription: nil Linear client")
+	}
+	if strings.TrimSpace(issueID) == "" {
+		return nil, usageErr(fmt.Errorf("setIssueDescription: empty issue id"))
+	}
+	resp, err := c.Mutate(issueDescriptionAppendMutation, map[string]any{
+		"id":    issueID,
+		"input": map[string]any{"description": body},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var parsed struct {
+		IssueUpdate struct {
+			Success bool           `json:"success"`
+			Issue   map[string]any `json:"issue"`
+		} `json:"issueUpdate"`
+	}
+	if err := json.Unmarshal(resp, &parsed); err != nil {
+		return nil, fmt.Errorf("parsing issueUpdate response: %w", err)
+	}
+	if !parsed.IssueUpdate.Success {
+		return nil, apiErr(fmt.Errorf("Linear reported issueUpdate success=false for issue %q", issueID))
+	}
+	return parsed.IssueUpdate.Issue, nil
+}
+
+// appendIssueDescriptionFrom appends to a description the caller already
+// hydrated, so no read happens between hydration and the write. This is the
+// variant the reconcile command uses when it holds an append guard hash.
+//
+//	func appendIssueDescriptionFrom(c *client.Client, issueID string, existing string, text string) (before string, after string, err error)
+//
+// issueID must be the issue UUID. before is the hydrated body exactly as
+// passed in, after is the committed body, and both are returned even though
+// only after was written, so the caller can hash the pair.
+func appendIssueDescriptionFrom(c *client.Client, issueID string, existing string, text string) (string, string, error) {
+	if strings.TrimSpace(text) == "" {
+		return existing, existing, usageErr(fmt.Errorf("appendIssueDescriptionFrom: empty append body for issue %q", issueID))
+	}
+	after := appendedDescriptionBody(existing, text)
+	if _, err := setIssueDescription(c, issueID, after); err != nil {
+		return existing, existing, err
+	}
+	return existing, after, nil
+}
+
+// appendIssueDescription performs a standalone read-modify-write append on a
+// single issue description: it reads the current body with the same live
+// issue read the edit command uses, joins the addition after a blank line,
+// and commits the result through issueUpdate.
+//
+// Exact signature, relied on by the reconcile command:
+//
+//	func appendIssueDescription(c *client.Client, issueID string, text string) (map[string]any, error)
+//
+// c is the *client.Client that issues_edit.go builds via flags.newClient().
+// issueID may be an issue UUID or a TEAM-NUMBER identifier. The returned map
+// is the decoded issueUpdate.issue payload. A caller that already hydrated
+// the issue should use appendIssueDescriptionFrom instead and skip the read.
+func appendIssueDescription(c *client.Client, issueID string, text string) (map[string]any, error) {
+	if c == nil {
+		return nil, fmt.Errorf("appendIssueDescription: nil Linear client")
+	}
+	if strings.TrimSpace(issueID) == "" {
+		return nil, usageErr(fmt.Errorf("appendIssueDescription: empty issue reference"))
+	}
+	if strings.TrimSpace(text) == "" {
+		return nil, usageErr(fmt.Errorf("appendIssueDescription: empty append body for issue %q", issueID))
+	}
+
+	raw, err := fetchIssueLive(c, issueID)
+	if err != nil {
+		return nil, err
+	}
+	var existing struct {
+		ID          string `json:"id"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(raw, &existing); err != nil {
+		return nil, fmt.Errorf("parsing existing issue %q: %w", issueID, err)
+	}
+	if existing.ID == "" {
+		return nil, notFoundErr(fmt.Errorf("issue %q did not include an id", issueID))
+	}
+	return setIssueDescription(c, existing.ID, appendedDescriptionBody(existing.Description, text))
+}

--- a/library/project-management/linear/internal/cli/issues_edit_append.go
+++ b/library/project-management/linear/internal/cli/issues_edit_append.go
@@ -133,9 +133,7 @@ func guardStaleDescription(c graphqlQueryer, issueID, readUpdatedAt, readDescrip
 	if current.Description == readDescription {
 		return nil
 	}
-	if readUpdatedAt != "" && current.UpdatedAt == readUpdatedAt {
-		return nil
-	}
+	_ = readUpdatedAt
 	// Exit 5: the write was refused because of upstream state, not because
 	// the invocation was wrong. No new exit code is minted for it, so the
 	// documented per-command code sets stay accurate.

--- a/library/project-management/linear/internal/cli/issues_edit_append.go
+++ b/library/project-management/linear/internal/cli/issues_edit_append.go
@@ -101,6 +101,53 @@ func appendedDescriptionBodyWith(existing, addition, separator string) string {
 	return trimmedExisting + separator + trimmedAddition
 }
 
+// guardStaleDescription refuses a description write whose body was composed
+// from a copy of the issue that is no longer current.
+//
+// Every append is a read-modify-write, and Linear's issueUpdate takes no
+// precondition: the mutation carries a whole description, so a concurrent edit
+// landing after the read is overwritten with a body that never contained it.
+// The window is not theoretical on this path. `issues edit` may resolve a
+// team, a parent, labels and a workflow state, and may upload media, between
+// reading the body and writing it back.
+//
+// The guard re-reads the issue immediately before the write and compares both
+// the timestamp and the body. It shrinks the window to that final round trip
+// rather than closing it, which is the most this API allows, and it turns the
+// remaining loss from silent into a refusal the caller can retry.
+func guardStaleDescription(c graphqlQueryer, issueID, readUpdatedAt, readDescription string) error {
+	if c == nil || issueID == "" {
+		return nil
+	}
+	raw, err := fetchIssueByIDLive(c, issueID)
+	if err != nil {
+		// A failed re-read is not proof of a conflict, and refusing here would
+		// turn a transient read failure into a failed write. The caller's own
+		// error handling covers a genuinely unreachable API.
+		return nil
+	}
+	var current struct {
+		Description string `json:"description"`
+		UpdatedAt   string `json:"updatedAt"`
+	}
+	if err := json.Unmarshal(raw, &current); err != nil {
+		return nil
+	}
+	if current.Description == readDescription {
+		return nil
+	}
+	if readUpdatedAt != "" && current.UpdatedAt == readUpdatedAt {
+		return nil
+	}
+	// Exit 5: the write was refused because of upstream state, not because
+	// the invocation was wrong. No new exit code is minted for it, so the
+	// documented per-command code sets stay accurate.
+	return apiErr(fmt.Errorf(
+		"issue %s was edited while this command was composing its new description, so writing now would delete that edit.\nRe-run the command to append to the current body",
+		issueID,
+	))
+}
+
 // setIssueDescription writes a fully composed description onto one issue and
 // returns the decoded issueUpdate.issue payload. It performs no read, so the
 // caller owns both the composition and any before/after hashing.
@@ -188,12 +235,16 @@ func appendIssueDescription(c *client.Client, issueID string, text string) (map[
 	var existing struct {
 		ID          string `json:"id"`
 		Description string `json:"description"`
+		UpdatedAt   string `json:"updatedAt"`
 	}
 	if err := json.Unmarshal(raw, &existing); err != nil {
 		return nil, fmt.Errorf("parsing existing issue %q: %w", issueID, err)
 	}
 	if existing.ID == "" {
 		return nil, notFoundErr(fmt.Errorf("issue %q did not include an id", issueID))
+	}
+	if err := guardStaleDescription(c, existing.ID, existing.UpdatedAt, existing.Description); err != nil {
+		return nil, err
 	}
 	return setIssueDescription(c, existing.ID, appendedDescriptionBody(existing.Description, text))
 }

--- a/library/project-management/linear/internal/cli/issues_edit_append.go
+++ b/library/project-management/linear/internal/cli/issues_edit_append.go
@@ -117,21 +117,18 @@ func appendedDescriptionBodyWith(existing, addition, separator string) string {
 // remaining loss from silent into a refusal the caller can retry.
 func guardStaleDescription(c graphqlQueryer, issueID, readUpdatedAt, readDescription string) error {
 	if c == nil || issueID == "" {
-		return nil
+		return apiErr(fmt.Errorf("cannot confirm the live description of issue %s is still the body this command read, so refusing the write", issueID))
 	}
 	raw, err := fetchIssueByIDLive(c, issueID)
 	if err != nil {
-		// A failed re-read is not proof of a conflict, and refusing here would
-		// turn a transient read failure into a failed write. The caller's own
-		// error handling covers a genuinely unreachable API.
-		return nil
+		return apiErr(fmt.Errorf("could not re-read issue %s before writing its description: %w\nRefusing the write rather than replacing a body that may have changed", issueID, err))
 	}
 	var current struct {
 		Description string `json:"description"`
 		UpdatedAt   string `json:"updatedAt"`
 	}
 	if err := json.Unmarshal(raw, &current); err != nil {
-		return nil
+		return apiErr(fmt.Errorf("could not parse the live description of issue %s before writing: %w\nRefusing the write rather than replacing a body that may have changed", issueID, err))
 	}
 	if current.Description == readDescription {
 		return nil

--- a/library/project-management/linear/internal/cli/issues_lifecycle.go
+++ b/library/project-management/linear/internal/cli/issues_lifecycle.go
@@ -1,0 +1,339 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+// Issue lifecycle and subscription surface (GAP-012, GAP-031).
+//
+// issueArchive was reachable only through pp-cleanup, which by construction
+// only touches ids in the pp_created fixture ledger, so closing out real work
+// had no archive path at all. issueUnarchive, issueDelete, issueSubscribe, and
+// issueUnsubscribe had no surface whatsoever. All five are live in
+// api-inventory.json.
+//
+// The subcommands are registered on the issues parent in issues.go.
+
+// resolveIssueTarget turns an issue identifier or UUID into the UUID a mutation
+// needs and enforces --trust-mode strict against the pp_created ledger. Every
+// issue mutation in this file goes through it, so strict mode cannot be
+// bypassed by reaching for a different verb.
+func resolveIssueTarget(c graphqlQueryer, flags *rootFlags, dbPath, issueRef string) (string, error) {
+	return resolveIssueTargetWith(c, flags, dbPath, issueRef, false)
+}
+
+// resolveIssueTargetWith is resolveIssueTarget with archived rows opted into.
+// Only `issues unarchive` passes true: its subject is archived by definition,
+// so resolving through the archive-excluding lookup made every TEAM-NUMBER
+// reference exit 3 not_found and left the UUID as the only usable handle. The
+// ledger check is identical on both paths, so widening the lookup widens
+// nothing else.
+func resolveIssueTargetWith(c graphqlQueryer, flags *rootFlags, dbPath, issueRef string, includeArchived bool) (string, error) {
+	issueID, err := resolveIssueIDWith(c, issueRef, includeArchived)
+	if err != nil {
+		return "", classifyLiveReadError(err, flags)
+	}
+	if err := enforceIssueTrustMode(flags, resolveDBPath(dbPath), issueID, issueRef); err != nil {
+		return "", err
+	}
+	return issueID, nil
+}
+
+// trustModeDryRunGuard applies the strict-mode ledger check on the --dry-run
+// path too, but only when the reference is already a UUID. A dry run must not
+// reach the network to resolve an identifier, and reporting "would archive" for
+// a target strict mode would refuse is a lie worth avoiding where it is cheap.
+func trustModeDryRunGuard(flags *rootFlags, dbPath, issueRef string) error {
+	if flags == nil || flags.trustMode != "strict" || !store.IsUUID(issueRef) {
+		return nil
+	}
+	return enforceIssueTrustMode(flags, resolveDBPath(dbPath), issueRef, issueRef)
+}
+
+// inheritedDBPath reads the --db value the issues parent declares as a
+// persistent flag. These subcommands are attached through the extension
+// registry and therefore never see the parent's dbPath variable, and declaring
+// a second --db of their own would shadow the inherited one.
+func inheritedDBPath(cmd *cobra.Command) string {
+	if f := cmd.Flags().Lookup("db"); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+func newIssuesArchiveCmd(flags *rootFlags) *cobra.Command {
+	var trash bool
+	cmd := &cobra.Command{
+		Use:   "archive <issue>",
+		Short: "Archive a Linear issue",
+		Long: `Archive a Linear issue via the issueArchive mutation.
+
+Accepts an issue identifier (ENG-123) or a UUID. This is the general-purpose
+archive path: pp-cleanup only ever touches issues in the local pp_created
+fixture ledger, so it cannot close out real work.
+
+Pass --trash to send the issue to the trash instead of the archive. Reverse a
+plain archive with 'issues unarchive'.`,
+		Example: `  linear-pp-cli issues archive ENG-123 --agent
+  linear-pp-cli issues archive ENG-123 --trash --yes --agent
+  linear-pp-cli issues archive ENG-123 --dry-run --agent`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dbPath := inheritedDBPath(cmd)
+			if flags.dryRun {
+				if err := trustModeDryRunGuard(flags, dbPath, args[0]); err != nil {
+					return err
+				}
+				return renderMutationDryRun(cmd, flags, "would_archive_issue", "issueArchive", map[string]any{
+					"input": map[string]any{"id": args[0], "trash": trash},
+				})
+			}
+			if trash {
+				if err := confirmMutation(cmd, flags, fmt.Sprintf("Trash issue %s instead of archiving it?", args[0])); err != nil {
+					return err
+				}
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			issueID, err := resolveIssueTarget(c, flags, dbPath, args[0])
+			if err != nil {
+				return err
+			}
+			vars := map[string]any{"id": issueID}
+			if trash {
+				vars["trash"] = true
+			}
+			resp, err := c.Mutate(client.IssueArchiveMutation, vars)
+			if err != nil {
+				return classifyGraphQLMutationError("issueArchive", err, flags)
+			}
+			issue, err := extractMutationObject(resp, "issueArchive", "entity")
+			if err != nil {
+				return err
+			}
+			return renderLiveObject(cmd, flags, issue, "issues")
+		},
+	}
+	cmd.Flags().BoolVar(&trash, "trash", false, "Trash the issue instead of archiving it")
+	return cmd
+}
+
+func newIssuesUnarchiveCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unarchive <issue>",
+		Short: "Restore an archived Linear issue",
+		Long: `Unarchive a Linear issue via the issueUnarchive mutation. Accepts an issue
+identifier (ENG-123) or a UUID.
+
+The identifier lookup opts into archived issues, which is the whole point: an
+archived issue is invisible to the ordinary lookup, so without that the only
+resolvable handle would be the UUID nobody has written down.`,
+		Example: `  linear-pp-cli issues unarchive ENG-123 --agent`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dbPath := inheritedDBPath(cmd)
+			if flags.dryRun {
+				if err := trustModeDryRunGuard(flags, dbPath, args[0]); err != nil {
+					return err
+				}
+				return renderMutationDryRun(cmd, flags, "would_unarchive_issue", "issueUnarchive", map[string]any{
+					"input": map[string]any{"id": args[0]},
+				})
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			// includeArchived: true. The subject of an unarchive is archived,
+			// so the ordinary resolver can never find it by identifier.
+			issueID, err := resolveIssueTargetWith(c, flags, dbPath, args[0], true)
+			if err != nil {
+				return err
+			}
+			resp, err := c.Mutate(client.IssueUnarchiveMutation, map[string]any{"id": issueID})
+			if err != nil {
+				return classifyGraphQLMutationError("issueUnarchive", err, flags)
+			}
+			issue, err := extractMutationObject(resp, "issueUnarchive", "entity")
+			if err != nil {
+				return err
+			}
+			return renderLiveObject(cmd, flags, issue, "issues")
+		},
+	}
+	return cmd
+}
+
+func newIssuesDeleteCmd(flags *rootFlags) *cobra.Command {
+	var permanent bool
+	cmd := &cobra.Command{
+		Use:   "delete <issue>",
+		Short: "Trash a Linear issue",
+		Long: `Delete (trash) a Linear issue via the issueDelete mutation.
+
+This is the trash, not the archive. Linear holds a trashed issue for a 30-day
+grace period and then removes it. Use 'issues archive' when the work is simply
+finished.
+
+--permanent sets permanentlyDelete, which skips the grace period entirely and
+cannot be undone. Linear allows it for admins only.
+
+Always requires confirmation unless --yes is set. Pass --ignore-missing to
+treat an already-deleted issue as a successful no-op.`,
+		Example: `  linear-pp-cli issues delete ENG-123 --yes --agent
+  linear-pp-cli issues delete ENG-123 --permanent --yes --agent
+  linear-pp-cli issues delete ENG-123 --dry-run --agent`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dbPath := inheritedDBPath(cmd)
+			if flags.dryRun {
+				if err := trustModeDryRunGuard(flags, dbPath, args[0]); err != nil {
+					return err
+				}
+				return renderMutationDryRun(cmd, flags, "would_delete_issue", "issueDelete", map[string]any{
+					"input": map[string]any{"id": args[0], "permanentlyDelete": permanent},
+				})
+			}
+			prompt := fmt.Sprintf("Trash issue %s? Linear keeps it for 30 days, then removes it.", args[0])
+			if permanent {
+				prompt = fmt.Sprintf("PERMANENTLY delete issue %s, skipping the 30-day grace period? This cannot be undone.", args[0])
+			}
+			if err := confirmMutation(cmd, flags, prompt); err != nil {
+				return err
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			issueID, err := resolveIssueTarget(c, flags, dbPath, args[0])
+			if err != nil {
+				return err
+			}
+			vars := map[string]any{"id": issueID}
+			if permanent {
+				vars["permanentlyDelete"] = true
+			}
+			resp, err := c.Mutate(client.IssueDeleteMutation, vars)
+			if err != nil {
+				return classifyGraphQLMutationError("issueDelete", err, flags)
+			}
+			issue, err := extractMutationObject(resp, "issueDelete", "entity")
+			if err != nil {
+				return err
+			}
+			return renderLiveObject(cmd, flags, issue, "issues")
+		},
+	}
+	cmd.Flags().BoolVar(&permanent, "permanent", false, "Skip the 30-day grace period and delete immediately (admin only, irreversible)")
+	return cmd
+}
+
+func newIssuesSubscribeCmd(flags *rootFlags) *cobra.Command {
+	var sub issueSubscriptionFlags
+	cmd := &cobra.Command{
+		Use:   "subscribe <issue>",
+		Short: "Subscribe a user to a Linear issue",
+		Long:  "Subscribe to a Linear issue via the issueSubscribe mutation. Defaults to the authenticated user. Pass --user with a user UUID or --user-email to subscribe someone else.",
+		Example: `  linear-pp-cli issues subscribe ENG-123 --agent
+  linear-pp-cli issues subscribe ENG-123 --user <user-uuid> --agent`,
+		Args: cobra.ExactArgs(1),
+		RunE: issueSubscriptionRunE(flags, &sub, issueSubscription{
+			event:    "would_subscribe_issue",
+			mutation: "issueSubscribe",
+			document: client.IssueSubscribeMutation,
+		}),
+	}
+	sub.bind(cmd)
+	return cmd
+}
+
+func newIssuesUnsubscribeCmd(flags *rootFlags) *cobra.Command {
+	var sub issueSubscriptionFlags
+	cmd := &cobra.Command{
+		Use:   "unsubscribe <issue>",
+		Short: "Unsubscribe a user from a Linear issue",
+		Long:  "Unsubscribe from a Linear issue via the issueUnsubscribe mutation. Defaults to the authenticated user. Pass --user with a user UUID or --user-email to unsubscribe someone else.",
+		Example: `  linear-pp-cli issues unsubscribe ENG-123 --agent
+  linear-pp-cli issues unsubscribe ENG-123 --user <user-uuid> --agent`,
+		Args: cobra.ExactArgs(1),
+		RunE: issueSubscriptionRunE(flags, &sub, issueSubscription{
+			event:    "would_unsubscribe_issue",
+			mutation: "issueUnsubscribe",
+			document: client.IssueUnsubscribeMutation,
+		}),
+	}
+	sub.bind(cmd)
+	return cmd
+}
+
+// issueSubscriptionFlags carries the two optional subject selectors both
+// subscription leaves accept. Each constructor owns its own copy and binds it
+// to its own command, so the shared RunE below holds no per-command state.
+type issueSubscriptionFlags struct {
+	user      string
+	userEmail string
+}
+
+func (f *issueSubscriptionFlags) bind(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.user, "user", "", "User UUID, defaults to the authenticated user")
+	cmd.Flags().StringVar(&f.userEmail, "user-email", "", "User email, defaults to the authenticated user")
+}
+
+// issueSubscription describes the two subscription mutations. They take the
+// identical argument triple (id, userId, userEmail) and return IssuePayload, so
+// they share one implementation.
+type issueSubscription struct {
+	event    string
+	mutation string
+	document string
+}
+
+func issueSubscriptionRunE(flags *rootFlags, sub *issueSubscriptionFlags, spec issueSubscription) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		dbPath := inheritedDBPath(cmd)
+		if sub.user != "" && sub.userEmail != "" {
+			return usageErr(fmt.Errorf("pass at most one of --user or --user-email, both default to the authenticated user when omitted"))
+		}
+		if sub.user != "" && !store.IsUUID(sub.user) {
+			return usageErr(fmt.Errorf("--user expects a user UUID (got %q), use --user-email for an address, or run 'linear-pp-cli users' to find the UUID", sub.user))
+		}
+		vars := map[string]any{"id": args[0]}
+		if sub.user != "" {
+			vars["userId"] = sub.user
+		}
+		if sub.userEmail != "" {
+			vars["userEmail"] = sub.userEmail
+		}
+		if flags.dryRun {
+			if err := trustModeDryRunGuard(flags, dbPath, args[0]); err != nil {
+				return err
+			}
+			return renderMutationDryRun(cmd, flags, spec.event, spec.mutation, map[string]any{"input": vars})
+		}
+		c, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		issueID, err := resolveIssueTarget(c, flags, dbPath, args[0])
+		if err != nil {
+			return err
+		}
+		vars["id"] = issueID
+		resp, err := c.Mutate(spec.document, vars)
+		if err != nil {
+			return classifyGraphQLMutationError(spec.mutation, err, flags)
+		}
+		issue, err := extractMutationObject(resp, spec.mutation, "issue")
+		if err != nil {
+			return err
+		}
+		return renderLiveObject(cmd, flags, issue, "issues")
+	}
+}

--- a/library/project-management/linear/internal/cli/issues_lifecycle.go
+++ b/library/project-management/linear/internal/cli/issues_lifecycle.go
@@ -45,14 +45,33 @@ func resolveIssueTargetWith(c graphqlQueryer, flags *rootFlags, dbPath, issueRef
 }
 
 // trustModeDryRunGuard applies the strict-mode ledger check on the --dry-run
-// path too, but only when the reference is already a UUID. A dry run must not
-// reach the network to resolve an identifier, and reporting "would archive" for
-// a target strict mode would refuse is a lie worth avoiding where it is cheap.
+// path. A dry run must not reach the network, so the reference is checked
+// against the ledger as given: the ledger records both the UUID and the
+// identifier the create mutation returned, which is what makes an offline
+// answer possible for a TEAM-NUMBER reference.
+//
+// It fails closed, like the live gate. Reporting "would update" for a target
+// the real invocation rejects after resolution is the failure this guard
+// exists to prevent, and a reference the ledger cannot vouch for offline is
+// exactly that case.
 func trustModeDryRunGuard(flags *rootFlags, dbPath, issueRef string) error {
-	if flags == nil || flags.trustMode != "strict" || !store.IsUUID(issueRef) {
+	if flags == nil || flags.trustMode != "strict" {
 		return nil
 	}
-	return enforceIssueTrustMode(flags, resolveDBPath(dbPath), issueRef, issueRef)
+	db, err := store.Open(resolveDBPath(dbPath))
+	if err != nil {
+		return usageErr(fmt.Errorf("trust-mode=strict: cannot read the local pp_created ledger at %s: %w\nRun 'linear-pp-cli sync' to create the store, or drop --trust-mode strict", resolveDBPath(dbPath), err))
+	}
+	defer db.Close()
+
+	created, err := db.IsPPCreatedRef(issueRef)
+	if err != nil {
+		return usageErr(fmt.Errorf("trust-mode=strict: reading the local pp_created ledger failed: %w", err))
+	}
+	if !created {
+		return usageErr(fmt.Errorf("trust-mode=strict: %s is not in the local pp_created ledger, so this CLI did not create it and the real invocation would refuse it.\nRun 'linear-pp-cli pp-test list' to see the fixtures this CLI owns, or drop --trust-mode strict to mutate pre-existing workspace issues", issueRef))
+	}
+	return nil
 }
 
 // inheritedDBPath reads the --db value the issues parent declares as a

--- a/library/project-management/linear/internal/cli/issues_write_guards_test.go
+++ b/library/project-management/linear/internal/cli/issues_write_guards_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+)
+
+// A dry run under --trust-mode strict must agree with the real invocation. The
+// real one resolves TEAM-NUMBER to a UUID and then refuses a target absent from
+// the pp_created ledger, so a dry run that reports "would update" for such a
+// target is a lie. The ledger records the identifier as well as the UUID, which
+// is what lets the dry run answer offline.
+func TestTrustModeDryRunGuardChecksIdentifiers(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.RecordPPFixture("11111111-1111-1111-1111-111111111111", "ENG-7", "Fixture", "sess-1"); err != nil {
+		t.Fatalf("RecordPPFixture: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	strict := &rootFlags{trustMode: "strict"}
+	loose := &rootFlags{}
+
+	if err := trustModeDryRunGuard(strict, dbPath, "ENG-7"); err != nil {
+		t.Fatalf("a ledger fixture named by identifier must pass: %v", err)
+	}
+	if err := trustModeDryRunGuard(strict, dbPath, "eng-7"); err != nil {
+		t.Fatalf("identifier comparison must not be case-sensitive: %v", err)
+	}
+	if err := trustModeDryRunGuard(strict, dbPath, "11111111-1111-1111-1111-111111111111"); err != nil {
+		t.Fatalf("a ledger fixture named by UUID must pass: %v", err)
+	}
+
+	err = trustModeDryRunGuard(strict, dbPath, "ENG-8")
+	if err == nil {
+		t.Fatal("an identifier absent from the ledger must be refused, not reported as a would-update")
+	}
+	var cerr *cliError
+	if !errors.As(err, &cerr) || cerr.code != 2 {
+		t.Fatalf("want exit code 2, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ENG-8") {
+		t.Fatalf("error must name the refused target: %v", err)
+	}
+
+	if err := trustModeDryRunGuard(loose, dbPath, "ENG-8"); err != nil {
+		t.Fatalf("the guard only applies under strict mode: %v", err)
+	}
+}
+
+// stubQueryer answers the single-issue read with a canned payload.
+type stubQueryer struct {
+	description string
+	updatedAt   string
+	calls       int
+}
+
+func (s *stubQueryer) QueryInto(_ string, _ map[string]any, out any) error {
+	s.calls++
+	payload := map[string]any{
+		"issue": map[string]any{
+			"id":          "11111111-1111-1111-1111-111111111111",
+			"identifier":  "ENG-7",
+			"description": s.description,
+			"updatedAt":   s.updatedAt,
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(raw, out)
+}
+
+// issueUpdate carries a whole description, so an append composed from a stale
+// body deletes whatever landed in between. The guard refuses that write instead
+// of performing it silently.
+func TestGuardStaleDescription(t *testing.T) {
+	t.Parallel()
+
+	unchanged := &stubQueryer{description: "original body", updatedAt: "2026-08-12T09:00:00Z"}
+	if err := guardStaleDescription(unchanged, "11111111-1111-1111-1111-111111111111", "2026-08-12T09:00:00Z", "original body"); err != nil {
+		t.Fatalf("an unchanged issue must not be refused: %v", err)
+	}
+	if unchanged.calls != 1 {
+		t.Fatalf("guard made %d reads, want exactly 1", unchanged.calls)
+	}
+
+	// A field other than the description moved: the body is still the one the
+	// append was composed from, so the write is safe.
+	touched := &stubQueryer{description: "original body", updatedAt: "2026-08-12T09:05:00Z"}
+	if err := guardStaleDescription(touched, "11111111-1111-1111-1111-111111111111", "2026-08-12T09:00:00Z", "original body"); err != nil {
+		t.Fatalf("a same-body issue must not be refused: %v", err)
+	}
+
+	moved := &stubQueryer{description: "original body plus someone else's paragraph", updatedAt: "2026-08-12T09:05:00Z"}
+	err := guardStaleDescription(moved, "11111111-1111-1111-1111-111111111111", "2026-08-12T09:00:00Z", "original body")
+	if err == nil {
+		t.Fatal("a description edited since the read must refuse the write")
+	}
+	var cerr *cliError
+	if !errors.As(err, &cerr) || cerr.code != 5 {
+		t.Fatalf("want exit code 5, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "would delete that edit") {
+		t.Fatalf("error must say what the write would destroy: %v", err)
+	}
+}

--- a/library/project-management/linear/internal/cli/issues_write_guards_test.go
+++ b/library/project-management/linear/internal/cli/issues_write_guards_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -65,10 +66,14 @@ type stubQueryer struct {
 	description string
 	updatedAt   string
 	calls       int
+	err         error
 }
 
 func (s *stubQueryer) QueryInto(_ string, _ map[string]any, out any) error {
 	s.calls++
+	if s.err != nil {
+		return s.err
+	}
 	payload := map[string]any{
 		"issue": map[string]any{
 			"id":          "11111111-1111-1111-1111-111111111111",
@@ -116,5 +121,14 @@ func TestGuardStaleDescription(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "would delete that edit") {
 		t.Fatalf("error must say what the write would destroy: %v", err)
+	}
+
+	broken := &stubQueryer{err: fmt.Errorf("linear unavailable")}
+	err = guardStaleDescription(broken, "11111111-1111-1111-1111-111111111111", "2026-08-12T09:00:00Z", "original body")
+	if err == nil {
+		t.Fatal("a failed freshness re-read must refuse the write")
+	}
+	if !errors.As(err, &cerr) || cerr.code != 5 {
+		t.Fatalf("want exit code 5 for a failed re-read, got %v", err)
 	}
 }

--- a/library/project-management/linear/internal/cli/relations.go
+++ b/library/project-management/linear/internal/cli/relations.go
@@ -1,0 +1,938 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+// Issue relations.
+//
+// Linear models every issue-to-issue link as one IssueRelation carrying an
+// IssueRelationType. The enum has exactly four values (blocks, duplicate,
+// related, similar) and they are schema values, not workspace vocabulary, so
+// naming them here is API data rather than a compiled-in workspace literal.
+//
+// "blocked by" is NOT a fifth type. A single IssueRelation{type: blocks,
+// issue: A, relatedIssue: B} is outgoing on A and incoming on B. The incoming
+// direction over a `blocks` relation is what a human calls "blocked by".
+// Every row this file emits carries `type` (the enum, verbatim) and
+// `direction` (outgoing or incoming) as separate fields, and no code path
+// ever writes "blocked_by" into a type.
+
+const (
+	relationDirectionOutgoing = "outgoing"
+	relationDirectionIncoming = "incoming"
+	relationDirectionBoth     = "both"
+)
+
+// issueRelationTypes are the IssueRelationType enum values, verified against
+// the introspected schema. Order is the enum's own order.
+var issueRelationTypes = []string{"blocks", "duplicate", "related", "similar"}
+
+// symmetricRelationTypes are the types whose meaning does not depend on which
+// side of the pair the relation was created from. `blocks` is directional (A
+// blocks B is not B blocks A) and `duplicate` is directional (A is a
+// duplicate of B), so both are excluded. Used only by the --idempotent
+// existing-relation check.
+var symmetricRelationTypes = map[string]bool{"related": true, "similar": true}
+
+func normalizeIssueRelationType(value string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	for _, t := range issueRelationTypes {
+		if normalized == t {
+			return normalized, nil
+		}
+	}
+	return "", usageErr(fmt.Errorf("--type %q is not a valid IssueRelationType. Valid types: %s", value, strings.Join(issueRelationTypes, ", ")))
+}
+
+// relationIssueRef is the flattened issue projection used on both sides of a
+// relation row. State is flattened to state_name / state_type so a consumer
+// can evaluate a state group without walking a nested object.
+type relationIssueRef struct {
+	ID         string `json:"id"`
+	Identifier string `json:"identifier"`
+	Title      string `json:"title"`
+	URL        string `json:"url,omitempty"`
+	ArchivedAt string `json:"archived_at,omitempty"`
+	StateName  string `json:"state_name,omitempty"`
+	StateType  string `json:"state_type,omitempty"`
+}
+
+func relationIssueRefOf(src client.IssueRelationIssue) relationIssueRef {
+	return relationIssueRef{
+		ID:         src.ID,
+		Identifier: src.Identifier,
+		Title:      src.Title,
+		URL:        src.URL,
+		ArchivedAt: src.ArchivedAt,
+		StateName:  src.State.Name,
+		StateType:  src.State.Type,
+	}
+}
+
+// relationRow is one rendered relation. Direction is relative to the issue
+// the command was asked about, never a property of the relation itself.
+type relationRow struct {
+	ID           string           `json:"id"`
+	Type         string           `json:"type"`
+	Direction    string           `json:"direction"`
+	Issue        relationIssueRef `json:"issue"`
+	RelatedIssue relationIssueRef `json:"related_issue"`
+	CreatedAt    string           `json:"created_at,omitempty"`
+	// ArchivedAt is the relation's own archivedAt, empty for a live relation.
+	// It is populated only when the read asked for archived rows.
+	ArchivedAt string `json:"archived_at,omitempty"`
+}
+
+// counterpart returns the issue on the far side of the relation from the
+// subject, which is the one worth showing in a table.
+func (r relationRow) counterpart() relationIssueRef {
+	if r.Direction == relationDirectionIncoming {
+		return r.Issue
+	}
+	return r.RelatedIssue
+}
+
+// relationLabel renders type plus direction as the phrase a human uses. This
+// is a presentation-layer string only: `blocked by` never appears in the
+// `type` field of any payload.
+func relationLabel(relType, direction string) string {
+	incoming := direction == relationDirectionIncoming
+	switch relType {
+	case "blocks":
+		if incoming {
+			return "blocked by"
+		}
+		return "blocks"
+	case "duplicate":
+		if incoming {
+			return "duplicated by"
+		}
+		return "duplicate of"
+	case "related":
+		return "related to"
+	case "similar":
+		return "similar to"
+	}
+	if incoming {
+		return relType + " (incoming)"
+	}
+	return relType
+}
+
+func relationRowsFrom(res client.IssueRelationsResult) []relationRow {
+	rows := make([]relationRow, 0, len(res.Relations)+len(res.InverseRelations))
+	for _, n := range res.Relations {
+		rows = append(rows, relationRowOf(n, relationDirectionOutgoing))
+	}
+	for _, n := range res.InverseRelations {
+		rows = append(rows, relationRowOf(n, relationDirectionIncoming))
+	}
+	sortRelationRows(rows)
+	return rows
+}
+
+func relationRowOf(n client.IssueRelationNode, direction string) relationRow {
+	return relationRow{
+		ID:           n.ID,
+		Type:         n.Type,
+		Direction:    direction,
+		Issue:        relationIssueRefOf(n.Issue),
+		RelatedIssue: relationIssueRefOf(n.RelatedIssue),
+		CreatedAt:    n.CreatedAt,
+		ArchivedAt:   n.ArchivedAt,
+	}
+}
+
+func sortRelationRows(rows []relationRow) {
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Type != rows[j].Type {
+			return rows[i].Type < rows[j].Type
+		}
+		if rows[i].Direction != rows[j].Direction {
+			return rows[i].Direction < rows[j].Direction
+		}
+		return rows[i].counterpart().Identifier < rows[j].counterpart().Identifier
+	})
+}
+
+func newRelationsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "relations",
+		Aliases: []string{"links"},
+		Short:   "Read and manage issue relations (blocks, duplicate, related, similar)",
+		Long: `Manage the IssueRelation graph.
+
+Linear has exactly four relation types: blocks, duplicate, related and
+similar. "blocked by" is not one of them. It is the incoming direction over a
+blocks relation, so every row carries a separate 'direction' field
+(outgoing or incoming) alongside the verbatim 'type'.`,
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,2,3,4,5,6,7"},
+		RunE:        parentNoSubcommandRunE(flags),
+	}
+	cmd.AddCommand(newRelationsListCmd(flags))
+	cmd.AddCommand(newRelationsCreateCmd(flags))
+	cmd.AddCommand(newRelationsDeleteCmd(flags))
+	return cmd
+}
+
+func newRelationsListCmd(flags *rootFlags) *cobra.Command {
+	var typeFilter, direction, dbPath string
+	var includeArchived bool
+	cmd := &cobra.Command{
+		Use:         "list <issue>",
+		Aliases:     []string{"ls"},
+		Short:       "List every relation touching one issue, in both directions",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		Long: `List an issue's relations.
+
+Reads Issue.relations (outgoing) and Issue.inverseRelations (incoming) and
+renders them as one list. Query.issueRelations takes no filter argument, so a
+relation read is always per-issue: there is no server-side way to ask for
+"every blocks relation in the workspace".
+
+Rows carry 'type' (the IssueRelationType enum value) and 'direction'
+(outgoing or incoming) as separate fields. An incoming blocks relation is
+what a human calls "blocked by". It is a direction, never a type.
+
+With --data-source live (the default via auto) relations are fetched from the
+API and written through to the local issue_relations table, so a later
+--data-source local read of the same issue works offline.
+
+--include-archived passes includeArchived: true to both relation connections,
+so relations that were archived alongside their issues come back too. Archived
+rows carry archived_at, and the issue projections on either side carry their
+own archived_at when the issue itself is archived. Without the flag an
+archived relation is invisible on both the live and the local path, even if a
+previous --include-archived read cached one.`,
+		Example: `  linear-pp-cli relations list ESP-1155
+  linear-pp-cli relations list ESP-1155 --type blocks --direction incoming --agent
+  linear-pp-cli relations list ESP-1155 --data-source local --json
+  linear-pp-cli relations list ESP-1155 --include-archived --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if typeFilter != "" {
+				normalized, err := normalizeIssueRelationType(typeFilter)
+				if err != nil {
+					return err
+				}
+				typeFilter = normalized
+			}
+			switch direction {
+			case relationDirectionBoth, relationDirectionOutgoing, relationDirectionIncoming:
+			default:
+				return usageErr(fmt.Errorf("--direction %q is invalid. Valid values: %s, %s, %s", direction, relationDirectionBoth, relationDirectionOutgoing, relationDirectionIncoming))
+			}
+			return runRelationsList(cmd, flags, resolveDBPath(dbPath), args[0], typeFilter, direction, includeArchived)
+		},
+	}
+	cmd.Flags().StringVar(&typeFilter, "type", "", "Only show relations of this IssueRelationType ("+strings.Join(issueRelationTypes, ", ")+")")
+	cmd.Flags().StringVar(&direction, "direction", relationDirectionBoth, "Which side to show: both, outgoing, or incoming (incoming blocks == blocked by)")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
+	cmd.Flags().BoolVar(&includeArchived, "include-archived", false, "Include archived relations (maps to the includeArchived connection argument)")
+	return cmd
+}
+
+func runRelationsList(cmd *cobra.Command, flags *rootFlags, dbPath, issueRef, typeFilter, direction string, includeArchived bool) error {
+	db, openErr := openStoreAt(dbPath)
+	if db != nil {
+		defer db.Close()
+	}
+
+	var rows []relationRow
+	var prov DataProvenance
+
+	fetchLocal := func(reason string) ([]relationRow, DataProvenance, error) {
+		if openErr != nil {
+			return nil, DataProvenance{}, fmt.Errorf("opening local database: %w\nRun 'linear-pp-cli relations list %s' with --data-source live first", openErr, issueRef)
+		}
+		if db == nil {
+			return nil, DataProvenance{}, notFoundErr(fmt.Errorf("no local relation snapshot. Relations are not part of 'sync', so run 'linear-pp-cli relations list %s --data-source live' once to populate it", issueRef))
+		}
+		subjectID, err := resolveIssueIDLocal(db, issueRef)
+		if err != nil {
+			return nil, DataProvenance{}, err
+		}
+		raw, err := db.ListIssueRelationsForIssue(subjectID)
+		if err != nil {
+			return nil, DataProvenance{}, err
+		}
+		local := make([]relationRow, 0, len(raw))
+		for _, r := range raw {
+			var node client.IssueRelationNode
+			if err := json.Unmarshal(r, &node); err != nil || node.ID == "" {
+				continue
+			}
+			dir := relationDirectionIncoming
+			if node.Issue.ID == subjectID {
+				dir = relationDirectionOutgoing
+			}
+			local = append(local, relationRowOf(node, dir))
+		}
+		sortRelationRows(local)
+		return local, localProvenance(db, "issue_relations", reason), nil
+	}
+
+	switch flags.dataSource {
+	case "local":
+		var err error
+		rows, prov, err = fetchLocal("user_requested")
+		if err != nil {
+			return err
+		}
+	default:
+		c, err := flags.newClient()
+		if err != nil {
+			return err
+		}
+		issueID, err := resolveIssueID(c, issueRef)
+		if err != nil {
+			if flags.dataSource == "live" || !isNetworkError(err) {
+				return classifyLiveReadError(err, flags)
+			}
+			rows, prov, err = fetchLocal("api_unreachable")
+			if err != nil {
+				return err
+			}
+			break
+		}
+		res, err := c.FetchIssueRelationsWith(issueID, 0, includeArchived)
+		if err != nil {
+			if flags.dataSource == "live" || !isNetworkError(err) {
+				return classifyLiveReadError(err, flags)
+			}
+			var fallbackErr error
+			rows, prov, fallbackErr = fetchLocal("api_unreachable")
+			if fallbackErr != nil {
+				return fmt.Errorf("API unreachable and no local relation snapshot for %s.\n\nOriginal error: %w", issueRef, err)
+			}
+			break
+		}
+		rows = relationRowsFrom(res)
+		prov = DataProvenance{Source: "live", ResourceType: "issue_relations", Reason: "user_requested"}
+		if db != nil {
+			writeThroughRelations(db, issueID, res)
+		}
+	}
+
+	filtered := make([]relationRow, 0, len(rows))
+	for _, r := range rows {
+		if typeFilter != "" && r.Type != typeFilter {
+			continue
+		}
+		if direction != relationDirectionBoth && r.Direction != direction {
+			continue
+		}
+		// The live path already excluded archived relations server-side, but
+		// the local snapshot may hold rows cached by an earlier
+		// --include-archived read. Re-applying the predicate here keeps the
+		// two paths answering the same question.
+		if !includeArchived && r.ArchivedAt != "" {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+
+	prov = attachFreshness(prov, flags)
+	printProvenance(cmd, len(filtered), prov)
+	if wantsHumanTable(cmd.OutOrStdout(), flags) {
+		return printRelationTable(cmd, filtered, includeArchived)
+	}
+	payload, err := json.Marshal(filtered)
+	if err != nil {
+		return err
+	}
+	return renderPayloadWithProvenance(cmd, flags, payload, prov, false)
+}
+
+func printRelationTable(cmd *cobra.Command, rows []relationRow, showArchived bool) error {
+	if len(rows) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No relations.")
+		return nil
+	}
+	tw := newTabWriter(cmd.OutOrStdout())
+	if showArchived {
+		fmt.Fprintln(tw, "RELATION\tISSUE\tSTATE\tARCHIVED\tTITLE\tRELATION-ID")
+	} else {
+		fmt.Fprintln(tw, "RELATION\tISSUE\tSTATE\tTITLE\tRELATION-ID")
+	}
+	for _, r := range rows {
+		other := r.counterpart()
+		if showArchived {
+			// A relation can be archived on its own, and either endpoint can
+			// be archived independently. Show whichever stamp exists, relation
+			// first, so the column is never silently empty for an archived row.
+			stamp := r.ArchivedAt
+			if stamp == "" {
+				stamp = other.ArchivedAt
+			}
+			if stamp == "" {
+				stamp = "-"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				relationLabel(r.Type, r.Direction),
+				other.Identifier,
+				other.StateName,
+				stamp,
+				truncate(other.Title, 48),
+				r.ID,
+			)
+			continue
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			relationLabel(r.Type, r.Direction),
+			other.Identifier,
+			other.StateName,
+			truncate(other.Title, 48),
+			r.ID,
+		)
+	}
+	return tw.Flush()
+}
+
+// writeThroughRelations mirrors a live relation read into the local snapshot.
+// Failures are advisory: a read must not fail because the cache write did.
+func writeThroughRelations(db *store.Store, issueID string, res client.IssueRelationsResult) {
+	records := make([]store.IssueRelationRecord, 0, len(res.Relations)+len(res.InverseRelations))
+	appendRecord := func(n client.IssueRelationNode) {
+		data, err := json.Marshal(n)
+		if err != nil {
+			return
+		}
+		records = append(records, store.IssueRelationRecord{
+			ID:             n.ID,
+			IssueID:        n.Issue.ID,
+			RelatedIssueID: n.RelatedIssue.ID,
+			Type:           n.Type,
+			Data:           data,
+		})
+	}
+	for _, n := range res.Relations {
+		appendRecord(n)
+	}
+	for _, n := range res.InverseRelations {
+		appendRecord(n)
+	}
+	if err := db.ReplaceIssueRelationsForIssue(issueID, records); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: local relation write-through failed: %v\n", err)
+	}
+}
+
+// resolveIssueIDLocal maps an identifier to a UUID using the local snapshot,
+// so a --data-source local relation read never touches the network.
+func resolveIssueIDLocal(db *store.Store, issueRef string) (string, error) {
+	if store.IsUUID(issueRef) {
+		return issueRef, nil
+	}
+	rows, err := db.ListIssues(map[string]string{"identifier": issueRef}, 1)
+	if err != nil {
+		return "", err
+	}
+	if len(rows) == 0 {
+		return "", notFoundErr(fmt.Errorf("issue %q not found in the local store. Run 'linear-pp-cli sync' or use --data-source live", issueRef))
+	}
+	var row struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rows[0], &row); err != nil || row.ID == "" {
+		return "", notFoundErr(fmt.Errorf("issue %q has no id in the local store. Run 'linear-pp-cli sync'", issueRef))
+	}
+	return row.ID, nil
+}
+
+func newRelationsCreateCmd(flags *rootFlags) *cobra.Command {
+	var relType, to, dbPath string
+	cmd := &cobra.Command{
+		Use:   "create <issue> --type <type> --to <issue>",
+		Short: "Create an issue relation (blocks, duplicate, related, similar)",
+		Long: `Create one IssueRelation from <issue> to --to.
+
+Direction matters for the two directional types. 'create A --type blocks --to
+B' means A blocks B, which makes B blocked by A. 'create A --type duplicate
+--to B' means A is a duplicate of B, so B is the canonical issue. 'related'
+and 'similar' are symmetric.
+
+To close A as a duplicate of B, prefer 'issues close-duplicate A --of B',
+which creates the relation and then sets the duplicate state in that order.
+
+--idempotent turns an already-existing identical relation into a successful
+no-op. For blocks and duplicate the existing-relation check is
+direction-sensitive. For the symmetric types related and similar it matches
+in either direction.`,
+		Example: `  linear-pp-cli relations create ESP-1155 --type blocks --to ESP-1160
+  linear-pp-cli relations create ESP-1155 --type related --to ESP-1161 --idempotent --agent
+  linear-pp-cli relations create ESP-1155 --type blocks --to ESP-1160 --dry-run --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if to == "" {
+				return usageErr(fmt.Errorf("--to is required (the issue on the other side of the relation)"))
+			}
+			if relType == "" {
+				return usageErr(fmt.Errorf("--type is required. Valid types: %s", strings.Join(issueRelationTypes, ", ")))
+			}
+			normalizedType, err := normalizeIssueRelationType(relType)
+			if err != nil {
+				return err
+			}
+			if flags.dryRun {
+				return renderMutationDryRun(cmd, flags, "would_create_relation", "issueRelationCreate", map[string]any{
+					"input": map[string]any{
+						"type":           normalizedType,
+						"issueId":        args[0],
+						"relatedIssueId": to,
+					},
+				})
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			issueID, err := resolveIssueID(c, args[0])
+			if err != nil {
+				return classifyLiveReadError(err, flags)
+			}
+			relatedID, err := resolveIssueID(c, to)
+			if err != nil {
+				return classifyLiveReadError(err, flags)
+			}
+			if issueID == relatedID {
+				return usageErr(fmt.Errorf("cannot relate %s to itself", args[0]))
+			}
+			if err := enforceIssueTrustMode(flags, resolveDBPath(dbPath), issueID, args[0]); err != nil {
+				return err
+			}
+
+			if flags.idempotent {
+				existing, err := findExistingRelation(c, issueID, relatedID, normalizedType)
+				if err != nil {
+					return classifyLiveReadError(err, flags)
+				}
+				if existing != nil {
+					return writeNoop(flags, "already_exists", fmt.Sprintf("relation already exists (%s, id %s)", relationLabel(existing.Type, existing.Direction), existing.ID))
+				}
+			}
+
+			node, err := createIssueRelation(c, issueID, relatedID, normalizedType)
+			if err != nil {
+				return classifyMutationError("issueRelationCreate", err, flags, nil)
+			}
+
+			row := relationRowOf(node, relationDirectionOutgoing)
+			if db, dbErr := store.Open(resolveDBPath(dbPath)); dbErr == nil {
+				defer db.Close()
+				if data, mErr := json.Marshal(node); mErr == nil {
+					_ = db.UpsertIssueRelation(store.IssueRelationRecord{
+						ID:             node.ID,
+						IssueID:        node.Issue.ID,
+						RelatedIssueID: node.RelatedIssue.ID,
+						Type:           node.Type,
+						Data:           data,
+					})
+				}
+			}
+
+			if flags.asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(map[string]any{
+					"event":         "relation_created",
+					"id":            row.ID,
+					"type":          row.Type,
+					"direction":     row.Direction,
+					"issue":         row.Issue,
+					"related_issue": row.RelatedIssue,
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s %s %s\n", row.Issue.Identifier, relationLabel(row.Type, row.Direction), row.RelatedIssue.Identifier)
+			fmt.Fprintf(cmd.OutOrStdout(), "  relation id: %s\n", row.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&relType, "type", "", "Relation type: "+strings.Join(issueRelationTypes, ", ")+" (required)")
+	cmd.Flags().StringVar(&to, "to", "", "The issue on the other side of the relation, identifier or UUID (required)")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path for the trust-mode ledger and relation write-through")
+	return cmd
+}
+
+// createIssueRelation issues the mutation and returns the created node.
+func createIssueRelation(c *client.Client, issueID, relatedID, relType string) (client.IssueRelationNode, error) {
+	resp, err := c.Mutate(client.IssueRelationCreateMutation, map[string]any{
+		"input": map[string]any{
+			"type":           relType,
+			"issueId":        issueID,
+			"relatedIssueId": relatedID,
+		},
+	})
+	if err != nil {
+		return client.IssueRelationNode{}, err
+	}
+	node, ok, err := client.DecodeIssueRelationCreate(resp)
+	if err != nil {
+		return client.IssueRelationNode{}, err
+	}
+	if !ok {
+		return client.IssueRelationNode{}, apiErr(fmt.Errorf("Linear reported issueRelationCreate success=false"))
+	}
+	return node, nil
+}
+
+// findExistingRelation looks for a relation of relType between the two
+// issues. Direction-sensitive for blocks and duplicate, direction-insensitive
+// for the symmetric types. Returns nil when there is no match.
+func findExistingRelation(c *client.Client, issueID, relatedID, relType string) (*relationRow, error) {
+	res, err := c.FetchIssueRelations(issueID, 0)
+	if err != nil {
+		return nil, err
+	}
+	for _, n := range res.Relations {
+		if n.Type == relType && n.RelatedIssue.ID == relatedID {
+			row := relationRowOf(n, relationDirectionOutgoing)
+			return &row, nil
+		}
+	}
+	if !symmetricRelationTypes[relType] {
+		return nil, nil
+	}
+	for _, n := range res.InverseRelations {
+		if n.Type == relType && n.Issue.ID == relatedID {
+			row := relationRowOf(n, relationDirectionIncoming)
+			return &row, nil
+		}
+	}
+	return nil, nil
+}
+
+func newRelationsDeleteCmd(flags *rootFlags) *cobra.Command {
+	var dbPath string
+	cmd := &cobra.Command{
+		Use:     "delete <relation-id>",
+		Aliases: []string{"rm"},
+		Short:   "Delete an issue relation by its relation UUID",
+		Long: `Delete one IssueRelation.
+
+The argument is the relation's own UUID, not an issue identifier. Get it from
+the RELATION-ID column of 'relations list <issue>'.
+
+Deleting is confirmed interactively unless --yes is passed. With
+--ignore-missing an already-deleted relation is a successful no-op.`,
+		Example: `  linear-pp-cli relations delete 9f1c2a5e-2b1d-4d2f-9a44-1f0c3f6a77aa --yes
+  linear-pp-cli relations delete 9f1c... --ignore-missing --agent`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			relationID := strings.TrimSpace(args[0])
+			if !store.IsUUID(relationID) {
+				return usageErr(fmt.Errorf("expected a relation UUID (got %q). Run 'linear-pp-cli relations list <issue>' and use the RELATION-ID column", args[0]))
+			}
+			if flags.dryRun {
+				return renderMutationDryRun(cmd, flags, "would_delete_relation", "issueRelationDelete", map[string]any{
+					"id": relationID,
+				})
+			}
+			if err := confirmRelationMutation(cmd, flags, fmt.Sprintf("Delete issue relation %s?", relationID)); err != nil {
+				return err
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			resp, err := c.Mutate(client.IssueRelationDeleteMutation, map[string]any{"id": relationID})
+			if err != nil {
+				if flags.ignoreMissing && isMissingEntityError(err) {
+					deleteRelationLocally(resolveDBPath(dbPath), relationID)
+					return writeNoop(flags, "already_deleted", "relation already deleted (no-op)")
+				}
+				return classifyDeleteError(err, flags)
+			}
+			entityID, ok, err := client.DecodeIssueRelationDelete(resp)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return apiErr(fmt.Errorf("Linear reported issueRelationDelete success=false for %s", relationID))
+			}
+			deleteRelationLocally(resolveDBPath(dbPath), relationID)
+			if flags.asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(map[string]any{
+					"event": "relation_deleted",
+					"id":    firstNonEmpty(entityID, relationID),
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted relation %s\n", firstNonEmpty(entityID, relationID))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path for the local relation snapshot")
+	return cmd
+}
+
+func deleteRelationLocally(dbPath, relationID string) {
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	_, _ = db.DeleteIssueRelation(relationID)
+}
+
+// isMissingEntityError reports whether a GraphQL failure means the target no
+// longer exists. Linear answers a delete of an unknown id with a 200 plus an
+// errors array, so the HTTP-404 branch in classifyDeleteError never fires for
+// the GraphQL transport and --ignore-missing needs this shape check too.
+func isMissingEntityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "could not find") ||
+		strings.Contains(msg, "does not exist") ||
+		strings.Contains(msg, "entity not found")
+}
+
+// confirmRelationMutation is the shared confirmation gate for the destructive
+// relation paths. --yes skips it, --no-input without --yes is a usage error
+// rather than a hang.
+func confirmRelationMutation(cmd *cobra.Command, flags *rootFlags, prompt string) error {
+	if flags.yes {
+		return nil
+	}
+	if flags.noInput {
+		return usageErr(fmt.Errorf("%s this needs explicit confirmation: pass --yes (or drop --no-input)", prompt))
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "%s [y/N] ", prompt)
+	var resp string
+	fmt.Fscanln(cmd.InOrStdin(), &resp)
+	if !strings.EqualFold(resp, "y") && !strings.EqualFold(resp, "yes") {
+		return usageErr(fmt.Errorf("aborted"))
+	}
+	return nil
+}
+
+// newIssuesCloseDuplicateCmd closes an issue as a duplicate of another, in
+// the only order that does not lose information.
+//
+// Linear removed the per-team markedAsDuplicateWorkflowStateId model
+// (deprecated on Team, TeamCreateInput and TeamUpdateInput, "Duplicates are
+// now system-managed via the native duplicate state"), so duplication is
+// carried by the IssueRelation graph. Setting a duplicate-typed state without
+// first creating the duplicate relation produces an orphaned close: the issue
+// reads as closed-as-duplicate with nothing recording what it duplicates.
+//
+// The ordering is therefore fixed and not configurable:
+//
+//	step 1  issueRelationCreate{type: duplicate, issue: <issue>, relatedIssue: <canonical>}
+//	step 2  issueUpdate{stateId: <the team's duplicate-typed state>}
+//
+// Step 1 failing leaves nothing done. Step 1 succeeding and step 2 failing
+// leaves the relation recorded and the issue open, which is recoverable and
+// exits 6 (partial) naming the step that failed. The reverse order has no
+// recoverable failure mode, which is why it is not offered.
+func newIssuesCloseDuplicateCmd(flags *rootFlags) *cobra.Command {
+	var canonical, duplicateState, dbPath string
+	cmd := &cobra.Command{
+		Use:     "close-duplicate <issue> --of <canonical-issue>",
+		Aliases: []string{"dupe"},
+		Short:   "Close an issue as a duplicate: create the duplicate relation, then set the duplicate state",
+		Long: `Close <issue> as a duplicate of --of.
+
+Two steps, in this order and no other:
+
+  1. issueRelationCreate with type duplicate, from <issue> to the canonical
+     issue. This is what records WHAT the issue duplicates.
+  2. issueUpdate setting <issue> to its team's duplicate-typed workflow state.
+
+Doing step 2 first (which 'issues edit --state-type duplicate' does on its
+own) produces an orphaned close. If step 1 fails nothing is changed. If step 2
+fails the relation still stands and the command exits 6 (partial) telling you
+which step failed and how to finish.
+
+The duplicate state is resolved at runtime from the issue's own team, by
+querying workflowStates filtered on type eq duplicate. A team with no
+duplicate-typed state is exit 3: nothing is guessed and no state name is
+compiled into this binary. Pass --duplicate-state when a team has more than
+one duplicate-typed state.`,
+		Example: `  linear-pp-cli issues close-duplicate ESP-1160 --of ESP-1155 --yes
+  linear-pp-cli issues close-duplicate ESP-1160 --of ESP-1155 --dry-run --json
+  linear-pp-cli issues close-duplicate ESP-1160 --of ESP-1155 --idempotent --agent`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if canonical == "" {
+				return usageErr(fmt.Errorf("--of is required (the canonical issue this one duplicates)"))
+			}
+			if flags.dryRun {
+				return renderMutationDryRun(cmd, flags, "would_close_duplicate", "issueRelationCreate+issueUpdate", map[string]any{
+					"steps": []map[string]any{
+						{
+							"step":     1,
+							"mutation": "issueRelationCreate",
+							"input": map[string]any{
+								"type":           "duplicate",
+								"issueId":        args[0],
+								"relatedIssueId": canonical,
+							},
+						},
+						{
+							"step":       2,
+							"mutation":   "issueUpdate",
+							"issue":      args[0],
+							"state_type": "duplicate",
+						},
+					},
+				})
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			raw, err := fetchIssueLive(c, args[0])
+			if err != nil {
+				return classifyLiveReadError(err, flags)
+			}
+			var subject struct {
+				ID         string `json:"id"`
+				Identifier string `json:"identifier"`
+				Title      string `json:"title"`
+				Team       struct {
+					ID  string `json:"id"`
+					Key string `json:"key"`
+				} `json:"team"`
+			}
+			if err := json.Unmarshal(raw, &subject); err != nil || subject.ID == "" {
+				return notFoundErr(fmt.Errorf("issue %q not found", args[0]))
+			}
+			canonicalID, err := resolveIssueID(c, canonical)
+			if err != nil {
+				return classifyLiveReadError(err, flags)
+			}
+			if canonicalID == subject.ID {
+				return usageErr(fmt.Errorf("cannot close %s as a duplicate of itself", args[0]))
+			}
+			if err := enforceIssueTrustMode(flags, resolveDBPath(dbPath), subject.ID, args[0]); err != nil {
+				return err
+			}
+
+			// Resolve the duplicate-typed state BEFORE the relation is
+			// created. A team with no duplicate state must fail before any
+			// mutation goes out, otherwise step 1 lands and step 2 can never
+			// succeed, turning a plain exit 3 into a pointless partial.
+			team := issueTeamInfo{ID: subject.Team.ID, Key: subject.Team.Key}
+			stateID, err := resolveDuplicateStateID(c, team, duplicateState)
+			if err != nil {
+				return err
+			}
+
+			if err := confirmRelationMutation(cmd, flags, fmt.Sprintf("Close %s as a duplicate of %s?", firstNonEmpty(subject.Identifier, args[0]), canonical)); err != nil {
+				return err
+			}
+
+			// Step 1: the relation. Always first.
+			relationID := ""
+			relationStatus := "created"
+			if flags.idempotent {
+				existing, findErr := findExistingRelation(c, subject.ID, canonicalID, "duplicate")
+				if findErr != nil {
+					return classifyLiveReadError(findErr, flags)
+				}
+				if existing != nil {
+					relationID = existing.ID
+					relationStatus = "already_existed"
+				}
+			}
+			if relationID == "" {
+				node, createErr := createIssueRelation(c, subject.ID, canonicalID, "duplicate")
+				if createErr != nil {
+					return classifyMutationError("issueRelationCreate", createErr, flags, nil)
+				}
+				relationID = node.ID
+			}
+
+			// Step 2: the state. A failure here is partial, not total: the
+			// relation from step 1 stands and the issue is still open.
+			if err := setIssueState(c, subject.ID, stateID); err != nil {
+				return partialFailureErr(fmt.Errorf(
+					"step 1 (issueRelationCreate) succeeded, relation %s records %s as a duplicate of %s, but step 2 (issueUpdate to the duplicate state) failed: %v\n%s is still OPEN. Finish with 'linear-pp-cli issues edit %s --state %s'",
+					relationID, firstNonEmpty(subject.Identifier, args[0]), canonical, err,
+					firstNonEmpty(subject.Identifier, args[0]), firstNonEmpty(subject.Identifier, args[0]), stateID,
+				))
+			}
+
+			if flags.asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(map[string]any{
+					"event":        "issue_closed_as_duplicate",
+					"identifier":   subject.Identifier,
+					"id":           subject.ID,
+					"canonical":    canonical,
+					"canonical_id": canonicalID,
+					"relation_id":  relationID,
+					"relation":     relationStatus,
+					"state_id":     stateID,
+					"steps":        []string{"issueRelationCreate", "issueUpdate"},
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s closed as a duplicate of %s\n", firstNonEmpty(subject.Identifier, args[0]), canonical)
+			fmt.Fprintf(cmd.OutOrStdout(), "  relation %s (%s), then duplicate state %s\n", relationID, relationStatus, stateID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&canonical, "of", "", "The canonical issue this one duplicates, identifier or UUID (required)")
+	cmd.Flags().StringVar(&duplicateState, "duplicate-state", "", "Disambiguate when the team has several duplicate-typed states: pass the state UUID or its exact name")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path for the trust-mode ledger")
+	return cmd
+}
+
+// resolveDuplicateStateID finds the team's duplicate-typed workflow state.
+// The state's NAME is workspace vocabulary and is never assumed: resolution
+// goes through WorkflowState.type, which is API-documented schema data.
+// override accepts a UUID or an exact state name for teams carrying more
+// than one duplicate-typed state.
+func resolveDuplicateStateID(c graphqlQueryer, team issueTeamInfo, override string) (string, error) {
+	if override != "" {
+		if store.IsUUID(override) {
+			return override, nil
+		}
+		return resolveWorkflowState(c, team, override, "")
+	}
+	stateID, err := resolveWorkflowState(c, team, "", "duplicate")
+	if err != nil {
+		return "", fmt.Errorf("%w\nA duplicate-typed state cannot be created by mutation (WorkflowStateCreateInput does not accept the duplicate type), so it has to already exist in Linear for this team", err)
+	}
+	return stateID, nil
+}
+
+// setIssueState is step 2 of the duplicate close.
+func setIssueState(c *client.Client, issueID, stateID string) error {
+	resp, err := c.Mutate(client.IssueUpdateMutation, map[string]any{
+		"id":    issueID,
+		"input": map[string]any{"stateId": stateID},
+	})
+	if err != nil {
+		return err
+	}
+	var parsed struct {
+		IssueUpdate struct {
+			Success bool `json:"success"`
+		} `json:"issueUpdate"`
+	}
+	if err := json.Unmarshal(resp, &parsed); err != nil {
+		return fmt.Errorf("parsing issueUpdate response: %w", err)
+	}
+	if !parsed.IssueUpdate.Success {
+		return fmt.Errorf("Linear reported issueUpdate success=false")
+	}
+	return nil
+}

--- a/library/project-management/linear/internal/cli/root.go
+++ b/library/project-management/linear/internal/cli/root.go
@@ -318,6 +318,8 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newTodayCmd(flags))
 	rootCmd.AddCommand(newBottleneckCmd(flags))
 	rootCmd.AddCommand(newBlockingCmd(flags))
+	rootCmd.AddCommand(newRelationsCmd(flags))
+	rootCmd.AddCommand(newUnblockedCmd(flags))
 	rootCmd.AddCommand(newSimilarCmd(flags))
 	rootCmd.AddCommand(newVelocityCmd(flags))
 	rootCmd.AddCommand(newSlippedCmd(flags))

--- a/library/project-management/linear/internal/cli/trust_gate.go
+++ b/library/project-management/linear/internal/cli/trust_gate.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+)
+
+// enforceIssueTrustMode is the mutation guard behind --trust-mode strict.
+//
+// The flag has always been documented as "refuses to mutate Linear issues not
+// in the local pp_created table", but store.IsPPCreated had no callers, so the
+// only thing strict mode actually did was demand a session tag on create. This
+// helper closes that hole: every issue-mutating path calls it with the
+// resolved issue UUID before the mutation goes out, and a target that is not
+// an unarchived row in the pp_created ledger is refused with exit code 2.
+//
+// The gate fails closed. A missing or unreadable ledger means the caller
+// cannot prove the issue is a fixture, so the mutation is refused rather than
+// waved through.
+//
+// pp-cleanup is deliberately exempt: it enumerates its targets from the ledger
+// itself, so re-checking membership there would be circular.
+func enforceIssueTrustMode(flags *rootFlags, dbPath, issueID, issueRef string) error {
+	if flags == nil || flags.trustMode != "strict" {
+		return nil
+	}
+	if issueRef == "" {
+		issueRef = issueID
+	}
+	if issueID == "" {
+		return usageErr(fmt.Errorf("trust-mode=strict: cannot verify %q against the local pp_created ledger without a resolved issue id", issueRef))
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return usageErr(fmt.Errorf("trust-mode=strict: cannot read the local pp_created ledger at %s: %w\nRun 'linear-pp-cli sync' to create the store, or drop --trust-mode strict to mutate pre-existing issues", dbPath, err))
+	}
+	defer db.Close()
+
+	created, err := db.IsPPCreated(issueID)
+	if err != nil {
+		return usageErr(fmt.Errorf("trust-mode=strict: reading the local pp_created ledger failed: %w", err))
+	}
+	if !created {
+		return usageErr(fmt.Errorf("trust-mode=strict: %s is not in the local pp_created ledger, so this CLI did not create it and refuses to mutate it.\nRun 'linear-pp-cli pp-test list' to see the fixtures this CLI owns, or drop --trust-mode strict to mutate pre-existing workspace issues", issueRef))
+	}
+	return nil
+}

--- a/library/project-management/linear/internal/cli/unblocked.go
+++ b/library/project-management/linear/internal/cli/unblocked.go
@@ -1,0 +1,345 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/groups"
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+// `unblocked`: which blocked issues are now actionable.
+//
+// One paged query, filtered client-side. IssueFilter.hasBlockedByRelations
+// looks like the server-side shortcut for "is this blocked" and is a trap:
+// Linear stops matching it once every blocker of an issue has closed, which
+// is exactly the state this command exists to report. Filtering the crawl on
+// it made the command structurally incapable of returning a row. Proven live
+// on 2026-08-11: completing blocker ACC-256 made blocked ACC-257 disappear
+// from the candidate set entirely, even under --show-blocked, while `relations
+// list` still showed the relation and `issues get` still showed ACC-257 open.
+//
+// So the query asks only for the open group (plus --team) and selects each
+// issue's inverseRelations inline:
+//
+//	issues(filter: {state: <open group>, team: ...}) {
+//	  nodes { ... inverseRelations(first: $relFirst) { nodes { type issue { state } } } }
+//	}
+//
+// "Blocked by something" is then a local test: keep an issue only when at
+// least one inverse relation carries type `blocks`. The blockers' own states
+// ride along in the same selection set, so the verdict costs no extra round
+// trip. When an issue's inline relation page is truncated the rest is paged
+// before any verdict, because a partial blocker set yields a confident wrong
+// answer.
+//
+// Closed is defined as the complement of the open group, not as its own list.
+// An issue counts as closed when the resolved open group does NOT match its
+// state. Under the shipped default `active` group (types triage, backlog,
+// unstarted, started) the complement is exactly completed, canceled and
+// duplicate. A workspace that redefines `active` in groups.toml moves both
+// sides of the test together, which is the point: there is no second,
+// hand-written "closed" predicate that could drift out of agreement.
+//
+// Scope: this answers which BLOCKED items became actionable. An open issue
+// with no blockers at all was never blocked, so it is dropped by the local
+// `blocks` test. Without a server-side relation predicate the query walks
+// every open issue in scope, so --team is the way to keep the crawl small.
+//
+// Live only. Relations are not part of `sync`, so meta.source is always
+// "live" and there is no local fallback to fall back to.
+
+// unblockedBlocker is one blocker of a candidate issue.
+type unblockedBlocker struct {
+	Identifier string `json:"identifier"`
+	Title      string `json:"title,omitempty"`
+	StateName  string `json:"state_name"`
+	StateType  string `json:"state_type"`
+	Closed     bool   `json:"closed"`
+}
+
+// unblockedRow is one issue whose blockers are all closed.
+type unblockedRow struct {
+	Identifier        string             `json:"identifier"`
+	ID                string             `json:"id"`
+	Title             string             `json:"title"`
+	URL               string             `json:"url,omitempty"`
+	Priority          string             `json:"priority"`
+	StateName         string             `json:"state_name"`
+	StateType         string             `json:"state_type"`
+	Team              string             `json:"team,omitempty"`
+	Blockers          []unblockedBlocker `json:"blockers"`
+	AllBlockersClosed bool               `json:"all_blockers_closed"`
+}
+
+func newUnblockedCmd(flags *rootFlags) *cobra.Command {
+	var teamFlag, stateFlag string
+	var limit, relLimit int
+	var includeStillBlocked bool
+	cmd := &cobra.Command{
+		Use:   "unblocked",
+		Short: "Show blocked issues whose blockers are now all closed",
+		Long: `Answer "what became actionable?".
+
+Lists open issues that HAVE blocking relations and whose every blocker sits in
+a closed state. An issue with no blockers is not a result: it was never
+blocked, so it never became unblocked.
+
+One query, filtered locally. IssueFilter's hasBlockedByRelations comparator
+looks like the server-side way to ask "is this blocked" and cannot be used:
+Linear stops matching it once every blocker of an issue closes, so filtering
+on it hid precisely the issues this command exists to surface. Instead the
+query asks for open issues and selects each one's inverseRelations inline,
+then keeps the issues carrying at least one incoming 'blocks' relation and
+tests every blocker's state locally.
+
+Without a server-side relation filter the crawl covers every open issue in
+scope, so pass --team to keep it small. --relation-limit sets how many blocker
+relations come back inline per issue, and anything past that is paged before
+the verdict rather than guessed.
+
+Closed is the complement of the open group, never a second hand-written list.
+An issue is closed when the group passed to --state does not match it. With
+the default 'active' group that is exactly the completed, canceled and
+duplicate state types. Redefine 'active' in groups.toml and both sides of the
+test move together.
+
+Relations are not synced, so this command is live only.`,
+		Example: `  linear-pp-cli unblocked
+  linear-pp-cli unblocked --team ESP --agent
+  linear-pp-cli unblocked --state active --show-blocked --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if limit <= 0 {
+				return usageErr(fmt.Errorf("--limit must be positive"))
+			}
+			if relLimit <= 0 {
+				return usageErr(fmt.Errorf("--relation-limit must be positive"))
+			}
+			return runUnblocked(cmd, flags, teamFlag, stateFlag, limit, relLimit, includeStillBlocked)
+		},
+	}
+	cmd.Flags().StringVar(&teamFlag, "team", "", "Filter to one team key or team UUID")
+	cmd.Flags().StringVar(&stateFlag, "state", "active", stateGroupFlagUsage)
+	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum candidate issues to examine per page")
+	cmd.Flags().IntVar(&relLimit, "relation-limit", 50, "Blocker relations to pull inline per candidate before paging the rest")
+	cmd.Flags().BoolVar(&includeStillBlocked, "show-blocked", false, "Also emit candidates that still have at least one open blocker (all_blockers_closed=false)")
+	return cmd
+}
+
+func runUnblocked(cmd *cobra.Command, flags *rootFlags, teamFlag, stateToken string, limit, relLimit int, includeStillBlocked bool) error {
+	if flags.dataSource == "local" {
+		return usageErr(fmt.Errorf("unblocked is live only: issue relations are not part of 'sync', so there is no local snapshot to compute blocker states from. Drop --data-source local"))
+	}
+	c, err := flags.newClient()
+	if err != nil {
+		return err
+	}
+
+	// One resolved predicate drives both sides of the answer: the server-side
+	// state filter on the crawl and the client-side blocker test. Closed is
+	// its complement.
+	set, err := resolveStateSet(flags, teamKeyForGroups(nil, teamFlag), stateToken)
+	if err != nil {
+		return err
+	}
+
+	// The crawl asks for the open group and nothing about relations.
+	// hasBlockedByRelations is the only relation predicate the server offers
+	// and it stops matching an issue once all of its blockers close, so it
+	// cannot appear here: it would filter out every row worth reporting.
+	filter := map[string]any{}
+	if stateFilter := groups.LiveFilter(set); stateFilter != nil {
+		filter["state"] = stateFilter
+	}
+	if teamFlag != "" {
+		filter["team"] = unblockedTeamFilter(teamFlag)
+	}
+
+	candidates, err := fetchUnblockedCandidates(c, filter, limit, relLimit)
+	if err != nil {
+		return classifyLiveReadError(err, flags)
+	}
+
+	// Local pass: a crawled issue is a candidate only if something blocks it,
+	// and then every blocker's state is resolved against the same predicate.
+	// Not matched by the open group == closed.
+	rows := make([]unblockedRow, 0, len(candidates))
+	for _, cand := range candidates {
+		inverse := cand.InverseRelations
+		if cand.RelationsTruncated {
+			// The inline page was capped. Computing "all blockers closed"
+			// from a partial blocker set would produce a confident wrong
+			// answer, so page the rest before deciding.
+			full, err := c.FetchIssueInverseRelations(cand.ID, relLimit)
+			if err != nil {
+				return classifyLiveReadError(err, flags)
+			}
+			inverse = full
+		}
+		blockers := make([]unblockedBlocker, 0, len(inverse))
+		allClosed := true
+		for _, rel := range inverse {
+			if rel.Type != "blocks" {
+				continue
+			}
+			blocker := rel.Issue
+			closed := !set.Match(blocker.State.Type, blocker.State.Name)
+			if !closed {
+				allClosed = false
+			}
+			blockers = append(blockers, unblockedBlocker{
+				Identifier: blocker.Identifier,
+				Title:      blocker.Title,
+				StateName:  blocker.State.Name,
+				StateType:  blocker.State.Type,
+				Closed:     closed,
+			})
+		}
+		if len(blockers) == 0 {
+			// Nothing blocks this issue: either it carries no inverse
+			// relations at all, or the ones it carries are `related`,
+			// `similar` or `duplicate`. It was never blocked, so it never
+			// became unblocked. This local test is what replaces the
+			// unusable hasBlockedByRelations server filter.
+			continue
+		}
+		if !allClosed && !includeStillBlocked {
+			continue
+		}
+		sort.Slice(blockers, func(i, j int) bool { return blockers[i].Identifier < blockers[j].Identifier })
+		rows = append(rows, unblockedRow{
+			Identifier:        cand.Identifier,
+			ID:                cand.ID,
+			Title:             cand.Title,
+			URL:               cand.URL,
+			Priority:          priorityLabel(cand.Priority),
+			StateName:         cand.State.Name,
+			StateType:         cand.State.Type,
+			Team:              cand.Team.Key,
+			Blockers:          blockers,
+			AllBlockersClosed: allClosed,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].AllBlockersClosed != rows[j].AllBlockersClosed {
+			return rows[i].AllBlockersClosed
+		}
+		return rows[i].Identifier < rows[j].Identifier
+	})
+
+	prov := attachFreshness(DataProvenance{
+		Source:       "live",
+		ResourceType: "issues",
+		Reason:       "relations_not_synced",
+	}, flags)
+	printProvenance(cmd, len(rows), prov)
+
+	if wantsHumanTable(cmd.OutOrStdout(), flags) {
+		if len(rows) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "Nothing became unblocked.")
+			return nil
+		}
+		tw := newTabWriter(cmd.OutOrStdout())
+		fmt.Fprintln(tw, "ID\tPRI\tBLOCKERS\tSTATE\tTITLE")
+		for _, r := range rows {
+			fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n", r.Identifier, r.Priority, len(r.Blockers), r.StateName, truncate(r.Title, 48))
+		}
+		return tw.Flush()
+	}
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return err
+	}
+	return renderPayloadWithProvenance(cmd, flags, payload, prov, false)
+}
+
+// unblockedCandidate is one crawled issue plus its inline blocker page.
+type unblockedCandidate struct {
+	ID         string
+	Identifier string
+	Title      string
+	URL        string
+	Priority   int
+	State      client.IssueRelationState
+	Team       struct {
+		ID  string
+		Key string
+	}
+	InverseRelations   []client.IssueRelationNode
+	RelationsTruncated bool
+}
+
+// fetchUnblockedCandidates walks the crawl to exhaustion. Every open issue in
+// scope comes back, blocked or not, because the server has no usable "is
+// blocked" predicate. The blocks test happens in the caller.
+func fetchUnblockedCandidates(c *client.Client, filter map[string]any, limit, relLimit int) ([]unblockedCandidate, error) {
+	var out []unblockedCandidate
+	cursor := ""
+	for {
+		vars := map[string]any{"first": limit, "filter": filter, "relFirst": relLimit}
+		if cursor != "" {
+			vars["after"] = cursor
+		}
+		var resp struct {
+			Issues struct {
+				Nodes []struct {
+					ID         string                    `json:"id"`
+					Identifier string                    `json:"identifier"`
+					Title      string                    `json:"title"`
+					URL        string                    `json:"url"`
+					Priority   int                       `json:"priority"`
+					State      client.IssueRelationState `json:"state"`
+					Team       struct {
+						ID  string `json:"id"`
+						Key string `json:"key"`
+					} `json:"team"`
+					InverseRelations struct {
+						Nodes    []client.IssueRelationNode `json:"nodes"`
+						PageInfo struct {
+							HasNextPage bool `json:"hasNextPage"`
+						} `json:"pageInfo"`
+					} `json:"inverseRelations"`
+				} `json:"nodes"`
+				PageInfo struct {
+					HasNextPage bool   `json:"hasNextPage"`
+					EndCursor   string `json:"endCursor"`
+				} `json:"pageInfo"`
+			} `json:"issues"`
+		}
+		if err := c.QueryInto(client.UnblockedCandidatesQuery, vars, &resp); err != nil {
+			return nil, err
+		}
+		for _, n := range resp.Issues.Nodes {
+			cand := unblockedCandidate{
+				ID:                 n.ID,
+				Identifier:         n.Identifier,
+				Title:              n.Title,
+				URL:                n.URL,
+				Priority:           n.Priority,
+				State:              n.State,
+				InverseRelations:   n.InverseRelations.Nodes,
+				RelationsTruncated: n.InverseRelations.PageInfo.HasNextPage,
+			}
+			cand.Team.ID = n.Team.ID
+			cand.Team.Key = n.Team.Key
+			out = append(out, cand)
+		}
+		if !resp.Issues.PageInfo.HasNextPage || resp.Issues.PageInfo.EndCursor == "" {
+			return out, nil
+		}
+		cursor = resp.Issues.PageInfo.EndCursor
+	}
+}
+
+// unblockedTeamFilter builds the TeamFilter fragment for a key or a UUID.
+func unblockedTeamFilter(team string) map[string]any {
+	if store.IsUUID(team) {
+		return map[string]any{"id": map[string]any{"eq": team}}
+	}
+	return map[string]any{"key": map[string]any{"eqIgnoreCase": team}}
+}

--- a/library/project-management/linear/internal/cli/write_families_a.go
+++ b/library/project-management/linear/internal/cli/write_families_a.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+// Shared plumbing for the tier-2 write families (labels, workflow states,
+// cycles, comment lifecycle, issue lifecycle). Everything here is mutation-side
+// only: read paths keep using the existing provenance helpers.
+
+// resolveWriteTeamID maps a team key, name, or UUID to the team UUID a mutation
+// input needs. A UUID passes straight through. Otherwise the synced local store
+// answers without a round trip, and only if that misses does the live lookup
+// run. c may be nil, in which case an unresolved key returns the input
+// unchanged so a --dry-run preview can still be rendered offline. Callers that
+// are about to mutate for real must pass a client.
+func resolveWriteTeamID(c graphqlQueryer, dbPath, teamRef string) (string, error) {
+	teamRef = strings.TrimSpace(teamRef)
+	if teamRef == "" || store.IsUUID(teamRef) {
+		return teamRef, nil
+	}
+	if db, err := openStoreAt(resolveDBPath(dbPath)); err == nil && db != nil {
+		defer db.Close()
+		if resolved, ok := resolveTeam(db, teamRef); ok && resolved.ID != "" {
+			return resolved.ID, nil
+		}
+	}
+	if c == nil {
+		return teamRef, nil
+	}
+	return resolveTeamIDLive(c, teamRef)
+}
+
+// confirmMutation gates a destructive, non-reversible mutation. --yes (and
+// therefore --agent) skips it. --no-input without --yes is refused as a usage
+// error rather than blocking forever on a prompt no one can answer.
+func confirmMutation(cmd *cobra.Command, flags *rootFlags, prompt string) error {
+	if flags != nil && flags.yes {
+		return nil
+	}
+	if flags != nil && flags.noInput {
+		return usageErr(fmt.Errorf("%s needs explicit confirmation: pass --yes (or remove --no-input)", cmd.CommandPath()))
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "%s [y/N] ", prompt)
+	var answer string
+	fmt.Fscanln(cmd.InOrStdin(), &answer)
+	if !strings.EqualFold(answer, "y") && !strings.EqualFold(answer, "yes") {
+		return usageErr(fmt.Errorf("aborted"))
+	}
+	return nil
+}
+
+// renderMutationEvent prints the result of a mutation that has no object to
+// render, which is every DeletePayload in the API. JSON mode gets the same
+// {event, ...} envelope shape renderMutationDryRun emits, so a caller can pair
+// would_delete_label with label_deleted without reshaping its parser.
+func renderMutationEvent(cmd *cobra.Command, flags *rootFlags, event string, fields map[string]any) error {
+	out := map[string]any{"event": event}
+	for key, value := range fields {
+		out[key] = value
+	}
+	if flags != nil && flags.asJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", event)
+	for _, key := range []string{"id", "entity_id", "identifier", "name"} {
+		if value, ok := fields[key]; ok {
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s: %v\n", key, value)
+		}
+	}
+	return nil
+}
+
+// extractDeletedEntityID pulls entityId out of a DeletePayload. Success=false
+// is an API error, not a silent no-op.
+func extractDeletedEntityID(resp json.RawMessage, mutationKey string) (string, error) {
+	var root map[string]struct {
+		Success  bool   `json:"success"`
+		EntityID string `json:"entityId"`
+	}
+	if err := json.Unmarshal(resp, &root); err != nil {
+		return "", fmt.Errorf("parsing %s response: %w", mutationKey, err)
+	}
+	payload, ok := root[mutationKey]
+	if !ok {
+		return "", fmt.Errorf("%s response missing %q", mutationKey, mutationKey)
+	}
+	if !payload.Success {
+		return "", apiErr(fmt.Errorf("Linear reported %s success=false", mutationKey))
+	}
+	return payload.EntityID, nil
+}
+
+// isGraphQLNotFound reports whether err is Linear telling us the target does
+// not exist. GraphQL answers 200 with an errors array, so classifyDeleteError's
+// HTTP 404 check never fires on this transport and --ignore-missing would be
+// dead on every mutation in this package without this test.
+//
+// Matching is on the API's own error prose, which is workspace-independent.
+func isGraphQLNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.HasPrefix(msg, "graphql:") {
+		return false
+	}
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "could not find") ||
+		strings.Contains(msg, "entity not found")
+}
+
+// classifyGraphQLMutationError is classifyMutationError plus --ignore-missing
+// handling for the GraphQL transport. Delete-shaped commands route through it
+// so a repeat delete is an exit-0 no-op when the caller asked for one.
+func classifyGraphQLMutationError(operation string, err error, flags *rootFlags) error {
+	if flags != nil && flags.ignoreMissing && isGraphQLNotFound(err) {
+		return writeNoop(flags, "already_deleted", "already deleted (no-op)")
+	}
+	if isGraphQLNotFound(err) {
+		return notFoundErr(err)
+	}
+	return classifyMutationError(operation, err, flags, nil)
+}
+
+// isGraphQLAlreadyExists reports whether err is Linear rejecting a create
+// because an equivalent record is already there. Used only to honour
+// --idempotent. An unrecognised message falls through to normal error
+// handling, so a real failure is never swallowed.
+func isGraphQLAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.HasPrefix(msg, "graphql:") {
+		return false
+	}
+	return strings.Contains(msg, "already exists") ||
+		strings.Contains(msg, "already been taken") ||
+		strings.Contains(msg, "duplicate")
+}
+
+// classifyGraphQLCreateError is classifyMutationError plus --idempotent
+// handling: a create that collides with an existing record exits 0 as a no-op
+// when the caller asked for that, matching the documented flag contract.
+func classifyGraphQLCreateError(operation string, err error, flags *rootFlags) error {
+	if flags != nil && flags.idempotent && isGraphQLAlreadyExists(err) {
+		return writeNoop(flags, "already_exists", "already exists (no-op)")
+	}
+	return classifyMutationError(operation, err, flags, nil)
+}
+
+// setOptionalString adds key to input only when value is non-empty, so a
+// partial update never sends a field the caller did not ask to change.
+// Linear treats an explicit null as "clear this field", which is not what an
+// unset flag means.
+func setOptionalString(input map[string]any, key, value string) {
+	if strings.TrimSpace(value) != "" {
+		input[key] = value
+	}
+}
+
+// setChangedString is setOptionalString for flags where the empty string is a
+// legitimate value the caller may want to write (clearing a description, for
+// example). It keys off cobra's Changed bit rather than emptiness.
+func setChangedString(cmd *cobra.Command, input map[string]any, flagName, key, value string) {
+	if cmd.Flags().Changed(flagName) {
+		input[key] = value
+	}
+}

--- a/library/project-management/linear/internal/client/batch_queries.go
+++ b/library/project-management/linear/internal/client/batch_queries.go
@@ -1,0 +1,55 @@
+package client
+
+// GraphQL documents for the issue batch mutations (GAP-034).
+//
+// Both mutation names, their argument names and their input shapes were read
+// out of the introspection snapshot in
+// .goal-linear-coverage/api-inventory.json before the documents were
+// written:
+//
+//	issueBatchCreate(input: IssueBatchCreateInput!): IssueBatchPayload!
+//	  IssueBatchCreateInput = { issues: [IssueCreateInput!]! }
+//	issueBatchUpdate(input: IssueUpdateInput!, ids: [UUID!]!): IssueBatchPayload!
+//
+// Note the asymmetry, which is Linear's and not a transcription slip: create
+// wraps its list in an input object, update takes the id list as a SEPARATE
+// argument alongside a single IssueUpdateInput applied to all of them. Both
+// return IssueBatchPayload { lastSyncId, issues, success }.
+//
+// Linear documents a ceiling of 50 on both: IssueBatchCreateInput is "Up to
+// 50 issues can be created in a single batch" and issueBatchUpdate.ids is
+// "Can't be more than 50 at a time". Callers enforce it before sending.
+
+// batchIssueFields matches the projection issueCreate selects, so a batch
+// create can feed the same pp_created ledger and local write-back path a
+// single create does without a second round trip.
+//
+// verified live in api-inventory.json
+const batchIssueFields = `id identifier title description url priority createdAt updatedAt
+      team { id key }
+      state { id name type }
+      assignee { id name displayName }
+      project { id name }
+      parent { id identifier title }`
+
+// IssueBatchCreateMutation creates up to 50 issues in one transaction.
+//
+// verified live in api-inventory.json
+const IssueBatchCreateMutation = `mutation($input: IssueBatchCreateInput!) {
+  issueBatchCreate(input: $input) {
+    success
+    issues { ` + batchIssueFields + ` }
+  }
+}`
+
+// IssueBatchUpdateMutation applies one IssueUpdateInput to up to 50 issues.
+// ids is [UUID!]!, so identifiers such as ENG-123 must be resolved to UUIDs
+// before the call.
+//
+// verified live in api-inventory.json
+const IssueBatchUpdateMutation = `mutation($input: IssueUpdateInput!, $ids: [UUID!]!) {
+  issueBatchUpdate(input: $input, ids: $ids) {
+    success
+    issues { ` + batchIssueFields + ` }
+  }
+}`

--- a/library/project-management/linear/internal/client/relations_paging_test.go
+++ b/library/project-management/linear/internal/client/relations_paging_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/config"
+)
+
+// A relation set that never exhausts must not come back as a short read: the
+// callers read "absent" as "no such relation", so a partial set silently drops
+// links from `relations list`, duplicates an existing relation on idempotent
+// create, and lets `unblocked` clear an issue whose blocker was never seen.
+func TestFetchIssueRelationsRefusesToTruncate(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requests.Add(1)
+		// Every page claims another page after it, so the loop can only end
+		// at the page bound.
+		fmt.Fprintf(w, `{"data":{"issue":{
+			"id":"11111111-1111-1111-1111-111111111111",
+			"identifier":"ENG-1",
+			"team":{"id":"team-1","key":"ENG"},
+			"relations":{"nodes":[{"id":"rel-%d","type":"blocks"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-%d"}},
+			"inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}
+		}}}`, n, n)
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{BaseURL: srv.URL}, 0, 0)
+	_, err := c.FetchIssueRelations("11111111-1111-1111-1111-111111111111", 50)
+	if err == nil {
+		t.Fatal("a relation set that never exhausted must be an error, not a partial result")
+	}
+	if !strings.Contains(err.Error(), "partial relation set") {
+		t.Fatalf("error does not name the cause: %v", err)
+	}
+	if got := requests.Load(); got != int64(maxRelationPages) {
+		t.Fatalf("paged %d times, want the %d page bound", got, maxRelationPages)
+	}
+}
+
+// The ordinary case still returns on exhaustion, with both sides collected.
+func TestFetchIssueRelationsReturnsOnExhaustion(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"issue":{
+			"id":"11111111-1111-1111-1111-111111111111",
+			"identifier":"ENG-1",
+			"team":{"id":"team-1","key":"ENG"},
+			"relations":{"nodes":[{"id":"rel-1","type":"blocks"}],"pageInfo":{"hasNextPage":false,"endCursor":""}},
+			"inverseRelations":{"nodes":[{"id":"rel-2","type":"blocks"}],"pageInfo":{"hasNextPage":false,"endCursor":""}}
+		}}}`)
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{BaseURL: srv.URL}, 0, 0)
+	res, err := c.FetchIssueRelations("11111111-1111-1111-1111-111111111111", 50)
+	if err != nil {
+		t.Fatalf("FetchIssueRelations: %v", err)
+	}
+	if len(res.Relations) != 1 || len(res.InverseRelations) != 1 {
+		t.Fatalf("collected %d outgoing and %d incoming relations, want 1 and 1", len(res.Relations), len(res.InverseRelations))
+	}
+	if res.TeamKey != "ENG" {
+		t.Fatalf("TeamKey = %q, want ENG", res.TeamKey)
+	}
+}

--- a/library/project-management/linear/internal/client/relations_queries.go
+++ b/library/project-management/linear/internal/client/relations_queries.go
@@ -1,0 +1,315 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GraphQL documents for the issue-relation surface (IssueRelationType:
+// blocks, duplicate, related, similar).
+//
+// Direction, not a fifth type. Linear stores "A blocks B" as a single
+// IssueRelation{type: blocks, issue: A, relatedIssue: B}. It appears in
+// A.relations (outgoing) and in B.inverseRelations (incoming). "blocked by"
+// is therefore the incoming direction over a `blocks` relation and is never
+// a value of IssueRelation.type. Every consumer of these documents must
+// render it as a direction.
+
+// IssueRelationsQuery reads both relation connections of one issue in a
+// single document. $id is the issue UUID: the top-level issue(id:) argument
+// behaves inconsistently with TEAM-NUMBER identifiers across workspaces, so
+// callers resolve the identifier first.
+//
+// Both connections select the same node shape so consumers never have to
+// branch on which connection a node came from. IssueRelation exposes both
+// `issue` (the relation source) and `relatedIssue` (the relation target),
+// verified against the introspected schema.
+//
+// $includeArchived maps to the includeArchived Boolean argument carried by
+// both Issue.relations and Issue.inverseRelations, verified live in
+// api-inventory.json. Declaring the variable changes nothing for a caller who
+// does not pass it: an unprovided variable makes the argument absent rather
+// than null, so the server default (exclude archived) still applies.
+//
+// archivedAt is selected on the relation itself (IssueRelation.archivedAt:
+// DateTime) and on both issue projections (Issue.archivedAt: DateTime), both
+// verified live in api-inventory.json. It is null on everything live, so it is
+// free on the default path and is the only thing that tells an archived row
+// apart once includeArchived is on.
+const IssueRelationsQuery = `query($id: String!, $first: Int!, $after: String, $inverseAfter: String, $includeArchived: Boolean) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+    url
+    state { id name type }
+    team { id key }
+    relations(first: $first, after: $after, includeArchived: $includeArchived) {
+      nodes {
+        id
+        type
+        createdAt
+        archivedAt
+        issue { id identifier title url archivedAt state { id name type } }
+        relatedIssue { id identifier title url archivedAt state { id name type } }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+    inverseRelations(first: $first, after: $inverseAfter, includeArchived: $includeArchived) {
+      nodes {
+        id
+        type
+        createdAt
+        archivedAt
+        issue { id identifier title url archivedAt state { id name type } }
+        relatedIssue { id identifier title url archivedAt state { id name type } }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}`
+
+// IssueRelationCreateMutation creates one relation. IssueRelationCreateInput
+// requires type, issueId and relatedIssueId.
+const IssueRelationCreateMutation = `mutation($input: IssueRelationCreateInput!) {
+  issueRelationCreate(input: $input) {
+    success
+    issueRelation {
+      id
+      type
+      createdAt
+      issue { id identifier title url state { id name type } }
+      relatedIssue { id identifier title url state { id name type } }
+    }
+  }
+}`
+
+// IssueRelationDeleteMutation deletes one relation by its UUID and returns
+// the DeletePayload, whose entityId echoes the deleted relation.
+const IssueRelationDeleteMutation = `mutation($id: String!) {
+  issueRelationDelete(id: $id) {
+    success
+    entityId
+  }
+}`
+
+// UnblockedCandidatesQuery is the single crawl behind `unblocked`.
+//
+// $filter carries the open-group state predicate and the optional team, and
+// deliberately carries nothing about relations. IssueFilter's
+// hasBlockedByRelations is a bare RelationExistsComparator, and worse than
+// merely coarse: Linear stops matching an issue once all of its blockers
+// close, so filtering on it drops exactly the issues `unblocked` reports.
+// "Blocked by something" and "are all its blockers closed" are both decided
+// client-side over the inverseRelations this document selects inline, which
+// is why each relation node carries the blocking issue's own state.
+const UnblockedCandidatesQuery = `query($first: Int!, $after: String, $filter: IssueFilter, $relFirst: Int!) {
+  issues(first: $first, after: $after, filter: $filter) {
+    nodes {
+      id
+      identifier
+      title
+      url
+      priority
+      state { id name type }
+      team { id key }
+      inverseRelations(first: $relFirst) {
+        nodes {
+          id
+          type
+          createdAt
+          issue { id identifier title url state { id name type } }
+          relatedIssue { id identifier title url state { id name type } }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}`
+
+// IssueRelationState is the workflow state carried on either side of a
+// relation. Type is one of the seven API-documented WorkflowState.type
+// values and is what group predicates are evaluated against.
+type IssueRelationState struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// IssueRelationIssue is the issue projection carried on both sides of a
+// relation node.
+type IssueRelationIssue struct {
+	ID         string             `json:"id"`
+	Identifier string             `json:"identifier"`
+	Title      string             `json:"title"`
+	URL        string             `json:"url,omitempty"`
+	ArchivedAt string             `json:"archivedAt,omitempty"`
+	State      IssueRelationState `json:"state"`
+}
+
+// IssueRelationNode is one IssueRelation. Type is the IssueRelationType enum
+// value as returned by the API. Issue is the relation source, RelatedIssue is
+// the relation target, both always populated by the documents above.
+type IssueRelationNode struct {
+	ID           string             `json:"id"`
+	Type         string             `json:"type"`
+	CreatedAt    string             `json:"createdAt,omitempty"`
+	ArchivedAt   string             `json:"archivedAt,omitempty"`
+	Issue        IssueRelationIssue `json:"issue"`
+	RelatedIssue IssueRelationIssue `json:"relatedIssue"`
+}
+
+// IssueRelationsResult is the fully paged result of IssueRelationsQuery for
+// one issue. Relations are the outgoing side, InverseRelations the incoming
+// side. Subject is the issue the two connections hang off.
+type IssueRelationsResult struct {
+	Subject          IssueRelationIssue  `json:"issue"`
+	TeamID           string              `json:"team_id,omitempty"`
+	TeamKey          string              `json:"team_key,omitempty"`
+	Relations        []IssueRelationNode `json:"relations"`
+	InverseRelations []IssueRelationNode `json:"inverse_relations"`
+}
+
+// relationConnection is the wire shape of either connection.
+type relationConnection struct {
+	Nodes    []IssueRelationNode `json:"nodes"`
+	PageInfo struct {
+		HasNextPage bool   `json:"hasNextPage"`
+		EndCursor   string `json:"endCursor"`
+	} `json:"pageInfo"`
+}
+
+// defaultRelationPageSize is the per-connection page size. Relation counts
+// per issue are small in practice, so one page usually exhausts both sides.
+const defaultRelationPageSize = 50
+
+// maxRelationPages bounds the paging loop so a pathological issue cannot
+// spin forever against the rate-limit budget.
+const maxRelationPages = 20
+
+// FetchIssueRelations reads both relation connections of one issue to
+// exhaustion, excluding archived relations. issueID must be a UUID.
+// pageSize <= 0 uses the default.
+func (c *Client) FetchIssueRelations(issueID string, pageSize int) (IssueRelationsResult, error) {
+	return c.FetchIssueRelationsWith(issueID, pageSize, false)
+}
+
+// FetchIssueRelationsWith is FetchIssueRelations with the includeArchived
+// connection argument exposed. includeArchived is only sent when true, so the
+// default path emits exactly the variable set it always emitted.
+//
+// Nodes are deduplicated by relation id, which keeps the loop safe when a
+// finished connection is re-requested with its last cursor while the other
+// side is still paging.
+func (c *Client) FetchIssueRelationsWith(issueID string, pageSize int, includeArchived bool) (IssueRelationsResult, error) {
+	var out IssueRelationsResult
+	if issueID == "" {
+		return out, fmt.Errorf("fetching issue relations: empty issue id")
+	}
+	if pageSize <= 0 {
+		pageSize = defaultRelationPageSize
+	}
+	seenOutgoing := map[string]bool{}
+	seenIncoming := map[string]bool{}
+	var after, inverseAfter string
+	for range maxRelationPages {
+		vars := map[string]any{"id": issueID, "first": pageSize}
+		if includeArchived {
+			vars["includeArchived"] = true
+		}
+		if after != "" {
+			vars["after"] = after
+		}
+		if inverseAfter != "" {
+			vars["inverseAfter"] = inverseAfter
+		}
+		var resp struct {
+			Issue *struct {
+				IssueRelationIssue
+				Team struct {
+					ID  string `json:"id"`
+					Key string `json:"key"`
+				} `json:"team"`
+				Relations        relationConnection `json:"relations"`
+				InverseRelations relationConnection `json:"inverseRelations"`
+			} `json:"issue"`
+		}
+		if err := c.QueryInto(IssueRelationsQuery, vars, &resp); err != nil {
+			return out, err
+		}
+		if resp.Issue == nil || resp.Issue.ID == "" {
+			return out, fmt.Errorf("issue %q not found", issueID)
+		}
+		out.Subject = resp.Issue.IssueRelationIssue
+		out.TeamID = resp.Issue.Team.ID
+		out.TeamKey = resp.Issue.Team.Key
+		for _, n := range resp.Issue.Relations.Nodes {
+			if n.ID == "" || seenOutgoing[n.ID] {
+				continue
+			}
+			seenOutgoing[n.ID] = true
+			out.Relations = append(out.Relations, n)
+		}
+		for _, n := range resp.Issue.InverseRelations.Nodes {
+			if n.ID == "" || seenIncoming[n.ID] {
+				continue
+			}
+			seenIncoming[n.ID] = true
+			out.InverseRelations = append(out.InverseRelations, n)
+		}
+		moreOutgoing := resp.Issue.Relations.PageInfo.HasNextPage && resp.Issue.Relations.PageInfo.EndCursor != ""
+		moreIncoming := resp.Issue.InverseRelations.PageInfo.HasNextPage && resp.Issue.InverseRelations.PageInfo.EndCursor != ""
+		if !moreOutgoing && !moreIncoming {
+			return out, nil
+		}
+		if moreOutgoing {
+			after = resp.Issue.Relations.PageInfo.EndCursor
+		}
+		if moreIncoming {
+			inverseAfter = resp.Issue.InverseRelations.PageInfo.EndCursor
+		}
+	}
+	return out, nil
+}
+
+// FetchIssueInverseRelations pages only the incoming side of one issue. Used
+// by the unblocked traversal when a candidate's first inline page of
+// inverseRelations was truncated, so the "all blockers closed" verdict is
+// never computed from a partial blocker set.
+func (c *Client) FetchIssueInverseRelations(issueID string, pageSize int) ([]IssueRelationNode, error) {
+	res, err := c.FetchIssueRelations(issueID, pageSize)
+	if err != nil {
+		return nil, err
+	}
+	return res.InverseRelations, nil
+}
+
+// DecodeIssueRelationCreate parses an issueRelationCreate response.
+func DecodeIssueRelationCreate(raw json.RawMessage) (IssueRelationNode, bool, error) {
+	var parsed struct {
+		IssueRelationCreate struct {
+			Success       bool              `json:"success"`
+			IssueRelation IssueRelationNode `json:"issueRelation"`
+		} `json:"issueRelationCreate"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return IssueRelationNode{}, false, fmt.Errorf("parsing issueRelationCreate response: %w", err)
+	}
+	return parsed.IssueRelationCreate.IssueRelation, parsed.IssueRelationCreate.Success, nil
+}
+
+// DecodeIssueRelationDelete parses an issueRelationDelete response and
+// returns the echoed entity id.
+func DecodeIssueRelationDelete(raw json.RawMessage) (string, bool, error) {
+	var parsed struct {
+		IssueRelationDelete struct {
+			Success  bool   `json:"success"`
+			EntityID string `json:"entityId"`
+		} `json:"issueRelationDelete"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return "", false, fmt.Errorf("parsing issueRelationDelete response: %w", err)
+	}
+	return parsed.IssueRelationDelete.EntityID, parsed.IssueRelationDelete.Success, nil
+}

--- a/library/project-management/linear/internal/client/relations_queries.go
+++ b/library/project-management/linear/internal/client/relations_queries.go
@@ -185,7 +185,11 @@ type relationConnection struct {
 const defaultRelationPageSize = 50
 
 // maxRelationPages bounds the paging loop so a pathological issue cannot
-// spin forever against the rate-limit budget.
+// spin forever against the rate-limit budget. Hitting the bound is an error,
+// never a short read: every consumer of this result treats "absent" as
+// "no such relation", so a silently truncated set makes `relations list` drop
+// links, makes idempotent creation duplicate an existing relation, and lets
+// `unblocked` call an issue actionable while an unseen blocker is still open.
 const maxRelationPages = 20
 
 // FetchIssueRelations reads both relation connections of one issue to
@@ -270,7 +274,10 @@ func (c *Client) FetchIssueRelationsWith(issueID string, pageSize int, includeAr
 			inverseAfter = resp.Issue.InverseRelations.PageInfo.EndCursor
 		}
 	}
-	return out, nil
+	return out, fmt.Errorf(
+		"issue %s has more relations than %d pages of %d can read: refusing to answer from a partial relation set, retry with a larger page size",
+		issueID, maxRelationPages, pageSize,
+	)
 }
 
 // FetchIssueInverseRelations pages only the incoming side of one issue. Used

--- a/library/project-management/linear/internal/client/write_families_a_queries.go
+++ b/library/project-management/linear/internal/client/write_families_a_queries.go
@@ -1,0 +1,254 @@
+package client
+
+// GraphQL documents for the tier-2 write families: issue labels, workflow
+// states, cycles, comment lifecycle, and issue lifecycle.
+//
+// Every mutation name, argument name, and input-object field used below was
+// read out of the introspection snapshot in
+// .goal-linear-coverage/api-inventory.json before the document was written.
+// Nothing here is guessed, and no deprecated field is selected (IssueLabel
+// .organization is deprecated and is deliberately absent).
+
+// Field projections shared by the documents in this file. Keeping them as
+// constants means a create and its matching update return byte-identical
+// shapes, so a caller can render either through the same code path.
+const (
+	issueLabelFields = `id name color description isGroup retiredAt lastAppliedAt createdAt updatedAt
+      team { id key name }
+      parent { id name }`
+
+	workflowStateFields = `id name type color description position createdAt updatedAt archivedAt
+      team { id key name }`
+
+	cycleFields = `id number name description startsAt endsAt completedAt autoArchivedAt
+      isActive isFuture isPast progress createdAt updatedAt
+      team { id key name }`
+
+	commentFields = `id body url quotedText createdAt updatedAt resolvedAt
+      user { id name displayName email }
+      issue { id identifier title }
+      parent { id }
+      resolvingUser { id name displayName }
+      resolvingComment { id }`
+
+	issueLifecycleFields = `id identifier title url archivedAt trashed updatedAt
+      state { id name type }
+      team { id key name }`
+)
+
+// IssueLabelCreateMutation creates a workspace label (teamId omitted) or a
+// team label (teamId set).
+//
+// verified live in api-inventory.json
+const IssueLabelCreateMutation = `mutation($input: IssueLabelCreateInput!) {
+  issueLabelCreate(input: $input) {
+    success
+    issueLabel { ` + issueLabelFields + ` }
+  }
+}`
+
+// verified live in api-inventory.json
+const IssueLabelUpdateMutation = `mutation($id: String!, $input: IssueLabelUpdateInput!) {
+  issueLabelUpdate(id: $id, input: $input) {
+    success
+    issueLabel { ` + issueLabelFields + ` }
+  }
+}`
+
+// IssueLabelDeleteMutation returns DeletePayload, which carries entityId
+// rather than the deleted object.
+//
+// verified live in api-inventory.json
+const IssueLabelDeleteMutation = `mutation($id: String!) {
+  issueLabelDelete(id: $id) {
+    success
+    entityId
+  }
+}`
+
+// IssueLabelRetireMutation is the soft-delete half of the modern pair: a
+// retired label stays visible on existing issues but cannot be applied to
+// new ones. Distinct from issueLabelDelete.
+//
+// verified live in api-inventory.json
+const IssueLabelRetireMutation = `mutation($id: String!) {
+  issueLabelRetire(id: $id) {
+    success
+    issueLabel { ` + issueLabelFields + ` }
+  }
+}`
+
+// verified live in api-inventory.json
+const IssueLabelRestoreMutation = `mutation($id: String!) {
+  issueLabelRestore(id: $id) {
+    success
+    issueLabel { ` + issueLabelFields + ` }
+  }
+}`
+
+// WorkflowStateCreateMutation requires type, name, color, and teamId.
+// WorkflowStateCreateInput.type accepts only backlog, unstarted, started,
+// completed, and canceled: triage and duplicate states are provisioned by
+// Linear itself and cannot be created through the API.
+//
+// verified live in api-inventory.json
+const WorkflowStateCreateMutation = `mutation($input: WorkflowStateCreateInput!) {
+  workflowStateCreate(input: $input) {
+    success
+    workflowState { ` + workflowStateFields + ` }
+  }
+}`
+
+// WorkflowStateUpdateMutation carries no type field. WorkflowStateUpdateInput
+// exposes only name, color, description, and position, so a state's type is
+// immutable once created.
+//
+// verified live in api-inventory.json
+const WorkflowStateUpdateMutation = `mutation($id: String!, $input: WorkflowStateUpdateInput!) {
+  workflowStateUpdate(id: $id, input: $input) {
+    success
+    workflowState { ` + workflowStateFields + ` }
+  }
+}`
+
+// WorkflowStateArchiveMutation returns WorkflowStateArchivePayload, whose
+// object field is named entity, not workflowState.
+//
+// verified live in api-inventory.json
+const WorkflowStateArchiveMutation = `mutation($id: String!) {
+  workflowStateArchive(id: $id) {
+    success
+    entity { ` + workflowStateFields + ` }
+  }
+}`
+
+// verified live in api-inventory.json
+const CycleCreateMutation = `mutation($input: CycleCreateInput!) {
+  cycleCreate(input: $input) {
+    success
+    cycle { ` + cycleFields + ` }
+  }
+}`
+
+// verified live in api-inventory.json
+const CycleUpdateMutation = `mutation($id: String!, $input: CycleUpdateInput!) {
+  cycleUpdate(id: $id, input: $input) {
+    success
+    cycle { ` + cycleFields + ` }
+  }
+}`
+
+// CycleArchiveMutation returns CycleArchivePayload, whose object field is
+// named entity, not cycle.
+//
+// verified live in api-inventory.json
+const CycleArchiveMutation = `mutation($id: String!) {
+  cycleArchive(id: $id) {
+    success
+    entity { ` + cycleFields + ` }
+  }
+}`
+
+// CycleShiftAllMutation takes CycleShiftAllInput, whose only two fields are
+// id (the cycle to start shifting from) and daysToShift (a Float).
+//
+// verified live in api-inventory.json
+const CycleShiftAllMutation = `mutation($input: CycleShiftAllInput!) {
+  cycleShiftAll(input: $input) {
+    success
+    cycle { ` + cycleFields + ` }
+  }
+}`
+
+// CycleStartUpcomingCycleTodayMutation takes a bare id and only accepts the
+// team's next not-yet-started cycle.
+//
+// verified live in api-inventory.json
+const CycleStartUpcomingCycleTodayMutation = `mutation($id: String!) {
+  cycleStartUpcomingCycleToday(id: $id) {
+    success
+    cycle { ` + cycleFields + ` }
+  }
+}`
+
+// verified live in api-inventory.json
+const CommentDeleteMutation = `mutation($id: String!) {
+  commentDelete(id: $id) {
+    success
+    entityId
+  }
+}`
+
+// CommentResolveMutation takes resolvingCommentId as a top-level optional
+// argument, not as an input object.
+//
+// verified live in api-inventory.json
+const CommentResolveMutation = `mutation($id: String!, $resolvingCommentId: String) {
+  commentResolve(id: $id, resolvingCommentId: $resolvingCommentId) {
+    success
+    comment { ` + commentFields + ` }
+  }
+}`
+
+// verified live in api-inventory.json
+const CommentUnresolveMutation = `mutation($id: String!) {
+  commentUnresolve(id: $id) {
+    success
+    comment { ` + commentFields + ` }
+  }
+}`
+
+// IssueArchiveMutation accepts an optional trash argument. Note that
+// issueArchive returns IssueArchivePayload, whose object field is entity.
+//
+// verified live in api-inventory.json
+const IssueArchiveMutation = `mutation($id: String!, $trash: Boolean) {
+  issueArchive(id: $id, trash: $trash) {
+    success
+    entity { ` + issueLifecycleFields + ` }
+  }
+}`
+
+// verified live in api-inventory.json
+const IssueUnarchiveMutation = `mutation($id: String!) {
+  issueUnarchive(id: $id) {
+    success
+    entity { ` + issueLifecycleFields + ` }
+  }
+}`
+
+// IssueDeleteMutation trashes an issue. permanentlyDelete skips the 30-day
+// grace period and is admin-only, so it stays behind an explicit flag.
+//
+// verified live in api-inventory.json
+const IssueDeleteMutation = `mutation($id: String!, $permanentlyDelete: Boolean) {
+  issueDelete(id: $id, permanentlyDelete: $permanentlyDelete) {
+    success
+    entity { ` + issueLifecycleFields + ` }
+  }
+}`
+
+// IssueSubscribeMutation defaults to the current user when neither userId nor
+// userEmail is supplied. Returns IssuePayload, whose object field is issue.
+//
+// verified live in api-inventory.json
+const IssueSubscribeMutation = `mutation($id: String!, $userId: String, $userEmail: String) {
+  issueSubscribe(id: $id, userId: $userId, userEmail: $userEmail) {
+    success
+    issue {
+      ` + issueLifecycleFields + `
+      subscribers { nodes { id name displayName email } }
+    }
+  }
+}`
+
+// verified live in api-inventory.json
+const IssueUnsubscribeMutation = `mutation($id: String!, $userId: String, $userEmail: String) {
+  issueUnsubscribe(id: $id, userId: $userId, userEmail: $userEmail) {
+    success
+    issue {
+      ` + issueLifecycleFields + `
+      subscribers { nodes { id name displayName email } }
+    }
+  }
+}`

--- a/library/project-management/linear/internal/store/pp_fixtures.go
+++ b/library/project-management/linear/internal/store/pp_fixtures.go
@@ -40,6 +40,29 @@ func (s *Store) IsPPCreated(issueID string) (bool, error) {
 	return n > 0, nil
 }
 
+// IsPPCreatedRef is IsPPCreated for a reference that may still be an issue
+// identifier rather than a UUID. The ledger records the identifier the create
+// mutation returned, so a strict-mode check can be answered offline: resolving
+// TEAM-NUMBER to a UUID needs the API, and --dry-run must not reach it.
+func (s *Store) IsPPCreatedRef(ref string) (bool, error) {
+	if ref == "" {
+		return false, nil
+	}
+	var n int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM pp_created
+		 WHERE archived_at IS NULL AND (issue_id = ? OR UPPER(IFNULL(identifier, '')) = UPPER(?))`,
+		ref, ref,
+	).Scan(&n)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
 // ListPPFixtures returns active (non-archived) fixtures for a given session,
 // or for all sessions if session is empty.
 func (s *Store) ListPPFixtures(session string) ([]PPFixture, error) {


### PR DESCRIPTION
## Gaps closed

- **GAP-008** Duplicate-close two-step trap: setting a duplicate-typed state without first creating the duplicate relation produces an orphaned close.
- **GAP-011** No append-to-description primitive: `issues edit --description` replaces the body wholesale. (MUST-SHIP 6 prerequisite)
- **GAP-012** `issueArchive` is reachable only through `pp-cleanup`, and there is no `issues archive`, `unarchive` or `delete`.
- **GAP-013** No `--due-date` on create or edit.
- **GAP-014** Broad input-field deficit: 27 of 36 live create fields and 26 of 34 live update fields had no flag, including `estimate`, `cycleId`, `projectMilestoneId`, `subscriberIds` and `teamId` on update.
- **GAP-015** `--label` is replace-only, so adding one label silently dropped the others.
- **GAP-016** Team default templates are never applied on create: `useDefaultTemplate` and `templateId` had no flags.
- **GAP-031** `issueSubscribe` / `issueUnsubscribe` absent.
- **GAP-034** Batch mutations absent: `issueBatchCreate` and `issueBatchUpdate`.
- **GAP-037** `--trust-mode strict` was weaker than documented: `store.IsPPCreated` had zero callers.

## Design

The input-field audit drove this slice: every live field on `IssueCreateInput` and `IssueUpdateInput` was enumerated against the existing flag set, and the uncovered ones were added rather than guessed at. Two of them were resolved questions rather than new work. `useDefaultTemplate` and `templateId` are live server-side fields with server-defined override precedence, so default-template support is two flags and not a client-side apply. `addedLabelIds` and `removedLabelIds` exist alongside `labelIds`, so label edits stop being lossy. `close-duplicate` is the ordering guarantee for the duplicate trap: relation first, state second, so a mid-flight failure leaves a linked pair rather than an orphaned close. The trust gate is now actually enforced: `--trust-mode strict` refuses to mutate any issue absent from the local `pp_created` ledger, with `pp-cleanup` exempt because it only ever touches ledger rows.

## Verification

```
$ linear-pp-cli issues close-duplicate ACC-258 --of ACC-257 --yes --agent
{"event":"issue_closed_as_duplicate","identifier":"ACC-258","canonical":"ACC-257",
 "relation":"created","relation_id":"b6758269-...","state_id":"31b3f3de-...",
 "steps":["issueRelationCreate","issueUpdate"]}
```

`steps` reports the documented order, relation first and then state, and the read-back confirms both halves landed:

```
$ linear-pp-cli issues get ACC-258 --data-source live --no-cache   -> state {"name":"Duplicate","type":"duplicate"}
$ linear-pp-cli relations list ACC-258 --no-cache                  -> duplicate outgoing ACC-258 -> ACC-257
```

New create flags, verified by read-back rather than by the mutation echo:

```
$ linear-pp-cli issues create --team ACC --title "..." --due-date 2026-09-01 --estimate 3 --use-default-template --trust-mode strict --agent
$ linear-pp-cli issues get ACC-259 --data-source live --json
identifier = "ACC-259"
dueDate    = "2026-09-01"
estimate   = 3
```

Lifecycle:

```
$ linear-pp-cli issues archive ACC-259 --yes --agent    -> archivedAt 2026-08-11T19:19:51.517Z
$ linear-pp-cli issues list --state all --team ACC --no-cache  -> ACC-259 present: False
$ linear-pp-cli issues archive ACC-263 --agent          -> archivedAt 2026-08-11T19:51:41.048Z
$ linear-pp-cli issues unarchive ACC-263 --agent        -> exit 0, archivedAt null
```

`unarchive` accepts an identifier, not only a UUID. The first cut of this command exited 3 `not_found` on every identifier because the resolver excluded archived issues, which is the only set unarchive can ever operate on.

Batch create and the trust ledger:

```
$ linear-pp-cli pp-test list --session <tag> --agent    -> 5 ledger rows: ACC-260, ACC-259, ACC-258, ACC-257, ACC-256
$ linear-pp-cli pp-cleanup --session <tag> --force      -> 5 archived, 0 failed
$ linear-pp-cli pp-test list --session <tag> --agent    -> null
```

Build, vet and the full test suite are green.

---

Stacked on #1694. Review the diff against `feat/linear-relations-unblocked`.
