### PR TITLE
fix(linear): preserve and verify issue labels

### DIFF
--- a/library/project-management/linear/.printing-press-patches/mob-1447-issue-label-reads.json
+++ b/library/project-management/linear/.printing-press-patches/mob-1447-issue-label-reads.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "mob-1447-issue-label-reads",
+  "applied_at": "2026-08-21",
+  "base_run_id": "20260518-232543",
+  "base_printing_press_version": "4.9.0",
+  "summary": "Issue reads retain Linear labels, and issue create verifies the mutation returned the exact requested label set.",
+  "reason": "Agents must be able to verify issue label state after a write; omitted read projections and unchecked create responses made missing or attached labels indistinguishable.",
+  "files": [
+    "internal/cli/issues.go",
+    "internal/cli/issues_create.go",
+    "internal/cli/label_resolve.go",
+    "internal/cli/mob1447_labels_test.go"
+  ],
+  "validated_outcome": "Released 2026.8.5 attached both a team label and a global label correctly; the repaired read paths return their exact IDs and names."
+}

--- a/library/project-management/linear/.printing-press-patches/mob-1447-issue-label-reads.json
+++ b/library/project-management/linear/.printing-press-patches/mob-1447-issue-label-reads.json
@@ -4,13 +4,14 @@
   "applied_at": "2026-08-21",
   "base_run_id": "20260518-232543",
   "base_printing_press_version": "4.9.0",
-  "summary": "Issue reads retain Linear labels, and issue create verifies the mutation returned the exact requested label set.",
-  "reason": "Agents must be able to verify issue label state after a write; omitted read projections and unchecked create responses made missing or attached labels indistinguishable.",
+  "summary": "Issue reads and edit write-backs retain Linear labels, and issue create verifies the mutation returned the exact requested label set.",
+  "reason": "Agents must be able to verify issue label state after a write; omitted projections, destructive edit write-backs, and unchecked create responses made missing or attached labels indistinguishable.",
   "files": [
     "internal/cli/issues.go",
     "internal/cli/issues_create.go",
+    "internal/cli/issues_edit.go",
     "internal/cli/label_resolve.go",
     "internal/cli/mob1447_labels_test.go"
   ],
-  "validated_outcome": "Released 2026.8.5 attached both a team label and a global label correctly; the repaired read paths return their exact IDs and names."
+  "validated_outcome": "Released 2026.8.5 attached team and global labels correctly; repaired reads and edit write-backs retain them, and a create mismatch remains locally reconcilable."
 }

--- a/library/project-management/linear/.printing-press-patches/mob-1447-issue-label-reads.json
+++ b/library/project-management/linear/.printing-press-patches/mob-1447-issue-label-reads.json
@@ -4,8 +4,8 @@
   "applied_at": "2026-08-21",
   "base_run_id": "20260518-232543",
   "base_printing_press_version": "4.9.0",
-  "summary": "Issue reads and edit write-backs retain Linear labels, and issue create verifies the mutation returned the exact requested label set.",
-  "reason": "Agents must be able to verify issue label state after a write; omitted projections, destructive edit write-backs, and unchecked create responses made missing or attached labels indistinguishable.",
+  "summary": "Issue reads and edit write-backs retain Linear labels, and issue create verifies the mutation returned the exact requested label set while preserving the created identity on failure.",
+  "reason": "Agents must be able to verify issue label state after a write; omitted projections, destructive edit write-backs, unchecked create responses, and unrecoverable mismatch failures made missing or attached labels indistinguishable.",
   "files": [
     "internal/cli/issues.go",
     "internal/cli/issues_create.go",
@@ -13,5 +13,5 @@
     "internal/cli/label_resolve.go",
     "internal/cli/mob1447_labels_test.go"
   ],
-  "validated_outcome": "Released 2026.8.5 attached team and global labels correctly; repaired reads and edit write-backs retain them, and a create mismatch remains locally reconcilable."
+  "validated_outcome": "Released 2026.8.5 attached team and global labels correctly; repaired reads and edit write-backs retain them, and a create mismatch exposes the remote identity even when local persistence is unavailable."
 }

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -175,7 +175,7 @@ These capabilities aren't available in any other tool for this API.
   linear-pp-cli issues edit ENG-123 --label-name "area:review-tooling" --agent
   ```
 
-  `--label-name` always performs a live Linear read to resolve the UUID, even when the surrounding issue write is a dry-run. Writes require a normalized exact label-name match. Team-owned labels and workspace-global labels (no team) both resolve; labels owned by another team do not. `--label` and `--label-name` can be combined; resolved IDs are de-duplicated before the mutation. On create, the CLI verifies the mutation's returned label IDs and fails visibly if Linear did not attach the requested set.
+  `--label-name` always performs a live Linear read to resolve the UUID, even when the surrounding issue write is a dry-run. Writes require a normalized exact label-name match. Team-owned labels and workspace-global labels (no team) both resolve; labels owned by another team do not. `--label` and `--label-name` can be combined; resolved IDs are de-duplicated before the mutation. On create, the CLI verifies the mutation's returned label IDs and fails visibly if Linear did not attach the requested set; the exit-5 agent envelope includes `created_issue.id`, `created_issue.identifier`, and `created_issue.url` so the remote issue remains recoverable if local persistence is unavailable.
 - **Project and initiative name resolution** — Resolve portfolio objects by human name before writing issue relationships.
 
   _Reach for this when a user gives an issue identifier plus a project or initiative name. `--project` is UUID-only; use `--project-name` when the input is a human project name._

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -37,7 +37,7 @@ If `--version` reports "command not found" after install, the runtime cannot see
 
 - Add `--agent` to commands unless a human-readable table is explicitly needed. It implies JSON, compact output, non-interactive mode, no color, and confirmation-safe scripting.
 - Use `--data-source live` for closeout/state/description checks where current truth matters. Use `issues search` for duplicate checks; it refreshes stale issue search data or fails visibly. Use `--data-source local` or `similar` only when stale/offline local duplicate search is intentional.
-- A missing `description` in compact output does not mean an empty issue body. Request it explicitly: `linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.name,url`.
+- Fields omitted from compact output are not absent from the issue. Request them explicitly, including nested labels: `linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.name,labels.nodes.id,labels.nodes.name,url`.
 - Fetch several known issues in one call with comma-separated identifiers: `linear-pp-cli issues ENG-123,ENG-124 --agent`. The result array preserves caller order and removes duplicate identifiers; a missing member fails the whole read instead of returning a partial set.
 - Prefer the canonical read and comment forms shown here. Common agent phrasing is accepted without changing behavior: `issues get|view|show ENG-123`, `documents get|view <ref>`, and `comments create` are compatibility aliases for `issues ENG-123`, `documents <ref>`, and `comments add`. The aliases accept the same global flags, comma reads, body files, targets, and media flags as their canonical commands; there is deliberately no `documents show` alias.
 - `--label` is UUID-only; `--label-name` resolves an exact label name at write time (team-owned or workspace-global). Before passing UUIDs to `issues create` or `issues edit`, run `linear-pp-cli labels list --team ENG --agent --select id,name,global,team.key`. The CLI preflights ownership and refuses cross-team labels before mutating.
@@ -175,7 +175,7 @@ These capabilities aren't available in any other tool for this API.
   linear-pp-cli issues edit ENG-123 --label-name "area:review-tooling" --agent
   ```
 
-  `--label-name` always performs a live Linear read to resolve the UUID, even when the surrounding issue write is a dry-run. Writes require a normalized exact label-name match. Team-owned labels and workspace-global labels (no team) both resolve; labels owned by another team do not. `--label` and `--label-name` can be combined; resolved IDs are de-duplicated before the mutation.
+  `--label-name` always performs a live Linear read to resolve the UUID, even when the surrounding issue write is a dry-run. Writes require a normalized exact label-name match. Team-owned labels and workspace-global labels (no team) both resolve; labels owned by another team do not. `--label` and `--label-name` can be combined; resolved IDs are de-duplicated before the mutation. On create, the CLI verifies the mutation's returned label IDs and fails visibly if Linear did not attach the requested set.
 - **Project and initiative name resolution** — Resolve portfolio objects by human name before writing issue relationships.
 
   _Reach for this when a user gives an issue identifier plus a project or initiative name. `--project` is UUID-only; use `--project-name` when the input is a human project name._
@@ -209,7 +209,7 @@ These capabilities aren't available in any other tool for this API.
 - **Current issue reads and comments** — Read full issue bodies and discussion without falling back to stale local state. `comments list` takes the issue positionally (preferred) or via `--issue`.
 
   ```bash
-  linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.id,state.name,url
+  linear-pp-cli issues ENG-123 --agent --data-source live --select identifier,title,description,state.id,state.name,labels.nodes.id,labels.nodes.name,url
   linear-pp-cli issues ENG-123,ENG-124 --agent --data-source live --select identifier,title,description,state.name,url
   linear-pp-cli comments list ENG-123 --agent
   linear-pp-cli comments list --issue ENG-123 --agent --limit 100

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -19,6 +19,16 @@ import (
 
 var errTeamFilterNotFound = errors.New("team not found")
 
+type issueLabel struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+type issueLabels struct {
+	Nodes []issueLabel `json:"nodes"`
+}
+
 // issueRow is the shared projection used by `issues list` and table rendering.
 // It mirrors the shape the sync writes to the `data` JSON column.
 type issueRow struct {
@@ -46,8 +56,9 @@ type issueRow struct {
 		DisplayName string `json:"displayName"`
 		Email       string `json:"email"`
 	} `json:"assignee,omitempty"`
-	UpdatedAt string `json:"updatedAt"`
-	URL       string `json:"url,omitempty"`
+	Labels    *issueLabels `json:"labels,omitempty"`
+	UpdatedAt string       `json:"updatedAt"`
+	URL       string       `json:"url,omitempty"`
 	// ArchivedAt is Issue.archivedAt, null on a live issue. It is the only
 	// thing that distinguishes an archived row once --include-archived is on.
 	ArchivedAt string `json:"archivedAt,omitempty"`
@@ -347,6 +358,7 @@ func fetchIssueLive(c graphqlQueryer, identifier string) (json.RawMessage, error
 				team { id key name }
 				project { id name }
 				assignee { id name displayName email }
+				labels { nodes { id name color } }
 			}
 		}
 	}`
@@ -372,6 +384,7 @@ func fetchIssueByIDLive(c graphqlQueryer, id string) (json.RawMessage, error) {
 			team { id key name }
 			project { id name }
 			assignee { id name displayName email }
+			labels { nodes { id name color } }
 		}
 	}`
 	var resp struct {
@@ -623,6 +636,9 @@ func runIssuesList(cmd *cobra.Command, flags *rootFlags, dbPath, assignee, state
 	}
 
 	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+		if flags.selectFields != "" {
+			return printJSONFiltered(cmd.OutOrStdout(), rows, flags)
+		}
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
 		return enc.Encode(rows)

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -250,6 +250,7 @@ sub-issue under an existing parent.`,
 						assignee { id name displayName }
 						project { id name }
 						parent { id identifier title }
+						labels { nodes { id name color } }
 					}
 				}
 			}`
@@ -293,6 +294,7 @@ sub-issue under an existing parent.`,
 							Identifier string `json:"identifier"`
 							Title      string `json:"title"`
 						} `json:"parent,omitempty"`
+						Labels issueLabels `json:"labels"`
 					} `json:"issue"`
 				} `json:"issueCreate"`
 			}
@@ -301,6 +303,15 @@ sub-issue under an existing parent.`,
 			}
 			if !parsed.IssueCreate.Success {
 				return apiErr(fmt.Errorf("Linear reported issueCreate success=false"))
+			}
+			if len(labelsFlag) > 0 {
+				observed := make([]string, 0, len(parsed.IssueCreate.Issue.Labels.Nodes))
+				for _, label := range parsed.IssueCreate.Issue.Labels.Nodes {
+					observed = append(observed, label.ID)
+				}
+				if !sameLabelIDs(labelsFlag, observed) {
+					return apiErr(fmt.Errorf("issue %s (%s) created with label mismatch: requested %v, observed %v", parsed.IssueCreate.Issue.Identifier, parsed.IssueCreate.Issue.ID, mergeLabelIDs(nil, labelsFlag), mergeLabelIDs(nil, observed)))
+				}
 			}
 
 			sess := resolvePPSession(flags, session)
@@ -324,6 +335,7 @@ sub-issue under an existing parent.`,
 					"description": parsed.IssueCreate.Issue.Description,
 					"url":         parsed.IssueCreate.Issue.URL,
 					"priority":    parsed.IssueCreate.Issue.Priority,
+					"labels":      parsed.IssueCreate.Issue.Labels,
 					"team": map[string]any{
 						"id":  parsed.IssueCreate.Issue.Team.ID,
 						"key": parsed.IssueCreate.Issue.Team.Key,

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -383,6 +383,19 @@ sub-issue under an existing parent.`,
 				fmt.Fprintf(os.Stderr, "warning: cannot open ledger at %s: %v\n", dbPath, dbErr)
 			}
 			if labelMismatchErr != nil {
+				if flags.asJSON {
+					flags.errorWritten = true
+					_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+						"error": labelMismatchErr.Error(),
+						"code":  ExitCode(labelMismatchErr),
+						"type":  cliErrorType(ExitCode(labelMismatchErr)),
+						"created_issue": map[string]string{
+							"id":         parsed.IssueCreate.Issue.ID,
+							"identifier": parsed.IssueCreate.Issue.Identifier,
+							"url":        parsed.IssueCreate.Issue.URL,
+						},
+					})
+				}
 				return labelMismatchErr
 			}
 

--- a/library/project-management/linear/internal/cli/issues_create.go
+++ b/library/project-management/linear/internal/cli/issues_create.go
@@ -304,13 +304,14 @@ sub-issue under an existing parent.`,
 			if !parsed.IssueCreate.Success {
 				return apiErr(fmt.Errorf("Linear reported issueCreate success=false"))
 			}
+			var labelMismatchErr error
 			if len(labelsFlag) > 0 {
 				observed := make([]string, 0, len(parsed.IssueCreate.Issue.Labels.Nodes))
 				for _, label := range parsed.IssueCreate.Issue.Labels.Nodes {
 					observed = append(observed, label.ID)
 				}
 				if !sameLabelIDs(labelsFlag, observed) {
-					return apiErr(fmt.Errorf("issue %s (%s) created with label mismatch: requested %v, observed %v", parsed.IssueCreate.Issue.Identifier, parsed.IssueCreate.Issue.ID, mergeLabelIDs(nil, labelsFlag), mergeLabelIDs(nil, observed)))
+					labelMismatchErr = apiErr(fmt.Errorf("issue %s (%s) created with label mismatch: requested %v, observed %v", parsed.IssueCreate.Issue.Identifier, parsed.IssueCreate.Issue.ID, mergeLabelIDs(nil, labelsFlag), mergeLabelIDs(nil, observed)))
 				}
 			}
 
@@ -380,6 +381,9 @@ sub-issue under an existing parent.`,
 				}
 			} else {
 				fmt.Fprintf(os.Stderr, "warning: cannot open ledger at %s: %v\n", dbPath, dbErr)
+			}
+			if labelMismatchErr != nil {
+				return labelMismatchErr
 			}
 
 			if flags.asJSON {

--- a/library/project-management/linear/internal/cli/issues_edit.go
+++ b/library/project-management/linear/internal/cli/issues_edit.go
@@ -251,6 +251,7 @@ Use --parent with an issue identifier or UUID to set/change parentage. Use
 						assignee { id name displayName email }
 						parent { id identifier title }
 						children { nodes { id identifier title } }
+						labels { nodes { id name color } }
 					}
 				}
 			}`

--- a/library/project-management/linear/internal/cli/label_resolve.go
+++ b/library/project-management/linear/internal/cli/label_resolve.go
@@ -148,6 +148,23 @@ func mergeLabelIDs(labelIDs, resolvedLabelIDs []string) []string {
 	return merged
 }
 
+func sameLabelIDs(left, right []string) bool {
+	left, right = mergeLabelIDs(nil, left), mergeLabelIDs(nil, right)
+	if len(left) != len(right) {
+		return false
+	}
+	want := make(map[string]bool, len(left))
+	for _, id := range left {
+		want[strings.ToLower(strings.TrimSpace(id))] = true
+	}
+	for _, id := range right {
+		if !want[strings.ToLower(strings.TrimSpace(id))] {
+			return false
+		}
+	}
+	return true
+}
+
 func internalLabelResolveClientErr() error {
 	return fmt.Errorf("internal error: --label-name resolution requires a live Linear client")
 }

--- a/library/project-management/linear/internal/cli/mob1447_labels_test.go
+++ b/library/project-management/linear/internal/cli/mob1447_labels_test.go
@@ -1,0 +1,198 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
+)
+
+func TestIssueReadsExposeLabels(t *testing.T) {
+	const (
+		issueID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		issue   = `{"id":"` + issueID + `","identifier":"MOB-1447","title":"Labels","priority":2,"estimate":3,"dueDate":"2026-08-30","updatedAt":"2026-08-21T00:00:00Z","url":"https://linear.app/issue/MOB-1447","state":{"id":"state-1","name":"In Progress","type":"started"},"team":{"id":"team-mob","key":"MOB","name":"Mobilyze"},"labels":{"nodes":[{"id":"label-bug","name":"kind:bug","color":"#f00"}]}}`
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(req.Query, "labels { nodes { id name color } }") {
+			t.Errorf("issue query omitted labels: %s", req.Query)
+		}
+		switch {
+		case strings.Contains(req.Query, "issue(id:"):
+			fmt.Fprintf(w, `{"data":{"issue":%s}}`, issue)
+		case strings.Contains(req.Query, "issues(filter:"):
+			fmt.Fprintf(w, `{"data":{"issues":{"nodes":[%s]}}}`, issue)
+		default:
+			fmt.Fprintf(w, `{"data":{"issues":{"nodes":[%s],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`, issue)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	for _, ref := range []string{"MOB-1447", issueID} {
+		out, err := executeRootForTest("issues", ref, "--agent", "--data-source", "live", "--select", "identifier,labels.nodes.id,labels.nodes.name")
+		if err != nil {
+			t.Fatalf("issues %s failed: %v\n%s", ref, err, out)
+		}
+		assertIssueLabelOutput(t, out)
+	}
+
+	dbPath := issueMultiTestDB(t)
+	out, err := executeRootForTest("issues", "list", "--agent", "--data-source", "live", "--state", "all", "--db", dbPath, "--select", "identifier,labels.nodes.id,labels.nodes.name")
+	if err != nil {
+		t.Fatalf("live issues list failed: %v\n%s", err, out)
+	}
+	assertIssueListLabelOutput(t, out)
+
+	out, err = executeRootForTest("issues", "list", "--agent", "--data-source", "local", "--state", "all", "--db", dbPath, "--select", "identifier,labels.nodes.id,labels.nodes.name")
+	if err != nil {
+		t.Fatalf("local issues list failed: %v\n%s", err, out)
+	}
+	assertIssueListLabelOutput(t, out)
+
+	out, err = executeRootForTest("issues", "list", "--agent", "--data-source", "live", "--state", "all", "--db", dbPath)
+	if err != nil {
+		t.Fatalf("unselected issues list failed: %v\n%s", err, out)
+	}
+	want := `[
+  {
+    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "identifier": "MOB-1447",
+    "title": "Labels",
+    "priority": 2,
+    "estimate": 3,
+    "dueDate": "2026-08-30",
+    "state": {
+      "name": "In Progress",
+      "type": "started"
+    },
+    "team": {
+      "id": "team-mob",
+      "key": "MOB"
+    },
+    "labels": {
+      "nodes": [
+        {
+          "id": "label-bug",
+          "name": "kind:bug",
+          "color": "#f00"
+        }
+      ]
+    },
+    "updatedAt": "2026-08-21T00:00:00Z",
+    "url": "https://linear.app/issue/MOB-1447"
+  }
+]
+`
+	if out != want {
+		t.Fatalf("unselected issues list contract changed:\n got: %s\nwant: %s", out, want)
+	}
+}
+
+func TestIssueCreateVerifiesReturnedLabels(t *testing.T) {
+	const teamID = "00000000-0000-0000-0000-000000000001"
+	for _, tt := range []struct {
+		name     string
+		observed string
+		wantErr  bool
+	}{
+		{name: "UUID and exact name in any response order", observed: `[{"id":"label-kind-bug","name":"kind:bug","color":"#f00"},{"id":"label-global","name":"source:user-report","color":"#00f"}]`},
+		{name: "success response omits requested UUID", observed: `[{"id":"label-kind-bug","name":"kind:bug","color":"#f00"}]`, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req client.GraphQLRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				switch {
+				case strings.Contains(req.Query, "issueLabels(first"):
+					fmt.Fprintf(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-kind-bug","name":"kind:bug","team":{"id":%q,"key":"MOB","name":"Mobilyze"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`, teamID)
+				case strings.Contains(req.Query, "issueLabels(filter"):
+					fmt.Fprintf(w, `{"data":{"issueLabels":{"nodes":[{"id":"label-global","name":"source:user-report","color":"#00f","team":null},{"id":"label-kind-bug","name":"kind:bug","color":"#f00","team":{"id":%q,"key":"MOB","name":"Mobilyze"}}]}}}`, teamID)
+				case strings.Contains(req.Query, "issueCreate"):
+					if !strings.Contains(req.Query, "labels { nodes { id name color } }") {
+						t.Errorf("issueCreate response omitted labels: %s", req.Query)
+					}
+					input, ok := req.Variables["input"].(map[string]any)
+					if !ok || fmt.Sprint(input["labelIds"]) != "[label-global label-kind-bug]" {
+						t.Fatalf("issueCreate labelIds = %#v, want UUID plus resolved name", input["labelIds"])
+					}
+					fmt.Fprintf(w, `{"data":{"issueCreate":{"success":true,"issue":{"id":"issue-200","identifier":"MOB-200","title":"Labels","url":"https://linear.app/issue/MOB-200","team":{"id":%q,"key":"MOB"},"state":{"id":"state-1","name":"Todo","type":"unstarted"},"labels":{"nodes":%s}}}}}`, teamID, tt.observed)
+				default:
+					t.Fatalf("unexpected query: %s", req.Query)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			t.Setenv("LINEAR_BASE_URL", srv.URL)
+			t.Setenv("LINEAR_API_KEY", "test-token")
+
+			dbPath := filepath.Join(t.TempDir(), "linear.db")
+			out, err := executeRootForTest("issues", "create", "--title", "Labels", "--team", teamID, "--label", "label-global", "--label-name", "kind:bug", "--session", "mob-1447-test", "--db", dbPath, "--agent", "--data-source", "live")
+			if tt.wantErr {
+				if err == nil || ExitCode(err) != 5 || !strings.Contains(err.Error(), "MOB-200 (issue-200)") || !strings.Contains(err.Error(), "label-global") || !strings.Contains(err.Error(), "label-kind-bug") {
+					t.Fatalf("label mismatch error = %v (code %d), want created issue and requested/observed IDs; output=%s", err, ExitCode(err), out)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("issues create with labels failed: %v\n%s", err, out)
+			}
+			local, err := executeRootForTest("issues", "MOB-200", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier,labels.nodes.id")
+			if err != nil || !strings.Contains(local, "label-global") || !strings.Contains(local, "label-kind-bug") {
+				t.Fatalf("created labels missing from local write-back: err=%v output=%s", err, local)
+			}
+		})
+	}
+}
+
+func assertIssueLabelOutput(t *testing.T, out string) {
+	t.Helper()
+	var payload struct {
+		Results struct {
+			Identifier string `json:"identifier"`
+			Labels     struct {
+				Nodes []struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"nodes"`
+			} `json:"labels"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil || payload.Results.Identifier != "MOB-1447" || len(payload.Results.Labels.Nodes) != 1 || payload.Results.Labels.Nodes[0].ID != "label-bug" || payload.Results.Labels.Nodes[0].Name != "kind:bug" {
+		t.Fatalf("issue labels missing from output: err=%v output=%s", err, out)
+	}
+}
+
+func assertIssueListLabelOutput(t *testing.T, out string) {
+	t.Helper()
+	var rows []struct {
+		Identifier string `json:"identifier"`
+		Labels     struct {
+			Nodes []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"nodes"`
+		} `json:"labels"`
+	}
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("issue-list output is not JSON: err=%v output=%s", err, out)
+	}
+	for _, row := range rows {
+		if row.Identifier == "MOB-1447" && len(row.Labels.Nodes) == 1 && row.Labels.Nodes[0].ID == "label-bug" && row.Labels.Nodes[0].Name == "kind:bug" {
+			return
+		}
+	}
+	t.Fatalf("issue-list labels missing from output: %s", out)
+}

--- a/library/project-management/linear/internal/cli/mob1447_labels_test.go
+++ b/library/project-management/linear/internal/cli/mob1447_labels_test.go
@@ -105,9 +105,11 @@ func TestIssueCreateVerifiesReturnedLabels(t *testing.T) {
 		name     string
 		observed string
 		wantErr  bool
+		dbFails  bool
 	}{
 		{name: "UUID and exact name in any response order", observed: `[{"id":"label-kind-bug","name":"kind:bug","color":"#f00"},{"id":"label-global","name":"source:user-report","color":"#00f"}]`},
 		{name: "success response omits requested UUID", observed: `[{"id":"label-kind-bug","name":"kind:bug","color":"#f00"}]`, wantErr: true},
+		{name: "mismatch exposes identity when persistence fails", observed: `[{"id":"label-kind-bug","name":"kind:bug","color":"#f00"}]`, wantErr: true, dbFails: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -139,10 +141,30 @@ func TestIssueCreateVerifiesReturnedLabels(t *testing.T) {
 			t.Setenv("LINEAR_API_KEY", "test-token")
 
 			dbPath := filepath.Join(t.TempDir(), "linear.db")
-			out, err := executeRootForTest("issues", "create", "--title", "Labels", "--team", teamID, "--label", "label-global", "--label-name", "kind:bug", "--session", "mob-1447-test", "--db", dbPath, "--agent", "--data-source", "live")
+			execute := executeRootForTest
+			if tt.dbFails {
+				dbPath = filepath.Join(t.TempDir(), "missing", "linear.db")
+				execute = executeRootForTestWithRenderedError
+			}
+			out, err := execute("issues", "create", "--title", "Labels", "--team", teamID, "--label", "label-global", "--label-name", "kind:bug", "--session", "mob-1447-test", "--db", dbPath, "--agent", "--data-source", "live")
 			if tt.wantErr {
 				if err == nil || ExitCode(err) != 5 || !strings.Contains(err.Error(), "MOB-200 (issue-200)") || !strings.Contains(err.Error(), "label-global") || !strings.Contains(err.Error(), "label-kind-bug") {
 					t.Fatalf("label mismatch error = %v (code %d), want created issue and requested/observed IDs; output=%s", err, ExitCode(err), out)
+				}
+				if tt.dbFails {
+					var envelope struct {
+						Code         int    `json:"code"`
+						Type         string `json:"type"`
+						CreatedIssue struct {
+							ID         string `json:"id"`
+							Identifier string `json:"identifier"`
+							URL        string `json:"url"`
+						} `json:"created_issue"`
+					}
+					if decodeErr := json.Unmarshal([]byte(out), &envelope); decodeErr != nil || envelope.Code != 5 || envelope.Type != "api" || envelope.CreatedIssue.ID != "issue-200" || envelope.CreatedIssue.Identifier != "MOB-200" || envelope.CreatedIssue.URL != "https://linear.app/issue/MOB-200" {
+						t.Fatalf("mismatch recovery envelope = %+v, decode error = %v, output=%s", envelope, decodeErr, out)
+					}
+					return
 				}
 				local, localErr := executeRootForTest("issues", "MOB-200", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier,labels.nodes.id")
 				if localErr != nil || !strings.Contains(local, "label-kind-bug") {

--- a/library/project-management/linear/internal/cli/mob1447_labels_test.go
+++ b/library/project-management/linear/internal/cli/mob1447_labels_test.go
@@ -144,6 +144,14 @@ func TestIssueCreateVerifiesReturnedLabels(t *testing.T) {
 				if err == nil || ExitCode(err) != 5 || !strings.Contains(err.Error(), "MOB-200 (issue-200)") || !strings.Contains(err.Error(), "label-global") || !strings.Contains(err.Error(), "label-kind-bug") {
 					t.Fatalf("label mismatch error = %v (code %d), want created issue and requested/observed IDs; output=%s", err, ExitCode(err), out)
 				}
+				local, localErr := executeRootForTest("issues", "MOB-200", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier,labels.nodes.id")
+				if localErr != nil || !strings.Contains(local, "label-kind-bug") {
+					t.Fatalf("mismatched issue missing from local write-back: err=%v output=%s", localErr, local)
+				}
+				fixtures, fixtureErr := executeRootForTestWithStdout("pp-test", "list", "--session", "mob-1447-test", "--db", dbPath, "--agent")
+				if fixtureErr != nil || !strings.Contains(fixtures, "MOB-200") {
+					t.Fatalf("mismatched issue missing from fixture ledger: err=%v output=%s", fixtureErr, fixtures)
+				}
 				return
 			}
 			if err != nil {
@@ -154,6 +162,33 @@ func TestIssueCreateVerifiesReturnedLabels(t *testing.T) {
 				t.Fatalf("created labels missing from local write-back: err=%v output=%s", err, local)
 			}
 		})
+	}
+}
+
+func TestIssueEditWriteBackRetainsLabels(t *testing.T) {
+	const issueID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req client.GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(req.Query, "issueUpdate") || !strings.Contains(req.Query, "labels { nodes { id name color } }") {
+			t.Fatalf("issueUpdate response omitted labels: %s", req.Query)
+		}
+		fmt.Fprint(w, `{"data":{"issueUpdate":{"success":true,"issue":{"id":"`+issueID+`","identifier":"MOB-300","title":"Updated","team":{"id":"team-mob","key":"MOB"},"state":{"id":"state-1","name":"Todo","type":"unstarted"},"labels":{"nodes":[{"id":"label-bug","name":"kind:bug","color":"#f00"}]}}}}}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("LINEAR_BASE_URL", srv.URL)
+	t.Setenv("LINEAR_API_KEY", "test-token")
+
+	dbPath := filepath.Join(t.TempDir(), "linear.db")
+	if _, err := executeRootForTest("issues", "edit", issueID, "--title", "Updated", "--db", dbPath, "--agent", "--data-source", "live"); err != nil {
+		t.Fatalf("issues edit failed: %v", err)
+	}
+	local, err := executeRootForTest("issues", "MOB-300", "--agent", "--data-source", "local", "--db", dbPath, "--select", "identifier,labels.nodes.id,labels.nodes.name")
+	if err != nil || !strings.Contains(local, "label-bug") || !strings.Contains(local, "kind:bug") {
+		t.Fatalf("edited labels missing from local write-back: err=%v output=%s", err, local)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve `labels.nodes[]` for issue reads by identifier, UUID, live list, and local list
- honor explicit dotted `--select` fields on issue lists without changing the existing no-select output path
- verify create-time labels against the authoritative `issueCreate` response as an unordered UUID set, and write observed labels into the local issue row
- document the read/write contract and record the generated-tree patch for future reprints

## Verification

- released 2026.8.5 fixture: create attached one team and one global label; independent GraphQL confirmed both while released reads omitted them
- patched live fixture: mutation verification passed; independent GraphQL plus immediate live/local CLI reads returned both labels; session cleanup archived the fixture
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `GOTOOLCHAIN=go1.26.6 govulncheck ./...`
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/project-management/linear/`
- supply-chain scanner: no findings

Linear: MOB-1447
