### PR TITLE
feat(linear): rebase --label-name issue writes from #1411

### DIFF
--- a/library/project-management/linear/.printing-press-patches/mob-340-mob-479-label-name-resolution.json
+++ b/library/project-management/linear/.printing-press-patches/mob-340-mob-479-label-name-resolution.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "mob-340-mob-479-label-name-resolution",
+  "applied_at": "2026-06-30",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "Issue create/edit can resolve exact Linear issue label names, including team-safe global labels, before writing labelIds.",
+  "reason": "Agents usually know label names rather than UUIDs; resolving names at write time prevents prose-only intended-label notes while preserving Linear team ownership validation.",
+  "files": [
+    "internal/cli/label_resolve.go",
+    "internal/cli/issues_create.go",
+    "internal/cli/issues_edit.go",
+    "internal/cli/linear_agent_test.go"
+  ]
+}

--- a/library/project-management/linear/.printing-press-patches/mob-630-label-name-media-and-dedup.json
+++ b/library/project-management/linear/.printing-press-patches/mob-630-label-name-media-and-dedup.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "mob-630-label-name-media-and-dedup",
+  "applied_at": "2026-06-30",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "Preserve existing issue descriptions when --label-name and --media are combined, resolve each distinct normalized --label-name once, and reuse edit metadata when no description fetch is needed.",
+  "reason": "The combined edit path needs regression coverage because label-name metadata loading must not prevent media edits from fetching and appending to the existing description. Duplicate label-name values previously caused redundant live label search calls before ID-level deduplication. Live issues edit also re-fetched issue metadata after --label-name had already loaded it, unless media needed the existing description body.",
+  "files": [
+    "internal/cli/issues_edit.go",
+    "internal/cli/label_resolve.go",
+    "internal/cli/linear_agent_test.go"
+  ],
+  "validated_outcome": "Targeted Go tests cover media append preservation, single lookup for duplicate normalized label names, and no redundant second issue metadata fetch on live issues edit when metadata is already loaded."
+}

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -40,7 +40,7 @@ If `--version` reports "command not found" after install, the runtime cannot see
 - A missing `description` in compact output does not mean an empty issue body. Request it explicitly: `linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.name,url`.
 - Fetch several known issues in one call with comma-separated identifiers: `linear-pp-cli issues ENG-123,ENG-124 --agent`. The result array preserves caller order and removes duplicate identifiers; a missing member fails the whole read instead of returning a partial set.
 - Prefer the canonical read and comment forms shown here. Common agent phrasing is accepted without changing behavior: `issues get|view|show ENG-123`, `documents get|view <ref>`, and `comments create` are compatibility aliases for `issues ENG-123`, `documents <ref>`, and `comments add`. The aliases accept the same global flags, comma reads, body files, targets, and media flags as their canonical commands; there is deliberately no `documents show` alias.
-- Before passing label UUIDs to `issues create` or `issues edit`, run `linear-pp-cli labels list --team ENG --agent --select id,name,global,team.key`. Use only global labels or labels owned by the target issue team; the CLI preflights label ownership and refuses cross-team labels before mutating.
+- `--label` is UUID-only; `--label-name` resolves an exact label name at write time (team-owned or workspace-global). Before passing UUIDs to `issues create` or `issues edit`, run `linear-pp-cli labels list --team ENG --agent --select id,name,global,team.key`. The CLI preflights ownership and refuses cross-team labels before mutating.
 - Never pass multiline Markdown, shell snippets, GraphQL, logs, backticks, `$()` expansions, or media-rich content as inline shell arguments. Write the body to a file or stdin and use the `*-file` / `*-stdin` flags below.
 
 ## When to Use This CLI
@@ -163,14 +163,19 @@ These capabilities aren't available in any other tool for this API.
   linear-pp-cli issues edit ENG-124 --parent ENG-123 --agent
   linear-pp-cli issues edit ENG-124 --no-parent --agent
   ```
-- **Team-safe issue labels** — Discover labels that are valid for the target Linear team, including global labels, before creating or editing issues.
+- **Team-safe issue labels** — Discover labels that are valid for the target Linear team, including global labels, then attach them by UUID or exact name.
 
-  _Reach for this before passing label UUIDs to `issues create` or `issues edit`; Linear rejects labels owned by another team, and the CLI preflights label ownership before mutating._
+  _Reach for this before attaching labels. `--label` is UUID-only; use `--label-name` when the input is a human label name. Linear rejects labels owned by another team, and the CLI preflights ownership before mutating._
 
   ```bash
   linear-pp-cli labels list --team ENG --agent --select id,name,global,team.key
   linear-pp-cli issues create --title "Title" --team ENG --label <global-or-eng-label-id> --agent
+  linear-pp-cli issues create --title "Title" --team ENG --label-name "kind:bug" --label-name "source:user-report" --agent
+  linear-pp-cli issues edit ENG-123 --label-name "area:review-tooling" --dry-run --agent
+  linear-pp-cli issues edit ENG-123 --label-name "area:review-tooling" --agent
   ```
+
+  `--label-name` always performs a live Linear read to resolve the UUID, even when the surrounding issue write is a dry-run. Writes require a normalized exact label-name match. Team-owned labels and workspace-global labels (no team) both resolve; labels owned by another team do not. `--label` and `--label-name` can be combined; resolved IDs are de-duplicated before the mutation.
 - **Project and initiative name resolution** — Resolve portfolio objects by human name before writing issue relationships.
 
   _Reach for this when a user gives an issue identifier plus a project or initiative name. `--project` is UUID-only; use `--project-name` when the input is a human project name._
@@ -476,7 +481,7 @@ Commands fall into three categories with different data-source semantics. Use `-
 
 - `labels list --team ENG`
 - Default (`--data-source auto`) reads live and returns global labels plus labels owned by the named team. `--data-source local` reads the synced `issue_labels` table after `linear-pp-cli sync`.
-- Use the returned IDs for `issues create --label` or `issues edit --label`; cross-team label IDs are rejected before the issue mutation is sent.
+- Use the returned IDs for `issues create --label` or `issues edit --label`, or skip the UUID lookup with `--label-name` on create/edit. Cross-team label IDs and names owned by another team are rejected before the issue mutation is sent.
 
 **The budget-conscious agent loop:**
 

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -22,6 +22,7 @@ func newIssuesCreateCmd(flags *rootFlags) *cobra.Command {
 	var descStdin bool
 	var priorityFlag int
 	var labelsFlag []string
+	var labelNamesFlag []string
 	var mediaFlag []string
 	var mediaPublic bool
 	var dbPath string
@@ -154,6 +155,21 @@ sub-issue under an existing parent.`,
 			}
 			if stateFlag != "" {
 				input["stateId"] = stateFlag
+			}
+			if len(labelNamesFlag) > 0 {
+				if c == nil {
+					var err error
+					lookupClient, err := newPortfolioLookupClient(flags)
+					if err != nil {
+						return err
+					}
+					c = lookupClient
+				}
+				resolvedLabelIDs, err := resolveLabelNamesForWriteLive(c, labelNamesFlag, teamFlag, flags)
+				if err != nil {
+					return err
+				}
+				labelsFlag = mergeLabelIDs(labelsFlag, resolvedLabelIDs)
 			}
 			if len(labelsFlag) > 0 {
 				input["labelIds"] = labelsFlag
@@ -397,6 +413,7 @@ sub-issue under an existing parent.`,
 	cmd.Flags().StringVar(&stateTypeFlag, "state-type", "", "Workflow state type (triage, backlog, unstarted, started, completed, canceled, duplicate); resolved against --team")
 	cmd.Flags().StringVar(&parentFlag, "parent", "", "Parent issue identifier or UUID; creates the issue as a sub-issue")
 	cmd.Flags().StringSliceVar(&labelsFlag, "label", nil, "Label UUIDs (repeatable)")
+	cmd.Flags().StringSliceVar(&labelNamesFlag, "label-name", nil, "Resolve and attach label(s) by exact name (repeatable; team-scoped + team-safe global)")
 	cmd.Flags().StringSliceVar(&mediaFlag, "media", nil, "Upload file and append it to the description markdown (repeatable)")
 	cmd.Flags().BoolVar(&mediaPublic, "media-public", false, "Request public Linear asset URLs for uploaded media")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (for team-key resolution and pp_created ledger)")

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -152,7 +152,8 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 					if err != nil {
 						return classifyLiveReadError(err, flags)
 					}
-					if err := parseIssueEditMetadata(args[0], existing, &issueID, &issueTeam, &issueMetaLoaded, &descBody, &descSet, false); err != nil {
+					loadDescription := len(mediaFlag) > 0 && !descSet
+					if err := parseIssueEditMetadata(args[0], existing, &issueID, &issueTeam, &issueMetaLoaded, &descBody, &descSet, loadDescription); err != nil {
 						return err
 					}
 				}

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -18,6 +18,7 @@ func newIssuesEditCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 	var noParentFlag bool
 	var priorityFlag int
 	var labelsFlag []string
+	var labelNamesFlag []string
 	var mediaFlag []string
 	var mediaPublic bool
 	cmd := &cobra.Command{
@@ -89,9 +90,6 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 			if noParentFlag {
 				input["parentId"] = nil
 			}
-			if len(labelsFlag) > 0 {
-				input["labelIds"] = labelsFlag
-			}
 
 			descBody, descSet, err := readMarkdownBody(cmd, markdownBodySpec{
 				InlineFlag: "description",
@@ -140,8 +138,35 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 					input["projectId"] = projectID
 				}
 			}
+			if len(labelNamesFlag) > 0 {
+				if c == nil {
+					var err error
+					lookupClient, err := newPortfolioLookupClient(flags)
+					if err != nil {
+						return err
+					}
+					c = lookupClient
+				}
+				if !issueMetaLoaded {
+					existing, err := fetchIssueLive(c, args[0])
+					if err != nil {
+						return classifyLiveReadError(err, flags)
+					}
+					if err := parseIssueEditMetadata(args[0], existing, &issueID, &issueTeam, &issueMetaLoaded, &descBody, &descSet, false); err != nil {
+						return err
+					}
+				}
+				resolvedLabelIDs, err := resolveLabelNamesForWriteLive(c, labelNamesFlag, firstNonEmpty(issueTeam.Key, issueTeam.ID), flags)
+				if err != nil {
+					return err
+				}
+				labelsFlag = mergeLabelIDs(labelsFlag, resolvedLabelIDs)
+			}
+			if len(labelsFlag) > 0 {
+				input["labelIds"] = labelsFlag
+			}
 			if len(input) == 0 && len(mediaFlag) == 0 && stateNameFlag == "" && stateTypeFlag == "" {
-				return usageErr(fmt.Errorf("no issue fields supplied; pass --title, --description-file, --media, --state, --state-name, --state-type, --project, --project-name, --assignee, --priority, --label, --parent, or --no-parent"))
+				return usageErr(fmt.Errorf("no issue fields supplied; pass --title, --description-file, --media, --state, --state-name, --state-type, --project, --project-name, --assignee, --priority, --label, --label-name, --parent, or --no-parent"))
 			}
 			if flags.dryRun {
 				out := map[string]any{"issue": args[0], "input": input}
@@ -164,33 +189,17 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 					return err
 				}
 			}
-			if (len(mediaFlag) > 0 && !descSet) || len(labelsFlag) > 0 || stateNameFlag != "" || stateTypeFlag != "" {
+			needsExistingDescription := len(mediaFlag) > 0 && !descSet
+			needsIssueMetadata := !issueMetaLoaded && (len(labelsFlag) > 0 || stateNameFlag != "" || stateTypeFlag != "")
+			if needsExistingDescription || needsIssueMetadata {
 				existing, err := fetchIssueLive(c, args[0])
 				if err != nil {
 					return classifyLiveReadError(err, flags)
 				}
-				var issue struct {
-					ID          string `json:"id"`
-					Description string `json:"description"`
-					Team        struct {
-						ID  string `json:"id"`
-						Key string `json:"key"`
-					} `json:"team"`
+				if err := parseIssueEditMetadata(args[0], existing, &issueID, &issueTeam, &issueMetaLoaded, &descBody, &descSet, needsExistingDescription); err != nil {
+					return err
 				}
-				if err := json.Unmarshal(existing, &issue); err != nil {
-					return fmt.Errorf("parsing existing issue: %w", err)
-				}
-				if issue.ID == "" {
-					return fmt.Errorf("issue %q did not include an id", args[0])
-				}
-				issueID = issue.ID
-				issueTeam = issueTeamInfo{ID: issue.Team.ID, Key: issue.Team.Key}
-				issueMetaLoaded = true
-				if len(mediaFlag) > 0 && !descSet {
-					descBody = issue.Description
-					descSet = true
-				}
-			} else {
+			} else if !issueMetaLoaded {
 				var err error
 				issueID, err = resolveIssueID(c, args[0])
 				if err != nil {
@@ -278,9 +287,35 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 	cmd.Flags().StringVar(&parentFlag, "parent", "", "Parent issue identifier or UUID")
 	cmd.Flags().BoolVar(&noParentFlag, "no-parent", false, "Clear issue parentage")
 	cmd.Flags().StringSliceVar(&labelsFlag, "label", nil, "Replacement label UUIDs (repeatable)")
+	cmd.Flags().StringSliceVar(&labelNamesFlag, "label-name", nil, "Resolve and attach label(s) by exact name (repeatable; team-scoped + team-safe global)")
 	cmd.Flags().StringSliceVar(&mediaFlag, "media", nil, "Upload file and append it to the description markdown (repeatable)")
 	cmd.Flags().BoolVar(&mediaPublic, "media-public", false, "Request public Linear asset URLs for uploaded media")
 	return cmd
+}
+
+func parseIssueEditMetadata(issueRef string, raw json.RawMessage, issueID *string, issueTeam *issueTeamInfo, issueMetaLoaded *bool, descBody *string, descSet *bool, loadDescription bool) error {
+	var issue struct {
+		ID          string `json:"id"`
+		Description string `json:"description"`
+		Team        struct {
+			ID  string `json:"id"`
+			Key string `json:"key"`
+		} `json:"team"`
+	}
+	if err := json.Unmarshal(raw, &issue); err != nil {
+		return fmt.Errorf("parsing existing issue: %w", err)
+	}
+	if issue.ID == "" {
+		return fmt.Errorf("issue %q did not include an id", issueRef)
+	}
+	*issueID = issue.ID
+	*issueTeam = issueTeamInfo{ID: issue.Team.ID, Key: issue.Team.Key}
+	*issueMetaLoaded = true
+	if loadDescription {
+		*descBody = issue.Description
+		*descSet = true
+	}
+	return nil
 }
 
 func writeIssueBack(dbPath string, raw json.RawMessage) {

--- a/library/project-management/linear/internal/cli/label_resolve.go
+++ b/library/project-management/linear/internal/cli/label_resolve.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type issueLabelRef struct {
+	ID   string  `json:"id"`
+	Name string  `json:"name"`
+	Team *refKey `json:"team,omitempty"`
+}
+
+func searchIssueLabelsLive(c graphqlQueryer, query, team string) ([]issueLabelRef, error) {
+	const gql = `query($first: Int!, $after: String, $filter: IssueLabelFilter) {
+		issueLabels(first: $first, after: $after, filter: $filter) {
+			nodes {
+				id name
+				team { id key name }
+			}
+			pageInfo { hasNextPage endCursor }
+		}
+	}`
+	needle := normalizePortfolioName(query)
+	teamNeedle := normalizePortfolioName(team)
+	filter := portfolioNameContainsFilter(query)
+	var out []issueLabelRef
+	var after any
+	for {
+		var resp struct {
+			IssueLabels struct {
+				Nodes []struct {
+					ID   string  `json:"id"`
+					Name string  `json:"name"`
+					Team *refKey `json:"team"`
+				} `json:"nodes"`
+				PageInfo pageInfo `json:"pageInfo"`
+			} `json:"issueLabels"`
+		}
+		vars := map[string]any{"first": 100, "after": after}
+		if filter != nil {
+			vars["filter"] = filter
+		}
+		if err := c.QueryInto(gql, vars, &resp); err != nil {
+			return nil, err
+		}
+		for _, label := range resp.IssueLabels.Nodes {
+			if !portfolioNameMatches(label.Name, needle) {
+				continue
+			}
+			if !matchingIssueLabelTeam(label.Team, teamNeedle) {
+				continue
+			}
+			out = append(out, issueLabelRef{ID: label.ID, Name: label.Name, Team: label.Team})
+		}
+		if !resp.IssueLabels.PageInfo.HasNextPage || resp.IssueLabels.PageInfo.EndCursor == "" {
+			break
+		}
+		after = resp.IssueLabels.PageInfo.EndCursor
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if strings.EqualFold(out[i].Name, out[j].Name) {
+			return out[i].ID < out[j].ID
+		}
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+	return out, nil
+}
+
+func resolveLabelNameForWriteLive(c graphqlQueryer, name, team string, flags *rootFlags) (string, error) {
+	if c == nil {
+		return "", internalLabelResolveClientErr()
+	}
+	matches, err := searchIssueLabelsLive(c, name, team)
+	if err != nil {
+		return "", classifyLiveReadError(err, flags)
+	}
+	exact := exactLabelMatches(matches, name)
+	if len(exact) == 1 {
+		return exact[0].ID, nil
+	}
+	if len(exact) > 1 {
+		return "", portfolioResolveErr(flags, "label", name, exact, true)
+	}
+	return "", portfolioResolveErr(flags, "label", name, matches, false)
+}
+
+func resolveLabelNamesForWriteLive(c graphqlQueryer, names []string, team string, flags *rootFlags) ([]string, error) {
+	if c == nil {
+		return nil, internalLabelResolveClientErr()
+	}
+	resolved := make([]string, 0, len(names))
+	seenNames := make(map[string]bool, len(names))
+	seenIDs := make(map[string]bool, len(names))
+	for _, name := range names {
+		nameKey := normalizePortfolioName(name)
+		if seenNames[nameKey] {
+			continue
+		}
+		seenNames[nameKey] = true
+		id, err := resolveLabelNameForWriteLive(c, name, team, flags)
+		if err != nil {
+			return nil, err
+		}
+		key := strings.ToLower(strings.TrimSpace(id))
+		if key == "" || seenIDs[key] {
+			continue
+		}
+		seenIDs[key] = true
+		resolved = append(resolved, id)
+	}
+	return resolved, nil
+}
+
+func exactLabelMatches(matches []issueLabelRef, name string) []issueLabelRef {
+	needle := normalizePortfolioName(name)
+	var exact []issueLabelRef
+	for _, m := range matches {
+		if normalizePortfolioName(m.Name) == needle {
+			exact = append(exact, m)
+		}
+	}
+	return exact
+}
+
+func matchingIssueLabelTeam(team *refKey, teamNeedle string) bool {
+	if teamNeedle == "" {
+		return true
+	}
+	if team == nil || (team.ID == "" && team.Key == "" && team.Name == "") {
+		return true
+	}
+	return normalizePortfolioName(team.ID) == teamNeedle || normalizePortfolioName(team.Key) == teamNeedle || normalizePortfolioName(team.Name) == teamNeedle
+}
+
+func mergeLabelIDs(labelIDs, resolvedLabelIDs []string) []string {
+	merged := make([]string, 0, len(labelIDs)+len(resolvedLabelIDs))
+	seen := make(map[string]bool, len(labelIDs)+len(resolvedLabelIDs))
+	for _, id := range append(labelIDs, resolvedLabelIDs...) {
+		key := strings.ToLower(strings.TrimSpace(id))
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		merged = append(merged, id)
+	}
+	return merged
+}
+
+func internalLabelResolveClientErr() error {
+	return fmt.Errorf("internal error: --label-name resolution requires a live Linear client")
+}

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -1100,6 +1100,7 @@ func TestIssuesEditLabelNameWithMediaPreservesDescription(t *testing.T) {
 		assetURL            = "https://asset.example/screenshot.png"
 	)
 	var sawMutation bool
+	issueFetchCalls := 0
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut && r.URL.Path == "/upload" {
@@ -1114,6 +1115,7 @@ func TestIssuesEditLabelNameWithMediaPreservesDescription(t *testing.T) {
 		}
 		switch {
 		case strings.Contains(req.Query, "issues(filter"):
+			issueFetchCalls++
 			fmt.Fprintf(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"MOB-340","title":"Existing","description":%q,"priority":0,"estimate":0,"dueDate":null,"url":"https://linear.app/acme/issue/MOB-340","updatedAt":"2026-06-30T00:00:00Z","createdAt":"2026-06-30T00:00:00Z","state":{"id":"state-1","name":"Todo","type":"unstarted"},"team":{"id":"team-mob","key":"MOB","name":"Mobilyze"},"project":null,"assignee":null}]}}}`, existingDescription)
 		case strings.Contains(req.Query, "issueLabels(first"):
 			requirePortfolioNameFilter(t, req, "area:review-tooling")
@@ -1173,6 +1175,9 @@ func TestIssuesEditLabelNameWithMediaPreservesDescription(t *testing.T) {
 	}
 	if !sawMutation {
 		t.Fatalf("issueUpdate mutation was not sent; output=%s", out)
+	}
+	if issueFetchCalls != 1 {
+		t.Fatalf("fetched issue metadata %d times, want 1", issueFetchCalls)
 	}
 }
 

--- a/library/project-management/linear/internal/cli/linear_agent_test.go
+++ b/library/project-management/linear/internal/cli/linear_agent_test.go
@@ -1010,6 +1010,407 @@ func TestIssuesCreateProjectNameMutationUsesResolvedUUID(t *testing.T) {
 	}
 }
 
+func TestIssuesCreateLabelNameDryRunUsesResolvedUUID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issueLabels(first"):
+			requirePortfolioNameFilter(t, req, "kind:bug")
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-kind-bug","name":"kind:bug","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "issueCreate"):
+			t.Fatalf("dry-run should not send issueCreate")
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "create", "--title", "Labeled ticket", "--team", "MOB", "--label-name", "kind:bug", "--dry-run", "--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("issues create --label-name --dry-run failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Input struct {
+			LabelIDs []string `json:"labelIds"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("dry-run output is not JSON: %v\n%s", err, out)
+	}
+	if strings.Join(got.Input.LabelIDs, ",") != "label-kind-bug" {
+		t.Fatalf("labelIds = %#v, want resolved label UUID; output=%s", got.Input.LabelIDs, out)
+	}
+}
+
+func TestIssuesEditLabelNameDryRunUsesResolvedUUID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issues(filter"):
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"MOB-340","title":"Existing","description":"","priority":0,"estimate":0,"dueDate":null,"url":"https://linear.app/acme/issue/MOB-340","updatedAt":"2026-06-30T00:00:00Z","createdAt":"2026-06-30T00:00:00Z","state":{"id":"state-1","name":"Todo","type":"unstarted"},"team":{"id":"team-mob","key":"MOB","name":"Mobilyze"},"project":null,"assignee":null}]}}}`)
+		case strings.Contains(req.Query, "issueLabels(first"):
+			requirePortfolioNameFilter(t, req, "area:review-tooling")
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-area-review-tooling","name":"area:review-tooling","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "issueUpdate"):
+			t.Fatalf("dry-run should not send issueUpdate")
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "edit", "MOB-340", "--label-name", "area:review-tooling", "--dry-run", "--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("issues edit --label-name --dry-run failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Input struct {
+			LabelIDs []string `json:"labelIds"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("dry-run output is not JSON: %v\n%s", err, out)
+	}
+	if strings.Join(got.Input.LabelIDs, ",") != "label-area-review-tooling" {
+		t.Fatalf("labelIds = %#v, want resolved label UUID; output=%s", got.Input.LabelIDs, out)
+	}
+}
+
+func TestIssuesEditLabelNameWithMediaPreservesDescription(t *testing.T) {
+	mediaPath := filepath.Join(t.TempDir(), "screenshot.png")
+	if err := os.WriteFile(mediaPath, []byte("image bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const (
+		existingDescription = "Existing description before upload."
+		assetURL            = "https://asset.example/screenshot.png"
+	)
+	var sawMutation bool
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && r.URL.Path == "/upload" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issues(filter"):
+			fmt.Fprintf(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"MOB-340","title":"Existing","description":%q,"priority":0,"estimate":0,"dueDate":null,"url":"https://linear.app/acme/issue/MOB-340","updatedAt":"2026-06-30T00:00:00Z","createdAt":"2026-06-30T00:00:00Z","state":{"id":"state-1","name":"Todo","type":"unstarted"},"team":{"id":"team-mob","key":"MOB","name":"Mobilyze"},"project":null,"assignee":null}]}}}`, existingDescription)
+		case strings.Contains(req.Query, "issueLabels(first"):
+			requirePortfolioNameFilter(t, req, "area:review-tooling")
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-area-review-tooling","name":"area:review-tooling","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "issueLabels(filter"):
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-area-review-tooling","name":"area:review-tooling","color":"#123456","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"}}]}}}`)
+		case strings.Contains(req.Query, "fileUpload"):
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"fileUpload": map[string]any{
+						"success": true,
+						"uploadFile": map[string]any{
+							"uploadUrl": srv.URL + "/upload",
+							"assetUrl":  assetURL,
+							"headers":   []map[string]string{},
+						},
+					},
+				},
+			}); err != nil {
+				t.Errorf("encode fileUpload response: %v", err)
+			}
+		case strings.Contains(req.Query, "issueUpdate"):
+			sawMutation = true
+			if got := req.Variables["id"]; got != "issue-1" {
+				t.Fatalf("issueUpdate id = %v, want issue-1", got)
+			}
+			input, ok := req.Variables["input"].(map[string]any)
+			if !ok {
+				t.Fatalf("issueUpdate input missing: %+v", req.Variables)
+			}
+			desc, ok := input["description"].(string)
+			if !ok {
+				t.Fatalf("issueUpdate description missing from input: %+v", input)
+			}
+			if !strings.Contains(desc, existingDescription) {
+				t.Fatalf("description dropped existing body: %q", desc)
+			}
+			if !strings.Contains(desc, "![screenshot.png]("+assetURL+")") {
+				t.Fatalf("description missing media markdown: %q", desc)
+			}
+			labels, ok := input["labelIds"].([]any)
+			if !ok || len(labels) != 1 || labels[0] != "label-area-review-tooling" {
+				t.Fatalf("labelIds = %#v, want resolved label UUID", input["labelIds"])
+			}
+			fmt.Fprintf(w, `{"data":{"issueUpdate":{"success":true,"issue":{"id":"issue-1","identifier":"MOB-340","title":"Existing","description":%q,"url":"https://linear.app/acme/issue/MOB-340","priority":0,"estimate":0,"dueDate":null,"createdAt":"2026-06-30T00:00:00Z","updatedAt":"2026-06-30T00:00:00Z","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"},"state":{"id":"state-1","name":"Todo","type":"unstarted"},"project":null,"assignee":null,"parent":null,"children":{"nodes":[]}}}}}`, desc)
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "edit", "MOB-340", "--label-name", "area:review-tooling", "--media", mediaPath, "--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("issues edit --label-name --media failed: %v\n%s", err, out)
+	}
+	if !sawMutation {
+		t.Fatalf("issueUpdate mutation was not sent; output=%s", out)
+	}
+}
+
+func TestIssuesEditLabelNameMergeDedupesWithoutRedundantMetadataFetch(t *testing.T) {
+	issueFetchCalls := 0
+	labelLookupCalls := 0
+	var sawMutation bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issues(filter"):
+			issueFetchCalls++
+			fmt.Fprint(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"MOB-340","title":"Existing","description":"","priority":0,"estimate":0,"dueDate":null,"url":"https://linear.app/acme/issue/MOB-340","updatedAt":"2026-06-30T00:00:00Z","createdAt":"2026-06-30T00:00:00Z","state":{"id":"state-1","name":"Todo","type":"unstarted"},"team":{"id":"team-mob","key":"MOB","name":"Mobilyze"},"project":null,"assignee":null}]}}}`)
+		case strings.Contains(req.Query, "issueLabels(first"):
+			labelLookupCalls++
+			requirePortfolioNameFilter(t, req, "area:review-tooling")
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-area-review-tooling","name":"area:review-tooling","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "issueLabels(filter"):
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-area-review-tooling","name":"area:review-tooling","color":"#123456","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"}}]}}}`)
+		case strings.Contains(req.Query, "issueUpdate"):
+			sawMutation = true
+			if got := req.Variables["id"]; got != "issue-1" {
+				t.Fatalf("issueUpdate id = %v, want issue-1", got)
+			}
+			input, ok := req.Variables["input"].(map[string]any)
+			if !ok {
+				t.Fatalf("issueUpdate input missing: %+v", req.Variables)
+			}
+			labels, ok := input["labelIds"].([]any)
+			if !ok || len(labels) != 1 || labels[0] != "label-area-review-tooling" {
+				t.Fatalf("labelIds = %#v, want one de-duped resolved label UUID", input["labelIds"])
+			}
+			fmt.Fprint(w, `{"data":{"issueUpdate":{"success":true,"issue":{"id":"issue-1","identifier":"MOB-340","title":"Existing","description":"","url":"https://linear.app/acme/issue/MOB-340","priority":0,"estimate":0,"dueDate":null,"createdAt":"2026-06-30T00:00:00Z","updatedAt":"2026-06-30T00:00:00Z","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"},"state":{"id":"state-1","name":"Todo","type":"unstarted"},"project":null,"assignee":null,"parent":null,"children":{"nodes":[]}}}}}`)
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "edit", "MOB-340", "--label-name", "area:review-tooling", "--label-name", " AREA:REVIEW-TOOLING ", "--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("issues edit duplicate --label-name failed: %v\n%s", err, out)
+	}
+	if !sawMutation {
+		t.Fatalf("issueUpdate mutation was not sent; output=%s", out)
+	}
+	if labelLookupCalls != 1 {
+		t.Fatalf("resolved duplicate --label-name values with %d lookups, want 1", labelLookupCalls)
+	}
+	if issueFetchCalls != 1 {
+		t.Fatalf("fetched issue metadata %d times, want 1", issueFetchCalls)
+	}
+}
+
+func TestIssuesCreateLabelNameAmbiguousReturnsCandidates(t *testing.T) {
+	createCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issueLabels(first"):
+			requirePortfolioNameFilter(t, req, "kind:bug")
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-kind-bug-a","name":"kind:bug","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"}},{"id":"label-kind-bug-b","name":"kind:bug","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "issueCreate"):
+			createCalled = true
+			http.Error(w, "issueCreate should not be called", http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTestWithRenderedError("issues", "create", "--title", "Labeled ticket", "--team", "MOB", "--label-name", "kind:bug", "--dry-run", "--agent", "--data-source", "live")
+	if err == nil {
+		t.Fatalf("ambiguous create --label-name succeeded unexpectedly:\n%s", out)
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("ExitCode() = %d, want 2; err=%v\n%s", got, err, out)
+	}
+	if createCalled {
+		t.Fatalf("issueCreate mutation was called despite ambiguous label")
+	}
+	var envelope struct {
+		Type       string          `json:"type"`
+		Error      string          `json:"error"`
+		Candidates []issueLabelRef `json:"candidates"`
+	}
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("ambiguous output is not JSON: %v\n%s", err, out)
+	}
+	if envelope.Type != "usage" || !strings.Contains(envelope.Error, "ambiguous") || len(envelope.Candidates) != 2 {
+		t.Fatalf("unexpected ambiguous envelope: %s", out)
+	}
+}
+
+func TestIssuesCreateLabelNameNotFoundReturnsEnvelope(t *testing.T) {
+	createCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issueLabels(first"):
+			requirePortfolioNameFilter(t, req, "missing-label")
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "issueCreate"):
+			createCalled = true
+			http.Error(w, "issueCreate should not be called", http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTestWithRenderedError("issues", "create", "--title", "Labeled ticket", "--team", "MOB", "--label-name", "missing-label", "--dry-run", "--agent", "--data-source", "live")
+	if err == nil {
+		t.Fatalf("missing create --label-name succeeded unexpectedly:\n%s", out)
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("ExitCode() = %d, want 2; err=%v\n%s", got, err, out)
+	}
+	if createCalled {
+		t.Fatalf("issueCreate mutation was called despite missing label")
+	}
+	var envelope struct {
+		Type       string          `json:"type"`
+		Error      string          `json:"error"`
+		Candidates []issueLabelRef `json:"candidates"`
+	}
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("missing output is not JSON: %v\n%s", err, out)
+	}
+	if envelope.Type != "usage" || !strings.Contains(envelope.Error, "not found") || len(envelope.Candidates) != 0 {
+		t.Fatalf("unexpected missing envelope: %s", out)
+	}
+}
+
+func TestIssuesCreateGlobalLabelNameDryRunResolvesWithTeam(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issueLabels(first"):
+			requirePortfolioNameFilter(t, req, "source:user-report")
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-source-user-report","name":"source:user-report","team":null},{"id":"label-other-team","name":"source:user-report","team":{"id":"team-other","key":"OTHER","name":"Other"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "issueCreate"):
+			t.Fatalf("dry-run should not send issueCreate")
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "create", "--title", "Labeled ticket", "--team", "MOB", "--label-name", "source:user-report", "--dry-run", "--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("issues create global --label-name --dry-run failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Input struct {
+			LabelIDs []string `json:"labelIds"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("dry-run output is not JSON: %v\n%s", err, out)
+	}
+	if strings.Join(got.Input.LabelIDs, ",") != "label-source-user-report" {
+		t.Fatalf("labelIds = %#v, want global label UUID; output=%s", got.Input.LabelIDs, out)
+	}
+}
+
+func TestIssuesCreateLabelAndLabelNameMergeDedupes(t *testing.T) {
+	labelLookupCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Query, "issueLabels(first"):
+			labelLookupCalls++
+			requirePortfolioNameFilter(t, req, "kind:bug")
+			fmt.Fprint(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-kind-bug","name":"kind:bug","team":{"id":"team-mob","key":"MOB","name":"Mobilyze"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case strings.Contains(req.Query, "issueCreate"):
+			t.Fatalf("dry-run should not send issueCreate")
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	out, err := executeRootForTest("issues", "create", "--title", "Labeled ticket", "--team", "MOB", "--label", "label-kind-bug", "--label", "label-manual", "--label-name", "kind:bug", "--label-name", " KIND:BUG ", "--dry-run", "--agent", "--data-source", "live")
+	if err != nil {
+		t.Fatalf("issues create --label + --label-name --dry-run failed: %v\n%s", err, out)
+	}
+	if labelLookupCalls != 1 {
+		t.Fatalf("resolved duplicate --label-name values with %d lookups, want 1", labelLookupCalls)
+	}
+	var got struct {
+		Input struct {
+			LabelIDs []string `json:"labelIds"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("dry-run output is not JSON: %v\n%s", err, out)
+	}
+	if strings.Join(got.Input.LabelIDs, ",") != "label-kind-bug,label-manual" {
+		t.Fatalf("labelIds = %#v, want UUID labels plus de-duped resolved label; output=%s", got.Input.LabelIDs, out)
+	}
+}
+
 func TestIssuesEditProjectRejectsNonUUIDDryRun(t *testing.T) {
 	out, err := executeRootForTestWithRenderedError("issues", "edit", "SYMPH-795", "--project", "Autonomous Backlog Manager & Dispatch Governance", "--dry-run", "--agent")
 	if err == nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Recreates @ericlitman's `--label-name` issue-write resolver from #1411 on current `mvanhorn/printing-press-library` `main`.
- This is a maintainer rebase follow-up, same class as #1571 → #1777 / #1246 → #1741: the contributor fork is CONFLICTING / DIRTY and ~1007 commits behind, so it cannot take a clean rebase (workflows permission / dirty merge-base mess).
- Validate SKILL.md never ran on #1411 because merge state is DIRTY. The leftover `docs(linear): document --label-name` commits (`51dd23d8` then `de300f69`) already landed on the fork; this PR ports that leftover onto current main without the 1007-behind SKILL / README / `.go-version` drift.
- Does not bounce the author and does not update, comment on, rebase, retitle, label, or merge #1411.

## What Changed

Original work by @ericlitman in #1411 (MOB-340 / MOB-479 / MOB-630): add a repeatable `--label-name` flag to `issues create` and `issues edit` that resolves an exact Linear label name to its UUID at write time, including team-safe workspace-global labels (`team==null`). Resolved IDs merge with `--label` UUIDs, de-duplicate, and still flow through `validateIssueLabelTeams`.

SKILL leftover from `51dd23d8` / `de300f69`: document `--label-name` next to team-safe labels. Current main already has Go 1.26.6, comma-separated issue reads, aliases, project-updates, and quoted `$SESSION` — those were not ported.

Maintainer leftover after Greptile P2 on this PR: when `--label-name` and `--media` are combined without an explicit description, the first issue metadata read now also loads the existing body so media append does not fetch the same issue twice.

Files changed (seven, linear only):

- `library/project-management/linear/internal/cli/label_resolve.go` (new)
- `library/project-management/linear/internal/cli/issues_create.go`
- `library/project-management/linear/internal/cli/issues_edit.go`
- `library/project-management/linear/internal/cli/linear_agent_test.go`
- `library/project-management/linear/.printing-press-patches/mob-340-mob-479-label-name-resolution.json`
- `library/project-management/linear/.printing-press-patches/mob-630-label-name-media-and-dedup.json`
- `library/project-management/linear/SKILL.md`

Does not touch README, repo-root `.go-version`, `.github/workflows/**`, `registry.json`, `cli-skills/**`, release-ledger files, `CHANGELOG.md`, or `.printing-press-release.json`.

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/project-management/linear/`
- [x] `go build ./...` from `library/project-management/linear`
- [x] `go vet ./...` from `library/project-management/linear`
- [x] `go test ./...` from `library/project-management/linear` (includes the new `--label-name` tests)
- [x] `git diff --check`
- [x] Re-ran the eight `--label-name` tests after the Greptile P2 fetch-dedup fix, including `TestIssuesEditLabelNameWithMediaPreservesDescription` now asserting a single issue metadata fetch

## Gaps / Follow-Up

- #1411 remains the original PR on `ericlitman:codex/mob-340-479-upstream`. Close or supersede it after this lands; do not rebase that fork through the dirty merge-base / workflows-permission gate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68e32ce5-5564-4ad1-b47c-2492e3b3d719?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68e32ce5-5564-4ad1-b47c-2492e3b3d719&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

