### PR TITLE
fix(amazon-orders): rebase amazon.in parser fix

### DIFF
--- a/library/commerce/amazon-orders/.printing-press-patches/amazon-in-order-localization.json
+++ b/library/commerce/amazon-orders/.printing-press-patches/amazon-in-order-localization.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "amazon-in-order-localization",
+  "applied_at": "2026-06-17",
+  "base_run_id": "20260510-105710",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Order-list parsing must read amazon.in (and other non-US marketplace) order cards correctly: day-first dates, marketplace-currency fallback, marketplace-absolute links, script-noise-free totals, and relative delivery ETAs.",
+  "reason": "Beyond INR symbol detection (see inr-order-list-totals), the published parser was shaped for amazon.com markup, so an authenticated amazon.in session still produced wrong structured data: (1) placedDate was empty because dateLikeRegex/ParseDate only accepted US month-first layouts, not day-first ('16 June 2026'); (2) order/track/invoice links were absolutized against a hardcoded https://www.amazon.com origin instead of the configured marketplace, so every link pointed at the wrong TLD; (3) Amazon inlines JSON/JS (tokens like '$0', 'total') inside order cards, which polluted money/label scans and corrupted totals until Text() skipped <script>/<style>/<noscript> subtrees; (4) delivery phrasing used by international marketplaces ('today', 'tomorrow', weekday names) never resolved to an ISO etaDate, leaving where-is-my-stuff/arriving-soon/late blank; (5) a marketplace-currency fallback (parser.MarketplaceCurrency / marketplaceCurrency() in root.go) is needed so amounts whose symbol is ambiguous fall back to the marketplace currency — '$' is intentionally left uncoded (returns \"\") because it spans USD/CAD/AUD/MXN, and pinning it to USD mislabeled amazon.ca/amazon.com.au orders.",
+  "files": [
+    "internal/parser/parser.go",
+    "internal/parser/orders_list.go",
+    "internal/parser/gift_cards.go",
+    "internal/cli/root.go",
+    "internal/parser/parser_test.go"
+  ],
+  "validated_outcome": "Parser tests cover day-first ParseDate, ambiguous-'$' currency fallback, weekday/relative ETA resolution, and script-subtree skipping; go build/vet/test ./... pass from the amazon-orders CLI directory. Verified live against a real amazon.in account: orders list returns correct INR totals, day-first placedDate, amazon.in-absolute links, and resolved etaDate across a full year-2026 walk."
+}

--- a/library/commerce/amazon-orders/.printing-press-patches/auth-refresh-nonzero-exit.json
+++ b/library/commerce/amazon-orders/.printing-press-patches/auth-refresh-nonzero-exit.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "auth-refresh-nonzero-exit",
+  "applied_at": "2026-06-17",
+  "base_run_id": "20260510-105710",
+  "base_printing_press_version": "4.2.2",
+  "summary": "auth refresh must exit non-zero when browser-session validation fails, so `auth refresh && orders list` gating still works.",
+  "reason": "When marketplace-cookie-domain reworked auth refresh to keep extracted cookies on a blocked validation probe, the RunE closure began falling through to `return nil` regardless of outcome, so auth refresh always exited 0. CI/cron scripts that chain `auth refresh && orders list` could no longer detect a blocked or expired session. The command now returns authErr (exit 4) on validation failure while still printing the human-readable warning; auth login deliberately stays warn-and-succeed because it has already persisted the cookies for later verification.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go build/vet/test ./... pass from the amazon-orders CLI directory; auth login retains its warn-and-exit-0 behavior, while auth refresh now surfaces a non-zero exit on a failed browser-session proof."
+}

--- a/library/commerce/amazon-orders/.printing-press-patches/marketplace-currency-completeness.json
+++ b/library/commerce/amazon-orders/.printing-press-patches/marketplace-currency-completeness.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "marketplace-currency-completeness",
+  "applied_at": "2026-07-20",
+  "base_run_id": "20260510-105710",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Every accepted Amazon marketplace domain must map to its ISO currency, and the mapping must resolve the registrable domain rather than substring-matching the base URL.",
+  "reason": "amazon-in-order-localization made currencyForMoneyToken return \"\" for the ambiguous \"$\" so the marketplace fallback could supply the right currency. That fallback was incomplete: marketplaceCurrency only covered 9 of the 22 domains in amazonMarketplaceDomains, so amazon.com.au (AUD), amazon.com.mx (MXN), amazon.sg (S$ -> SGD) and amazon.com.br (R$ -> BRL) silently fell through to the USD default and mis-tagged real amounts — the '$' change did not actually fix those marketplaces. The lookup also substring-matched the raw URL, which is fragile because marketplace domains nest (\"amazon.com.au\" and \"amazon.com.mx\" both contain \"amazon.com\"), so ordering alone decided correctness. The table is now exhaustive and keyed on the registrable domain resolved by cookieDomainFromBaseURL, with tests asserting both directions of parity against amazonMarketplaceDomains so a newly accepted marketplace cannot ship without a currency.",
+  "files": [
+    "internal/cli/root.go",
+    "internal/cli/marketplace_currency_test.go"
+  ],
+  "validated_outcome": "go build ./..., go vet ./internal/cli/..., and go test ./... pass from this CLI directory. New tests cover the dollar-sign marketplaces (USD/CAD/AUD/MXN/SGD/BRL), symbol-bearing marketplaces (INR/GBP/EUR/JPY), scheme-less and path-bearing host forms, non-Amazon and empty input falling back to USD, and two-way parity between marketplaceCurrencies and amazonMarketplaceDomains."
+}

--- a/library/commerce/amazon-orders/go.mod
+++ b/library/commerce/amazon-orders/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/library/commerce/amazon-orders/internal/cli/auth.go
+++ b/library/commerce/amazon-orders/internal/cli/auth.go
@@ -311,11 +311,15 @@ func newAuthRefreshCmd(flags *rootFlags) *cobra.Command {
 				return authErr(err)
 			}
 
-			if validateBrowserSessionOrWarn(w, cfg, func() error {
+			if !validateBrowserSessionOrWarn(w, cfg, func() error {
 				return validateAndWriteBrowserSessionProofWithRetry(cfg, flags, waitTimeout)
 			}) {
-				fmt.Fprintf(w, "Browser session proof refreshed at %s\n", browserSessionProofPath(cfg))
+				// Restore a non-zero exit so scripts using `auth refresh && orders list`
+				// don't treat a blocked/expired session as success. The warning above
+				// carries the human-readable detail.
+				return authErr(fmt.Errorf("browser session validation failed; cookies saved but the session is not authenticated"))
 			}
+			fmt.Fprintf(w, "Browser session proof refreshed at %s\n", browserSessionProofPath(cfg))
 			return nil
 		},
 	}

--- a/library/commerce/amazon-orders/internal/cli/marketplace_currency_test.go
+++ b/library/commerce/amazon-orders/internal/cli/marketplace_currency_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import "testing"
+
+func TestMarketplaceCurrency(t *testing.T) {
+	tests := []struct {
+		baseURL string
+		want    string
+	}{
+		// Dollar-sign marketplaces: currencyForMoneyToken returns "" for "$",
+		// so these rely entirely on this fallback being correct.
+		{"https://www.amazon.com", "USD"},
+		{"https://www.amazon.ca", "CAD"},
+		{"https://www.amazon.com.au", "AUD"},
+		{"https://www.amazon.com.mx", "MXN"},
+		{"https://www.amazon.sg", "SGD"},
+		{"https://www.amazon.com.br", "BRL"},
+		// Symbol-bearing marketplaces still resolve correctly.
+		{"https://www.amazon.in", "INR"},
+		{"https://www.amazon.co.uk", "GBP"},
+		{"https://www.amazon.de", "EUR"},
+		{"https://www.amazon.co.jp", "JPY"},
+		// Host forms without scheme / with trailing path.
+		{"amazon.com.au", "AUD"},
+		{"https://www.amazon.in/gp/css/order-history", "INR"},
+		// Unknown or malformed input falls back to USD rather than erroring.
+		{"https://example.com", "USD"},
+		{"", "USD"},
+	}
+	for _, tt := range tests {
+		if got := marketplaceCurrency(tt.baseURL); got != tt.want {
+			t.Errorf("marketplaceCurrency(%q) = %q, want %q", tt.baseURL, got, tt.want)
+		}
+	}
+}
+
+// Every marketplace the CLI accepts for cookie/auth purposes must have a
+// currency mapping; otherwise its orders silently mis-tag as USD.
+func TestEveryMarketplaceDomainHasACurrency(t *testing.T) {
+	for domain := range amazonMarketplaceDomains {
+		if _, ok := marketplaceCurrencies[domain]; !ok {
+			t.Errorf("marketplaceCurrencies is missing an entry for %q", domain)
+		}
+	}
+}
+
+// Guard the inverse too, so the currency table doesn't drift to domains the
+// auth allowlist would reject.
+func TestCurrencyTableHasNoUnknownDomains(t *testing.T) {
+	for domain := range marketplaceCurrencies {
+		if _, ok := amazonMarketplaceDomains[domain]; !ok {
+			t.Errorf("marketplaceCurrencies has %q, which is not an accepted Amazon marketplace domain", domain)
+		}
+	}
+}

--- a/library/commerce/amazon-orders/internal/cli/root.go
+++ b/library/commerce/amazon-orders/internal/cli/root.go
@@ -227,27 +227,50 @@ func ExitCode(err error) int {
 	return 1
 }
 
+// marketplaceCurrencies maps every Amazon marketplace domain in
+// amazonMarketplaceDomains to the ISO currency it transacts in. This must stay
+// complete: currencyForMoneyToken deliberately returns "" for the ambiguous "$"
+// (and symbols like S$/R$ that parse as "$"), so any marketplace missing here
+// silently falls back to USD and mis-tags real amounts.
+var marketplaceCurrencies = map[string]string{
+	"amazon.ae":     "AED",
+	"amazon.ca":     "CAD",
+	"amazon.cn":     "CNY",
+	"amazon.co.jp":  "JPY",
+	"amazon.co.uk":  "GBP",
+	"amazon.com":    "USD",
+	"amazon.com.au": "AUD",
+	"amazon.com.be": "EUR",
+	"amazon.com.br": "BRL",
+	"amazon.com.mx": "MXN",
+	"amazon.com.tr": "TRY",
+	"amazon.de":     "EUR",
+	"amazon.eg":     "EGP",
+	"amazon.es":     "EUR",
+	"amazon.fr":     "EUR",
+	"amazon.in":     "INR",
+	"amazon.it":     "EUR",
+	"amazon.nl":     "EUR",
+	"amazon.pl":     "PLN",
+	"amazon.sa":     "SAR",
+	"amazon.se":     "SEK",
+	"amazon.sg":     "SGD",
+}
+
 // marketplaceCurrency maps an Amazon marketplace base URL to the ISO currency
 // it transacts in, used as the fallback when an order card has no
-// currency-marked amount to parse.
+// currency-marked amount to parse. It resolves the registrable marketplace
+// domain first (rather than substring-matching the raw URL), because domains
+// nest — "amazon.com.au" and "amazon.com.mx" both contain "amazon.com".
 func marketplaceCurrency(baseURL string) string {
-	host := strings.ToLower(baseURL)
-	switch {
-	case strings.Contains(host, "amazon.in"):
-		return "INR"
-	case strings.Contains(host, "amazon.co.uk"):
-		return "GBP"
-	case strings.Contains(host, "amazon.de"), strings.Contains(host, "amazon.fr"),
-		strings.Contains(host, "amazon.it"), strings.Contains(host, "amazon.es"),
-		strings.Contains(host, "amazon.nl"):
-		return "EUR"
-	case strings.Contains(host, "amazon.ca"):
-		return "CAD"
-	case strings.Contains(host, "amazon.co.jp"):
-		return "JPY"
-	default:
+	domain, err := cookieDomainFromBaseURL(baseURL)
+	if err != nil {
 		return "USD"
 	}
+	if cur, ok := marketplaceCurrencies[strings.TrimPrefix(domain, ".")]; ok {
+		return cur
+	}
+	return "USD"
 }
 
 func (f *rootFlags) newClient() (*client.Client, error) {

--- a/library/commerce/amazon-orders/internal/cli/root.go
+++ b/library/commerce/amazon-orders/internal/cli/root.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
 	"github.com/spf13/cobra"
 )
 
@@ -226,10 +227,40 @@ func ExitCode(err error) int {
 	return 1
 }
 
+// marketplaceCurrency maps an Amazon marketplace base URL to the ISO currency
+// it transacts in, used as the fallback when an order card has no
+// currency-marked amount to parse.
+func marketplaceCurrency(baseURL string) string {
+	host := strings.ToLower(baseURL)
+	switch {
+	case strings.Contains(host, "amazon.in"):
+		return "INR"
+	case strings.Contains(host, "amazon.co.uk"):
+		return "GBP"
+	case strings.Contains(host, "amazon.de"), strings.Contains(host, "amazon.fr"),
+		strings.Contains(host, "amazon.it"), strings.Contains(host, "amazon.es"),
+		strings.Contains(host, "amazon.nl"):
+		return "EUR"
+	case strings.Contains(host, "amazon.ca"):
+		return "CAD"
+	case strings.Contains(host, "amazon.co.jp"):
+		return "JPY"
+	default:
+		return "USD"
+	}
+}
+
 func (f *rootFlags) newClient() (*client.Client, error) {
 	cfg, err := config.Load(f.configPath)
 	if err != nil {
 		return nil, configErr(err)
+	}
+	// Point the HTML parsers at the configured marketplace so relative links
+	// absolutize to the right origin and orders without a currency-marked total
+	// fall back to the marketplace's currency (e.g. amazon.in -> INR).
+	if cfg.BaseURL != "" {
+		parser.MarketplaceBaseURL = cfg.BaseURL
+		parser.MarketplaceCurrency = marketplaceCurrency(cfg.BaseURL)
 	}
 	c := client.New(cfg, f.timeout, f.rateLimit)
 	c.DryRun = f.dryRun

--- a/library/commerce/amazon-orders/internal/cli/store_dependent.go
+++ b/library/commerce/amazon-orders/internal/cli/store_dependent.go
@@ -41,31 +41,6 @@ Run 'amazon-orders-pp-cli sync' periodically to populate it.`,
 	return cmd
 }
 
-func newSubscribeAndSaveCmd(flags *rootFlags) *cobra.Command {
-	var minOccurrences int
-	cmd := &cobra.Command{
-		Use:   "subscribe-and-save",
-		Short: "Recurring purchases inferred from order history (de-facto subscriptions).",
-		Long: `Heuristic detector: same ASIN ordered on a regular cadence (every N±k days).
-
-REQUIRES SYNC HISTORY: this command needs at least 3 months of synced
-order history to detect cadences with confidence. Until then it returns
-an empty result with a warning. Run 'amazon-orders-pp-cli sync' to
-populate the store.`,
-		Example:     "  amazon-orders-pp-cli subscribe-and-save --min-occurrences 3 --json",
-		Annotations: map[string]string{"mcp:read-only": "true"},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if dryRunOK(flags) {
-				return nil
-			}
-			fmt.Fprintln(os.Stderr, "subscribe-and-save: requires synced order history with item-level detail. Run 'sync --full-details' first; needs >= 3 months of data to be useful.")
-			return printJSONFiltered(cmd.OutOrStdout(), []map[string]any{}, flags)
-		},
-	}
-	cmd.Flags().IntVar(&minOccurrences, "min-occurrences", 3, "Minimum repeat purchases to flag as recurring.")
-	return cmd
-}
-
 func newReturnsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "returns",

--- a/library/commerce/amazon-orders/internal/cli/subscribe_and_save.go
+++ b/library/commerce/amazon-orders/internal/cli/subscribe_and_save.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
+	"github.com/spf13/cobra"
+)
+
+// SubscribeSaveItem is one inferred recurring purchase (a de-facto subscription).
+type SubscribeSaveItem struct {
+	ASIN            string `json:"asin,omitempty"`
+	Title           string `json:"title"`
+	Occurrences     int    `json:"occurrences"`
+	FirstOrdered    string `json:"firstOrdered,omitempty"`
+	LastOrdered     string `json:"lastOrdered,omitempty"`
+	AvgIntervalDays int    `json:"avgIntervalDays,omitempty"`
+	NextExpected    string `json:"nextExpected,omitempty"`
+	Regular         bool   `json:"regular"`
+}
+
+// newSubscribeAndSaveCmd detects items bought on a regular cadence directly from
+// the live order-history listing — no local store / sync required.
+func newSubscribeAndSaveCmd(flags *rootFlags) *cobra.Command {
+	var minOccurrences int
+	var window string
+	var maxPages int
+
+	cmd := &cobra.Command{
+		Use:   "subscribe-and-save",
+		Short: "Recurring purchases inferred from order history (de-facto subscriptions).",
+		Long: `Groups order history by ASIN and measures the spacing between repeat
+purchases to surface items you buy on a regular cadence — candidates for
+actual Subscribe & Save, and de-facto subscriptions you may not realize you
+have. Computed live from the order-history listing; no sync required.
+
+Widen --window to scan more history: cadences spanning multiple years need a
+wider window than the default current-year scan.`,
+		Example:     "  amazon-orders-pp-cli subscribe-and-save --min-occurrences 3 --json",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			orders, err := fetchOrderListPages(cmd.Context(), c, window, maxPages)
+			if err != nil {
+				return err
+			}
+			items := detectRecurringPurchases(orders, minOccurrences)
+			return printJSONFiltered(cmd.OutOrStdout(), items, flags)
+		},
+	}
+	cmd.Flags().IntVar(&minOccurrences, "min-occurrences", 3, "Minimum repeat purchases of the same ASIN to flag as recurring.")
+	cmd.Flags().StringVar(&window, "window", defaultYearWindow(), "Time window to scan: year-YYYY, last30days, months-3, months-6, archived.")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 12, "Maximum order-history pages to walk (10 orders/page).")
+	return cmd
+}
+
+// detectRecurringPurchases groups orders by ASIN and reports those purchased at
+// least minOccurrences times, with cadence statistics. An item is flagged
+// Regular when its purchase intervals are consistent (low coefficient of
+// variation), distinguishing a true cadence from sporadic re-buys.
+func detectRecurringPurchases(orders []parser.OrderSummary, minOccurrences int) []SubscribeSaveItem {
+	if minOccurrences < 2 {
+		minOccurrences = 2
+	}
+	type group struct {
+		title string
+		dates []time.Time
+	}
+	groups := map[string]*group{}
+	for _, o := range orders {
+		d := parser.ParseDate(o.PlacedDate)
+		if d.IsZero() {
+			continue // can't place it on a timeline (e.g. unparsed digital-order date)
+		}
+		for i, asin := range o.ASINs {
+			if asin == "" {
+				continue
+			}
+			g, ok := groups[asin]
+			if !ok {
+				g = &group{}
+				groups[asin] = g
+			}
+			if g.title == "" && i < len(o.ItemTitles) {
+				g.title = o.ItemTitles[i]
+			}
+			g.dates = append(g.dates, d)
+		}
+	}
+
+	out := []SubscribeSaveItem{}
+	for asin, g := range groups {
+		if len(g.dates) < minOccurrences {
+			continue
+		}
+		sort.Slice(g.dates, func(i, j int) bool { return g.dates[i].Before(g.dates[j]) })
+
+		intervals := make([]float64, 0, len(g.dates)-1)
+		for i := 1; i < len(g.dates); i++ {
+			intervals = append(intervals, g.dates[i].Sub(g.dates[i-1]).Hours()/24)
+		}
+		mean := meanFloat(intervals)
+
+		title := g.title
+		if title == "" {
+			title = "(no title)"
+		}
+		last := g.dates[len(g.dates)-1]
+		item := SubscribeSaveItem{
+			ASIN:            asin,
+			Title:           title,
+			Occurrences:     len(g.dates),
+			FirstOrdered:    g.dates[0].Format("2006-01-02"),
+			LastOrdered:     last.Format("2006-01-02"),
+			AvgIntervalDays: int(math.Round(mean)),
+			Regular:         len(intervals) >= 2 && coefficientOfVariation(intervals, mean) <= 0.4,
+		}
+		if mean > 0 {
+			item.NextExpected = last.AddDate(0, 0, int(math.Round(mean))).Format("2006-01-02")
+		}
+		out = append(out, item)
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Regular != out[j].Regular {
+			return out[i].Regular // regular cadences first
+		}
+		if out[i].Occurrences != out[j].Occurrences {
+			return out[i].Occurrences > out[j].Occurrences
+		}
+		return out[i].AvgIntervalDays < out[j].AvgIntervalDays
+	})
+	return out
+}
+
+func meanFloat(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, x := range xs {
+		sum += x
+	}
+	return sum / float64(len(xs))
+}
+
+// coefficientOfVariation is stddev/mean — a unitless measure of how regular the
+// intervals are. Lower means a more consistent cadence.
+func coefficientOfVariation(xs []float64, mean float64) float64 {
+	if len(xs) == 0 || mean == 0 {
+		return math.Inf(1)
+	}
+	var ss float64
+	for _, x := range xs {
+		ss += (x - mean) * (x - mean)
+	}
+	return math.Sqrt(ss/float64(len(xs))) / mean
+}

--- a/library/commerce/amazon-orders/internal/cli/subscribe_and_save_test.go
+++ b/library/commerce/amazon-orders/internal/cli/subscribe_and_save_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/internal/parser"
+)
+
+func TestDetectRecurringPurchases(t *testing.T) {
+	orders := []parser.OrderSummary{
+		// AAA "Coffee" — bought on a steady ~30-day cadence (regular).
+		{PlacedDate: "2026-01-01", ASINs: []string{"AAA"}, ItemTitles: []string{"Coffee"}},
+		{PlacedDate: "2026-01-31", ASINs: []string{"AAA"}, ItemTitles: []string{"Coffee"}},
+		{PlacedDate: "2026-03-02", ASINs: []string{"AAA"}, ItemTitles: []string{"Coffee"}},
+		{PlacedDate: "2026-04-01", ASINs: []string{"AAA"}, ItemTitles: []string{"Coffee"}},
+		// BBB "Cable" — bought twice, far apart (repeat but not a regular cadence).
+		{PlacedDate: "2026-01-01", ASINs: []string{"BBB"}, ItemTitles: []string{"Cable"}},
+		{PlacedDate: "2026-06-01", ASINs: []string{"BBB"}, ItemTitles: []string{"Cable"}},
+		// CCC — one-off, must be excluded at min-occurrences 2.
+		{PlacedDate: "2026-02-15", ASINs: []string{"CCC"}, ItemTitles: []string{"Charger"}},
+		// Unparseable date — must be skipped, not panic.
+		{PlacedDate: "", ASINs: []string{"AAA"}, ItemTitles: []string{"Coffee"}},
+	}
+
+	got := detectRecurringPurchases(orders, 2)
+
+	if len(got) != 2 {
+		t.Fatalf("got %d recurring items, want 2: %+v", len(got), got)
+	}
+
+	// Regular cadence sorts first.
+	coffee := got[0]
+	if coffee.ASIN != "AAA" {
+		t.Fatalf("first item = %q, want AAA (regular cadence sorts first)", coffee.ASIN)
+	}
+	if coffee.Occurrences != 4 {
+		t.Errorf("Coffee occurrences = %d, want 4", coffee.Occurrences)
+	}
+	if coffee.AvgIntervalDays != 30 {
+		t.Errorf("Coffee avgIntervalDays = %d, want 30", coffee.AvgIntervalDays)
+	}
+	if !coffee.Regular {
+		t.Errorf("Coffee Regular = false, want true")
+	}
+	if coffee.FirstOrdered != "2026-01-01" || coffee.LastOrdered != "2026-04-01" {
+		t.Errorf("Coffee range = %s..%s, want 2026-01-01..2026-04-01", coffee.FirstOrdered, coffee.LastOrdered)
+	}
+	if coffee.NextExpected != "2026-05-01" {
+		t.Errorf("Coffee nextExpected = %q, want 2026-05-01", coffee.NextExpected)
+	}
+
+	cable := got[1]
+	if cable.ASIN != "BBB" {
+		t.Errorf("second item = %q, want BBB", cable.ASIN)
+	}
+	if cable.Regular {
+		t.Errorf("Cable Regular = true, want false (single, wide interval)")
+	}
+}
+
+func TestDetectRecurringPurchasesRespectsMinOccurrences(t *testing.T) {
+	orders := []parser.OrderSummary{
+		{PlacedDate: "2026-01-01", ASINs: []string{"AAA"}, ItemTitles: []string{"Coffee"}},
+		{PlacedDate: "2026-02-01", ASINs: []string{"AAA"}, ItemTitles: []string{"Coffee"}},
+	}
+	if got := detectRecurringPurchases(orders, 3); len(got) != 0 {
+		t.Errorf("with min-occurrences 3 and 2 purchases, got %d items, want 0", len(got))
+	}
+}

--- a/library/commerce/amazon-orders/internal/parser/gift_cards.go
+++ b/library/commerce/amazon-orders/internal/parser/gift_cards.go
@@ -29,7 +29,7 @@ func ParseGiftCards(htmlBytes []byte) (*GiftCardPage, error) {
 	if err != nil {
 		return nil, err
 	}
-	page := &GiftCardPage{Currency: "USD"}
+	page := &GiftCardPage{Currency: MarketplaceCurrency}
 	docText := Text(doc)
 
 	// Balance: text near "Total balance" or "balance is".

--- a/library/commerce/amazon-orders/internal/parser/orders_list.go
+++ b/library/commerce/amazon-orders/internal/parser/orders_list.go
@@ -2,9 +2,61 @@ package parser
 
 import (
 	"strings"
+	"time"
 
 	"golang.org/x/net/html"
 )
+
+// nowFunc returns the current time; overridable in tests for deterministic
+// resolution of relative delivery phrasing.
+var nowFunc = time.Now
+
+var weekdayNames = map[string]time.Weekday{
+	"sunday": time.Sunday, "monday": time.Monday, "tuesday": time.Tuesday,
+	"wednesday": time.Wednesday, "thursday": time.Thursday,
+	"friday": time.Friday, "saturday": time.Saturday,
+}
+
+// resolveDeliveryDate converts Amazon's delivery phrasing into an ISO
+// YYYY-MM-DD date. It handles relative forms used by international marketplaces
+// ("today", "tomorrow", and weekday names like "Friday") as well as absolute
+// calendar dates ("16 June", "June 16, 2026"). Returns "" when nothing resolves.
+func resolveDeliveryDate(window string) string {
+	now := nowFunc()
+	head := strings.ToLower(window)
+	if len(head) > 40 {
+		head = head[:40]
+	}
+	switch {
+	case strings.Contains(head, "today"):
+		return now.Format("2006-01-02")
+	case strings.Contains(head, "tomorrow"):
+		return now.AddDate(0, 0, 1).Format("2006-01-02")
+	}
+	for name, wd := range weekdayNames {
+		if strings.Contains(head, name) {
+			delta := (int(wd) - int(now.Weekday()) + 7) % 7
+			return now.AddDate(0, 0, delta).Format("2006-01-02")
+		}
+	}
+	if d := FirstDateLike(window); d != "" {
+		if t := ParseDate(d); !t.IsZero() {
+			return t.Format("2006-01-02")
+		}
+	}
+	return ""
+}
+
+// MarketplaceBaseURL is the origin used to absolutize relative order/track/invoice
+// links found in the order-history HTML. It defaults to the US marketplace and is
+// overridden at startup from the configured base_url (e.g. https://www.amazon.in)
+// so links point at the user's actual marketplace rather than amazon.com.
+var MarketplaceBaseURL = "https://www.amazon.com"
+
+// MarketplaceCurrency is the fallback ISO currency assigned to an order when no
+// currency-marked amount is found in its card. It defaults to USD and is set from
+// the configured marketplace at startup (e.g. INR for amazon.in).
+var MarketplaceCurrency = "USD"
 
 // OrderSummary is the per-order data extracted from the order-history listing
 // page. Detail-only fields (item.unit_price, payment_method, full ship_to
@@ -81,7 +133,7 @@ func ParseOrderList(htmlBytes []byte) (*OrderListPage, error) {
 }
 
 func parseOrderCard(card *html.Node) OrderSummary {
-	s := OrderSummary{Currency: "USD"}
+	s := OrderSummary{Currency: MarketplaceCurrency}
 	cardText := Text(card)
 
 	// Order ID — most reliable signal.
@@ -154,6 +206,10 @@ func extractStatus(cardText string) (status, eta, delivered string) {
 		return "Cancelled", "", ""
 	case strings.Contains(lower, "out for delivery"):
 		status = "Out for delivery"
+		if i := strings.Index(lower, "out for delivery"); i >= 0 {
+			eta = resolveDeliveryDate(cardText[i+len("out for delivery"):min(i+len("out for delivery")+80, len(cardText))])
+		}
+		return
 	case strings.Contains(lower, "delivered"):
 		status = "Delivered"
 		if i := strings.Index(lower, "delivered"); i >= 0 {
@@ -168,12 +224,9 @@ func extractStatus(cardText string) (status, eta, delivered string) {
 	case strings.Contains(lower, "arriving"):
 		status = "Arriving"
 		if i := strings.Index(lower, "arriving"); i >= 0 {
-			window := cardText[i:min(i+80, len(cardText))]
-			if d := FirstDateLike(window); d != "" {
-				if t := ParseDate(d); !t.IsZero() {
-					eta = t.Format("2006-01-02")
-				}
-			}
+			// Window starts after the word "arriving" so relative terms
+			// ("today"/"tomorrow"/weekday) aren't shadowed by the label itself.
+			eta = resolveDeliveryDate(cardText[i+len("arriving"):min(i+len("arriving")+80, len(cardText))])
 		}
 		return
 	case strings.Contains(lower, "shipped"):
@@ -224,7 +277,9 @@ func extractCardLinks(card *html.Node) (detailURL, invoiceURL, trackURL string, 
 	return
 }
 
-// abs prepends https://www.amazon.com to a relative URL when needed.
+// abs prepends the configured marketplace origin (MarketplaceBaseURL) to a
+// relative URL when needed, so links resolve to the user's marketplace (e.g.
+// amazon.in) rather than always amazon.com.
 func abs(href string) string {
 	if href == "" {
 		return ""
@@ -232,13 +287,14 @@ func abs(href string) string {
 	if strings.HasPrefix(href, "http://") || strings.HasPrefix(href, "https://") {
 		return href
 	}
+	base := strings.TrimRight(MarketplaceBaseURL, "/")
 	if strings.HasPrefix(href, "//") {
 		return "https:" + href
 	}
 	if strings.HasPrefix(href, "/") {
-		return "https://www.amazon.com" + href
+		return base + href
 	}
-	return "https://www.amazon.com/" + href
+	return base + "/" + href
 }
 
 func min(a, b int) int {

--- a/library/commerce/amazon-orders/internal/parser/orders_list.go
+++ b/library/commerce/amazon-orders/internal/parser/orders_list.go
@@ -36,6 +36,11 @@ func resolveDeliveryDate(window string) string {
 	for name, wd := range weekdayNames {
 		if strings.Contains(head, name) {
 			delta := (int(wd) - int(now.Weekday()) + 7) % 7
+			if delta == 0 {
+				// "arriving Wednesday" on a Wednesday means next Wednesday;
+				// same-day deliveries say "today", handled above.
+				delta = 7
+			}
 			return now.AddDate(0, 0, delta).Format("2006-01-02")
 		}
 	}

--- a/library/commerce/amazon-orders/internal/parser/parser.go
+++ b/library/commerce/amazon-orders/internal/parser/parser.go
@@ -215,7 +215,10 @@ func currencyForMoneyToken(token string) string {
 	case "₹", "RS", "RS.", "INR":
 		return "INR"
 	case "$":
-		return "USD"
+		// "$" is ambiguous: USD (amazon.com), CAD (amazon.ca), AUD (amazon.com.au),
+		// MXN (amazon.com.mx). Return "" so callers fall back to MarketplaceCurrency
+		// instead of pinning to USD.
+		return ""
 	case "£":
 		return "GBP"
 	case "€":

--- a/library/commerce/amazon-orders/internal/parser/parser.go
+++ b/library/commerce/amazon-orders/internal/parser/parser.go
@@ -241,6 +241,8 @@ func ParseDate(s string) time.Time {
 		s = strings.TrimSpace(s[i+3:])
 	}
 	formats := []string{
+		// ISO (the form OrderSummary.PlacedDate is normalized to).
+		"2006-01-02",
 		// US month-first
 		"January 2, 2006", "Jan 2, 2006", "January 2", "Jan 2",
 		// Non-US day-first (amazon.in et al.): "16 June 2026", "5 May"

--- a/library/commerce/amazon-orders/internal/parser/parser.go
+++ b/library/commerce/amazon-orders/internal/parser/parser.go
@@ -31,8 +31,10 @@ var asinRegex = regexp.MustCompile(`/dp/([A-Z0-9]{10})`)
 // "$1,234.56", "-₹1,234.56", "Rs. 999.00", "INR 2,500.00").
 var moneyRegex = regexp.MustCompile(`(?i)(-?)\s*(₹|rs\.?|inr|\$|£|€)\s*([0-9][0-9,]*(?:\.\d{2})?)`)
 
-// dateLikeRegex tolerates "May 5, 2026", "May 5", "Jan 1, 2026".
-var dateLikeRegex = regexp.MustCompile(`\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2}(?:,\s*\d{4})?\b`)
+// dateLikeRegex tolerates both US month-first ("May 5, 2026", "May 5") and
+// non-US day-first ("5 May 2026", "16 June") layouts. amazon.in and other
+// international marketplaces render the day-first form.
+var dateLikeRegex = regexp.MustCompile(`\b(?:\d{1,2}\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)(?:\s+\d{4})?|(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2}(?:,\s*\d{4})?)\b`)
 
 // last4Regex matches "ending in 1234" or "****1234" payment hints.
 var last4Regex = regexp.MustCompile(`(?:ending in|ending|\*+)\s*(\d{4})`)
@@ -126,13 +128,21 @@ func Attr(n *html.Node, key string) string {
 }
 
 // Text returns the concatenated text content of n with whitespace collapsed.
-// Wraps cliutil.CleanText for HTML entity unescaping.
+// Wraps cliutil.CleanText for HTML entity unescaping. <script>/<style>/<noscript>
+// subtrees are skipped: Amazon inlines JSON and JS (containing tokens like "$0"
+// and "total") inside order cards, which otherwise pollute label/money scans.
 func Text(n *html.Node) string {
 	if n == nil {
 		return ""
 	}
 	var sb strings.Builder
 	Walk(n, func(x *html.Node) bool {
+		if x.Type == html.ElementNode {
+			switch x.Data {
+			case "script", "style", "noscript":
+				return false // skip this subtree entirely
+			}
+		}
 		if x.Type == html.TextNode {
 			sb.WriteString(x.Data)
 			sb.WriteString(" ")
@@ -227,7 +237,12 @@ func ParseDate(s string) time.Time {
 	if i := strings.Index(s, " - "); i >= 0 {
 		s = strings.TrimSpace(s[i+3:])
 	}
-	formats := []string{"January 2, 2006", "Jan 2, 2006", "January 2", "Jan 2"}
+	formats := []string{
+		// US month-first
+		"January 2, 2006", "Jan 2, 2006", "January 2", "Jan 2",
+		// Non-US day-first (amazon.in et al.): "16 June 2026", "5 May"
+		"2 January 2006", "2 Jan 2006", "2 January", "2 Jan",
+	}
 	for _, f := range formats {
 		if t, err := time.Parse(f, s); err == nil {
 			// If year is missing, assume current year.

--- a/library/commerce/amazon-orders/internal/parser/parser_test.go
+++ b/library/commerce/amazon-orders/internal/parser/parser_test.go
@@ -72,7 +72,9 @@ func TestExtractMoneyWithCurrency(t *testing.T) {
 		{"TOTAL ₹1,234.56", 1234.56, "INR", true},
 		{"TOTAL Rs. 999.00", 999.00, "INR", true},
 		{"TOTAL INR 2,500.00", 2500.00, "INR", true},
-		{"TOTAL $51.46", 51.46, "USD", true},
+		// "$" is ambiguous across dollar marketplaces, so currency is left empty
+		// for the caller to fill from MarketplaceCurrency.
+		{"TOTAL $51.46", 51.46, "", true},
 		{"TOTAL £12.34", 12.34, "GBP", true},
 		{"no money", 0, "", false},
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Rebased the amazon-orders amazon.in parser/auth patch series onto current `main` on upstream branch `tmchow/rebase-pr-1246-eb94`.
- Preserved the PR 1246 amazon.in parser/auth/patch changes while dropping the stale repo-root `.go-version` addition; the branch keeps `main`'s `.go-version` at `1.26.6`.
- Bumped `library/commerce/amazon-orders/go.mod` from `go 1.26.5` to the repo-wide `go 1.26.6` floor; `go mod tidy` produced no additional file changes.
- Skipped the older marketplace-cookie commit during replay where `main` already contained the equivalent marketplace-domain/auth-interstitial support.

## What Changed

- Keeps the amazon.in order parsing updates, marketplace currency fallback test, auth-refresh exit-code behavior, and subscribe-and-save command additions from PR 1246.
- Adds the three amazon-orders patch metadata entries from the original PR.
- Does not touch generated `registry.json`, generated `cli-skills/`, release-ledger files, or repo-root `.go-version`.

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/commerce/amazon-orders/`
- [x] `go build ./...` from `library/commerce/amazon-orders`
- [x] `go vet ./...` from `library/commerce/amazon-orders`
- [x] `go test ./...` from `library/commerce/amazon-orders`
- [x] `govulncheck ./...` from `library/commerce/amazon-orders`
- [x] `git diff --check`

## Gaps / Follow-Up

- Direct push to `kunalchopra-nitj:fix/amazon-orders-marketplace-domain` was rejected by GitHub because moving the fork branch to current `main` would update workflow files and this GitHub App token lacks `workflows` permission on that fork. This upstream branch is available as the conflict-free replacement/update source for PR 1246.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-947e2171-5206-4ede-a723-e4336f32eb94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-947e2171-5206-4ede-a723-e4336f32eb94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

