### PR TITLE
fix(gitignore): ignore symlinked project skill installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,10 +66,17 @@ AGENTS.override.md
 # experimental skills live next to this checkout without being published from
 # this public repo. Already-tracked files remain tracked unless intentionally
 # removed from git later.
-.claude/skills/
-.skills/
-.agents/skills/
-.codex/skills/
-.cursor/skills/
-.gemini/skills/
+#
+# Deliberately no trailing slashes: a trailing slash matches directories only,
+# and git classifies a symlink as a file. Sharing one skill install across git
+# worktrees by symlinking these paths is common, and a slash-suffixed pattern
+# leaves that symlink untracked-but-not-ignored -- exactly what these rules
+# exist to prevent. Keep them slashless so both the real directory and a
+# symlink to it are ignored.
+.claude/skills
+.skills
+.agents/skills
+.codex/skills
+.cursor/skills
+.gemini/skills
 /skills-lock.json


### PR DESCRIPTION
## Summary

The six project-scoped skill install patterns added in #1409 carry trailing slashes. A trailing slash matches **directories only**, and git classifies a symlink as a file — so a symlinked skills directory is untracked but *not* ignored. It shows in `git status` as `?? .claude/skills` and one `git add -A` sweeps it into a commit.

That is the precise failure #1409 set out to prevent:

> Project-scoped private agent skills can now live beside this public library checkout **without showing up as untracked files or getting committed by accident.**

Symlinking is the natural way to share one skill install across git worktrees, since worktrees share `.git` but not untracked files. Anyone doing that today has an unignored path sitting in a public-repo checkout.

Dropping the trailing slashes makes each pattern match the real directory, a symlink to it, and its contents. `/skills-lock.json` is already slashless and is unchanged.

## Why this survived two rounds of review

Both #1409 and #1410 verified with a path *inside* the directory:

```
git check-ignore -v .claude/skills/example
```

That passes with or without the trailing slash, because the parent directory match propagates to contents. Neither PR tested the directory entry itself, and neither tested a symlink — so the gap was invisible to the check that was run.

## Verification

Reproduced in a throwaway repo containing only these patterns, testing each path three ways. Before (trailing slashes, current `main`):

| Pattern | real dir | symlink |
|---|---|---|
| `.claude/skills` | IGNORED | **NOT-IGNORED** |
| `.agents/skills` | IGNORED | **NOT-IGNORED** |
| `.codex/skills` | IGNORED | **NOT-IGNORED** |
| `.cursor/skills` | IGNORED | **NOT-IGNORED** |
| `.gemini/skills` | IGNORED | **NOT-IGNORED** |
| `.skills` | IGNORED | **NOT-IGNORED** |

After this change:

| Pattern | real dir | nested file | symlink |
|---|---|---|---|
| `.claude/skills` | IGNORED | IGNORED | IGNORED |
| `.agents/skills` | IGNORED | IGNORED | IGNORED |
| `.codex/skills` | IGNORED | IGNORED | IGNORED |
| `.cursor/skills` | IGNORED | IGNORED | IGNORED |
| `.gemini/skills` | IGNORED | IGNORED | IGNORED |
| `.skills` | IGNORED | IGNORED | IGNORED |

Both invariants the original PRs asserted are preserved:

- nested files under a real skills directory stay ignored
- root `/skills-lock.json` IGNORED, nested `skills/example/skills-lock.json` NOT-IGNORED

The only behavior newly caught is a plain *file* at one of these six paths, which has no legitimate use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
