### PR TITLE
fix(fireflies): rebase updateMeetingTitle/updateMeetingPrivacy input-object shape

### DIFF
--- a/library/productivity/fireflies/.printing-press-patches/update-meeting-input-object-shape.json
+++ b/library/productivity/fireflies/.printing-press-patches/update-meeting-input-object-shape.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "update-meeting-input-object-shape",
+  "applied_at": "2026-08-21",
+  "base_run_id": "20260509-005754",
+  "base_printing_press_version": "4.0.6",
+  "summary": "transcripts update must send updateMeetingTitle/updateMeetingPrivacy as input-object mutations returning meeting fields, matching the live Fireflies API.",
+  "reason": "The live Fireflies API uses updateMeetingTitle(input: UpdateMeetingTitleInput!) and updateMeetingPrivacy(input: UpdateMeetingPrivacyInput!) and returns meeting fields, not flat (id:, title:)/(id:, privacy:) arguments returning { success message }. The generated flat shape made transcripts update fail on every live call. Original mutation-shape fix by @erash11 in #1571.",
+  "files": [
+    "internal/cli/transcripts_ff.go",
+    "spec.yaml"
+  ],
+  "validated_outcome": "Local go build/vet/test and verify-skill pass on current main. #1571 live-tested the title path against the Fireflies API (returns {\"title\": \"...\"}); the privacy branch is the same input-object shape from the docs and was not live-tested to avoid mutating a real meeting's privacy."
+}

--- a/library/productivity/fireflies/go.mod
+++ b/library/productivity/fireflies/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/printing-press-library/library/productivity/fireflies
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/library/productivity/fireflies/internal/cli/transcripts_ff.go
+++ b/library/productivity/fireflies/internal/cli/transcripts_ff.go
@@ -871,16 +871,16 @@ func newTranscriptsUpdateCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if title != "" {
-				const q = `mutation UpdateMeetingTitle($id: String!, $title: String!) { updateMeetingTitle(id: $id, title: $title) { success message } }`
-				data, err := client.Query(cmd.Context(), q, map[string]any{"id": args[0], "title": title}, "updateMeetingTitle")
+				const q = `mutation UpdateMeetingTitle($input: UpdateMeetingTitleInput!) { updateMeetingTitle(input: $input) { title } }`
+				data, err := client.Query(cmd.Context(), q, map[string]any{"input": map[string]any{"id": args[0], "title": title}}, "updateMeetingTitle")
 				if err != nil {
 					return fmt.Errorf("updating title: %w", err)
 				}
 				return printJSONFiltered(cmd.OutOrStdout(), data, flags)
 			}
 			if privacy != "" {
-				const q = `mutation UpdateMeetingPrivacy($id: String!, $privacy: String!) { updateMeetingPrivacy(id: $id, privacy: $privacy) { success message } }`
-				data, err := client.Query(cmd.Context(), q, map[string]any{"id": args[0], "privacy": privacy}, "updateMeetingPrivacy")
+				const q = `mutation UpdateMeetingPrivacy($input: UpdateMeetingPrivacyInput!) { updateMeetingPrivacy(input: $input) { id title privacy } }`
+				data, err := client.Query(cmd.Context(), q, map[string]any{"input": map[string]any{"id": args[0], "privacy": privacy}}, "updateMeetingPrivacy")
 				if err != nil {
 					return fmt.Errorf("updating privacy: %w", err)
 				}

--- a/library/productivity/fireflies/spec.yaml
+++ b/library/productivity/fireflies/spec.yaml
@@ -61,10 +61,10 @@ type Query {
 
 type Mutation {
   """Update a meeting title"""
-  updateMeetingTitle(id: String!, title: String!): MutationResult
+  updateMeetingTitle(input: UpdateMeetingTitleInput!): Transcript
 
   """Update meeting privacy"""
-  updateMeetingPrivacy(id: String!, privacy: String!): MutationResult
+  updateMeetingPrivacy(input: UpdateMeetingPrivacyInput!): Transcript
 
   """Update meeting channel/folder"""
   updateMeetingChannel(id: String!, channel_id: String!): MutationResult
@@ -378,6 +378,16 @@ input AttendeeInput {
   displayName: String
   email: String
   phoneNumber: String
+}
+
+input UpdateMeetingTitleInput {
+  id: String!
+  title: String!
+}
+
+input UpdateMeetingPrivacyInput {
+  id: String!
+  privacy: String!
 }
 
 scalar DateTime


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Recreates @erash11's mutation-shape fix from #1571 on current `mvanhorn/printing-press-library` `main`.
- This is a maintainer rebase follow-up, same class as #1246 → #1741: the contributor fork cannot take a workflow-touching rebase because GitHub App tokens lack `workflows` permission (`refusing to allow a GitHub App to create or update workflow '.github/workflows/update-cli-release-ledger.yml'`).
- Does not bounce the author and does not update, comment on, or merge #1571.

## What Changed

Original work by @erash11 in #1571. `transcripts update` was sending the generated flat mutations:

```graphql
mutation UpdateMeetingTitle($id: String!, $title: String!) { updateMeetingTitle(id: $id, title: $title) { success message } }
mutation UpdateMeetingPrivacy($id: String!, $privacy: String!) { updateMeetingPrivacy(id: $id, privacy: $privacy) { success message } }
```

The live Fireflies API uses input-object mutations that return meeting fields. This PR applies that shape on current main.

Maintainer leftovers on top of #1571:

- Pin `library/productivity/fireflies/go.mod` from `go 1.26.5` to the repo-wide `go 1.26.6` floor. `go mod tidy` produced no additional file changes. No `catalog-go-1266` patch (same as #1741 for a one-CLI floor bump).
- Add `.printing-press-patches/update-meeting-input-object-shape.json` so a regen keeps the live API contract.

Files changed:

- `library/productivity/fireflies/internal/cli/transcripts_ff.go`
- `library/productivity/fireflies/spec.yaml`
- `library/productivity/fireflies/go.mod`
- `library/productivity/fireflies/.printing-press-patches/update-meeting-input-object-shape.json`

Does not touch `.github/workflows/**`, `registry.json`, `cli-skills/**`, release-ledger files, `CHANGELOG.md`, `.printing-press-release.json`, or repo-root `.go-version`.

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/productivity/fireflies/`
- [x] `go build ./...` from `library/productivity/fireflies`
- [x] `go vet ./...` from `library/productivity/fireflies`
- [x] `go test ./...` from `library/productivity/fireflies` (including `internal/store`; no SQLITE_BUSY flake on this Linux runner)
- [x] `git diff --check`

#1571 already live-tested the title path against the Fireflies API.

## Gaps / Follow-Up

- #1571 remains the original draft on `erash11:fix/fireflies-update-mutations` (~527 commits behind). Close or supersede it after this lands; do not rebase that fork through the workflow-permission gate.
- Privacy branch was not live-tested (same as #1571) to avoid mutating a real meeting's privacy.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcd6fea3-1979-47e0-bbcc-72664a6c4e43?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcd6fea3-1979-47e0-bbcc-72664a6c4e43&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

