### PR TITLE
fix(release-ledger): recover ranges lost to concurrency-group eviction

### DIFF
--- a/.github/workflows/update-cli-release-ledger.yml
+++ b/.github/workflows/update-cli-release-ledger.yml
@@ -32,11 +32,13 @@ jobs:
   update:
     name: Update and commit
     runs-on: ubuntu-latest
-    # Queue release-ledger runs, but do not share this group with sibling
-    # generated-artifact workflows. GitHub keeps only one pending run per
-    # concurrency group, so a shared group lets unrelated workflows evict a
-    # pending release-ledger run. Push races with sibling workflows are handled
-    # by the bounded retry below.
+    # Keep release-ledger runs serialized because push.sh rebases but cannot
+    # recover rebase conflicts or recompute CalVer versions. GitHub permits
+    # only one pending run per group: a newer push can evict a pending sibling,
+    # and this workflow's own ledger push can self-evict a pending run too.
+    # Each successful ledger commit records the logical commit processed
+    # through; a later surviving run starts from that low-water mark and
+    # replays every first-parent commit after it, so either eviction is recoverable.
     concurrency:
       group: update-cli-release-ledger-main
       cancel-in-progress: false
@@ -53,61 +55,111 @@ jobs:
         id: meta
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_SHA: ${{ github.sha }}
+          MANUAL_CHANGED_FROM: ${{ inputs.changed_from }}
+          MANUAL_CHANGED_TO: ${{ inputs.changed_to }}
         run: |
           set -euo pipefail
 
-          changed_from="${{ inputs.changed_from || github.event.before }}"
-          changed_to="${{ inputs.changed_to || github.sha }}"
+          release_subject='chore(releases): update CLI release ledger [skip ci]'
+          low_water_mark=''
+          legacy_release_commit=''
+          while IFS=$'\t' read -r release_commit release_subject_candidate; do
+            if [ "$release_subject_candidate" != "$release_subject" ]; then
+              continue
+            fi
+            if [ -z "$legacy_release_commit" ]; then
+              legacy_release_commit="$release_commit"
+            fi
+            marker="$(git show -s --format=%B "$release_commit" | awk '/^Processed through: / { sub(/^Processed through: /, ""); print; exit }')"
+            if [[ "$marker" =~ ^[0-9a-fA-F]{40}$ ]] && git cat-file -e "$marker^{commit}" 2>/dev/null; then
+              low_water_mark="$marker"
+              break
+            fi
+          done < <(git log --first-parent --format='%H%x09%s')
+          if [ -z "$low_water_mark" ] && [ -n "$legacy_release_commit" ]; then
+            # Older bot commits predate the marker; their first parent is the
+            # closest available representation of the already-processed tip.
+            low_water_mark="$(git rev-parse "$legacy_release_commit^")"
+          fi
+
+          if [ -n "$MANUAL_CHANGED_FROM" ] || [ -n "$MANUAL_CHANGED_TO" ]; then
+            # Explicit workflow_dispatch inputs are an escape hatch for
+            # repairing or replaying a deliberately chosen range.
+            changed_from="$MANUAL_CHANGED_FROM"
+            changed_to="$MANUAL_CHANGED_TO"
+          else
+            changed_from="$low_water_mark"
+            changed_to="$EVENT_SHA"
+          fi
           if [ -z "$changed_from" ] || [ "$changed_from" = "0000000000000000000000000000000000000000" ]; then
             changed_from="$(git rev-list --max-parents=0 HEAD | tail -n 1)"
           fi
           if [ -z "$changed_to" ]; then
             changed_to="$(git rev-parse HEAD)"
           fi
+          changed_from="$(git rev-parse "$changed_from^{commit}")"
+          changed_to="$(git rev-parse "$changed_to^{commit}")"
 
-          pr_number="$(gh api \
-            -H 'Accept: application/vnd.github+json' \
-            "repos/${GITHUB_REPOSITORY}/commits/${changed_to}/pulls" \
-            --jq '.[0].number // ""' 2>/dev/null || true)"
-          pr_title="$(gh api \
-            -H 'Accept: application/vnd.github+json' \
-            "repos/${GITHUB_REPOSITORY}/commits/${changed_to}/pulls" \
-            --jq '.[0].title // ""' 2>/dev/null || true)"
-          pr_url="$(gh api \
-            -H 'Accept: application/vnd.github+json' \
-            "repos/${GITHUB_REPOSITORY}/commits/${changed_to}/pulls" \
-            --jq '.[0].html_url // ""' 2>/dev/null || true)"
-          if [ -z "$pr_title" ]; then
-            pr_title="$(git log -1 --pretty=%s "$changed_to")"
-          fi
+          commits="$(go run ./tools/release-ledger/main.go \
+            --list-first-parent \
+            --changed-from "$changed_from" \
+            --changed-to "$changed_to")"
 
           {
             echo "changed_from=$changed_from"
             echo "changed_to=$changed_to"
             echo "released_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "pr_number=$pr_number"
-            echo "pr_title<<EOF"
-            echo "$pr_title"
+            echo "commits<<EOF"
+            echo "$commits"
             echo "EOF"
-            echo "pr_url=$pr_url"
           } >> "$GITHUB_OUTPUT"
       - name: Run release-ledger
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_COMMITS: ${{ steps.meta.outputs.commits }}
+          RELEASED_AT: ${{ steps.meta.outputs.released_at }}
         run: |
           set -euo pipefail
-          args=(
-            --changed-from "${{ steps.meta.outputs.changed_from }}"
-            --changed-to "${{ steps.meta.outputs.changed_to }}"
-            --released-at "${{ steps.meta.outputs.released_at }}"
-            --source-commit "${{ steps.meta.outputs.changed_to }}"
-            --change-title "${{ steps.meta.outputs.pr_title }}"
-          )
-          if [ -n "${{ steps.meta.outputs.pr_number }}" ]; then
-            args+=(--change-pr "${{ steps.meta.outputs.pr_number }}")
+          if [ -z "$RELEASE_COMMITS" ]; then
+            echo "No first-parent commits to process."
+            exit 0
           fi
-          if [ -n "${{ steps.meta.outputs.pr_url }}" ]; then
-            args+=(--change-url "${{ steps.meta.outputs.pr_url }}")
-          fi
-          go run ./tools/release-ledger/main.go "${args[@]}"
+
+          while IFS= read -r changed_to; do
+            [ -z "$changed_to" ] && continue
+            changed_from="$(git rev-parse "$changed_to^")"
+            pr_number="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/commits/${changed_to}/pulls" \
+              --jq '.[0].number // ""' 2>/dev/null || true)"
+            pr_title="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/commits/${changed_to}/pulls" \
+              --jq '.[0].title // ""' 2>/dev/null || true)"
+            pr_url="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/commits/${changed_to}/pulls" \
+              --jq '.[0].html_url // ""' 2>/dev/null || true)"
+            if [ -z "$pr_title" ]; then
+              pr_title="$(git log -1 --pretty=%s "$changed_to")"
+            fi
+
+            args=(
+              --changed-from "$changed_from"
+              --changed-to "$changed_to"
+              --released-at "$RELEASED_AT"
+              --source-commit "$changed_to"
+              --change-title "$pr_title"
+            )
+            if [ -n "$pr_number" ]; then
+              args+=(--change-pr "$pr_number")
+            fi
+            if [ -n "$pr_url" ]; then
+              args+=(--change-url "$pr_url")
+            fi
+            go run ./tools/release-ledger/main.go "${args[@]}"
+          done <<< "$RELEASE_COMMITS"
       - name: Commit if changed
         run: |
           set -euo pipefail
@@ -118,7 +170,9 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add library
-          git commit -m "chore(releases): update CLI release ledger [skip ci]"
+          git commit \
+            -m "chore(releases): update CLI release ledger [skip ci]" \
+            -m "Processed through: ${{ steps.meta.outputs.changed_to }}"
           # A sibling writer can land after a rebase but before the push.
           # Retry the complete fetch/rebase/push sequence.
           bash .github/scripts/push-generated-artifact/push.sh main

--- a/.github/workflows/update-cli-release-ledger.yml
+++ b/.github/workflows/update-cli-release-ledger.yml
@@ -83,14 +83,15 @@ jobs:
             low_water_mark="$(git rev-parse "$legacy_release_commit^")"
           fi
 
-          if [ -n "$MANUAL_CHANGED_FROM" ] || [ -n "$MANUAL_CHANGED_TO" ]; then
-            # Explicit workflow_dispatch inputs are an escape hatch for
-            # repairing or replaying a deliberately chosen range.
+          changed_from="$low_water_mark"
+          changed_to="$EVENT_SHA"
+          # Explicit workflow_dispatch inputs are independent escape hatches
+          # for repairing or replaying a deliberately chosen range.
+          if [ -n "$MANUAL_CHANGED_FROM" ]; then
             changed_from="$MANUAL_CHANGED_FROM"
+          fi
+          if [ -n "$MANUAL_CHANGED_TO" ]; then
             changed_to="$MANUAL_CHANGED_TO"
-          else
-            changed_from="$low_water_mark"
-            changed_to="$EVENT_SHA"
           fi
           if [ -z "$changed_from" ] || [ "$changed_from" = "0000000000000000000000000000000000000000" ]; then
             changed_from="$(git rev-list --max-parents=0 HEAD | tail -n 1)"

--- a/tools/release-ledger/main.go
+++ b/tools/release-ledger/main.go
@@ -9,6 +9,7 @@
 //	go run ./tools/release-ledger/main.go --init-missing
 //	go run ./tools/release-ledger/main.go --changed-from <sha> --changed-to <sha>
 //	go run ./tools/release-ledger/main.go --check --changed-from <sha> --changed-to <sha>
+//	go run ./tools/release-ledger/main.go --list-first-parent --changed-from <sha> --changed-to <sha>
 package main
 
 import (
@@ -64,15 +65,16 @@ type printingPressManifest struct {
 }
 
 type options struct {
-	initMissing  bool
-	check        bool
-	changedFrom  string
-	changedTo    string
-	releasedAt   time.Time
-	sourceCommit string
-	changeTitle  string
-	changePR     int
-	changeURL    string
+	initMissing     bool
+	check           bool
+	listFirstParent bool
+	changedFrom     string
+	changedTo       string
+	releasedAt      time.Time
+	sourceCommit    string
+	changeTitle     string
+	changePR        int
+	changeURL       string
 }
 
 type updateResult struct {
@@ -85,6 +87,16 @@ func main() {
 	opts, err := parseFlags()
 	if err != nil {
 		log.Fatal(err)
+	}
+	if opts.listFirstParent {
+		commits, err := firstParentCommits(opts.changedFrom, opts.changedTo)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, commit := range commits {
+			fmt.Println(commit)
+		}
+		return
 	}
 
 	results, err := run(opts)
@@ -117,6 +129,7 @@ func parseFlags() (options, error) {
 	var releasedAt string
 	flag.BoolVar(&opts.initMissing, "init-missing", false, "initialize CLIs missing release metadata")
 	flag.BoolVar(&opts.check, "check", false, "exit non-zero if the selected release ledger entries would change")
+	flag.BoolVar(&opts.listFirstParent, "list-first-parent", false, "list first-parent commits in the selected range")
 	flag.StringVar(&opts.changedFrom, "changed-from", "", "git ref to diff from when selecting changed CLIs")
 	flag.StringVar(&opts.changedTo, "changed-to", "", "git ref to diff to when selecting changed CLIs")
 	flag.StringVar(&releasedAt, "released-at", "", "release timestamp (RFC3339); defaults to now")
@@ -128,6 +141,9 @@ func parseFlags() (options, error) {
 
 	if opts.initMissing && (opts.changedFrom != "" || opts.changedTo != "") {
 		return opts, errors.New("--init-missing cannot be combined with --changed-from/--changed-to")
+	}
+	if opts.listFirstParent && (opts.initMissing || opts.check) {
+		return opts, errors.New("--list-first-parent cannot be combined with --init-missing/--check")
 	}
 	if !opts.initMissing && (opts.changedFrom == "" || opts.changedTo == "") {
 		return opts, errors.New("use --init-missing or provide both --changed-from and --changed-to")
@@ -229,6 +245,17 @@ func listCLIDirs(root string) ([]string, error) {
 	}
 	sort.Strings(dirs)
 	return dirs, nil
+}
+
+func firstParentCommits(from, to string) ([]string, error) {
+	out, err := gitOutput("rev-list", "--first-parent", "--reverse", from+".."+to)
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
 }
 
 func changedCLIKeys(from, to string) (map[string]bool, error) {

--- a/tools/release-ledger/main_test.go
+++ b/tools/release-ledger/main_test.go
@@ -36,6 +36,59 @@ func TestNextVersion(t *testing.T) {
 	}
 }
 
+func TestFirstParentCommitsExcludesSideBranchCommits(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.name", "Test")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+
+	writeFile(t, repo, "README.md", "base\n")
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "base")
+	base := gitOutputIn(t, repo, "rev-parse", "HEAD")
+
+	writeFile(t, repo, "main.txt", "main\n")
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "main-line")
+	mainLine := gitOutputIn(t, repo, "rev-parse", "HEAD")
+
+	runGit(t, repo, "checkout", "-b", "side", base)
+	writeFile(t, repo, "side.txt", "side\n")
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "side-line")
+	sideLine := gitOutputIn(t, repo, "rev-parse", "HEAD")
+
+	runGit(t, repo, "checkout", "-B", "main", mainLine)
+	runGit(t, repo, "merge", "--no-ff", sideLine, "-m", "merge-side")
+	merge := gitOutputIn(t, repo, "rev-parse", "HEAD")
+	writeFile(t, repo, "after.txt", "after\n")
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "after-merge")
+	afterMerge := gitOutputIn(t, repo, "rev-parse", "HEAD")
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Fatalf("restore wd: %v", err)
+		}
+	})
+
+	got, err := firstParentCommits(base, afterMerge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{mainLine, merge, afterMerge}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("firstParentCommits() = %v, want %v", got, want)
+	}
+}
+
 func TestNextReleaseVersionIsIdempotentForSameSourceCommit(t *testing.T) {
 	releasedAt := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
 	got, err := nextReleaseVersion(releaseManifest{


### PR DESCRIPTION
Closes #1707.

## What breaks today

GitHub keeps one pending run per concurrency group. This workflow serializes on `update-cli-release-ledger-main`, so when two merges to `library/**` land close together while a run is executing, the queued run is evicted and the commits it would have stamped are never processed by anyone.

That is not hypothetical. On 2026-08-13 the run for the scrape-creators reprint (#1680) was evicted by a merge arriving 36 seconds later. That CLI's changelog goes from `2026.8.1 - 2026-08-08` straight to `2026.8.2 - 2026-08-17`: the reprint has no release of its own, and nine days of its history read as if nothing shipped. The comment above the concurrency block already explained why the group must not be *shared* with sibling workflows, but the same single pending slot lets this workflow evict its own queued runs.

## Why the serialization stays

The obvious fix is a per-run group so nothing ever queues. I ruled it out. `push.sh` rebases and retries, but it cannot resolve a rebase conflict, and it does not recompute the version after a rebase. Two runs starting from the same base can mint the same CalVer for the same CLI, and nothing downstream would catch it. Losing a range is bad; publishing two different trees under one version label is worse.

## What this changes instead

Each ledger commit now carries a second line, `Processed through: <sha>`. A run derives `changed_from` from that low-water mark instead of `github.event.before`, so an evicted range is picked up by the next run that survives. Bot commits predating the marker fall back to their first parent.

A run can now cover several merges, which the old single PR lookup could not attribute correctly: it queried the PR for `changed_to` once and stamped every CLI in the range with it. The ledger tool gains `--list-first-parent`, and the workflow walks the range one first-parent commit at a time, resolving PR number, title and URL per commit.

Re-processing an already-stamped commit is safe: `nextReleaseVersion` is idempotent for a given source commit, pinned by the existing `TestNextReleaseVersionIsIdempotentForSameSourceCommit`.

`workflow_dispatch` inputs still override the marker, so manual replays and repairs work as before.

## Verification

| Check | Result |
|---|---|
| `go test ./tools/release-ledger/...` | PASS, including a new test that builds a repo with a merge and pins that `firstParentCommits` skips side-branch commits |
| Workflow YAML parse | PASS |
| `bash -n` on every `run` block | PASS |
| `verify-supply-chain/scan.py --base-ref main` | PASS, no findings |

## Residual risk for the reviewer

No live Actions concurrency race was simulated, so the marker's behavior under real eviction is worth a second opinion.

Ranges skipped before the first marker exists are not recovered automatically and need a manual `workflow_dispatch`. #1680 in particular is not coming back: this stops the next loss, it does not repair the last one.
