### PR TITLE
docs: point leftover install recipes at @mvanhorn/printing-press-library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ library/<category>/<cli-slug>/      — one published CLI per directory
 
 cli-skills/pp-<slug>/SKILL.md       — generated per-CLI skill mirror for direct installs
 
-npm/                                — @mvanhorn/printing-press npm installer wrapper
+npm/                                — @mvanhorn/printing-press-library npm installer wrapper
 
 registry.json                       — top-level catalog: every CLI's name, category, description, path, MCP metadata
 tools/generate-skills/              — regenerates cli-skills/pp-*
@@ -329,11 +329,11 @@ Do not tie this version to `npm/package.json`. The ClawHub discovery skill and n
 
 ## NPM installer surface
 
-`@mvanhorn/printing-press` lives in `npm/`. The `printing-press` command reads the live `registry.json`, resolves a catalog name to its published Go module path, runs `go install`, and installs the matching `cli-skills/pp-<name>` skill with `skills@latest`.
+`@mvanhorn/printing-press-library` lives in `npm/`. The `printing-press-library` command reads the live `registry.json`, resolves a catalog name to its published Go module path, runs `go install`, and installs the matching `cli-skills/pp-<name>` skill with `skills@latest`. The older `@mvanhorn/printing-press` package was renamed; do not present it as the current installer.
 
 Adding or updating a CLI does not require an npm publish. The package is a thin installer over the catalog; new CLIs become installable as soon as `registry.json`, `library/`, and `cli-skills/` are updated on `main`.
 
-The repo is public, the package is published, and `npx -y @mvanhorn/printing-press install <name>` works end-to-end for unauthenticated users.
+The repo is public, the package is published, and `npx -y @mvanhorn/printing-press-library install <name>` works end-to-end for unauthenticated users.
 
 ## Releasing the npm installer
 
@@ -427,7 +427,7 @@ Known pitfalls the verifier handles:
 - A subcommand sharing a leaf name with a top-level command (e.g. `profile save` vs. top-level `save`) — resolved via `rootCmd.AddCommand` lookup + constructor naming convention (`new{Parent1}{Parent2}{Leaf}Cmd`).
 - `$(...)` command substitution in recipes can look like positional args — reported as `[likely false positive]` and not blocking.
 
-**Watch out for: external-tool flags embedded in SKILL.md install instructions.** Every `--flag` token anywhere in SKILL.md is checked against the printed CLI's source. SKILL.md sometimes embeds install commands from *other* tools (the `npx -y @mvanhorn/printing-press install ... --cli-only` line in the Prerequisites section, `hermes skills install ... --force`, `claude mcp add`, `go install`, etc.) whose flags don't exist in the printed CLI's `internal/cli/*.go`. The verifier's `COMMON_FLAGS` set in `.github/scripts/verify-skill/verify_skill.py` is the allowlist of flags that don't need a CLI-source declaration.
+**Watch out for: external-tool flags embedded in SKILL.md install instructions.** Every `--flag` token anywhere in SKILL.md is checked against the printed CLI's source. SKILL.md sometimes embeds install commands from *other* tools (the `npx -y @mvanhorn/printing-press-library install ... --cli-only` line in the Prerequisites section, `hermes skills install ... --force`, `claude mcp add`, `go install`, etc.) whose flags don't exist in the printed CLI's `internal/cli/*.go`. The verifier's `COMMON_FLAGS` set in `.github/scripts/verify-skill/verify_skill.py` is the allowlist of flags that don't need a CLI-source declaration.
 
 **When you add a new install/usage instruction to SKILL.md that introduces a new `--flag`, add it to `COMMON_FLAGS` in the same change.** Otherwise the verifier will fail across every CLI on the next regen with `[flag-names] (any): --your-flag is referenced in SKILL.md but not declared in any internal/cli/*.go`. Currently allowlisted external flags: `cli-only`, `skill-only`, `registry-url` (npm installer), `force` (hermes).
 

--- a/cli-skills/AGENTS.md
+++ b/cli-skills/AGENTS.md
@@ -21,6 +21,6 @@ After editing `library/<cat>/<slug>/SKILL.md`, the post-merge `generate-skills.y
 
 ## Why this directory exists
 
-`cli-skills/` is the install surface for `npx -y skills@latest add pp-<slug>` and the `@mvanhorn/printing-press` npm installer. Skill consumers (Claude Code, agent frameworks) read from here. `library/` is the human-authored source of truth; this directory is the consumable output.
+`cli-skills/` is the install surface for `npx -y skills@latest add pp-<slug>` and the `@mvanhorn/printing-press-library` npm installer. Skill consumers (Claude Code, agent frameworks) read from here. `library/` is the human-authored source of truth; this directory is the consumable output.
 
 See the repo-root [`AGENTS.md`](../AGENTS.md) → **"Generated artifacts: `registry.json`, `cli-skills/`"** for the full convention.

--- a/library/ai/openart/README.md
+++ b/library/ai/openart/README.md
@@ -11,13 +11,13 @@ Printed by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 The recommended path installs both the `openart-pp-cli` binary and the `pp-openart` agent skill in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install openart
+npx -y @mvanhorn/printing-press-library install openart
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install openart --cli-only
+npx -y @mvanhorn/printing-press-library install openart --cli-only
 ```
 
 

--- a/library/ai/openart/SKILL.md
+++ b/library/ai/openart/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `openart-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install openart --cli-only
+   npx -y @mvanhorn/printing-press-library install openart --cli-only
    ```
 2. Verify: `openart-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/developer-tools/framer/README.md
+++ b/library/developer-tools/framer/README.md
@@ -13,26 +13,26 @@ Printed by [@ioncom](https://github.com/ioncom) (ioncom).
 The recommended path installs both the `framer-pp-cli` binary and the `pp-framer` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install framer
+npx -y @mvanhorn/printing-press-library install framer
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install framer --cli-only
+npx -y @mvanhorn/printing-press-library install framer --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install framer --skill-only
+npx -y @mvanhorn/printing-press-library install framer --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install framer --agent claude-code
-npx -y @mvanhorn/printing-press install framer --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install framer --agent claude-code
+npx -y @mvanhorn/printing-press-library install framer --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/npm/README.md
+++ b/library/developer-tools/npm/README.md
@@ -7,13 +7,13 @@ Research npm packages by metadata, downloads, maintainers, freshness, and depend
 The recommended path installs both the `npm-pp-cli` binary and the `pp-npm` agent skill in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install npm
+npx -y @mvanhorn/printing-press-library install npm
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install npm --cli-only
+npx -y @mvanhorn/printing-press-library install npm --cli-only
 ```
 
 

--- a/library/developer-tools/yeswehack/README.md
+++ b/library/developer-tools/yeswehack/README.md
@@ -11,13 +11,13 @@ Learn more at [YesWeHack](https://api.yeswehack.com).
 The recommended path installs both the `yeswehack-pp-cli` binary and the `pp-yeswehack` agent skill in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install yeswehack
+npx -y @mvanhorn/printing-press-library install yeswehack
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install yeswehack --cli-only
+npx -y @mvanhorn/printing-press-library install yeswehack --cli-only
 ```
 
 

--- a/library/developer-tools/yeswehack/SKILL.md
+++ b/library/developer-tools/yeswehack/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `yeswehack-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install yeswehack --cli-only
+   npx -y @mvanhorn/printing-press-library install yeswehack --cli-only
    ```
 2. Verify: `yeswehack-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/marketing/dataforseo/README.md
+++ b/library/marketing/dataforseo/README.md
@@ -11,13 +11,13 @@ Created by [@mazzsterr](https://github.com/mazzsterr) (Mazzsterr).
 The recommended path installs both the `dataforseo-pp-cli` binary and the `pp-dataforseo` agent skill in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install dataforseo
+npx -y @mvanhorn/printing-press-library install dataforseo
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install dataforseo --cli-only
+npx -y @mvanhorn/printing-press-library install dataforseo --cli-only
 ```
 
 

--- a/library/marketing/dataforseo/SKILL.md
+++ b/library/marketing/dataforseo/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `dataforseo-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install dataforseo --cli-only
+   npx -y @mvanhorn/printing-press-library install dataforseo --cli-only
    ```
 2. Verify: `dataforseo-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/media-and-entertainment/foxnews/README.md
+++ b/library/media-and-entertainment/foxnews/README.md
@@ -5,7 +5,7 @@ Read Fox News headlines from the public **Google Publisher RSS** feeds on `moxie
 ## Install
 
 ```bash
-npx -y @mvanhorn/printing-press install foxnews --cli-only
+npx -y @mvanhorn/printing-press-library install foxnews --cli-only
 ```
 
 Or from this directory:

--- a/library/media-and-entertainment/foxnews/SKILL.md
+++ b/library/media-and-entertainment/foxnews/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `foxnews-pp-cli` binary. **Verify the CLI is installed bef
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install foxnews --cli-only
+   npx -y @mvanhorn/printing-press-library install foxnews --cli-only
    ```
 2. Verify: `foxnews-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/other/ufo-goat/README.md
+++ b/library/other/ufo-goat/README.md
@@ -9,13 +9,13 @@ The first CLI for the War.gov/UFO declassified files portal. Search across every
 The recommended path installs both the `ufo-goat-pp-cli` binary and the `pp-ufo` agent skill in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install ufo
+npx -y @mvanhorn/printing-press-library install ufo
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ufo --cli-only
+npx -y @mvanhorn/printing-press-library install ufo --cli-only
 ```
 
 ### Without Node (Go fallback)

--- a/library/other/ufo-goat/SKILL.md
+++ b/library/other/ufo-goat/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `ufo-goat-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install ufo-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install ufo-goat --cli-only
    ```
 2. Verify: `ufo-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/payments/prediction-goat/README.md
+++ b/library/payments/prediction-goat/README.md
@@ -11,26 +11,26 @@ Printed by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 The recommended path installs both the `prediction-goat-pp-cli` binary and the `pp-prediction-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install prediction-goat
+npx -y @mvanhorn/printing-press-library install prediction-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install prediction-goat --cli-only
+npx -y @mvanhorn/printing-press-library install prediction-goat --cli-only
 ```
 
 For skill only - installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install prediction-goat --skill-only
+npx -y @mvanhorn/printing-press-library install prediction-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable - agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install prediction-goat --agent claude-code
-npx -y @mvanhorn/printing-press install prediction-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install prediction-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install prediction-goat --agent claude-code --agent codex
 ```
 
 ### Without Node

--- a/library/payments/prediction-goat/SKILL.md
+++ b/library/payments/prediction-goat/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `prediction-goat-pp-cli` binary. You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install prediction-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install prediction-goat --cli-only
    ```
 2. Verify: `prediction-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This is a docs-only rename of leftover install recipes that still named the old npm package `@mvanhorn/printing-press`. The published installer is `@mvanhorn/printing-press-library` (binary `printing-press-library`).

Greptile flagged [PR #1750](https://github.com/mvanhorn/printing-press-library/pull/1750) (booksy) for using the **new** package name because repo-root `AGENTS.md` was still teaching the old one. milloni correctly noted that 413 `cli-skills` already use `printing-press-library` vs 6 leftover library sources on the old name. Booksy is already correct and is not in this PR.

## What changed

- **Repo-root `AGENTS.md`:** layout line, "NPM installer surface", and the SKILL.md verifier example now use `@mvanhorn/printing-press-library` / `printing-press-library`. One historical note records the rename; the old package is no longer presented as current.
- **`cli-skills/AGENTS.md`:** install-surface sentence now names `@mvanhorn/printing-press-library`.
- **6 leftover CLIs** (both `README.md` and `SKILL.md`; `cli-skills/pp-*` mirrors stay bot-regenerated post-merge):
  - `library/media-and-entertainment/foxnews`
  - `library/ai/openart`
  - `library/other/ufo-goat`
  - `library/developer-tools/yeswehack`
  - `library/marketing/dataforseo`
  - `library/payments/prediction-goat`
- **Extra leftover READMEs** (SKILL.md already used the new package):
  - `library/developer-tools/framer/README.md`
  - `library/developer-tools/npm/README.md`

## Left alone on purpose

- Manuscripts, proofs, plans, CHANGELOG, and `npm/README.md` migration notes that mention the old package as history.
- Generated `cli-skills/pp-*/SKILL.md` and `registry.json`.
- `npm/package.json` version (no package behavior change).
- Generated `erank-pp-cli skill install` help text in `library/marketing/erank/internal/cli/skill.go` — that is generated CLI output, not a README/SKILL/AGENTS recipe.

## Validation

- `rg '@mvanhorn/printing-press install' library AGENTS.md cli-skills/AGENTS.md` has no remaining README / SKILL / AGENTS current recipes.
- `verify_skill.py` passed on the six leftover CLIs (prediction-goat still has two pre-existing `[likely false positive]` positional-arg notices).
- `git diff --check` is clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c08a3ff7-a32d-4ff6-bf5f-611708f943c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c08a3ff7-a32d-4ff6-bf5f-611708f943c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

