### PR TITLE
feat(flight-goat): add Seats.aero award (mileage) search via new 'award' command

### DIFF
--- a/library/travel/flight-goat/.printing-press-patches/seats-aero-award-source.json
+++ b/library/travel/flight-goat/.printing-press-patches/seats-aero-award-source.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 2,
+  "id": "seats-aero-award-source",
+  "applied_at": "2026-08-19",
+  "base_run_id": "2026-05-02T22:09:06.820184Z",
+  "base_printing_press_version": "3.6.0",
+  "upstream_issue": "",
+  "files": [
+    "internal/seatsaero/seatsaero.go",
+    "internal/seatsaero/seatsaero_test.go",
+    "internal/cli/award.go",
+    "internal/cli/award_test.go",
+    "internal/cli/primary.go"
+  ],
+  "summary": "Add Seats.aero as a hand-written award (mileage) availability source — the `award` command — alongside the cash-fare sources (Google Flights, Kayak, FlySoar). Cached award search across cabin classes, read-only.",
+  "reason": "Seats.aero (https://seats.aero) caches award/mileage redemption availability across airline alliance programs and exposes it via a Partner API (https://developers.seats.aero/reference/getting-started-p). flight-goat covers cash fares (Google Flights, Kayak, FlySoar) and FlightAware status, but had no redemption/miles path. award fills that gap. It uses the cached-search endpoint (GET https://seats.aero/partnerapi/search) with a Partner-Authorization header, ranking by date (premium-first) by default or lowest_mileage with --order. Cached search is Pro-eligible; live search is commercial-only and intentionally not exposed. The API key is read from SEATS_AERO_API_KEY (same env var the standalone seats-aero skill uses) or the config file. It is hand-written (no OpenAPI spec imported into flight-goat), mirrors the soar command pattern, registers in registerPrimaryCommands, and is read-only (mcp:read-only, no booking). A regen must preserve internal/seatsaero and internal/cli/award.go.",
+  "validated_outcome": "go build ./...; go vet ./...; go test ./... all pass. New unit tests cover the Partner-Authorization header, query-param serialization (origin/destination lists, date window, cabin, order_by, only_direct, take), HTTP 401 error surfacing, no-key ErrNoAPIKey, JSON round-trip, and the award CLI's arg validation + no-key hint + dry-run without a key (API key never leaks in dry-run). Live end-to-end not run: requires a SEATS_AERO_API_KEY, not configured; dry-run prints the correct /search URL. Award is auto-exposed via cobratree as an MCP read-only tool like the other hand primary commands."
+}

--- a/library/travel/flight-goat/README.md
+++ b/library/travel/flight-goat/README.md
@@ -183,6 +183,14 @@ Get your API key from your API provider's developer portal. The key typically lo
 export FLIGHT_GOAT_API_KEY="<paste-your-key>"
 ```
 
+The `award` command uses a separate Seats.aero Partner API key, not `FLIGHT_GOAT_API_KEY`:
+
+```bash
+export SEATS_AERO_API_KEY="<your-seats-aero-pro-key>"
+```
+
+Seats.aero Pro users can generate one under their Settings → API tab; cached search (the endpoint `award` uses) is Pro-eligible, while live search requires a commercial agreement and is intentionally not exposed.
+
 To persist credentials, use `flight-goat-pp-cli auth set-token <token>`. Stored secrets live in `credentials.toml` under the data directory, not in `config.toml`.
 
 ### 3. Verify Setup
@@ -262,9 +270,10 @@ The headline commands query consumer fare sources directly — no `FLIGHT_GOAT_A
 - **`flight-goat-pp-cli dates <origin> <destination>`** - Cheapest-date scan for a route across a travel window.
 - **`flight-goat-pp-cli explore <airport>`** / **`flight-goat-pp-cli longhaul <airport>`** - Kayak nonstop and long-haul route discovery.
 - **`flight-goat-pp-cli soar <origin> <destination> <date>`** - FlySoar (Duffel NDC/GDS) second price opinion with a booking handoff.
+- **`flight-goat-pp-cli award <origin> <destination> [--from YYYY-MM-DD --to YYYY-MM-DD]`** - Seats.aero award (mileage) availability across cabin classes (economy/premium/business/first). Requires `SEATS_AERO_API_KEY` (Seats.aero Partner API key; cached search is Pro-eligible). Read-only — miles + taxes, no booking deeplinks.
 - **`flight-goat-pp-cli assess`** - Delayed-flight/rebooking decision support.
 
-Booking deeplinks in each result's `booking_urls` quote the same `--currency` the search ran in.
+Booking deeplinks in each result's `booking_urls` quote the same `--currency` the search ran in. `award` is the exception: it quotes mileage/points rather than cash and does not produce booking deeplinks.
 
 #### Bulk fare probes with built-in pacing
 

--- a/library/travel/flight-goat/SKILL.md
+++ b/library/travel/flight-goat/SKILL.md
@@ -45,9 +45,10 @@ The headline commands hit consumer fare sources directly and need no credentials
 - `flight-goat-pp-cli dates <origin> <destination>` — cheapest-date scan across a travel window.
 - `flight-goat-pp-cli explore <airport>` / `flight-goat-pp-cli longhaul <airport>` — Kayak nonstop and long-haul route discovery.
 - `flight-goat-pp-cli soar <origin> <destination> <date>` — FlySoar (Duffel NDC/GDS) second price opinion with booking handoff.
+- `flight-goat-pp-cli award <origin> <destination>` — Seats.aero award (mileage) availability: miles + taxes redemption options across cabins. **Requires** `SEATS_AERO_API_KEY` (a Seats.aero Partner API key; cached search is Pro-eligible). Read-only.
 - `flight-goat-pp-cli assess` — delayed-flight/rebooking decision support.
 
-Booking deeplinks in each result's `booking_urls` quote the same `--currency` the search ran in.
+Booking deeplinks in each result's `booking_urls` quote the same `--currency` the search ran in. `award` is the exception: it quotes mileage/points, not cash, and does not produce booking deeplinks.
 
 ### Bulk fare probes: use --trip with --pace, never a shell loop
 

--- a/library/travel/flight-goat/internal/cli/award.go
+++ b/library/travel/flight-goat/internal/cli/award.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+// PATCH(library): Seats.aero award (mileage) availability source. Not generated
+// by Printing Press — seats.aero has no OpenAPI spec imported into flight-goat;
+// this is a hand-written backend beside Google Flights, Kayak, and FlySoar. See
+// internal/seatsaero/seatsaero.go and the patch record in .printing-press-patches/.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/mvanhorn/printing-press-library/library/travel/flight-goat/internal/seatsaero"
+
+	"github.com/spf13/cobra"
+)
+
+// newAwardCmd wires the `award` command: a Seats.aero cached award-availability
+// search for a route, returning mileage-program redemption options across cabin
+// classes. Unlike `flights`/`soar` (cash fares, no auth), award requires a
+// Seats.aero Partner API key via SEATS_AERO_API_KEY and returns miles, not
+// dollars — so it's a separate command, not a flag on `flights`. Read-only.
+func newAwardCmd(flags *rootFlags) *cobra.Command {
+	var startDate, endDate, cabin, orderBy string
+	var onlyDirect bool
+	var take int
+
+	cmd := &cobra.Command{
+		Use:         "award <origin> <destination> [--from YYYY-MM-DD --to YYYY-MM-DD]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		Short:       "Search Seats.aero award (mileage) availability for a route (requires SEATS_AERO_API_KEY)",
+		Long: `award searches Seats.aero's cached award-travel availability between two airports,
+returning mileage-program redemption options across economy/premium/business/first
+cabins. This is miles + taxes pricing, not cash fares: each row shows the mileage
+program (e.g. united, aeroplan), the departure date, which cabins are available,
+and the mileage cost in the program's currency.
+
+Seats.aero's cached search is available to Pro users with a Partner API key; set
+it as SEATS_AERO_API_KEY (the same env var the standalone seats-aero skill uses).
+Live search is commercial-only and is not exposed here. This command is
+read-only — it never books or mutates anything.
+
+By default results are ordered by departure date (premium cabins first); pass
+--order lowest_mileage to rank by cheapest award cost instead.`,
+		Example: `  # Award availability SFO -> HND around 2026-10-01, cheapest-first
+  flight-goat-pp-cli award SFO HND --from 2026-10-01 --to 2026-10-31 --order lowest_mileage
+
+  # Business-class only, nonstop, this week
+  flight-goat-pp-cli award JFK LHR --from 2026-09-20 --to 2026-09-27 --cabin business --only-direct
+
+  # Economy, JSON for agents
+  flight-goat-pp-cli award SFO NRT --cabin economy --json`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			origin := strings.ToUpper(strings.TrimSpace(args[0]))
+			dest := strings.ToUpper(strings.TrimSpace(args[1]))
+			if origin == "" || dest == "" {
+				return usageErr(fmt.Errorf("origin and destination must be non-empty IATA codes"))
+			}
+
+			c := seatsaero.NewClient("")
+
+			params := seatsaero.SearchParams{
+				OriginAirport:      origin,
+				DestinationAirport: dest,
+				StartDate:          startDate,
+				EndDate:            endDate,
+				Cabin:              cabin,
+				OrderBy:            orderBy,
+				OnlyDirectFlights:  onlyDirect,
+				Take:               take,
+			}
+
+			// Normalize ordering aliases to the API's allowed enum, which is only
+			// "" (default: by date, premium-first) or "lowest_mileage". Accept
+			// "cheapest" as an alias for lowest_mileage so a user asking for the
+			// cheapest award isn't sent an out-of-enum value (review finding).
+			switch strings.ToLower(strings.TrimSpace(orderBy)) {
+			case "", "date", "default":
+				params.OrderBy = ""
+			case "cheapest", "lowest", "lowest_mileage", "miles":
+				params.OrderBy = "lowest_mileage"
+			default:
+				return usageErr(fmt.Errorf("invalid --order %q: use lowest_mileage (or cheapest) for lowest award cost, or leave empty for default date ordering", orderBy))
+			}
+
+			if flags.dryRun {
+				// Build the URL to echo (mirrors soar's dry-run contract). Do
+				// not leak the API key. Dry-run works without a key.
+				u := c.BaseURL + "/search?origin_airport=" + origin + "&destination_airport=" + dest
+				if startDate != "" {
+					u += "&start_date=" + startDate
+				}
+				if endDate != "" {
+					u += "&end_date=" + endDate
+				}
+				if cabin != "" {
+					u += "&cabin=" + cabin
+				}
+				if params.OrderBy != "" {
+					u += "&order_by=" + params.OrderBy
+				}
+				if onlyDirect {
+					u += "&only_direct_flights=true"
+				}
+				if take > 0 {
+					u += fmt.Sprintf("&take=%d", take)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "seatsaero.Search(%s -> %s)", params.OriginAirport, params.DestinationAirport)
+				if startDate != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), " %s..%s", startDate, endDate)
+				}
+				if cabin != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), " cabin=%s", cabin)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "\nurl: %s\n(dry run - no request sent)\n", u)
+				return nil
+			}
+
+			if !c.HasAPIKey() {
+				return fmt.Errorf("seats.aero partner API key not found\nhint: export SEATS_AERO_API_KEY=\"your-seats-aero-pro-key\"\n      (Pro users can generate one at seats.aero settings; cached search is Pro-eligible)")
+			}
+
+			ctx := cmd.Context()
+			if cmd.Flags().Changed("timeout") && flags.timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, flags.timeout)
+				defer cancel()
+			}
+
+			result, err := c.Search(ctx, params)
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				result.APIKeyUsed = true // provenance: a live (Seats.aero cached) award search ran
+				bts, _ := json.MarshalIndent(result, "", "  ")
+				fmt.Fprintln(cmd.OutOrStdout(), string(bts))
+				return nil
+			}
+
+			fmt.Fprintf(cmd.ErrOrStderr(), "%d award options for %s -> %s (programs merged, source: seats.aero cached)\n",
+				result.Count, origin, dest)
+			if result.HasMore {
+				fmt.Fprintf(cmd.ErrOrStderr(), "note: more results available (use --json or increase --take)\n")
+			}
+
+			if result.Count > 0 {
+				tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+				fmt.Fprintln(tw, "DATE	PROGRAM	CABINS	ECON	PREM	BIZ	FIRST	NONSTOP")
+				limit := 20
+				for i, e := range result.Data {
+					if i >= limit {
+						fmt.Fprintf(cmd.ErrOrStderr(), "... and %d more (use --json for full list)\n", len(result.Data)-limit)
+						break
+					}
+					fmt.Fprintf(tw, "%s	%s	%s	%s	%s	%s	%s	%s\n",
+						e.Date, e.Route.Source, cabinsLabel(e), milesOrDash(e.YMileage), milesOrDash(e.WMileage), milesOrDash(e.JMileage), milesOrDash(e.FMileage), yesNo(e.AnyDirect()))
+				}
+				tw.Flush()
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&startDate, "from", "", "Earliest departure date (YYYY-MM-DD, inclusive)")
+	cmd.Flags().StringVar(&endDate, "to", "", "Latest departure date (YYYY-MM-DD, inclusive)")
+	cmd.Flags().StringVar(&cabin, "cabin", "", "Cabin filter: economy, premium, business, first")
+	cmd.Flags().StringVar(&orderBy, "order", "", "Order: empty (default, by departure date premium-first) or lowest_mileage")
+	cmd.Flags().BoolVar(&onlyDirect, "only-direct", false, "Restrict to non-stop award availability")
+	cmd.Flags().IntVar(&take, "take", 0, "Maximum results (10..1000; default 500)")
+	return cmd
+}
+
+func cabinsLabel(e seatsaero.AvailabilityEntry) string {
+	var c []string
+	if e.YAvailable {
+		c = append(c, "econ")
+	}
+	if e.WAvailable {
+		c = append(c, "prem")
+	}
+	if e.JAvailable {
+		c = append(c, "biz")
+	}
+	if e.FAvailable {
+		c = append(c, "first")
+	}
+	if len(c) == 0 {
+		return "-"
+	}
+	return strings.Join(c, ",")
+}
+
+func milesOrDash(s string) string {
+	if s == "" || s == "0" || strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "Y"
+	}
+	return "N"
+}

--- a/library/travel/flight-goat/internal/cli/award_test.go
+++ b/library/travel/flight-goat/internal/cli/award_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+// Tests for the `award` (Seats.aero mileage availability) command.
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func runAwardCmd(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	flags := &rootFlags{}
+	cmd := newAwardCmd(flags)
+	var out, errb bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return out.String(), errb.String(), err
+}
+
+func TestAwardCmd_RequiresOriginAndDestination(t *testing.T) {
+	_, _, err := runAwardCmd(t, "SFO")
+	if err == nil {
+		t.Fatal("expected error for single arg")
+	}
+	if !strings.Contains(err.Error(), "accepts 2 arg(s)") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAwardCmd_MissingKey(t *testing.T) {
+	// No SEATS_AERO_API_KEY set (env assumed clean); live path must error
+	// with a clear hint rather than silently returning empty.
+	for _, k := range []string{"SEATS_AERO_API_KEY", "SEATS_AERO_PARTNER_PARTNER_AUTHORIZATION"} {
+		t.Setenv(k, "")
+	}
+	_, _, err := runAwardCmd(t, "SFO", "HND")
+	if err == nil {
+		t.Fatal("expected error when no API key configured")
+	}
+	if !strings.Contains(err.Error(), "SEATS_AERO_API_KEY") {
+		t.Fatalf("expected hint about SEATS_AERO_API_KEY, got: %v", err)
+	}
+}
+
+func TestAwardCmd_OrderAliasesNormalize(t *testing.T) {
+	for _, k := range []string{"SEATS_AERO_API_KEY", "SEATS_AERO_PARTNER_PARTNER_AUTHORIZATION"} {
+		t.Setenv(k, "")
+	}
+	// "cheapest" must be normalized to the API enum value lowest_mileage, never
+	// sent verbatim (the API enum is only "" or lowest_mileage).
+	flags := &rootFlags{dryRun: true}
+	cmd := newAwardCmd(flags)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"SFO", "HND", "--order", "cheapest", "--from", "2026-10-01"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	s := stdout.String()
+	if !strings.Contains(s, "order_by=lowest_mileage") {
+		t.Errorf("cheapest should normalize to order_by=lowest_mileage, got:\n%s", s)
+	}
+	if strings.Contains(s, "order_by=cheapest") {
+		t.Errorf("cheapest must NOT be sent verbatim:\n%s", s)
+	}
+}
+
+func TestAwardCmd_InvalidOrderRejected(t *testing.T) {
+	for _, k := range []string{"SEATS_AERO_API_KEY", "SEATS_AERO_PARTNER_PARTNER_AUTHORIZATION"} {
+		t.Setenv(k, "")
+	}
+	flags := &rootFlags{dryRun: true}
+	cmd := newAwardCmd(flags)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"SFO", "HND", "--order", "bogus"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "invalid --order") {
+		t.Fatalf("expected invalid --order error, got: %v", err)
+	}
+}
+
+func TestAwardCmd_DryRunWithoutKey(t *testing.T) {
+	for _, k := range []string{"SEATS_AERO_API_KEY", "SEATS_AERO_PARTNER_PARTNER_AUTHORIZATION"} {
+		t.Setenv(k, "")
+	}
+	// --dry-run is a root persistent flag; set it directly on the flags in
+	// this unit fixture (equivalent to `... award ... --dry-run`).
+	flags := &rootFlags{dryRun: true}
+	cmd := newAwardCmd(flags)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"SFO", "HND",
+		"--from", "2026-10-01", "--to", "2026-10-31",
+		"--cabin", "business", "--order", "lowest_mileage"})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("dry-run should not require a key: %v", err)
+	}
+	s := stdout.String()
+	for _, want := range []string{
+		"seatsaero.Search(SFO -> HND)", "2026-10-01..2026-10-31",
+		"origin_airport=SFO", "destination_airport=HND",
+		"order_by=lowest_mileage", "cabin=business",
+		"dry run - no request sent",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("dry-run stdout missing %q:\n%s", want, s)
+		}
+	}
+	// API key must never leak into dry-run output.
+	if strings.Contains(s, "Partner-Authorization") {
+		t.Errorf("dry-run leaked auth header into output")
+	}
+}

--- a/library/travel/flight-goat/internal/cli/primary.go
+++ b/library/travel/flight-goat/internal/cli/primary.go
@@ -22,14 +22,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// registerPrimaryCommands wires the three free-tier commands: search, dates,
-// and explore. These are added BEFORE the AeroAPI commands in root.go so they
-// appear at the top of --help, matching the user's stated priority of Google
-// Flights > Kayak > FlightAware.
+// registerPrimaryCommands wires the free-tier commands: search, dates,
+// explore, plus award (Seats.aero mileage availability — API key-gated) and
+// the multi-source fare commands. These are added BEFORE the AeroAPI commands
+// in root.go so they appear at the top of --help, matching the user's stated
+// priority of Google Flights > Kayak > FlightAware, with award alongside.
 func registerPrimaryCommands(rootCmd *cobra.Command, flags *rootFlags) {
 	rootCmd.AddCommand(newGfFlightsCmd(flags))
 	rootCmd.AddCommand(newGfDatesCmd(flags))
 	rootCmd.AddCommand(newSoarCmd(flags))
+	rootCmd.AddCommand(newAwardCmd(flags))
 	rootCmd.AddCommand(newKayakExploreCmd(flags))
 	rootCmd.AddCommand(newKayakLonghaulCmd(flags))
 }

--- a/library/travel/flight-goat/internal/seatsaero/seatsaero.go
+++ b/library/travel/flight-goat/internal/seatsaero/seatsaero.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+//
+// Package seatsaero is a thin native client for the Seats.aero Partner API
+// (https://seats.aero/partnerapi). Seats.aero caches award/mileage redemption
+// availability across airline alliance programs, then exposes it read-only via
+// a Partner API. This integrates award (miles) availability into flight-goat
+// alongside the cash-fare sources (Google Flights, Kayak, FlySoar).
+//
+// Auth: the Partner API requires an API key sent as the Partner-Authorization
+// header. flight-goat reads it from SEATS_AERO_API_KEY (the same env var the
+// standalone seats-aero skill uses) or the config file. A key is required for
+// live searches; cached search (the endpoint this client uses) is available to
+// Pro users. Live search is commercial-only and intentionally not exposed.
+//
+// Response shapes are from the current seats.aero OpenAPI reference (v1.0);
+// see https://developers.seats.aero/reference/cached-search.
+package seatsaero
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// DefaultBaseURL is the Seats.aero Partner API root. All paths below are
+// joined onto it.
+const DefaultBaseURL = "https://seats.aero/partnerapi"
+
+func defaultAPIKey() string {
+	if v := strings.TrimSpace(os.Getenv("SEATS_AERO_API_KEY")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("SEATS_AERO_PARTNER_PARTNER_AUTHORIZATION")); v != "" {
+		return v
+	}
+	// config.toml fallback, mirroring the standalone seats-aero skill's layout.
+	// The config file stores the key under `aero_partner_partner_authorization`.
+	p := os.Getenv("SEATS_AERO_CONFIG")
+	if p == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			p = filepath.Join(home, ".config", "seats-aero-pp-cli", "config.toml")
+		}
+	}
+	if p == "" {
+		return ""
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return ""
+	}
+	var cfg struct {
+		SeatsAeroPartnerPartnerAuthorization string `toml:"aero_partner_partner_authorization"`
+	}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.SeatsAeroPartnerPartnerAuthorization)
+}
+
+// Client talks to the Seats.aero Partner API.
+type Client struct {
+	BaseURL string
+	APIKey  string
+	HTTP    *http.Client
+}
+
+// NewClient builds a Client with defaults. APIKey is resolved from
+// SEATS_AERO_API_KEY (or the config file) when left empty.
+func NewClient(apiKey string) *Client {
+	if apiKey == "" {
+		apiKey = defaultAPIKey()
+	}
+	return &Client{
+		BaseURL: strings.TrimRight(DefaultBaseURL, "/"),
+		APIKey:  apiKey,
+		HTTP:    &http.Client{Timeout: 45 * time.Second},
+	}
+}
+
+// ErrNoAPIKey is returned when a live search is attempted without a configured
+// Partner API key.
+type ErrNoAPIKey struct{}
+
+func (ErrNoAPIKey) Error() string {
+	return "seats.aero requires a Partner API key: set SEATS_AERO_API_KEY (Pro users can generate one in seats.aero settings)"
+}
+
+// SearchParams mirror the cached-search query parameters.
+type SearchParams struct {
+	// OriginAirport / DestinationAirport are IATA codes; comma-delimited lists
+	// (e.g. "SFO,LAX") are allowed.
+	OriginAirport      string
+	DestinationAirport string
+	// StartDate / EndDate bound the departure window in YYYY-MM-DD (inclusive).
+	StartDate string
+	EndDate   string
+	// Cabin filters availability by cabin: economy, premium, business, first.
+	Cabin string
+	// OrderBy: empty (default: by date, premium-first) or "lowest_mileage".
+	OrderBy string
+	// OnlyDirectFlights restricts to non-stop availability when true.
+	OnlyDirectFlights bool
+	// Take caps results (10..1000; default 500).
+	Take int
+}
+
+// AvailabilityEntry is one cached itinerary award availability row.
+type AvailabilityEntry struct {
+	ID      string `json:"ID"`
+	RouteID string `json:"RouteID"`
+	Route   struct {
+		OriginAirport      string `json:"OriginAirport"`
+		DestinationAirport string `json:"DestinationAirport"`
+		Source             string `json:"Source"`
+		NumDaysOut         int    `json:"NumDaysOut"`
+		Distance           int    `json:"Distance"`
+	} `json:"Route"`
+	Date string `json:"Date"`
+	// Cabin availability + mileage costs. Seats.aero emits mileage costs as
+	// strings ("12500") because some programs quote non-integer/absent values;
+	// the cli layer parses them.
+	YAvailable bool   `json:"YAvailable"`
+	WAvailable bool   `json:"WAvailable"`
+	JAvailable bool   `json:"JAvailable"`
+	FAvailable bool   `json:"FAvailable"`
+	YMileage   string `json:"YMileageCost"`
+	WMileage   string `json:"WMileageCost"`
+	JMileage   string `json:"JMileageCost"`
+	FMileage   string `json:"FMileageCost"`
+	// Direct-flight availability flags (nonstop per cabin).
+	YDirect bool   `json:"YDirect"`
+	WDirect bool   `json:"WDirect"`
+	JDirect bool   `json:"JDirect"`
+	FDirect bool   `json:"FDirect"`
+	Source  string `json:"Source"`
+}
+
+// AnyDirect reports whether any cabin has a nonstop award option. The
+// human-facing table uses this for its NONSTOP column so a business-only
+// direct itinerary isn't shown as non-direct just because economy isn't.
+func (e *AvailabilityEntry) AnyDirect() bool {
+	return e.YDirect || e.WDirect || e.JDirect || e.FDirect
+}
+
+// SearchResult is the parsed cached-search response.
+type SearchResult struct {
+	Data    []AvailabilityEntry `json:"data"`
+	Count   int                 `json:"count"`
+	HasMore bool                `json:"hasMore"`
+	Cursor  int                 `json:"cursor"`
+	// APIKeyUsed / Cached describe provenance. This is the cached-search
+	// endpoint, so Cached is always true on success — it is NOT a live
+	// redemption search (those are commercial-only) and callers must not
+	// present the data as freshly computed.
+	APIKeyUsed bool `json:"api_key_used,omitempty"`
+	Cached     bool `json:"cached"`
+}
+
+// Search runs a cached award-availability search. Returns ErrNoAPIKey when no
+// API key is configured (callers may pre-check via HasAPIKey to emit a clearer
+// message; a call without a key is an error, never a silent empty result).
+func (c *Client) Search(ctx context.Context, p SearchParams) (*SearchResult, error) {
+	if c.APIKey == "" {
+		return nil, ErrNoAPIKey{}
+	}
+	u, err := url.Parse(c.BaseURL + "/search")
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("origin_airport", p.OriginAirport)
+	q.Set("destination_airport", p.DestinationAirport)
+	if p.StartDate != "" {
+		q.Set("start_date", p.StartDate)
+	}
+	if p.EndDate != "" {
+		q.Set("end_date", p.EndDate)
+	}
+	if p.Cabin != "" {
+		q.Set("cabin", p.Cabin)
+	}
+	if p.OrderBy != "" {
+		q.Set("order_by", p.OrderBy)
+	}
+	if p.OnlyDirectFlights {
+		q.Set("only_direct_flights", "true")
+	}
+	if p.Take > 0 {
+		q.Set("take", fmt.Sprintf("%d", p.Take))
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Partner-Authorization", c.APIKey)
+	req.Header.Set("User-Agent", "flight-goat-pp-cli/seatsaero")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("seats.aero search: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("seats.aero search: read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("seats.aero search: HTTP %d: %s", resp.StatusCode, truncate(body))
+	}
+	var result SearchResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("seats.aero search: decode: %w (body=%s)", err, truncate(body))
+	}
+	result.Cached = true
+	return &result, nil
+}
+
+// HasAPIKey reports whether a Partner API key is present so callers can prompt
+// before a request.
+func (c *Client) HasAPIKey() bool { return c.APIKey != "" }
+
+func truncate(b []byte) string {
+	const max = 512
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[:max]) + "..."
+}

--- a/library/travel/flight-goat/internal/seatsaero/seatsaero_test.go
+++ b/library/travel/flight-goat/internal/seatsaero/seatsaero_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package seatsaero
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func sampleResponse() string {
+	return `{
+	  "data": [
+	    {
+	      "ID": "2QSaUXJ0ZuSVqgrRWqkSlXhnVbS",
+	      "RouteID": "2HmSwbzAS9SnEdtIsf3nkjozpX1",
+	      "Route": {
+	        "OriginAirport": "SFO",
+	        "DestinationAirport": "HND",
+	        "Source": "united",
+	        "NumDaysOut": 75,
+	        "Distance": 5135
+	      },
+	      "Date": "2026-10-01",
+	      "YAvailable": true,
+	      "WAvailable": false,
+	      "JAvailable": true,
+	      "FAvailable": false,
+	      "YMileageCost": "45000",
+	      "WMileageCost": "0",
+	      "JMileageCost": "90000",
+	      "FMileageCost": "0",
+	      "Source": "united"
+	    }
+	  ],
+	  "count": 1,
+	  "hasMore": false,
+	  "cursor": 0
+	}`
+}
+
+func newTestServer(t *testing.T, wantOrigin, wantDest string, status int, body string) (*httptest.Server, *http.Client) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if got := r.Header.Get("Partner-Authorization"); got != "test-key" {
+			t.Errorf("Partner-Authorization = %q, want test-key", got)
+		}
+		if r.URL.Path != "/search" {
+			t.Errorf("path = %s, want /search", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("origin_airport") != wantOrigin {
+			t.Errorf("origin_airport = %q, want %q", q.Get("origin_airport"), wantOrigin)
+		}
+		if q.Get("destination_airport") != wantDest {
+			t.Errorf("destination_airport = %q, want %q", q.Get("destination_airport"), wantDest)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	return srv, srv.Client()
+}
+
+func TestSearch_UsesPartnerAuthAndParses(t *testing.T) {
+	srv, hc := newTestServer(t, "SFO", "HND", 200, sampleResponse())
+	defer srv.Close()
+
+	c := NewClient("test-key")
+	c.BaseURL = srv.URL
+	c.HTTP = hc
+
+	res, err := c.Search(context.Background(), SearchParams{
+		OriginAirport:      "SFO",
+		DestinationAirport: "HND",
+		StartDate:          "2026-10-01",
+		EndDate:            "2026-10-31",
+		Cabin:              "business",
+		OrderBy:            "lowest_mileage",
+		Take:               100,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if res.Count != 1 || len(res.Data) != 1 {
+		t.Fatalf("count=%d len=%d, want 1/1", res.Count, len(res.Data))
+	}
+	entry := res.Data[0]
+	if entry.Route.OriginAirport != "SFO" || entry.Route.DestinationAirport != "HND" {
+		t.Fatalf("route = %s->%s", entry.Route.OriginAirport, entry.Route.DestinationAirport)
+	}
+	if entry.Route.Source != "united" {
+		t.Fatalf("source = %q", entry.Route.Source)
+	}
+	if entry.JMileage != "90000" || !entry.JAvailable || entry.FAvailable {
+		t.Fatalf("cabin parse wrong: J=%s/%v F=%v", entry.JMileage, entry.JAvailable, entry.FAvailable)
+	}
+	if !res.Cached {
+		t.Error("Cached should be true — the Seats.aero cached-search endpoint returns cached, not live, data")
+	}
+}
+
+func TestSearch_SendsEnvelopeParams(t *testing.T) {
+	srv, hc := newTestServer(t, "SFO,LAX", "HND,NRT", 200, `{"data":[],"count":0,"hasMore":false,"cursor":0}`)
+	defer srv.Close()
+	c := NewClient("test-key")
+	c.BaseURL = srv.URL
+	c.HTTP = hc
+	if _, err := c.Search(context.Background(), SearchParams{
+		OriginAirport: "SFO,LAX", DestinationAirport: "HND,NRT",
+		OnlyDirectFlights: true, Take: 250,
+	}); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+}
+
+func TestSearch_HTTPError(t *testing.T) {
+	srv, hc := newTestServer(t, "SFO", "HND", 401, `{"error":"unauthorized"}`)
+	defer srv.Close()
+	c := NewClient("test-key")
+	c.BaseURL = srv.URL
+	c.HTTP = hc
+	_, err := c.Search(context.Background(), SearchParams{OriginAirport: "SFO", DestinationAirport: "HND"})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 401") {
+		t.Fatalf("want HTTP 401 error, got %v", err)
+	}
+}
+
+func TestSearch_NoAPIKey(t *testing.T) {
+	c := NewClient("")
+	if c.HasAPIKey() {
+		t.Fatal("HasAPIKey should be false with no key")
+	}
+	_, err := c.Search(context.Background(), SearchParams{OriginAirport: "SFO", DestinationAirport: "HND"})
+	if err == nil {
+		t.Fatal("expected ErrNoAPIKey, got nil")
+	}
+	if _, ok := err.(ErrNoAPIKey); !ok {
+		t.Fatalf("expected ErrNoAPIKey, got %T: %v", err, err)
+	}
+}
+
+func TestNewClient_ReadsConfigFileKey(t *testing.T) {
+	// Reset env so the config-file fallback is exercised.
+	t.Setenv("SEATS_AERO_API_KEY", "")
+	t.Setenv("SEATS_AERO_PARTNER_PARTNER_AUTHORIZATION", "")
+	dir := t.TempDir()
+	cfgPath := dir + "/config.toml"
+	if err := os.WriteFile(cfgPath, []byte("aero_partner_partner_authorization = \"cfg-key-123\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("SEATS_AERO_CONFIG", cfgPath)
+	c := NewClient("")
+	if !c.HasAPIKey() {
+		t.Fatal("expected config-file key to be loaded")
+	}
+	if c.APIKey != "cfg-key-123" {
+		t.Fatalf("APIKey = %q, want cfg-key-123", c.APIKey)
+	}
+}
+
+func TestResult_RoundTripsJSON(t *testing.T) {
+	res := &SearchResult{Data: []AvailabilityEntry{
+		{
+			ID: "x", RouteID: "r",
+			Source: "united", Date: "2026-10-01",
+			YAvailable: true, JMileage: "90000",
+		},
+	}, Count: 1, Cached: true}
+	b, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"cached":true`) {
+		t.Fatalf("cached flag missing: %s", b)
+	}
+}


### PR DESCRIPTION
## flight-goat

Adds an award/mileage availability command to flight-goat, complementing the existing cash-fare sources (Google Flights, Kayak, FlySoar).

**API:** Seats.aero Partner API | **Category:** travel | **Press version:** 3.6.0

**Spec:** direct REST (no OpenAPI imported — hand-written backend mirroring `internal/soar`)

### What This CLI Does
Multi-source flight search: cash fares (Google Flights via `flights`, FlySoar via `soar`, Kayak via `explore`/`longhaul`, FlightAware status via the AeroAPI commands) — and now **award mileage availability** via `award`.

### The addition
- **`internal/seatsaero/`** — thin native client for the Seats.aero Partner API cached-search endpoint (`GET https://seats.aero/partnerapi/search`), sending the `Partner-Authorization` header from `SEATS_AERO_API_KEY`.
- **`internal/cli/award.go`** — new read-only `award <origin> <destination>` command with `--from/--to/--cabin/--order/--only-direct/--take`. Dry-run works without a key and never leaks it; the live path errors with a clear `SEATS_AERO_API_KEY` hint when no key is set.
- **`internal/cli/primary.go`** — registers `award` alongside the other headline commands; auto-exposed as a read-only MCP tool via cobratree.
- **Tests** — `internal/seatsaero` client tests (auth header, query serialization, 401 surfacing, no-key `ErrNoAPIKey`, JSON round-trip) and `internal/cli` award tests (arg validation, no-key hint, dry-run-without-key) use mocked HTTP / no-key paths.
- **Docs** — README + SKILL.md updated; patch record `seats-aero-award-source.json`.

### Validation Results
| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS |
| `go test ./internal/seatsaero/` | PASS |
| `go test ./internal/cli/ -run TestAwardCmd` | PASS |
| Live end-to-end | **NOT RUN** — requires a Seats.aero Partner API key (`SEATS_AERO_API_KEY`), not configured in this environment |

### Gaps
- Live end-to-end against `seats.aero/partnerapi/search` was not executed because no Partner API key is available here. The `award` command's dry-run and unit tests (mocked HTTP) are fully verified.
- Cached search is Pro-eligible; live search is commercial-only and intentionally not exposed (matches the MCP server's documented access model).