### PR TITLE
fix(hotel-goat): repair Trivago source after upstream MCP API change

### DIFF
--- a/library/travel/hotel-goat/.printing-press-patches/hotel-goat-trivago-suggestions-fix.json
+++ b/library/travel/hotel-goat/.printing-press-patches/hotel-goat-trivago-suggestions-fix.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "hotel-goat-trivago-suggestions-fix",
+  "applied_at": "2026-08-19",
+  "base_run_id": "20260523-203231",
+  "base_printing_press_version": "4.13.0",
+  "summary": "Fix Trivago source after upstream MCP API change: server removed trivago-search-suggestions, so the CLI now searches trivago-accommodation-search by destination query; tolerate localized review_count strings and the missing booking_url field.",
+  "reason": "Trivago's public MCP server (mcp.trivago.com/mcp, serverInfo 'trivago Accommodation Search' v0.4.0) dropped the trivago-search-suggestions tool. The CLI's suggestion->area flow therefore returned 'tool not found' and every --source trivago/both run yielded zero results. The current server only exposes trivago-accommodation-search (now takes a free-form query and resolves the destination itself) and trivago-accommodation-radius-search. The response schema also changed: review_count is now a localized string (\u002225,429\u0022) and booking_url is no longer returned (only accommodation_url).",
+  "files": [
+    "internal/trivago/client.go",
+    "internal/trivago/client_test.go",
+    "internal/trivago/merge.go",
+    "internal/cli/hotel_helpers.go"
+  ],
+  "validated_outcome": "Live dogfood against San Francisco 2026-09-15/17 returned 25 Trivago-only accommodations with parsed review counts (25,429) and populated booking links; go test ./... passes; go vet clean. Suggestions/AreaSearch flow removed; Search(query) added."
+}

--- a/library/travel/hotel-goat/README.md
+++ b/library/travel/hotel-goat/README.md
@@ -6,9 +6,9 @@ hotel-goat fans out across two cash-price sources by default:
 - **Google Hotels** — scraped from the server-rendered page (same data the web UI shows)
 - **Trivago** — called via Trivago's public MCP server (`https://mcp.trivago.com/mcp`), which exposes OTA-aggregated rates from Booking.com, Expedia, Agoda, Hotels.com, Priceline, etc.
 
-Pick a single source with `--source google` or `--source trivago`; the default is `--source both`. When both sources see the same property (matched on lat/lng + name overlap), the OTA prices are merged into one `prices[]` array. Trivago-only properties are appended as standalone rows so the agent gets a wider candidate set.
+Pick a single source with `--source google` or `--source trivago`; the default is `--source both`. When both sources see the same property (matched on lat/lng + name overlap), the OTA prices are merged into one `prices[]` array. Trivago-only properties are appended as standalone rows so the agent gets a wider candidate set. Note: Trivago's MCP server no longer exposes a search-suggestions tool, so hotel-goat searches `trivago-accommodation-search` with the destination query directly (no separate geocoding step).
 
-Trivago is geolocated server-side and returns EUR regardless of client hints. When the headline currency differs (typically Google's USD vs Trivago's EUR), each Trivago price is converted via the Frankfurter ECB FX endpoint (free, no key, 24h on-disk cache) so the agent compares apples-to-apples. The source label records what happened:
+When the headline currency differs (e.g. Trivago returned EUR but Google's is USD), each Trivago price is converted via the Frankfurter ECB FX endpoint (free, no key, 24h on-disk cache) so the agent compares apples-to-apples. The source label records what happened:
 
 - **`trivago/<OTA> [EUR 802 -> USD]`** — FX conversion succeeded. The numeric `price` and headline `price_per_night` are the converted (USD) values; the native EUR amount is preserved in the label so the agent can see both.
 - **`trivago/<OTA> [EUR]`** — FX lookup failed (offline, Frankfurter outage). The numeric `price` is the native EUR value; the headline `price_per_night` is NOT overridden, so cross-source comparisons remain meaningful.

--- a/library/travel/hotel-goat/internal/cli/hotel_helpers.go
+++ b/library/travel/hotel-goat/internal/cli/hotel_helpers.go
@@ -277,27 +277,20 @@ func fetchAndParseHotels(ctx context.Context, location, checkin, checkout string
 	return filterHotels(hotels, opts), wouldURL, nil
 }
 
-// fetchTrivagoFor resolves `location` to a Trivago area id/ns via the
-// suggestions tool and runs an area search. Two-call cost amortizes
-// because Trivago returns up to ~50 results per area, which is plenty
-// for the merge to find Google overlaps.
+// fetchTrivagoFor runs a query-based Trivago search for `location`.
+// Trivago's MCP server dropped trivago-search-suggestions, so we no longer
+// resolve the location to an area id/ns; the trivago-accommodation-search
+// tool resolves the query destination itself. One call returns up to ~50
+// results, which is plenty for the merge to find Google overlaps.
 func fetchTrivagoFor(ctx context.Context, location, checkin, checkout string, opts hotelSearchOpts) ([]trivago.Accommodation, error) {
 	c := trivago.NewClient()
-	sug, err := c.Suggestions(ctx, location)
-	if err != nil {
-		return nil, err
-	}
-	for _, s := range sug {
-		if s.ID == 0 || s.NS == 0 {
-			continue
-		}
-		return c.AreaSearch(ctx, trivago.AreaOpts{
-			ID: s.ID, NS: s.NS,
-			Arrival: checkin, Departure: checkout,
-			Adults: opts.Adults, Rooms: opts.Rooms,
-		})
-	}
-	return nil, nil
+	return c.Search(ctx, trivago.SearchOpts{
+		Query:     location,
+		Arrival:   checkin,
+		Departure: checkout,
+		Adults:    opts.Adults,
+		Rooms:     opts.Rooms,
+	})
 }
 
 func buildHotelsRequestURL(location, checkin, checkout string, extras map[string]string) string {

--- a/library/travel/hotel-goat/internal/trivago/client.go
+++ b/library/travel/hotel-goat/internal/trivago/client.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -282,27 +284,77 @@ func truncate(b []byte) string {
 // trivago-accommodation-search and -radius-search output. Prices are
 // returned as preformatted strings (e.g. "$199") because Trivago localizes
 // the currency symbol; callers parse the numeric value with ParsePrice.
+// Field notes for the current API (serverInfo "trivago Accommodation
+// Search" v0.4.0):
+//   - review_count is a localized string ("25,429"); callers use
+//     ParseReviewCount to get the int. ReviewCount's custom
+//     UnmarshalJSON accepts both a bare JSON number and a string so a
+//     schema drift in either direction stays tolerant.
+//   - booking_url is not returned today — only accommodation_url — so
+//     BookingURL falls back to URL (accommodation_url) during decode.
 type Accommodation struct {
-	ID            string  `json:"accommodation_id"`
-	Name          string  `json:"accommodation_name"`
-	URL           string  `json:"accommodation_url"`
-	Address       string  `json:"address"`
-	PostalCode    string  `json:"postal_code"`
-	CountryCity   string  `json:"country_city"`
-	Currency      string  `json:"currency"`
-	PricePerNight string  `json:"price_per_night"`
-	PricePerStay  string  `json:"price_per_stay"`
-	Advertiser    string  `json:"advertisers"`
-	BookingURL    string  `json:"booking_url"`
-	HotelRating   int     `json:"hotel_rating"`
-	ReviewRating  string  `json:"review_rating"`
-	ReviewCount   int     `json:"review_count"`
-	Latitude      float64 `json:"latitude"`
-	Longitude     float64 `json:"longitude"`
-	Distance      string  `json:"distance"`
-	Image         string  `json:"main_image"`
-	Amenities     string  `json:"top_amenities"`
-	Description   string  `json:"description"`
+	ID            string      `json:"accommodation_id"`
+	Name          string      `json:"accommodation_name"`
+	URL           string      `json:"accommodation_url"`
+	Address       string      `json:"address"`
+	PostalCode    string      `json:"postal_code"`
+	CountryCity   string      `json:"country_city"`
+	Currency      string      `json:"currency"`
+	PricePerNight string      `json:"price_per_night"`
+	PricePerStay  string      `json:"price_per_stay"`
+	Advertiser    string      `json:"advertisers"`
+	BookingURL    string      `json:"booking_url"`
+	HotelRating   int         `json:"hotel_rating"`
+	ReviewRating  string      `json:"review_rating"`
+	ReviewCount   ReviewCount `json:"review_count"`
+	Latitude      float64     `json:"latitude"`
+	Longitude     float64     `json:"longitude"`
+	Distance      string      `json:"distance"`
+	Image         string      `json:"main_image"`
+	Amenities     string      `json:"top_amenities"`
+	Description   string      `json:"description"`
+}
+
+// ReviewCount is a tolerance wrapper around Trivago's review_count field,
+// which the current API emits as a localized string ("25,429"). Accepting
+// a bare JSON number too means a server change in either direction won't
+// fail the whole decode. Use ParseReviewCount to get an int.
+type ReviewCount string
+
+// UnmarshalJSON accepts a JSON string or a JSON number.
+func (r *ReviewCount) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		*r = ReviewCount(s)
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(b, &n); err == nil {
+		*r = ReviewCount(n.String())
+		return nil
+	}
+	return nil
+}
+
+// ParseReviewCount returns the integer from a localized review-count
+// string like "25,429", "1.563", or "42". Returns 0 when unparseable.
+func ParseReviewCount(s string) int {
+	if s == "" {
+		return 0
+	}
+	clean := priceRE.FindString(s)
+	if clean == "" {
+		return 0
+	}
+	// Strip thousands separators: keep the rightmost as decimal only when
+	// it has 1-2 trailing digits (a decimal), else drop it. Reviews are
+	// whole numbers, so collapse every , and . except a trailing decimal.
+	if i := strings.LastIndexAny(clean, ",."); i >= 0 && len(clean)-i-1 <= 2 {
+		clean = clean[:i] + strings.ReplaceAll(clean[i+1:], ",", "") + strings.ReplaceAll(clean[:i], ",", "")
+	}
+	cleaned := strings.NewReplacer(",", "", ".", "").Replace(clean)
+	n, _ := strconv.Atoi(cleaned)
+	return n
 }
 
 type Suggestion struct {
@@ -318,6 +370,16 @@ type Suggestion struct {
 type RadiusOpts struct {
 	Lat, Lng           float64
 	RadiusMeters       int
+	Arrival, Departure string
+	Adults, Rooms      int
+}
+
+// SearchOpts are the arguments for the query-based
+// trivago-accommodation-search tool (the current API's primary entry
+// point). The server resolves the query to a destination itself, so no
+// separate suggestions/geocoding step is needed.
+type SearchOpts struct {
+	Query              string
 	Arrival, Departure string
 	Adults, Rooms      int
 }
@@ -343,16 +405,14 @@ func (c *Client) RadiusSearch(ctx context.Context, o RadiusOpts) ([]Accommodatio
 	return decodeAccommodations(raw)
 }
 
-type AreaOpts struct {
-	ID, NS             int
-	Arrival, Departure string
-	Adults, Rooms      int
-}
-
-func (c *Client) AreaSearch(ctx context.Context, o AreaOpts) ([]Accommodation, error) {
+// Search runs trivago-accommodation-search with a free-form destination
+// query. This is the replacement for the old suggestions->area flow: the
+// server dropped trivago-search-suggestions, so resolving `<location>` to
+// an id/ns pair is no longer possible (or necessary) — passing the query
+// string directly returns the same ~50-result candidate set.
+func (c *Client) Search(ctx context.Context, o SearchOpts) ([]Accommodation, error) {
 	args := map[string]any{
-		"id":        o.ID,
-		"ns":        o.NS,
+		"query":     o.Query,
 		"arrival":   o.Arrival,
 		"departure": o.Departure,
 	}
@@ -369,40 +429,6 @@ func (c *Client) AreaSearch(ctx context.Context, o AreaOpts) ([]Accommodation, e
 	return decodeAccommodations(raw)
 }
 
-func (c *Client) Suggestions(ctx context.Context, query string) ([]Suggestion, error) {
-	raw, err := c.callTool(ctx, "trivago-search-suggestions", map[string]any{"query": query})
-	if err != nil {
-		return nil, err
-	}
-	var wrapper struct {
-		StructuredContent struct {
-			Suggestions []Suggestion `json:"suggestions"`
-		} `json:"structuredContent"`
-		Content []struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		} `json:"content"`
-	}
-	if err := json.Unmarshal(raw, &wrapper); err != nil {
-		return nil, err
-	}
-	if len(wrapper.StructuredContent.Suggestions) > 0 {
-		return wrapper.StructuredContent.Suggestions, nil
-	}
-	for _, c := range wrapper.Content {
-		if c.Type != "text" {
-			continue
-		}
-		var s struct {
-			Suggestions []Suggestion `json:"suggestions"`
-		}
-		if json.Unmarshal([]byte(c.Text), &s) == nil && len(s.Suggestions) > 0 {
-			return s.Suggestions, nil
-		}
-	}
-	return nil, nil
-}
-
 func decodeAccommodations(raw json.RawMessage) ([]Accommodation, error) {
 	var wrapper struct {
 		StructuredContent struct {
@@ -417,7 +443,11 @@ func decodeAccommodations(raw json.RawMessage) ([]Accommodation, error) {
 		return nil, err
 	}
 	if len(wrapper.StructuredContent.Accommodations) > 0 {
-		return wrapper.StructuredContent.Accommodations, nil
+		acc := wrapper.StructuredContent.Accommodations
+		for i := range acc {
+			acc[i].BookingURL = bookingLink(acc[i])
+		}
+		return acc, nil
 	}
 	for _, c := range wrapper.Content {
 		if c.Type != "text" {
@@ -427,6 +457,9 @@ func decodeAccommodations(raw json.RawMessage) ([]Accommodation, error) {
 			Accommodations []Accommodation `json:"accommodations"`
 		}
 		if json.Unmarshal([]byte(c.Text), &s) == nil && len(s.Accommodations) > 0 {
+			for i := range s.Accommodations {
+				s.Accommodations[i].BookingURL = bookingLink(s.Accommodations[i])
+			}
 			return s.Accommodations, nil
 		}
 	}

--- a/library/travel/hotel-goat/internal/trivago/client.go
+++ b/library/travel/hotel-goat/internal/trivago/client.go
@@ -323,6 +323,11 @@ type ReviewCount string
 
 // UnmarshalJSON accepts a JSON string or a JSON number.
 func (r *ReviewCount) UnmarshalJSON(b []byte) error {
+	// JSON null is a missing count, not an unsupported type.
+	if bytes.Equal(bytes.TrimSpace(b), []byte("null")) {
+		*r = ""
+		return nil
+	}
 	var s string
 	if err := json.Unmarshal(b, &s); err == nil {
 		*r = ReviewCount(s)

--- a/library/travel/hotel-goat/internal/trivago/client.go
+++ b/library/travel/hotel-goat/internal/trivago/client.go
@@ -333,7 +333,7 @@ func (r *ReviewCount) UnmarshalJSON(b []byte) error {
 		*r = ReviewCount(n.String())
 		return nil
 	}
-	return nil
+	return fmt.Errorf("trivago: review_count must be a string or number, got %s", b)
 }
 
 // ParseReviewCount returns the integer from a localized review-count

--- a/library/travel/hotel-goat/internal/trivago/client_test.go
+++ b/library/travel/hotel-goat/internal/trivago/client_test.go
@@ -145,3 +145,62 @@ func TestCallTool_NilLimiter_NoPanic(t *testing.T) {
 		t.Fatalf("callTool with nil Limiter returned error: %v", err)
 	}
 }
+
+func TestParseReviewCount(t *testing.T) {
+	cases := map[string]int{
+		"":          0,
+		"42":        42,
+		"25,429":    25429,
+		"1.563":     1563,
+		"8,000":     8000,
+		"0":         0,
+		"no digits": 0,
+		"1,234,567": 1234567,
+	}
+	for in, want := range cases {
+		if got := ParseReviewCount(in); got != want {
+			t.Errorf("ParseReviewCount(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+// TestReviewCount_UnmarshalStringAndNumber locks in the tolerant custom
+// unmarshaler: Trivago currently returns review_count as a localized
+// string ("25,429") but has returned a bare number in the past. Both must
+// decode without failing the whole accommodation list.
+func TestReviewCount_UnmarshalStringAndNumber(t *testing.T) {
+	var byString, byNumber ReviewCount
+	if err := json.Unmarshal([]byte(`"25,429"`), &byString); err != nil {
+		t.Fatalf("string review_count unmarshal: %v", err)
+	}
+	if string(byString) != "25,429" {
+		t.Fatalf("string got %q", string(byString))
+	}
+	if err := json.Unmarshal([]byte(`25429`), &byNumber); err != nil {
+		t.Fatalf("number review_count unmarshal: %v", err)
+	}
+	if string(byNumber) != "25429" {
+		t.Fatalf("number got %q", string(byNumber))
+	}
+}
+
+// TestDecodeAccommodations_BookingURLFallback confirms that when the API
+// omits booking_url (as it does today — only accommodation_url is
+// returned), decode backfills BookingURL from URL so booking links keep
+// working downstream.
+func TestDecodeAccommodations_BookingURLFallback(t *testing.T) {
+	raw := json.RawMessage(`{"structuredContent":{"accommodations":[{"accommodation_id":"x1","accommodation_name":"A Hotel","accommodation_url":"https://trivago/u","review_count":"25,429"}]}}`)
+	accs, err := decodeAccommodations(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(accs) != 1 {
+		t.Fatalf("got %d accommodations", len(accs))
+	}
+	if accs[0].BookingURL != "https://trivago/u" {
+		t.Fatalf("BookingURL = %q, want accommodation_url fallback", accs[0].BookingURL)
+	}
+	if ParseReviewCount(string(accs[0].ReviewCount)) != 25429 {
+		t.Fatalf("review count = %v, want 25429", accs[0].ReviewCount)
+	}
+}

--- a/library/travel/hotel-goat/internal/trivago/client_test.go
+++ b/library/travel/hotel-goat/internal/trivago/client_test.go
@@ -184,6 +184,31 @@ func TestReviewCount_UnmarshalStringAndNumber(t *testing.T) {
 	}
 }
 
+// TestReviewCount_UnmarshalNull treats JSON null as a missing count (empty
+// ReviewCount, ParseReviewCount 0). Erroring would fail the whole
+// accommodations list when any hotel omits reviews.
+func TestReviewCount_UnmarshalNull(t *testing.T) {
+	var r ReviewCount
+	if err := json.Unmarshal([]byte("null"), &r); err != nil {
+		t.Fatalf("null review_count unmarshal: %v", err)
+	}
+	if r != "" {
+		t.Fatalf("null got %q, want empty ReviewCount", r)
+	}
+	if got := ParseReviewCount(string(r)); got != 0 {
+		t.Fatalf("ParseReviewCount of null-decoded value = %d, want 0", got)
+	}
+}
+
+func TestReviewCount_UnmarshalUnsupportedType(t *testing.T) {
+	for _, raw := range []string{"true", "{}", "[]"} {
+		var r ReviewCount
+		if err := json.Unmarshal([]byte(raw), &r); err == nil {
+			t.Errorf("unmarshal %s: expected error, got nil (value %q)", raw, r)
+		}
+	}
+}
+
 // TestDecodeAccommodations_BookingURLFallback confirms that when the API
 // omits booking_url (as it does today — only accommodation_url is
 // returned), decode backfills BookingURL from URL so booking links keep

--- a/library/travel/hotel-goat/internal/trivago/merge.go
+++ b/library/travel/hotel-goat/internal/trivago/merge.go
@@ -183,20 +183,30 @@ func accommodationToHotel(ctx context.Context, t Accommodation, targetCurrency s
 		Longitude:     t.Longitude,
 		HotelClass:    t.HotelRating,
 		Rating:        rating,
-		Reviews:       t.ReviewCount,
+		Reviews:       ParseReviewCount(string(t.ReviewCount)),
 		PricePerNight: displayPrice,
 		Currency:      currency,
 		Amenities:     splitCSV(t.Amenities),
 		Prices: []parser.OTAPrice{{
 			Source: source,
 			Price:  displayPrice,
-			Link:   t.BookingURL,
+			Link:   bookingLink(t),
 		}},
-		BookingURLs: parser.BookingURLs{Primary: t.BookingURL, HotelURL: t.URL},
+		BookingURLs: parser.BookingURLs{Primary: bookingLink(t), HotelURL: t.URL},
 		Images:      imgs,
 		Description: t.Description,
 		Thumbnail:   t.Image,
 	}
+}
+
+// bookingLink returns the best usable booking URL for an accommodation.
+// The current Trivago API no longer returns a separate booking_url field —
+// only accommodation_url — so BookingURL defaults to that.
+func bookingLink(t Accommodation) string {
+	if t.BookingURL != "" {
+		return t.BookingURL
+	}
+	return t.URL
 }
 
 func splitCSV(s string) []string {


### PR DESCRIPTION
## hotel-goat

Fixes the Trivago cash-price source, which had been returning zero results because Trivago's public MCP server removed the `trivago-search-suggestions` tool.

**API:** Trivago MCP (mcp.trivago.com/mcp) | **Category:** travel | **Press version:** 4.13.0

**Spec:** internal (Google Hotels + Trivago MCP)

### What This CLI Does
Multi-source cash-hotel metasearch (Google Hotels + Trivago), per-OTA price breakdown with FX normalization, deep booking links, agent-native JSON.

### The bug
`internal/cli/hotel_helpers.go` resolved `<location>` → Trivago area id/ns via the now-removed `trivago-search-suggestions` tool. Every `--source trivago` / `--source both` run printed `tool 'trivago-search-suggestions' not found` and returned 0 hotels.

### The fix
- **`internal/trivago/client.go`** — add `Client.Search(query)` calling `trivago-accommodation-search` with the destination query directly (server resolves it), and remove the obsolete `Suggestions`/`AreaSearch`/`AreaOpts`. Also make the schema tolerant: `review_count` is now a localized string (`"25,429"`) so it decodes via a `ReviewCount` type with tolerant `UnmarshalJSON`; booking URL falls back to `accommodation_url` since `booking_url` is no longer returned.
- **`internal/trivago/merge.go`** — parse review count, use a `bookingLink` helper.
- **`internal/cli/hotel_helpers.go`** — `fetchTrivagoFor` calls `Search(query)`.
- **`internal/trivago/client_test.go`** — new tests for `ParseReviewCount`, `ReviewCount` unmarshalling, and the booking-URL fallback.
- **`.printing-press-patches/hotel-goat-trivago-suggestions-fix.json`** — patch record.
- **`README.md`** — corrected the Trivago note.

### Validation Results
| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./internal/trivago/` | PASS |
| `go test ./...` | PASS |
| Live dogfood (`hotels "San Francisco" 2026-09-15 2026-09-17 --source trivago --agent`) | PASS — 25 results, parsed review counts, booked links |

### Gaps
Cross-source name/lat-lng merge heuristics unchanged; `near` still uses its own OpenStreetMap geocoding path.