### PR TITLE
fix(nejm): bump Go floor to 1.26.6 for stdlib vulnerability fixes

### DIFF
--- a/library/health/nejm/go.mod
+++ b/library/health/nejm/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/printing-press-library/library/health/nejm
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/enetx/surf v1.0.199


### PR DESCRIPTION
## Problem

`library/health/nejm/go.mod` still declares `go 1.26.5`. Against that floor, `govulncheck` reports five reachable Go standard library vulnerabilities:

```
Vulnerability #1: GO-2026-6218
Vulnerability #2: GO-2026-6090
Vulnerability #3: GO-2026-6089
Vulnerability #4: GO-2026-5972
Vulnerability #5: GO-2026-5026
```

`Your code is affected by 5 vulnerabilities from the Go standard library.`

All five are fixed in Go 1.26.6.

## Why this module was missed

The nejm CLI is the only one of the six CLIs I contributed that is still on the 1.26.5 floor:

| CLI | go.mod floor |
| --- | --- |
| thelancet | 1.26.6 |
| drug-enforcement | 1.26.6 |
| grants | 1.26.6 |
| **nejm** | **1.26.5** |
| retraction-checker | 1.26.6 |
| scientific-consensus | 1.26.6 |

`#1735` (align Go fallback docs with toolchain floor) already updated this module's docs — both `README.md:38` and `SKILL.md:32` state the CLI requires Go 1.26.6 or newer. The `go.mod` floor was left behind, so the module's declared floor and its own documentation currently disagree.

`#1737` (remove redundant toolchain directives) touched sibling modules but not this one. There is no `toolchain` directive in `library/health/nejm/go.mod`, so nothing needed removal here.

## Change

One line, one file:

```diff
-go 1.26.5
+go 1.26.6
```

## Verification

Run locally in `library/health/nejm`:

| Check | Result |
| --- | --- |
| `govulncheck ./...` | `No vulnerabilities found.` (was 5) |
| `go build ./...` | exit 0 |
| `go vet ./...` | clean |
| `go test ./... -count=1` | 6/6 packages ok, 0 failures |
| `git diff --stat` | 1 file changed, 1 insertion(+), 1 deletion(-) |

Test packages passing: `internal/cli`, `internal/client`, `internal/cliutil`, `internal/mcp`, `internal/mcp/cobratree`, `internal/store`.

No dependency versions changed and no generated artifacts were touched.