### PR TITLE
fix(benzinga): keep 0-based sync pages and resume watermark

### DIFF
--- a/library/other/benzinga/.printing-press-patches/sync-zero-based-page-and-resume-watermark.json
+++ b/library/other/benzinga/.printing-press-patches/sync-zero-based-page-and-resume-watermark.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "sync-zero-based-page-and-resume-watermark",
+  "applied_at": "2026-08-22",
+  "base_run_id": "20260627-034058-2c1f9c5c",
+  "base_printing_press_version": "4.27.0",
+  "summary": "Page-int sync fallback is 0-indexed, and incomplete syncs must not advance last_synced_at.",
+  "reason": "Benzinga page params start at 0. Treating an omitted first-page cursor as page 1 jumped the next request to page 2 and dropped page 1. SaveSyncState also stamped last_synced_at after every page and on --max-pages exits, so a resume reused the old page cursor under a newly narrowed updatedSince and skipped older unfetched rows. A regen must keep 0-based page math and a resume save that does not move the incremental watermark.",
+  "files": [
+    "internal/cli/sync.go",
+    "internal/cli/sync_page_cursor_test.go",
+    "internal/store/store.go",
+    "internal/store/sync_resume_test.go"
+  ],
+  "validated_outcome": "nextPageIntCursor(\"\")==\"1\"; SaveSyncResume keeps the prior last_synced_at; go test ./internal/cli ./internal/store pass."
+}

--- a/library/other/benzinga/.printing-press-patches/sync-zero-based-page-and-resume-watermark.json
+++ b/library/other/benzinga/.printing-press-patches/sync-zero-based-page-and-resume-watermark.json
@@ -5,7 +5,7 @@
   "base_run_id": "20260627-034058-2c1f9c5c",
   "base_printing_press_version": "4.27.0",
   "summary": "Page-int sync fallback is 0-indexed, and incomplete syncs must not advance last_synced_at.",
-  "reason": "Benzinga page params start at 0. Treating an omitted first-page cursor as page 1 jumped the next request to page 2 and dropped page 1. SaveSyncState also stamped last_synced_at after every page and on --max-pages exits, so a resume reused the old page cursor under a newly narrowed updatedSince and skipped older unfetched rows. A regen must keep 0-based page math and a resume save that does not move the incremental watermark.",
+  "reason": "Benzinga page params start at 0, so treating an omitted first-page cursor as page 1 jumped to page 2 and dropped page 1. A regen must keep 0-based page math and preserve the incremental watermark when saving an incomplete sync's resume cursor.",
   "files": [
     "internal/cli/sync.go",
     "internal/cli/sync_page_cursor_test.go",

--- a/library/other/benzinga/internal/cli/sync.go
+++ b/library/other/benzinga/internal/cli/sync.go
@@ -530,11 +530,11 @@ func syncResource(ctx context.Context, c interface {
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
 		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
-			currentPage, _ := strconv.Atoi(cursor)
-			if currentPage < 1 {
-				currentPage = 1
-			}
-			nextCursor = strconv.Itoa(currentPage + 1)
+			// Benzinga page params are 0-indexed (CLI --page defaults to 0).
+			// An empty cursor means we just fetched the default first page
+			// (page 0, often omitted from the query string). Treating that as
+			// page 1 would jump to page 2 and drop every record on page 1.
+			nextCursor = nextPageIntCursor(cursor)
 			hasMore = true
 		}
 		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
@@ -738,8 +738,11 @@ func syncResource(ctx context.Context, c interface {
 			}
 		}
 
-		// Save cursor after each page for resumability
-		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
+		// Save the page cursor for resumability without advancing
+		// last_synced_at. Bumping the watermark here would make the next
+		// run resume this cursor under a newly narrowed updatedSince and
+		// permanently skip older unfetched rows.
+		if err := db.SaveSyncResume(resource, nextCursor, totalCount); err != nil {
 			// Non-fatal: log and continue
 			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
 		}
@@ -775,13 +778,15 @@ func syncResource(ctx context.Context, c interface {
 		}
 	}
 
-	// Final sync state: clear cursor on natural completion, but preserve the
-	// resume cursor when an operator intentionally capped the page budget.
-	finalCursor := ""
-	if capExitHit {
-		finalCursor = capExitCursor
+	// Final sync state: bump last_synced_at only on a proven-complete
+	// enumeration. A capped or otherwise incomplete run keeps the resume
+	// cursor and the previous watermark so the next call continues the
+	// same result set.
+	if outcome.complete {
+		_ = db.SaveSyncState(resource, "", totalCount)
+	} else if capExitHit {
+		_ = db.SaveSyncResume(resource, capExitCursor, totalCount)
 	}
-	_ = db.SaveSyncState(resource, finalCursor, totalCount)
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in
@@ -812,6 +817,17 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
+}
+
+// nextPageIntCursor advances a 0-indexed page cursor. Empty or unparsable
+// input is page 0 (Benzinga's default first page), so the next request is
+// page 1 — not page 2.
+func nextPageIntCursor(cursor string) string {
+	currentPage, err := strconv.Atoi(strings.TrimSpace(cursor))
+	if err != nil || currentPage < 0 {
+		currentPage = 0
+	}
+	return strconv.Itoa(currentPage + 1)
 }
 
 // paginationDefaults holds the resolved pagination parameter names and page size.

--- a/library/other/benzinga/internal/cli/sync_page_cursor_test.go
+++ b/library/other/benzinga/internal/cli/sync_page_cursor_test.go
@@ -1,0 +1,23 @@
+// Copyright 2026 waveriderai and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import "testing"
+
+func TestNextPageIntCursorZeroIndexed(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{in: "", want: "1"},
+		{in: "0", want: "1"},
+		{in: "1", want: "2"},
+		{in: " 2 ", want: "3"},
+		{in: "not-a-page", want: "1"},
+		{in: "-1", want: "1"},
+	}
+	for _, c := range cases {
+		if got := nextPageIntCursor(c.in); got != c.want {
+			t.Errorf("nextPageIntCursor(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/library/other/benzinga/internal/store/store.go
+++ b/library/other/benzinga/internal/store/store.go
@@ -1418,15 +1418,41 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 	return err
 }
 
+// SaveSyncResume stores a pagination cursor and count without touching
+// last_synced_at. Incomplete syncs (page caps, stuck cursors) must keep
+// the previous incremental watermark so the next run resumes the same
+// result set instead of combining an old page cursor with a new since=.
+func (s *Store) SaveSyncResume(resourceType, cursor string, count int) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.db.Exec(
+		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
+		 VALUES (?, ?, NULL, ?)
+		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
+		 total_count = excluded.total_count`,
+		resourceType, cursor, count,
+	)
+	return err
+}
+
 func (s *Store) GetSyncState(resourceType string) (cursor string, lastSynced time.Time, count int, err error) {
+	var lastSyncedRaw sql.NullString
 	err = s.db.QueryRow(
 		`SELECT last_cursor, last_synced_at, total_count FROM sync_state WHERE resource_type = ?`,
 		resourceType,
-	).Scan(&cursor, &lastSynced, &count)
+	).Scan(&cursor, &lastSyncedRaw, &count)
 	if err == sql.ErrNoRows {
 		return "", time.Time{}, 0, nil
 	}
-	return
+	if err != nil {
+		return "", time.Time{}, 0, err
+	}
+	if lastSyncedRaw.Valid && lastSyncedRaw.String != "" {
+		if ts, parseErr := time.Parse(time.RFC3339, lastSyncedRaw.String); parseErr == nil {
+			lastSynced = ts
+		}
+	}
+	return cursor, lastSynced, count, nil
 }
 
 // SaveSyncCursor stores the pagination cursor for a resource type.

--- a/library/other/benzinga/internal/store/sync_resume_test.go
+++ b/library/other/benzinga/internal/store/sync_resume_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 waveriderai and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveSyncResumePreservesWatermark(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	if err := s.SaveSyncState("news", "", 100); err != nil {
+		t.Fatalf("complete save: %v", err)
+	}
+	_, watermark, _, err := s.GetSyncState("news")
+	if err != nil {
+		t.Fatalf("get after complete: %v", err)
+	}
+	if watermark.IsZero() {
+		t.Fatal("complete save should set last_synced_at")
+	}
+
+	time.Sleep(15 * time.Millisecond)
+	if err := s.SaveSyncResume("news", "3", 145); err != nil {
+		t.Fatalf("resume save: %v", err)
+	}
+	cursor, got, count, err := s.GetSyncState("news")
+	if err != nil {
+		t.Fatalf("get after resume: %v", err)
+	}
+	if cursor != "3" {
+		t.Fatalf("cursor = %q, want 3", cursor)
+	}
+	if count != 145 {
+		t.Fatalf("count = %d, want 145", count)
+	}
+	if !got.Equal(watermark) {
+		t.Fatalf("last_synced_at changed from %v to %v", watermark, got)
+	}
+}
+
+func TestSaveSyncResumeFirstInsertHasNoWatermark(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	if err := s.SaveSyncResume("news", "1", 15); err != nil {
+		t.Fatalf("resume save: %v", err)
+	}
+	cursor, watermark, count, err := s.GetSyncState("news")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if cursor != "1" || count != 15 {
+		t.Fatalf("cursor/count = %q/%d, want 1/15", cursor, count)
+	}
+	if !watermark.IsZero() {
+		t.Fatalf("first incomplete save should leave last_synced_at unset, got %v", watermark)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#1787 landed the benzinga CLI on main at `5a141f50d`, before Greptile's two P1s were in the merge SHA. This is the leftover sync-correctness follow-up.

Greptile on #1787 scored 3/5 with two valid P1s:

1. **Zero-based page skip.** Benzinga `--page` defaults to 0. The page-int fallback treated an omitted first-page cursor as page 1, so the next request jumped to page 2 and dropped every record on page 1.
2. **Incomplete sync advances `last_synced_at`.** Mid-page and `--max-pages` exits called `SaveSyncState`, so a resume combined the old page cursor with a newly narrowed `updatedSince` and permanently skipped older unfetched rows.

## What Changed

- `nextPageIntCursor` treats empty/unparsable as page 0, so the next request is page 1.
- Incomplete syncs persist the page cursor via `SaveSyncResume` and leave the previous `last_synced_at` alone. Only a proven-complete enumeration stamps the watermark.
- `GetSyncState` reads a nullable watermark so a first incomplete insert does not fail the scan.
- Patch index: `.printing-press-patches/sync-zero-based-page-and-resume-watermark.json`.

**API:** benzinga | **Category:** other | **Press version:** 4.27.0  
**Required env:** `BENZINGA_API_KEY` (unchanged)

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/other/benzinga/`
- [x] `go build ./...` from `library/other/benzinga/`
- [x] `go vet ./...`
- [x] `go test ./...` (includes `TestNextPageIntCursorZeroIndexed` and `TestSaveSyncResume*`)

No `registry.json` / `cli-skills/` / release-ledger edits.

## Gaps / Follow-Up

Design leftover from #1787 still stands: CLI `search` in auto/live mode hits `/api/v2/logos/search`, not local news FTS. Local FTS remains `--data-source local` only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ea3af1f-fdc1-49f5-8a79-490288ef5192?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ea3af1f-fdc1-49f5-8a79-490288ef5192&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

