### PR TITLE
fix(scientific-consensus): let a stronger heuristic outrank a generic review pubtype

### DIFF
--- a/library/other/scientific-consensus/.printing-press-patches/generic-review-pubtype-defers-to-heuristic.json
+++ b/library/other/scientific-consensus/.printing-press-patches/generic-review-pubtype-defers-to-heuristic.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "generic-review-pubtype-defers-to-heuristic",
+  "applied_at": "2026-08-20",
+  "base_run_id": "20260620-165352-e55cec69",
+  "base_printing_press_version": "4.24.0",
+  "summary": "ClassifyDesign returned on the first recognised publication type, so the one generic label in pubtypeMap — \"review\" — ended the cascade before the title/abstract heuristics ran. The generic label now defers: the heuristics still run and the stronger of the two answers wins, while every specific pubtype returns immediately as before and is never overridden by a weaker heuristic.",
+  "reason": "Every pubtypeMap key except \"review\" names a specific design; \"review\" is the label a source can apply to a work whose own title and abstract call it a meta-analysis. Measured on 10.3389/fnut.2022.1084455, a 2023 pooled analysis of 55 RCTs titled \"A systematic review and meta-analysis\" and repeating the phrase twice in its abstract: tagged only \"Review\", it classified as narrative-review at tier 1; with pubtypes removed so the heuristics could run, the identical title and abstract classified as meta-analysis at tier 9. An eight-point swing on exactly the design the consensus engine should weight most heavily.",
+  "files": [
+    "internal/scengine/evidence.go"
+  ],
+  "validated_outcome": "Table-driven tests in evidence_generic_review_test.go: a \"Review\"-only meta-analysis classifies as meta-analysis via the heuristic method; a \"Review\"-only work with no design cues in its text stays narrative-review via the pubtype method; a \"Meta-Analysis\" pubtype still returns outright; a \"Randomized Controlled Trial\" pubtype is not demoted by a narrative-review heuristic match; and a work with no pubtypes leaves the heuristics in charge. The full scengine suite passes unchanged."
+}

--- a/library/other/scientific-consensus/internal/scengine/evidence.go
+++ b/library/other/scientific-consensus/internal/scengine/evidence.go
@@ -100,7 +100,7 @@ type Classification struct {
 // pubtypeMap maps authoritative publication-type labels (PubMed MeSH pubtype or
 // Semantic Scholar publicationTypes) to a Design. Keys are lowercased.
 var pubtypeMap = map[string]Design{
-	"meta-analysis":                DesignMetaAnalysis,
+	"meta-analysis":               DesignMetaAnalysis,
 	"systematic review":           DesignSystematicReview,
 	"randomized controlled trial": DesignRCT,
 	"controlled clinical trial":   DesignRCT,
@@ -142,7 +142,14 @@ func ClassifyDesign(title, abstract, openalexType string, pubTypes []string) Cla
 			}
 		}
 	}
-	if best != DesignUnknown {
+	// Every pubtype except the generic "review" names a specific design and is
+	// trusted outright. "review" is the one label a source can apply to a work
+	// whose own title and abstract call it a meta-analysis: measured on
+	// 10.3389/fnut.2022.1084455, a 55-RCT meta-analysis tagged only "Review",
+	// that costs the work eight tier points (9 -> 1). So when the generic label
+	// is all that came back, the heuristics still run and the stronger of the
+	// two answers wins.
+	if best != DesignUnknown && best != DesignNarrativeReview {
 		return Classification{Design: best, Tier: TierWeight(best), Method: MethodPubMedPubType}
 	}
 
@@ -150,8 +157,15 @@ func ClassifyDesign(title, abstract, openalexType string, pubTypes []string) Cla
 	hay := strings.ToLower(title + ". " + abstract)
 	for _, t := range heuristicTiers {
 		if t.re.MatchString(hay) {
-			return Classification{Design: t.design, Tier: TierWeight(t.design), Method: MethodHeuristic}
+			if TierRank(t.design) < bestRank {
+				return Classification{Design: t.design, Tier: TierWeight(t.design), Method: MethodHeuristic}
+			}
+			break
 		}
+	}
+	// The generic pubtype stands when the heuristics found nothing stronger.
+	if best != DesignUnknown {
+		return Classification{Design: best, Tier: TierWeight(best), Method: MethodPubMedPubType}
 	}
 
 	// 3. Coarse OpenAlex type fallback.

--- a/library/other/scientific-consensus/internal/scengine/evidence_generic_review_test.go
+++ b/library/other/scientific-consensus/internal/scengine/evidence_generic_review_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 laci141 and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package scengine
+
+import "testing"
+
+// A source that tags a meta-analysis with nothing but the generic "review"
+// pubtype used to cost the work eight tier points, because the cascade returned
+// on the first authoritative label and never reached the heuristics. Measured on
+// 10.3389/fnut.2022.1084455, a 55-RCT meta-analysis: tier 9 became tier 1.
+func TestGenericReviewPubtypeYieldsToStrongerHeuristic(t *testing.T) {
+	const (
+		metaTitle = "The effects of green tea supplementation on cardiovascular " +
+			"risk factors: A systematic review and meta-analysis"
+		metaAbstract = "The current systematic review and meta-analysis study aimed " +
+			"to establish the effects. Meta-analyses were carried out using a " +
+			"random-effects model."
+		plainTitle    = "Beneficial effects of green tea"
+		plainAbstract = "An overview of what is known about green tea and health."
+	)
+
+	tests := []struct {
+		name       string
+		title      string
+		abstract   string
+		pubTypes   []string
+		wantDesign Design
+		wantMethod Method
+	}{
+		{
+			name:       "generic review yields to a stronger heuristic",
+			title:      metaTitle,
+			abstract:   metaAbstract,
+			pubTypes:   []string{"Review"},
+			wantDesign: DesignMetaAnalysis,
+			wantMethod: MethodHeuristic,
+		},
+		{
+			name:       "generic review stands when the heuristics find nothing",
+			title:      plainTitle,
+			abstract:   plainAbstract,
+			pubTypes:   []string{"Review"},
+			wantDesign: DesignNarrativeReview,
+			wantMethod: MethodPubMedPubType,
+		},
+		{
+			name:       "a specific pubtype still wins outright",
+			title:      plainTitle,
+			abstract:   plainAbstract,
+			pubTypes:   []string{"Meta-Analysis"},
+			wantDesign: DesignMetaAnalysis,
+			wantMethod: MethodPubMedPubType,
+		},
+		{
+			name:       "a specific pubtype is not overridden by a weaker heuristic",
+			title:      "A narrative review of green tea",
+			abstract:   "This narrative review surveys the literature.",
+			pubTypes:   []string{"Randomized Controlled Trial"},
+			wantDesign: DesignRCT,
+			wantMethod: MethodPubMedPubType,
+		},
+		{
+			name:       "no pubtypes leaves the heuristics in charge",
+			title:      metaTitle,
+			abstract:   metaAbstract,
+			pubTypes:   nil,
+			wantDesign: DesignMetaAnalysis,
+			wantMethod: MethodHeuristic,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyDesign(tc.title, tc.abstract, "review", tc.pubTypes)
+			if got.Design != tc.wantDesign {
+				t.Errorf("design = %q, want %q", got.Design, tc.wantDesign)
+			}
+			if got.Method != tc.wantMethod {
+				t.Errorf("method = %q, want %q", got.Method, tc.wantMethod)
+			}
+			if want := TierWeight(tc.wantDesign); got.Tier != want {
+				t.Errorf("tier = %v, want %v", got.Tier, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix(scientific-consensus): let a stronger heuristic outrank a generic review pubtype

ClassifyDesign returned on the first authoritative publication type it
recognised. Every entry in pubtypeMap names a specific design except one:
"review", which a source can apply to a work whose own title and abstract
call it a meta-analysis. When that generic label was all that came back, the
cascade stopped there and the title/abstract heuristics never ran.

Measured on 10.3389/fnut.2022.1084455, a 2023 pooled analysis of 55 RCTs
whose title reads "A systematic review and meta-analysis" and whose abstract
repeats it twice. Tagged only "Review", it classified as narrative-review at
tier 1. With the pubtypes removed so the heuristics could run, the same
title and abstract classified as meta-analysis at tier 9 — an eight-point
swing on a work the consensus engine should weight most heavily.

The generic label now defers: the heuristics run, and the stronger of the
two answers wins. A specific pubtype still returns immediately and is never
overridden by a weaker heuristic, and "review" still stands when the
heuristics find nothing better. Covered by five table cases.