### PR TITLE
fix(cli): repair agent-capture doctor probe and capture docs

### DIFF
--- a/library/developer-tools/agent-capture/.printing-press-patches/catalog-go-1266-xml-vuln-floor.json
+++ b/library/developer-tools/agent-capture/.printing-press-patches/catalog-go-1266-xml-vuln-floor.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "catalog-go-1266-xml-vuln-floor",
+  "applied_at": "2026-08-17",
+  "base_run_id": "20260405-115134",
+  "base_printing_press_version": "0.4.0",
+  "summary": "Raise the published CLI Go toolchain floor to a release with the reachable encoding/xml recursion guard fix.",
+  "reason": "The agent-capture package graph reaches encoding/xml through its syntax-highlighting imports; Go 1.26.6 carries the standard-library fix for GO-2026-6088 while preserving the catalog's package-reachability vulnerability gate.",
+  "files": [
+    "go.mod"
+  ],
+  "validated_outcome": "govulncheck ./... no longer reports GO-2026-6088 for agent-capture after the scoped module floor bump."
+}

--- a/library/developer-tools/agent-capture/.printing-press-patches/doctor-remotion-versions-and-capture-doc-runtime-truth.json
+++ b/library/developer-tools/agent-capture/.printing-press-patches/doctor-remotion-versions-and-capture-doc-runtime-truth.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "doctor-remotion-versions-and-capture-doc-runtime-truth",
+  "applied_at": "2026-08-17",
+  "base_run_id": "20260405-115134",
+  "base_printing_press_version": "0.4.0",
+  "summary": "Keep agent-capture docs and health probes aligned with the runtime tools it actually delegates to.",
+  "reason": "The published CLI shells out to macOS screencapture(1) rather than linking screencapturekit-go, and Remotion exposes a versions command rather than a --version flag for doctor to probe successfully.",
+  "files": [
+    "internal/capture/capture.go",
+    "internal/cli/doctor.go",
+    "internal/cli/doctor_test.go"
+  ],
+  "validated_outcome": "The internal/cli unit test asserts doctor builds npx remotion versions without requiring Remotion to be installed."
+}

--- a/library/developer-tools/agent-capture/go.mod
+++ b/library/developer-tools/agent-capture/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/printing-press-library/library/developer-tools/agent-capture
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alecthomas/chroma/v2 v2.23.1

--- a/library/developer-tools/agent-capture/internal/capture/capture.go
+++ b/library/developer-tools/agent-capture/internal/capture/capture.go
@@ -1,10 +1,12 @@
-// Package capture wraps ScreenCaptureKit via tfsoares/screencapturekit-go
-// for window/display enumeration, screenshots, and recording.
+// Package capture uses macOS' built-in screencapture(1) command for
+// screenshots and video recordings.
 //
-// The screencapturekit-go library uses a subprocess bridge pattern:
-// it compiles a Swift CLI binary and shells out to it from Go.
-// This avoids writing custom cgo+ObjC bridge code while providing
-// full ScreenCaptureKit access.
+// On modern macOS, screencapture's video implementation is backed by
+// ScreenCaptureKit inside the operating system, but this package does not link
+// a ScreenCaptureKit Go binding or the tfsoares/screencapturekit-go module.
+// Because recording is delegated to screencapture(1), agent-capture does not
+// control frame rate directly; recording duration is governed by the
+// screencapture -V option.
 package capture
 
 import (

--- a/library/developer-tools/agent-capture/internal/cli/doctor.go
+++ b/library/developer-tools/agent-capture/internal/cli/doctor.go
@@ -115,7 +115,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// Check 6: Remotion (optional - simulated demo rendering)
 	npxPath, npxErr := exec.LookPath("npx")
 	if npxErr == nil {
-		remCheck := exec.CommandContext(ctx, npxPath, "remotion", "--version")
+		remCheck := remotionProbeCommand(ctx, npxPath)
 		if out, err := remCheck.Output(); err == nil && len(out) > 0 {
 			checks = append(checks, doctorCheck{
 				Name:    "remotion",
@@ -164,4 +164,8 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		fmt.Println("\nSome checks failed. Fix the issues above and re-run 'agent-capture doctor'.")
 	}
 	return nil
+}
+
+func remotionProbeCommand(ctx context.Context, npxPath string) *exec.Cmd {
+	return exec.CommandContext(ctx, npxPath, "remotion", "versions")
 }

--- a/library/developer-tools/agent-capture/internal/cli/doctor_test.go
+++ b/library/developer-tools/agent-capture/internal/cli/doctor_test.go
@@ -1,0 +1,16 @@
+package cli
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestRemotionProbeCommandUsesVersions(t *testing.T) {
+	cmd := remotionProbeCommand(context.Background(), "/usr/bin/npx")
+
+	want := []string{"/usr/bin/npx", "remotion", "versions"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("remotion probe argv = %#v, want %#v", cmd.Args, want)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Correct `internal/capture` package documentation to describe the macOS `screencapture(1)` implementation and recording constraints.
- Change `agent-capture doctor` to probe Remotion with `npx remotion versions` instead of unsupported `--version`.
- Add a unit test for the Remotion probe argv and record the generated-tree patch metadata.
- Raise only the touched `agent-capture` module floor to Go 1.26.6 after required `govulncheck` surfaced reachable GO-2026-6088 in Go 1.26.5.

Closes #1679.
Closes #1677.

## Published CLI Metadata

**API:** `agent-capture` | **Category:** `developer-tools` | **Press version:** `0.4.0`
**Spec:** plan-driven (`/Users/mvanhorn/docs/plans/2026-04-05-004-feat-agent-capture-cli-plan.md`)  
**Required env:** none

## What Changed

- Package docs now describe delegated `screencapture(1)` usage, SCK backing on modern macOS, lack of direct frame-rate control, and duration via `-V`.
- Remotion doctor probe now builds `npx remotion versions`.
- Test coverage asserts the probe argv without invoking Remotion.
- Patch records capture both the runtime-truth/probe repair and the scoped Go vulnerability floor repair.

## CLI Shape

```bash
$ agent-capture --help
agent-capture consolidates macOS screen capture, window recording, GIF conversion,
frame stitching, and styled code screenshots into one agent-native CLI.

Built on ScreenCaptureKit for window-level targeting that ffmpeg can't do.
Every command supports --json for machine parsing by AI agents.
```

## What This CLI Does

Record, screenshot, and convert macOS windows and screens for AI agent evidence.

## Manuscripts

- [Research Brief](./library/developer-tools/agent-capture/.manuscripts/20260405-115134/research/)
- [Shipcheck Results](./library/developer-tools/agent-capture/.manuscripts/20260405-115134/proofs/)

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/developer-tools/agent-capture/`
- [x] `go mod tidy` from the touched CLI root
- [x] `go build ./...` from the touched CLI root
- [x] `go vet ./...` from the touched CLI root
- [x] `go test ./...` from the touched CLI root
- [x] `govulncheck ./...` from the touched CLI root
- [x] `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`
- [x] `git diff --check origin/main...HEAD`

## Gaps / Follow-Up

- None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26cdef3d-2c4a-4d4c-ba41-4b80c430bca5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26cdef3d-2c4a-4d4c-ba41-4b80c430bca5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

