### PR TITLE
fix(recipe-goat): document recipe stack in agent surfaces

### DIFF
--- a/library/food-and-dining/recipe-goat/.printing-press-patches/recipe-stack-agent-surface-index.json
+++ b/library/food-and-dining/recipe-goat/.printing-press-patches/recipe-stack-agent-surface-index.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "recipe-stack-agent-surface-index",
+  "applied_at": "2026-08-17",
+  "base_run_id": "20260426-002121",
+  "base_printing_press_version": "3.6.0",
+  "summary": "Recipe Goat's agent docs and curated which index must advertise the full recipe stack, not only the USDA foods endpoints.",
+  "reason": "The published binary includes cross-site recipe search/ranking, recipe inspection, substitutions, cookbook, meal-planning, cook-log, and data workflow commands; a foods-only SKILL.md and which index route agent recipe queries to the wrong surface.",
+  "files": [
+    "SKILL.md",
+    "internal/cli/which.go",
+    "internal/cli/which_test.go"
+  ],
+  "validated_outcome": "The which regression keeps recipe search above foods search for natural-language recipe queries while retaining foods search as a discoverable nutrition lookup."
+}

--- a/library/food-and-dining/recipe-goat/SKILL.md
+++ b/library/food-and-dining/recipe-goat/SKILL.md
@@ -47,6 +47,80 @@ This CLI uses Chrome-compatible HTTP transport for browser-facing endpoints. It 
 
 ## Command Reference
 
+**goat** — Cross-site recipe ranker
+
+- `recipe-goat-pp-cli goat <query>` — Fetch candidates across curated recipe sites, then rank by query relevance, rating, review volume, recency, and site trust
+
+**search** — Recipe title search across curated sites
+
+- `recipe-goat-pp-cli search <query>` — Search recipe titles across curated sites without fetching the full recipe; use `--site`, `--kid-friendly`, `--in-season`, and `--limit` to narrow results
+
+**recipe** — Fetch, open, and inspect recipes
+
+- `recipe-goat-pp-cli recipe get <url>` — Fetch and render a recipe from its source URL, with optional serving scaling, unit conversion, Markdown/plain output, and USDA nutrition backfill
+- `recipe-goat-pp-cli recipe open <id>` — Open a saved recipe in the default browser
+- `recipe-goat-pp-cli recipe reviews <id>` — Show the review-modification digest placeholder for a saved recipe
+- `recipe-goat-pp-cli recipe cost <id>` — Estimate per-serving cost for a saved recipe
+
+**trending** — Top recipes on curated recipe sites
+
+- `recipe-goat-pp-cli trending` — Show recipes currently featured on each site's homepage; use `--site` and `--limit` to scope the fan-out
+
+**sub** — Culinary substitutions
+
+- `recipe-goat-pp-cli sub <ingredient>` — Look up substitutions for an ingredient, optionally filtered by context or vegan-friendly suggestions
+
+**trust** — Site trust scores for the ranker
+
+- `recipe-goat-pp-cli trust list` — List built-in per-site trust scores
+- `recipe-goat-pp-cli trust set <site> <delta>` — Save a local per-site trust adjustment for ranker experimentation
+
+**save** — Local cookbook capture
+
+- `recipe-goat-pp-cli save [url]` — Fetch and save one recipe URL, or read URLs from stdin with `--stdin`; attach local tags with `--tags`
+
+**cookbook** — Local cookbook search, tags, and pantry match
+
+- `recipe-goat-pp-cli cookbook list` — List saved recipes, optionally filtered by tag, site, or author
+- `recipe-goat-pp-cli cookbook search <query>` — Full-text search saved recipes by title and ingredients, with include/exclude ingredient filters
+- `recipe-goat-pp-cli cookbook match` — Find saved recipes you can make from pantry ingredients supplied with `--have`
+- `recipe-goat-pp-cli cookbook tag <id> <tag>[,<tag>]` — Attach one or more tags to a saved recipe
+- `recipe-goat-pp-cli cookbook untag <id> <tag>` — Remove a tag from a saved recipe
+- `recipe-goat-pp-cli cookbook remove <id>` — Remove a recipe from the local cookbook
+
+**tonight** — Dinner picker from the local cookbook
+
+- `recipe-goat-pp-cli tonight` — Pick dinner from saved recipes by max time, recency, dietary filters, tag, and result limit
+
+**meal-plan** — Meal planning and shopping lists
+
+- `recipe-goat-pp-cli meal-plan set <date> <meal> <recipe-id>` — Plan a saved recipe for a specific date and meal slot
+- `recipe-goat-pp-cli meal-plan show` — Show planned meals over a date range or current week
+- `recipe-goat-pp-cli meal-plan remove <date> <meal>` — Clear a planned meal slot
+- `recipe-goat-pp-cli meal-plan shopping-list` — Aggregate ingredients across planned meals, optionally grouped by aisle or exported as Markdown, text, or CSV
+
+**cook** — Cooking session log
+
+- `recipe-goat-pp-cli cook log <recipe-id>` — Log a cooking session with rating, notes, and optional date
+- `recipe-goat-pp-cli cook history` — List past cooking sessions, optionally filtered by recipe or time window
+
+**sync** — Local SQLite sync for API-backed resources
+
+- `recipe-goat-pp-cli sync` — Sync API data to local SQLite for offline search and analysis, with resource, checkpoint, pagination, and concurrency controls
+
+**export** — Data export
+
+- `recipe-goat-pp-cli export <resource> [id]` — Export API data as JSONL or JSON for backup, migration, or analysis
+
+**import** — JSONL import
+
+- `recipe-goat-pp-cli import <resource>` — Import records from JSONL by issuing API create/upsert calls; use `--dry-run` to preview without sending
+
+**workflow** — Compound data workflows
+
+- `recipe-goat-pp-cli workflow archive` — Sync all supported resources to the local store for offline access and search
+- `recipe-goat-pp-cli workflow status` — Show local archive status and sync state
+
 **foods** — USDA FoodData Central — ingredient nutrition lookups
 
 - `recipe-goat-pp-cli foods get` — Get a specific food by FDC ID

--- a/library/food-and-dining/recipe-goat/internal/cli/which.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/which.go
@@ -28,6 +28,35 @@ type whichEntry struct {
 // `--help`; `which` exists to resolve a natural-language capability
 // query to one of the commands the skill says matter most.
 var whichIndex = []whichEntry{
+	{Command: "goat", Description: "Fetch and rank recipe candidates across curated sites by relevance, ratings, reviews, recency, and site trust", Group: "recipe search"},
+	{Command: "search", Description: "Search recipe titles across curated sites by dish, ingredient, or keyword without fetching full recipes", Group: "recipe search"},
+	{Command: "recipe get", Description: "Fetch and render a recipe URL with optional scaling, unit conversion, Markdown output, and USDA nutrition backfill", Group: "recipe"},
+	{Command: "recipe open", Description: "Open a saved recipe in the default browser", Group: "recipe"},
+	{Command: "recipe reviews", Description: "Show the review-derived modification digest placeholder for a saved recipe", Group: "recipe"},
+	{Command: "recipe cost", Description: "Estimate per-serving cost for a saved recipe", Group: "recipe"},
+	{Command: "trending", Description: "Show top recipes currently featured on curated recipe sites' homepages", Group: "recipe discovery"},
+	{Command: "sub", Description: "Look up culinary substitutions for an ingredient with context and vegan-friendly filters", Group: "ingredient substitutions"},
+	{Command: "trust list", Description: "List built-in per-site trust scores used by the cross-site recipe ranker", Group: "ranking trust"},
+	{Command: "trust set", Description: "Save a local per-site trust adjustment for ranker experimentation", Group: "ranking trust"},
+	{Command: "save", Description: "Fetch and save recipe URLs to the local cookbook with optional tags", Group: "cookbook"},
+	{Command: "cookbook list", Description: "List saved recipes in the local cookbook filtered by tag, site, or author", Group: "cookbook"},
+	{Command: "cookbook search", Description: "Full-text search saved recipes by title and ingredients, with include and exclude ingredient filters", Group: "cookbook search"},
+	{Command: "cookbook match", Description: "Find saved recipes you can make from pantry ingredients and an allowed missing-ingredient count", Group: "pantry cookbook"},
+	{Command: "cookbook tag", Description: "Attach one or more tags to a saved recipe", Group: "cookbook"},
+	{Command: "cookbook untag", Description: "Remove a tag from a saved recipe", Group: "cookbook"},
+	{Command: "cookbook remove", Description: "Remove a recipe from the local cookbook", Group: "cookbook"},
+	{Command: "tonight", Description: "Pick dinner from saved recipes by max cook time, recency, dietary filters, tag, and limit", Group: "meal planning"},
+	{Command: "meal-plan set", Description: "Plan a saved recipe for a date and meal slot", Group: "meal planning"},
+	{Command: "meal-plan show", Description: "Show planned meals over a date range or current week", Group: "meal planning"},
+	{Command: "meal-plan remove", Description: "Clear a planned meal slot", Group: "meal planning"},
+	{Command: "meal-plan shopping-list", Description: "Aggregate ingredients across planned meals into a shopping list grouped by aisle or exported as Markdown, text, or CSV", Group: "shopping list"},
+	{Command: "cook log", Description: "Log a cooking session with rating, notes, and optional date", Group: "cook log"},
+	{Command: "cook history", Description: "List past cooking sessions by recipe or time window", Group: "cook log"},
+	{Command: "sync", Description: "Sync API-backed resources to local SQLite for offline search and analysis", Group: "data"},
+	{Command: "export", Description: "Export API data as JSONL or JSON for backup, migration, or analysis", Group: "data"},
+	{Command: "import", Description: "Import records from JSONL by issuing API create or upsert calls, with dry-run preview support", Group: "data"},
+	{Command: "workflow archive", Description: "Sync all supported resources to the local store for offline access and search", Group: "data workflow"},
+	{Command: "workflow status", Description: "Show local archive status and sync state", Group: "data workflow"},
 	{Command: "foods get", Description: "Get a specific food by FDC ID", Group: "foods"},
 	{Command: "foods list", Description: "List foods paginated", Group: "foods"},
 	{Command: "foods search", Description: "Search USDA FoodData Central for foods matching a query", Group: "foods"},
@@ -136,14 +165,14 @@ func newWhichCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{
 			"pp:typed-exit-codes": "0,2",
 		},
-		Long: `which resolves a natural-language capability query (for example, "search messages" or "stale tickets") to the best matching command from this CLI's curated feature index.
+		Long: `which resolves a natural-language capability query (for example, "search recipes" or "ingredient substitution") to the best matching command from this CLI's curated feature index.
 
 Exit codes:
   0  at least one match found
   2  no confident match - the query did not score against any indexed capability; fall back to '--help' or 'search' if this CLI has one`,
-		Example: `  recipe-goat-pp-cli which "stale tickets"
-  recipe-goat-pp-cli which "bottleneck"
-  recipe-goat-pp-cli which --limit 1 "send message"
+		Example: `  recipe-goat-pp-cli which "search recipes by ingredient"
+  recipe-goat-pp-cli which "substitute buttermilk"
+  recipe-goat-pp-cli which --limit 1 "shopping list"
   recipe-goat-pp-cli which                                # list the full capability index`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(whichIndex) == 0 {

--- a/library/food-and-dining/recipe-goat/internal/cli/which_test.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/which_test.go
@@ -96,3 +96,49 @@ func TestWhichIndex_ExistsAndIsWellFormed(t *testing.T) {
 		}
 	}
 }
+
+func TestWhichIndex_RecipeSearchQueryPrefersRecipeSearch(t *testing.T) {
+	got := rankWhich(whichIndex, "search for recipes using a specific ingredient", 3)
+	if len(got) == 0 {
+		t.Fatalf("expected recipe search match, got zero")
+	}
+	if got[0].Entry.Command != "search" {
+		t.Fatalf("top match: want search, got %s (%+v)", got[0].Entry.Command, got)
+	}
+	for _, match := range got {
+		if match.Entry.Command == "foods search" {
+			return
+		}
+	}
+	t.Fatalf("expected foods search to remain discoverable below recipe search, got %+v", got)
+}
+
+func TestWhichIndex_CoversRecipeStack(t *testing.T) {
+	want := []string{
+		"goat",
+		"search",
+		"recipe get",
+		"trending",
+		"sub",
+		"trust list",
+		"save",
+		"cookbook match",
+		"tonight",
+		"meal-plan shopping-list",
+		"cook log",
+		"sync",
+		"export",
+		"import",
+		"workflow archive",
+		"foods search",
+	}
+	have := map[string]bool{}
+	for _, entry := range whichIndex {
+		have[entry.Command] = true
+	}
+	for _, command := range want {
+		if !have[command] {
+			t.Errorf("whichIndex missing %q", command)
+		}
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Closes #1731.
- Expands recipe-goat's library SKILL.md Command Reference beyond USDA `foods` to cover the implemented recipe search/ranking, recipe inspection, substitutions, cookbook, meal-planning, cook-log, data, and workflow commands.
- Updates the curated `which` feature index so natural-language recipe searches resolve to recipe commands before `foods search`.
- Adds a recipe-goat patch record and targeted `which` regressions for the reported query shape.

## Published CLI Metadata

**API:** `recipe-goat` | **Category:** `food-and-dining` | **Press version:** `3.6.0`
**Spec:** `library/food-and-dining/recipe-goat/spec.yaml`  
**Required env:** `USDA_FDC_API_KEY` for USDA nutrition lookups

## What Changed

- `library/food-and-dining/recipe-goat/SKILL.md` now documents the implemented recipe stack plus `foods`.
- `internal/cli/which.go` now indexes the recipe stack and uses recipe-goat examples.
- `internal/cli/which_test.go` now checks that "search for recipes using a specific ingredient" prefers `search` while keeping `foods search` discoverable.

## CLI Shape

```bash
$ recipe-goat-pp-cli --help
Manage recipe-goat resources via the recipe-goat API.

Add --agent to any command for JSON output + non-interactive mode.
Run 'recipe-goat-pp-cli doctor' to verify auth and connectivity.

Usage:
  recipe-goat-pp-cli [command]

Available Commands:
  agent-context Emit structured JSON describing this CLI for agents
  auth          Manage the optional USDA_FDC_API_KEY (enables features that require it; not needed for core commands)
  completion    Generate the autocompletion script for the specified shell
  cook          Track what you cooked — log sessions and view history
  cookbook      Manage your saved cookbook (list, search, tag, match)
  doctor        Check CLI health
  export        Export data to JSONL or JSON for backup, migration, or analysis
  feedback      Record feedback about this CLI (local by default; upstream opt-in)
  foods         USDA FoodData Central — ingredient nutrition lookups
  goat          Cross-site recipe ranker — fetch candidates and rank by query relevance, rating, popularity, and site trust
  help          Help about any command
  import        Import data from JSONL file via API create/upsert calls
  meal-plan     Plan meals by date and slot, and generate shopping lists
  profile       Named sets of flags saved for reuse
  recipe        Fetch, open, and inspect recipes from curated sites
  save          Save a recipe to the local cookbook
  search        Search recipe titles across curated sites without fetching the full recipes (returns metadata only)
  sub           Look up culinary substitutions for an ingredient, optionally filtered by recipe context (baking, dairy-free, etc.)
  sync          Sync API data to local SQLite for offline search and analysis
  tonight       Pick dinner from your saved cookbook by max cook time, recency, and dietary tags
  trending      Show the top recipes currently featured on each site's homepage
  trust         View and override per-site trust scores used by the cross-site ranker
  version       Print version
  which         Find the command that implements a capability
  workflow      Compound workflows that combine multiple API operations

Flags:
      --agent                Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)
      --compact              Return only key fields (id, name, status, timestamps) for minimal token usage
      --config string        Config file path
      --csv                  Output as CSV (table and array responses)
      --data-source string   Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default "auto")
      --deliver string       Route output to a sink: stdout (default), file:<path>, webhook:<url>
      --dry-run              Show request without sending
  -h, --help                 help for recipe-goat-pp-cli
      --human-friendly       Enable colored output and rich formatting
      --json                 Output as JSON
      --no-cache             Bypass response cache
      --no-color             Disable colored output
      --no-input             Disable all interactive prompts (for CI/agents)
      --plain                Output as plain tab-separated text
      --profile string       Apply values from a saved profile (see 'recipe-goat-pp-cli profile list')
      --quiet                Bare output, one value per line
      --rate-limit float     Max requests per second (0 to disable)
      --select string        Comma-separated fields to include in output (e.g. --select id,name,status)
      --timeout duration     Request timeout (default 30s)
  -v, --version              version for recipe-goat-pp-cli
      --yes                  Skip confirmation prompts (for agents and scripts)

Use "recipe-goat-pp-cli [command] --help" for more information about a command.
```

## What This CLI Does

Recipe Goat searches trusted recipe sites, ranks results, saves a local cookbook, and enriches nutrition data with USDA FoodData Central. It also supports substitutions, pantry matching, meal plans, cook logs, and local data workflows.

## Manuscripts

- [Research Brief](./library/food-and-dining/recipe-goat/.manuscripts/20260426-002121/research/)
- [Shipcheck Results](./library/food-and-dining/recipe-goat/.manuscripts/20260426-002121/proofs/)

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/food-and-dining/recipe-goat/`
- [x] `go build ./...` from `library/food-and-dining/recipe-goat/`
- [x] `go vet ./...` from `library/food-and-dining/recipe-goat/`
- [x] `go test ./...` from `library/food-and-dining/recipe-goat/`
- [x] `GOTOOLCHAIN=go1.26.6 go run golang.org/x/vuln/cmd/govulncheck@latest ./...` from `library/food-and-dining/recipe-goat/` (matches repo `.go-version`)
- [x] `go run ./cmd/recipe-goat-pp-cli which "search for recipes using a specific ingredient" --json` returns `search`, `cookbook search`, then `foods search`
- [x] `go run ./tools/generate-skills/main.go` (confirmed only generated `cli-skills/pp-recipe-goat/SKILL.md` would change; restored per generated-artifact rules)
- [x] `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`
- [x] `git diff --check`

## Gaps / Follow-Up

- `cli-skills/pp-recipe-goat/SKILL.md` is generated from the library SKILL source and intentionally not committed in this PR per repository generated-artifact rules; post-merge `generate-skills.yml` will mirror the source update.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d05b1ae0-e9a6-4bff-a9a5-c32ad6433937?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d05b1ae0-e9a6-4bff-a9a5-c32ad6433937&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

