### PR TITLE
feat(scientific-consensus): add DeepSeek provider, pin sampling temperature to 0

### DIFF
--- a/library/other/scientific-consensus/.printing-press-patches/deepseek-provider-and-temperature-zero.json
+++ b/library/other/scientific-consensus/.printing-press-patches/deepseek-provider-and-temperature-zero.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "deepseek-provider-and-temperature-zero",
+  "applied_at": "2026-08-19",
+  "base_run_id": "20260620-165352-e55cec69",
+  "base_printing_press_version": "4.24.0",
+  "summary": "DeepSeek registered as an optional stance provider (DEEPSEEK_API_KEY, compile-time deepseek-chat) in the shared OpenAI-compatible helper, placed after Anthropic/OpenAI and before Gemini/Groq/Mistral; all OpenAI-compatible providers now send temperature 0 so stance labels are reproducible.",
+  "reason": "A reprint must keep DeepSeek in that priority slot (DEEPSEEK_API_KEY, compile-time deepseek-chat) and keep temperature 0 on the shared OpenAI-compatible helper — otherwise the optional low-cost path disappears and the same work/claim can receive different stance labels across runs.",
+  "files": ["internal/scengine/llm_stance.go"],
+  "validated_outcome": "Author measured DeepSeek deepseek-chat temperature 0 across 13 stored corpora / 295 works, 0 call errors, 5m22s; unrelated-claim control 36/39 vs heuristic 12/39. No new dependencies."
+}

--- a/library/other/scientific-consensus/README.md
+++ b/library/other/scientific-consensus/README.md
@@ -120,7 +120,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 ## Authentication
 
-No API key required for any command. Optional env vars raise limits or enable AI summarization: NCBI_API_KEY (PubMed, higher rate limit), SEMANTIC_SCHOLAR_API_KEY (Semantic Scholar enrichment), and OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY (enhanced summarization). Everything works without them.
+No API key required for any command. Optional env vars raise limits or enable AI summarization: NCBI_API_KEY (PubMed, higher rate limit), SEMANTIC_SCHOLAR_API_KEY (Semantic Scholar enrichment), and ANTHROPIC_API_KEY / OPENAI_API_KEY / DEEPSEEK_API_KEY / GEMINI_API_KEY (enhanced summarization; first configured key wins — DeepSeek sits after Anthropic/OpenAI and before Gemini/Groq/Mistral; OpenAI-compatible providers sample at temperature 0). Everything works without them.
 
 ## Quick Start
 
@@ -481,7 +481,7 @@ Static request headers can be configured under `headers`; per-command header ove
 ### API-specific
 - **Semantic Scholar results missing or sparse** — Semantic Scholar rate-limits keyless requests (HTTP 429). Set SEMANTIC_SCHOLAR_API_KEY or rely on OpenAlex/PubMed/Europe PMC; commands degrade gracefully.
 - **PubMed throttling on large syncs** — Set NCBI_API_KEY to raise the rate limit from 3 to 10 requests/second.
-- **consensus reports method=heuristic** — Stance classification is lexical without an AI key. Set OPENAI_API_KEY, ANTHROPIC_API_KEY, or GEMINI_API_KEY for AI-assisted stance detection.
+- **consensus reports method=heuristic** — Stance classification is lexical without an AI key. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPSEEK_API_KEY, or GEMINI_API_KEY for AI-assisted stance detection (priority: Anthropic, OpenAI, DeepSeek, then Gemini/Groq/Mistral; sampling is temperature 0).
 - **Empty results offline** — Run 'scientific-consensus sync "<topic>"' first to populate the local store, or use --data-source live.
 
 ## Sources & Inspiration

--- a/library/other/scientific-consensus/SKILL.md
+++ b/library/other/scientific-consensus/SKILL.md
@@ -299,7 +299,7 @@ Returns `nodes` (id, title, year, cited\_by\_count) and `edges` (from → to) bo
 
 ## Auth Setup
 
-No API key required for any command. Optional env vars raise limits or enable AI summarization: NCBI_API_KEY (PubMed, higher rate limit), SEMANTIC_SCHOLAR_API_KEY (Semantic Scholar enrichment), and OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY (enhanced summarization). Everything works without them.
+No API key required for any command. Optional env vars raise limits or enable AI summarization: NCBI_API_KEY (PubMed, higher rate limit), SEMANTIC_SCHOLAR_API_KEY (Semantic Scholar enrichment), and ANTHROPIC_API_KEY / OPENAI_API_KEY / DEEPSEEK_API_KEY / GEMINI_API_KEY (enhanced summarization; first configured key wins — DeepSeek sits after Anthropic/OpenAI and before Gemini/Groq/Mistral; OpenAI-compatible providers sample at temperature 0). Everything works without them.
 
 Run `scientific-consensus-pp-cli doctor` to verify setup.
 

--- a/library/other/scientific-consensus/internal/scengine/llm_stance.go
+++ b/library/other/scientific-consensus/internal/scengine/llm_stance.go
@@ -10,10 +10,10 @@ package scengine
 // the heuristic — the LLM path never blocks, never retries indefinitely, and
 // never crashes the command.
 //
-// All five integrations use net/http directly: no external SDKs, no Python, no
+// All six integrations use net/http directly: no external SDKs, no Python, no
 // subprocess calls. Each provider's request/response handling lives in its own
-// small private function (callAnthropic, callOpenAI, callGemini, callGroq,
-// callMistral) so they can be reviewed independently.
+// small private function (callAnthropic, callOpenAI, callDeepSeek, callGemini,
+// callGroq, callMistral) so they can be reviewed independently.
 
 import (
 	"bytes"
@@ -43,9 +43,17 @@ type provider struct {
 
 // providers is the priority-ordered list. The FIRST one whose env var is set
 // (non-empty) wins.
+//
+// deepseek sits after the two incumbents and before the rest: it is the
+// cheapest per-call option here, which matters because stance classification
+// issues ONE call PER WORK, so a 25-work run is 25 calls. Placing it above
+// gemini/groq/mistral means a user who has configured several keys gets the
+// low-cost path by default, while anyone who deliberately set an Anthropic or
+// OpenAI key still gets what they asked for.
 var providers = []provider{
 	{name: "anthropic", envVar: "ANTHROPIC_API_KEY", call: callAnthropic},
 	{name: "openai", envVar: "OPENAI_API_KEY", call: callOpenAI},
+	{name: "deepseek", envVar: "DEEPSEEK_API_KEY", call: callDeepSeek},
 	{name: "gemini", envVar: "GEMINI_API_KEY", call: callGemini},
 	{name: "groq", envVar: "GROQ_API_KEY", call: callGroq},
 	{name: "mistral", envVar: "MISTRAL_API_KEY", call: callMistral},
@@ -88,7 +96,7 @@ func LLMProviderName() string {
 func ClassifyStanceWithLLM(ctx context.Context, title, abstract, claim string) (Stance, float64, error) {
 	p, key := activeProvider()
 	if p == nil {
-		return "", 0, errors.New("no LLM provider configured (set one of ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, MISTRAL_API_KEY)")
+		return "", 0, errors.New("no LLM provider configured (set one of ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPSEEK_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, MISTRAL_API_KEY)")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, llmTimeout)
@@ -260,6 +268,19 @@ func callOpenAI(ctx context.Context, apiKey, prompt string) (string, error) {
 		"gpt-4o-mini", apiKey, prompt)
 }
 
+// ---- DeepSeek (OpenAI-compatible) ------------------------------------------
+
+// callDeepSeek uses DeepSeek's OpenAI-compatible endpoint. The model name is a
+// deliberate constant rather than an env var: a stance corpus measured under
+// one model is not comparable to one measured under another, and letting the
+// model drift silently between runs would make every future regression
+// unattributable.
+func callDeepSeek(ctx context.Context, apiKey, prompt string) (string, error) {
+	return openAICompatible(ctx,
+		"https://api.deepseek.com/v1/chat/completions",
+		"deepseek-chat", apiKey, prompt)
+}
+
 // ---- Groq (OpenAI-compatible) ----------------------------------------------
 
 func callGroq(ctx context.Context, apiKey, prompt string) (string, error) {
@@ -276,11 +297,12 @@ func callMistral(ctx context.Context, apiKey, prompt string) (string, error) {
 		"mistral-small-latest", apiKey, prompt)
 }
 
-// openAICompatible handles the three providers that share the OpenAI Chat
-// Completions request/response shape (OpenAI, Groq, Mistral).
+// openAICompatible handles the four providers that share the OpenAI Chat
+// Completions request/response shape (OpenAI, DeepSeek, Groq, Mistral).
 func openAICompatible(ctx context.Context, url, model, apiKey, prompt string) (string, error) {
 	body := map[string]any{
-		"model": model,
+		"model":       model,
+		"temperature": 0,
 		"messages": []map[string]string{
 			{"role": "user", "content": prompt},
 		},


### PR DESCRIPTION
## Summary

Adds DeepSeek as a sixth optional LLM stance provider, and pins `temperature: 0` for all OpenAI-compatible providers.

One file, `internal/scengine/llm_stance.go`, 29 insertions and 7 deletions. No new dependencies.

## Why DeepSeek

Stance classification issues **one API call per work**, so a 25-work run is 25 calls and a 300-work regression sweep is 300. Cost per call is therefore the dominant constraint on how much measurement is affordable.

DeepSeek is placed after `anthropic` and `openai` but before `gemini`/`groq`/`mistral`. A user who deliberately set an Anthropic or OpenAI key still gets what they asked for; a user with several keys configured gets the low-cost path by default.

The model name is a compile-time constant rather than an env var. A stance corpus measured under one model is not comparable to one measured under another, and silent model drift between runs would make any future regression unattributable.

## Why temperature: 0

This is the more consequential half of the change, and it affects the existing OpenAI, Groq and Mistral paths as well as DeepSeek, because it lives in the shared `openAICompatible` helper.

Without it, the same work and the same claim can receive different stance labels on different runs. In a consensus engine, reproducibility is the product: a user who reruns `consensus "does X cause Y"` and gets a different verdict has no way to tell whether the evidence changed or the sampler did.

Flagging this explicitly as a deliberate behaviour change to the three incumbent providers, not an accidental side effect.

## Measurement

I ran the LLM path against the heuristic across 13 stored corpora to check the provider works end to end before proposing it. DeepSeek `deepseek-chat`, temperature 0, 295 works, 5m22s wall time, 0 call errors.

| Probe | LLM | Heuristic |
| --- | --- | --- |
| Unrelated-claim control (correct answer is inconclusive) | 36/39 (92.3%) | 12/39 (30.8%) |
| Mean reported confidence | 0.883 | 0.692 |
| Label disagreement vs heuristic | 155/295 (52.5%) | n/a |

The unrelated-claim control is the one worth reading: works are scored against a claim they have nothing to do with, so the correct label is `inconclusive`. The heuristic answers from paper tone and gets it wrong most of the time; the LLM path abstains.

Two caveats I am not hiding:

- Mean confidence of 0.883 is higher than the heuristic's, and I have not yet established that it is calibrated rather than merely confident. That is separate work and not part of this PR.
- No hand-labelled gold set exists yet, so the table above measures behaviour and agreement, not ground-truth accuracy.

This PR does not change the default. The keyless heuristic remains the default path when no provider key is set, and `stance_method` still reports honestly which path produced a result.

## Verification

Run in `library/other/scientific-consensus`:

| Check | Result |
| --- | --- |
| `go build ./...` | exit 0 |
| `go vet ./...` | clean |
| `go test ./internal/scengine/ -count=1` | ok, 0.513s |
| `gofmt -l` on the LF copy of the file | clean |
| `git diff --stat` | 1 file changed, 29 insertions(+), 7 deletions(-) |