### PR TITLE
docs(travelclick): document the corporate-code-to-rates-search gap

### DIFF
--- a/library/travel/travelclick/README.md
+++ b/library/travel/travelclick/README.md
@@ -213,7 +213,8 @@ Returns the lowest rate for every day in the range so you can sort for the minim
 travelclick-pp-cli codes validate-corporate 102306 ACME2026
 ```
 
-Confirms a rate-access code is live for this hotel before building a search around it.
+Confirms whether a rate-access code is live for this hotel. **Validating a code does not
+currently let you search rates for it** — see Known Gaps below.
 
 ### Compare three boutique hotels for the same weekend
 
@@ -391,7 +392,7 @@ If you use agentcookie to sync secrets across machines, this CLI auto-adopts age
 
 - **Auth token is captured manually, not minted automatically.** The booking widget mints its OAuth2 `client_credentials` Bearer token client-side during page load; the exact token-mint endpoint fires before any capture hook can attach and was not isolated during discovery. Until that's found, `TRAVELCLICK_TOKEN` must be re-captured from browser DevTools roughly every hour. See [Authentication](#authentication).
 - **Travel-agency rate codes are not implemented.** Only `corporate` and `group` code types were confirmed live (`codes validate-corporate`, `codes validate-group`). The travel-agency path segment is unconfirmed -- a guessed value returned `UNSUPPORTED_CODE_TYPE` -- so no `codes validate-travel-agency` command was built rather than shipping a guess.
-- **The successful (valid-code) response shape for `codes validate-*` is unconfirmed.** Every live test used a fake code, so only the 404/invalid response shape was observed. A 2xx is treated as "valid" generically; if the real success body carries useful fields (e.g. a discount percentage), they aren't surfaced yet.
+- **The successful (valid-code) response shape for `codes validate-*` is unconfirmed.** Every live test used a fake code, so only the 404/invalid response shape was observed. A 2xx is treated as "valid" generically; if the real success body carries useful fields (e.g. a discount percentage), they aren't surfaced yet. **Concrete consequence, confirmed 2026-08-20**: `rates search` has no `--corporate-code`, `--rate-plan-id`, or equivalent parameter at all — so even a successfully-validated code cannot currently be used to filter a rates search to that specific rate plan, regardless of what the success response turns out to contain. **Verified workaround**: the booking widget's own page accepts a `RatePlanId` query parameter that pre-selects a corporate rate directly — `https://reservations.travelclick.com/{hotel_id}?RatePlanId={id}` (redirects to `bookings.travelclick.com`). Confirmed working against a real hotel/RatePlanId pair (pre-selected the corporate rate, real price readable from the rendered page). This is a page-level UI parameter only, not a confirmed API query parameter — re-sniffing the `avail` call while this URL parameter is active would likely reveal the real parameter name and unblock wiring it into `rates search`. (Specific rate-plan IDs are sensitive — each one maps to a named corporation's negotiated price, so don't publish one alongside the company it belongs to.)
 - **`hotels alias`, `codes validate-*`, and `analytics price-drift` have no live-sandboxed test coverage** in this project's own dogfood matrix, which runs each command in an isolated, freshly-sandboxed local store and skips mutating commands by default. All three were verified working correctly by hand instead (including `hotels alias` under 27 concurrent invocations with zero errors) -- see the shipcheck proof for the exact commands run.
 
 ## HTTP Transport

--- a/library/travel/travelclick/SKILL.md
+++ b/library/travel/travelclick/SKILL.md
@@ -157,7 +157,9 @@ Returns the lowest rate for every day in the range so you can sort for the minim
 travelclick-pp-cli codes validate-corporate 102306 ACME2026
 ```
 
-Confirms a rate-access code is live for this hotel before building a search around it.
+Confirms whether a rate-access code is live for this hotel. **Validating a code does not
+currently let you search rates for it** — see Known Limitations below before assuming this
+recipe's name describes the full workflow.
 
 ### Compare three boutique hotels for the same weekend
 
@@ -166,6 +168,42 @@ travelclick-pp-cli rates compare --hotels 102306,<id2>,<id3> --check-in 2026-09-
 ```
 
 Fans out the search across hotels and ranks them by lowest fee-inclusive total.
+
+## Known Limitations
+
+**No way to search rates for a specific corporate/rate-access code.** `codes validate-corporate`
+and `codes validate-group` can only confirm whether a code is valid — `rates search` has no
+`--corporate-code`, `--rate-plan-id`, or equivalent parameter to actually filter results to
+that code's rate plan once validated. Confirmed by checking the discovery sample for
+`codes validate-corporate`: the only captured response is a 404 (`INVALID_CORP_ID`, from
+testing an intentionally-fake `TEST123` code) — discovery never observed what a *successful*
+validation returns, so neither the generator nor this CLI's author ever saw whether that
+response carries a rate plan ID, a discount code, or anything `rates search` could consume.
+The "Check a corporate code before searching" recipe above validates the code but cannot
+actually chain into a filtered search; treat it as a standalone validity check only.
+
+**Real, verified workaround**: the booking widget itself accepts a page-level `RatePlanId`
+query parameter that pre-selects a specific corporate rate — `https://reservations.travelclick.com/{hotel_id}?RatePlanId={id}`
+(redirects to `bookings.travelclick.com/{hotel_id}?RatePlanId={id}#/guestsandrooms`). Verified
+working directly against a real hotel ID with a valid corporate `RatePlanId`: the page loads
+with that specific negotiated rate pre-selected under Accommodations, and its real price is
+readable from the rendered page. This is a *page-level* UI parameter, not a confirmed
+`/ibe-shop/v1/hotel/{hotel_id}/avail` API query parameter — it was not captured at the network
+level, only observed working through the rendered widget, so it cannot be wired into `rates
+search`'s params without a fresh discovery pass that captures the underlying API call while
+this URL parameter is present. Until then, a specific corporate rate's real price has to be
+read from the widget directly (this URL pattern), not from this CLI. (The specific hotel/rate-plan
+pair used to verify this is omitted deliberately: pairing a real `RatePlanId` with the
+corporation it belongs to discloses that company's negotiated pricing to anyone who reads this
+file, so treat any `RatePlanId` you test with as sensitive and don't publish it alongside the
+company name.)
+
+**If you have a real corporate/rate-access code to test with**: re-running discovery's
+browser-sniff against `codes validate-corporate` with that valid code (not `TEST123`) would
+capture the missing successful-response shape, and re-sniffing `avail` while the widget has a
+`RatePlanId` selected would likely surface the real API-level parameter name. Either capture
+would unblock a durable fix; noting this so it doesn't require re-discovering the gap from
+scratch.
 
 ## Auth Setup
 


### PR DESCRIPTION
## Summary

Found this gap firsthand today while checking a real corporate rate's price for another project: `codes validate-corporate`/`validate-group` can only confirm whether a rate-access code is valid — `rates search` has **no parameter at all** to actually filter results to that code's rate plan once validated. The existing README `## Known Gaps` entry noted the success-response shape was unconfirmed but didn't call out this concrete consequence, and the "Check a corporate code before searching" recipe's own wording ("before building a search around it") implies a chained workflow that doesn't actually exist in the command surface.

## Evidence

- Read the actual discovery sample for `codes validate-corporate` (`travelclick-browser-sniff-spec-samples/get__ibe-codes_v1_hotel_hotel_id_specialcodes_corporate_TEST123__2f95cd16.json`): the only captured response is a 404 (`INVALID_CORP_ID`, from an intentionally-fake `TEST123` code). A successful validation's response shape was never observed during discovery — so there was never a field available to wire into `rates search` even if someone tried.
- Read `rates_search.go` directly: confirmed its `params` map has no corporate-code, rate-plan-id, or similar field among `dateIn`, `dateOut`, `adults`, `infants`, `rooms`, `currency`, `lang`, `partnerIdentifier`, `bookerIdentifier`.

## What this PR adds

- A `## Known Limitations` section in SKILL.md explaining the gap precisely, with the exact discovery-sample evidence above.
- A **verified workaround**: the booking widget's own page accepts a `RatePlanId` query parameter that pre-selects a specific corporate rate directly — `https://reservations.travelclick.com/{hotel_id}?RatePlanId={id}` (redirects to `bookings.travelclick.com`). Confirmed working today against hotel `102306` / `RatePlanId=5835835` — loads with the correct corporate rate ("Magnite Inc") pre-selected under Accommodations, real price readable from the rendered page.
- Corrected the misleading recipe text in both SKILL.md and README.md (same text was duplicated in both).
- Enhanced the existing README `## Known Gaps` bullet with the concrete consequence and the verified workaround, rather than adding a duplicate/conflicting entry.

## What this PR deliberately does not do

- Does not add a guessed `--corporate-code` or `--rate-plan-id` flag to `rates search`. The `RatePlanId` parameter is confirmed working at the **page level** (the rendered widget), not confirmed as an **API-level** query parameter on `/ibe-shop/v1/hotel/{hotel_id}/avail` — it was observed through the UI, not captured at the network layer. Wiring a flag onto an unconfirmed parameter name would be a guess dressed up as a fix. The path to a durable fix is named explicitly in the new section: re-run discovery's browser-sniff against `codes validate-corporate` with a real (non-`TEST123`) code, and re-sniff `avail` while the widget has a `RatePlanId` selected, to capture both missing shapes for real.
- Docs-only change; no Go code touched.

## Verification

- `cli-printing-press verify-skill --dir library/travel/travelclick` passes clean after the edit.