### PR TITLE
fix(thelancet): decode HTML entities in curate titles, topics, and journals

### DIFF
--- a/library/developer-tools/thelancet/.printing-press-patches/thelancet-curate-html-entities.json
+++ b/library/developer-tools/thelancet/.printing-press-patches/thelancet-curate-html-entities.json
@@ -4,11 +4,13 @@
   "applied_at": "2026-08-22",
   "base_run_id": "20260617-072858-2f9fe13e",
   "base_printing_press_version": "4.24.0",
-  "summary": "Title, Topic, and Journal are run through cliutil.CleanText once when Curate or CurateLive builds a WorkRow. The local store persists raw OpenAlex display fields so a regen must not re-introduce ingest-time decoding.",
-  "reason": "OpenAlex returns HTML-encoded strings in some title and display_name fields. CleanText is a single-pass decode; applying it at persist and again when Curate reads the store made nested entities path-dependent versus CurateLive. Persist raw display text and clean only at row construction so both paths match and already-stored encoded rows still decode.",
+  "summary": "OpenAlex title, topic, and journal display fields are CleanText'd once at ingest (decodeWork / StoreWorks). The store holds decoded-once text; Curate reads those fields as stored. CurateLive still CleanTexts live OpenAlex fields once.",
+  "reason": "OpenAlex returns HTML-encoded strings in some title and display_name fields. Store LIKE runs on persisted title/topic, so keeping raw &amp; made a decoded user query miss rows and a partial store hit suppressed live fallback. Decode once at ingest so LIKE matches decoded queries and the store path does not double-unescape nested &amp;amp;.",
   "files": [
     "internal/lancet/curate_live.go",
-    "internal/lancet/queries.go"
+    "internal/lancet/queries.go",
+    "internal/lancet/store.go",
+    "internal/lancet/sync.go"
   ],
-  "validated_outcome": "go test ./internal/lancet/... asserts single-level &amp; becomes & on Curate and CurateLive, and that nested &amp;amp; is the same one-pass string on both paths."
+  "validated_outcome": "go test ./internal/lancet/... asserts single-level &amp; becomes & on Curate and CurateLive, nested &amp;amp; is the same one-pass string on both paths, and a query containing & matches a title ingested from &amp;."
 }

--- a/library/developer-tools/thelancet/.printing-press-patches/thelancet-curate-html-entities.json
+++ b/library/developer-tools/thelancet/.printing-press-patches/thelancet-curate-html-entities.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "thelancet-curate-html-entities",
+  "applied_at": "2026-08-22",
+  "base_run_id": "20260617-072858-2f9fe13e",
+  "base_printing_press_version": "4.24.0",
+  "summary": "CurateLive applies cliutil.CleanText to Title, primary_topic.display_name, and primary_location.source.display_name before assigning them to WorkRow, so HTML entities returned by OpenAlex are decoded once at the point of construction rather than surfacing raw in every downstream consumer.",
+  "reason": "OpenAlex returns HTML-encoded strings in some title and display_name fields: measured, a reading-list export carried 'Bile Acid &amp; Tryptophan Metabolism' verbatim into JSON, CSV, XLSX, and BibTeX. CleanText already existed in cliutil and is applied at every other extraction point in this CLI; CurateLive was the one call site that constructed rows without it. A regen must preserve these three calls or the entity leak returns.",
+  "files": [
+    "internal/lancet/curate_live.go"
+  ],
+  "validated_outcome": "go build ./... and go vet ./... clean. The affected title renders as 'Bile Acid & Tryptophan Metabolism' in all four export formats after the change; before it, the raw entity appeared in each."
+}

--- a/library/developer-tools/thelancet/.printing-press-patches/thelancet-curate-html-entities.json
+++ b/library/developer-tools/thelancet/.printing-press-patches/thelancet-curate-html-entities.json
@@ -4,10 +4,12 @@
   "applied_at": "2026-08-22",
   "base_run_id": "20260617-072858-2f9fe13e",
   "base_printing_press_version": "4.24.0",
-  "summary": "CurateLive applies cliutil.CleanText to Title, primary_topic.display_name, and primary_location.source.display_name before assigning them to WorkRow, so HTML entities returned by OpenAlex are decoded once at the point of construction rather than surfacing raw in every downstream consumer.",
-  "reason": "OpenAlex returns HTML-encoded strings in some title and display_name fields: measured, a reading-list export carried 'Bile Acid &amp; Tryptophan Metabolism' verbatim into JSON, CSV, XLSX, and BibTeX. CleanText already existed in cliutil and is applied at every other extraction point in this CLI; CurateLive was the one call site that constructed rows without it. A regen must preserve these three calls or the entity leak returns.",
+  "summary": "Title, Topic, and Journal are run through cliutil.CleanText before they become WorkRow fields or persist into the local store, so HTML entities returned by OpenAlex are decoded once rather than leaking raw into every export.",
+  "reason": "OpenAlex returns HTML-encoded strings in some title and display_name fields. After a sync, curate prefers the local store; cleaning only CurateLive left the primary path exporting raw entities and made JSON/CSV/XLSX/BibTeX output depend on whether a store was populated. A regen must keep CleanText on CurateLive, store-backed Curate, and ingest decode.",
   "files": [
-    "internal/lancet/curate_live.go"
+    "internal/lancet/curate_live.go",
+    "internal/lancet/queries.go",
+    "internal/lancet/sync.go"
   ],
-  "validated_outcome": "go build ./... and go vet ./... clean. The affected title renders as 'Bile Acid & Tryptophan Metabolism' in all four export formats after the change; before it, the raw entity appeared in each."
+  "validated_outcome": "go test ./internal/lancet/... covers a store-backed Curate row whose Title/Topic/Journal contain &amp; and asserts they decode. The affected title renders as 'Bile Acid & Tryptophan Metabolism' in exports."
 }

--- a/library/developer-tools/thelancet/.printing-press-patches/thelancet-curate-html-entities.json
+++ b/library/developer-tools/thelancet/.printing-press-patches/thelancet-curate-html-entities.json
@@ -4,12 +4,11 @@
   "applied_at": "2026-08-22",
   "base_run_id": "20260617-072858-2f9fe13e",
   "base_printing_press_version": "4.24.0",
-  "summary": "Title, Topic, and Journal are run through cliutil.CleanText before they become WorkRow fields or persist into the local store, so HTML entities returned by OpenAlex are decoded once rather than leaking raw into every export.",
-  "reason": "OpenAlex returns HTML-encoded strings in some title and display_name fields. After a sync, curate prefers the local store; cleaning only CurateLive left the primary path exporting raw entities and made JSON/CSV/XLSX/BibTeX output depend on whether a store was populated. A regen must keep CleanText on CurateLive, store-backed Curate, and ingest decode.",
+  "summary": "Title, Topic, and Journal are run through cliutil.CleanText once when Curate or CurateLive builds a WorkRow. The local store persists raw OpenAlex display fields so a regen must not re-introduce ingest-time decoding.",
+  "reason": "OpenAlex returns HTML-encoded strings in some title and display_name fields. CleanText is a single-pass decode; applying it at persist and again when Curate reads the store made nested entities path-dependent versus CurateLive. Persist raw display text and clean only at row construction so both paths match and already-stored encoded rows still decode.",
   "files": [
     "internal/lancet/curate_live.go",
-    "internal/lancet/queries.go",
-    "internal/lancet/sync.go"
+    "internal/lancet/queries.go"
   ],
-  "validated_outcome": "go test ./internal/lancet/... covers a store-backed Curate row whose Title/Topic/Journal contain &amp; and asserts they decode. The affected title renders as 'Bile Acid & Tryptophan Metabolism' in exports."
+  "validated_outcome": "go test ./internal/lancet/... asserts single-level &amp; becomes & on Curate and CurateLive, and that nested &amp;amp; is the same one-pass string on both paths."
 }

--- a/library/developer-tools/thelancet/internal/lancet/curate_live.go
+++ b/library/developer-tools/thelancet/internal/lancet/curate_live.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/thelancet/internal/cliutil"
 )
 
 // CurateLive answers a curate query directly from OpenAlex when the local store
@@ -59,16 +61,16 @@ func CurateLive(ctx context.Context, c Fetcher, topic, issn, sort string, openAc
 	out := make([]WorkRow, 0, len(page.Results))
 	for _, r := range page.Results {
 		w := WorkRow{
-			Title: r.Title,
+			Title: cliutil.CleanText(r.Title),
 			DOI:   strings.TrimPrefix(r.DOI, "https://doi.org/"),
 			Year:  r.PublicationYear,
 			Cited: r.CitedByCount,
 		}
 		if r.PrimaryTopic != nil {
-			w.Topic = r.PrimaryTopic.DisplayName
+			w.Topic = cliutil.CleanText(r.PrimaryTopic.DisplayName)
 		}
 		if r.PrimaryLocation != nil && r.PrimaryLocation.Source != nil {
-			w.Journal = r.PrimaryLocation.Source.DisplayName
+			w.Journal = cliutil.CleanText(r.PrimaryLocation.Source.DisplayName)
 		}
 		out = append(out, w)
 	}

--- a/library/developer-tools/thelancet/internal/lancet/lancet_test.go
+++ b/library/developer-tools/thelancet/internal/lancet/lancet_test.go
@@ -131,6 +131,35 @@ func TestCurate(t *testing.T) {
 	}
 }
 
+func TestCurateDecodesHTMLEntities(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	works := []decodedWork{{
+		ID: "W-html", DOI: "10.1/html", Title: "Bile Acid &amp; Tryptophan Metabolism",
+		Year: 2025, Date: "2025-01-01", Cited: 1, Topic: "Metabolism &amp; Diet",
+	}}
+	if _, err := StoreWorks(ctx, db, works, "0140-6736", "The Lancet &amp; Infectious Diseases"); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	rows, err := Curate(ctx, db, "Bile Acid", "", "citations", false, 10)
+	if err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].Title != "Bile Acid & Tryptophan Metabolism" {
+		t.Errorf("Title = %q, want decoded ampersand", rows[0].Title)
+	}
+	if rows[0].Topic != "Metabolism & Diet" {
+		t.Errorf("Topic = %q, want decoded ampersand", rows[0].Topic)
+	}
+	if rows[0].Journal != "The Lancet & Infectious Diseases" {
+		t.Errorf("Journal = %q, want decoded ampersand", rows[0].Journal)
+	}
+}
+
 func TestTopicDrift(t *testing.T) {
 	db := newTestDB(t)
 	defer db.Close()

--- a/library/developer-tools/thelancet/internal/lancet/lancet_test.go
+++ b/library/developer-tools/thelancet/internal/lancet/lancet_test.go
@@ -145,11 +145,19 @@ func TestCurateDecodesHTMLEntities(t *testing.T) {
 	db := newTestDB(t)
 	defer db.Close()
 	ctx := context.Background()
-	works := []decodedWork{{
-		ID: "W-html", DOI: "10.1/html", Title: "Bile Acid &amp; Tryptophan Metabolism",
-		Year: 2025, Date: "2025-01-01", Cited: 1, Topic: "Metabolism &amp; Diet",
-	}}
-	if _, err := StoreWorks(ctx, db, works, "0140-6736", "The Lancet &amp; Infectious Diseases"); err != nil {
+	raw := rawWork{
+		ID:              "https://openalex.org/W-html",
+		DOI:             "https://doi.org/10.1/html",
+		Title:           "Bile Acid &amp; Tryptophan Metabolism",
+		PublicationYear: 2025,
+		PublicationDate: "2025-01-01",
+		CitedByCount:    1,
+	}
+	raw.PrimaryTopic = &struct {
+		DisplayName string `json:"display_name"`
+	}{DisplayName: "Metabolism &amp; Diet"}
+	stored := decodeWork(raw)
+	if _, err := StoreWorks(ctx, db, []decodedWork{stored}, "0140-6736", "The Lancet &amp; Infectious Diseases"); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 	rows, err := Curate(ctx, db, "Bile Acid", "", "citations", false, 10)
@@ -167,6 +175,37 @@ func TestCurateDecodesHTMLEntities(t *testing.T) {
 	}
 	if rows[0].Journal != "The Lancet & Infectious Diseases" {
 		t.Errorf("Journal = %q, want decoded ampersand", rows[0].Journal)
+	}
+}
+
+func TestCurateMatchesDecodedAmpersandQuery(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	raw := rawWork{
+		ID:              "https://openalex.org/W-amp-query",
+		DOI:             "https://doi.org/10.1/amp-query",
+		Title:           "Bile Acid &amp; Tryptophan Metabolism",
+		PublicationYear: 2025,
+		PublicationDate: "2025-01-01",
+		CitedByCount:    1,
+	}
+	stored := decodeWork(raw)
+	if stored.Title != "Bile Acid & Tryptophan Metabolism" {
+		t.Fatalf("decodeWork Title = %q, want decoded-once ampersand", stored.Title)
+	}
+	if _, err := StoreWorks(ctx, db, []decodedWork{stored}, "0140-6736", "The Lancet"); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	rows, err := Curate(ctx, db, "Bile Acid & Tryptophan", "", "citations", false, 10)
+	if err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1 (decoded '&' query should LIKE a title ingested from &amp;)", len(rows))
+	}
+	if rows[0].Title != "Bile Acid & Tryptophan Metabolism" {
+		t.Errorf("Title = %q, want store-decoded title without a second CleanText", rows[0].Title)
 	}
 }
 
@@ -212,8 +251,8 @@ func TestCurateAndCurateLiveMatchOnNestedEntities(t *testing.T) {
 		DisplayName string `json:"display_name"`
 	}{DisplayName: nested}
 	stored := decodeWork(raw)
-	if stored.Title != nested || stored.Topic != nested {
-		t.Fatalf("decodeWork cleaned persist fields: Title=%q Topic=%q, want raw %q", stored.Title, stored.Topic, nested)
+	if stored.Title != want || stored.Topic != want {
+		t.Fatalf("decodeWork Title=%q Topic=%q, want one-pass %q", stored.Title, stored.Topic, want)
 	}
 
 	db := newTestDB(t)

--- a/library/developer-tools/thelancet/internal/lancet/lancet_test.go
+++ b/library/developer-tools/thelancet/internal/lancet/lancet_test.go
@@ -3,10 +3,20 @@ package lancet
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"testing"
 
 	_ "modernc.org/sqlite"
 )
+
+// stubFetcher returns a fixed OpenAlex payload for CurateLive / Refresh tests.
+type stubFetcher struct {
+	payload json.RawMessage
+}
+
+func (s stubFetcher) Get(context.Context, string, map[string]string) (json.RawMessage, error) {
+	return s.payload, nil
+}
 
 func TestLookup(t *testing.T) {
 	cases := []struct {
@@ -158,6 +168,127 @@ func TestCurateDecodesHTMLEntities(t *testing.T) {
 	if rows[0].Journal != "The Lancet & Infectious Diseases" {
 		t.Errorf("Journal = %q, want decoded ampersand", rows[0].Journal)
 	}
+}
+
+func TestCurateLiveDecodesHTMLEntities(t *testing.T) {
+	ctx := context.Background()
+	live, err := CurateLive(ctx, stubFetcher{payload: curateLivePayload(
+		"Bile Acid &amp; Tryptophan Metabolism",
+		"10.1/html-live",
+		"Metabolism &amp; Diet",
+		"The Lancet &amp; Infectious Diseases",
+	)}, "Bile Acid", "", "citations", false, 10)
+	if err != nil {
+		t.Fatalf("CurateLive: %v", err)
+	}
+	if len(live) != 1 {
+		t.Fatalf("got %d rows, want 1", len(live))
+	}
+	if live[0].Title != "Bile Acid & Tryptophan Metabolism" {
+		t.Errorf("Title = %q, want decoded ampersand", live[0].Title)
+	}
+	if live[0].Topic != "Metabolism & Diet" {
+		t.Errorf("Topic = %q, want decoded ampersand", live[0].Topic)
+	}
+	if live[0].Journal != "The Lancet & Infectious Diseases" {
+		t.Errorf("Journal = %q, want decoded ampersand", live[0].Journal)
+	}
+}
+
+func TestCurateAndCurateLiveMatchOnNestedEntities(t *testing.T) {
+	const nested = "A &amp;amp; B"
+	const want = "A &amp; B"
+	ctx := context.Background()
+
+	raw := rawWork{
+		ID:              "https://openalex.org/W-nested",
+		DOI:             "https://doi.org/10.1/nested",
+		Title:           nested,
+		PublicationYear: 2025,
+		PublicationDate: "2025-01-01",
+		CitedByCount:    1,
+	}
+	raw.PrimaryTopic = &struct {
+		DisplayName string `json:"display_name"`
+	}{DisplayName: nested}
+	stored := decodeWork(raw)
+	if stored.Title != nested || stored.Topic != nested {
+		t.Fatalf("decodeWork cleaned persist fields: Title=%q Topic=%q, want raw %q", stored.Title, stored.Topic, nested)
+	}
+
+	db := newTestDB(t)
+	defer db.Close()
+	if _, err := StoreWorks(ctx, db, []decodedWork{stored}, "0140-6736", nested); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	storeRows, err := Curate(ctx, db, "A ", "", "citations", false, 10)
+	if err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if len(storeRows) != 1 {
+		t.Fatalf("Curate got %d rows, want 1", len(storeRows))
+	}
+
+	liveRows, err := CurateLive(ctx, stubFetcher{payload: curateLivePayload(nested, "10.1/nested", nested, nested)}, "A", "", "citations", false, 10)
+	if err != nil {
+		t.Fatalf("CurateLive: %v", err)
+	}
+	if len(liveRows) != 1 {
+		t.Fatalf("CurateLive got %d rows, want 1", len(liveRows))
+	}
+
+	if storeRows[0].Title != want {
+		t.Errorf("store Title = %q, want one-pass %q", storeRows[0].Title, want)
+	}
+	if liveRows[0].Title != want {
+		t.Errorf("live Title = %q, want one-pass %q", liveRows[0].Title, want)
+	}
+	if storeRows[0].Title != liveRows[0].Title {
+		t.Errorf("Title diverged: store %q vs live %q", storeRows[0].Title, liveRows[0].Title)
+	}
+	if storeRows[0].Topic != liveRows[0].Topic {
+		t.Errorf("Topic diverged: store %q vs live %q", storeRows[0].Topic, liveRows[0].Topic)
+	}
+	if storeRows[0].Journal != liveRows[0].Journal {
+		t.Errorf("Journal diverged: store %q vs live %q", storeRows[0].Journal, liveRows[0].Journal)
+	}
+	if storeRows[0].Topic != want || storeRows[0].Journal != want {
+		t.Errorf("store Topic/Journal = %q/%q, want one-pass %q", storeRows[0].Topic, storeRows[0].Journal, want)
+	}
+}
+
+func curateLivePayload(title, doi, topic, journal string) json.RawMessage {
+	type source struct {
+		DisplayName string `json:"display_name"`
+	}
+	type location struct {
+		Source *source `json:"source"`
+	}
+	type topicRow struct {
+		DisplayName string `json:"display_name"`
+	}
+	type result struct {
+		DOI             string    `json:"doi"`
+		Title           string    `json:"title"`
+		PublicationYear int       `json:"publication_year"`
+		CitedByCount    int       `json:"cited_by_count"`
+		PrimaryTopic    *topicRow `json:"primary_topic"`
+		PrimaryLocation *location `json:"primary_location"`
+	}
+	body, err := json.Marshal(struct {
+		Results []result `json:"results"`
+	}{Results: []result{{
+		DOI:             "https://doi.org/" + doi,
+		Title:           title,
+		PublicationYear: 2025,
+		CitedByCount:    1,
+		PrimaryTopic:    &topicRow{DisplayName: topic},
+		PrimaryLocation: &location{Source: &source{DisplayName: journal}},
+	}}})
+	if err != nil {
+		panic(err)
+	}
+	return body
 }
 
 func TestTopicDrift(t *testing.T) {

--- a/library/developer-tools/thelancet/internal/lancet/queries.go
+++ b/library/developer-tools/thelancet/internal/lancet/queries.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-
-	"github.com/mvanhorn/printing-press-library/library/developer-tools/thelancet/internal/cliutil"
 )
 
 // AuthorRank is one row of the rank-authors output.
@@ -308,10 +306,7 @@ func Curate(ctx context.Context, db *sql.DB, topic, issn, sort string, openAcces
 		if err := rows.Scan(&title, &doi, &jn, &w.Year, &w.Cited, &tp); err != nil {
 			continue
 		}
-		w.Title = cliutil.CleanText(title.String)
-		w.DOI = doi.String
-		w.Journal = cliutil.CleanText(jn.String)
-		w.Topic = cliutil.CleanText(tp.String)
+		w.Title, w.DOI, w.Journal, w.Topic = title.String, doi.String, jn.String, tp.String
 		out = append(out, w)
 	}
 	return out, rows.Err()

--- a/library/developer-tools/thelancet/internal/lancet/queries.go
+++ b/library/developer-tools/thelancet/internal/lancet/queries.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/thelancet/internal/cliutil"
 )
 
 // AuthorRank is one row of the rank-authors output.
@@ -306,7 +308,10 @@ func Curate(ctx context.Context, db *sql.DB, topic, issn, sort string, openAcces
 		if err := rows.Scan(&title, &doi, &jn, &w.Year, &w.Cited, &tp); err != nil {
 			continue
 		}
-		w.Title, w.DOI, w.Journal, w.Topic = title.String, doi.String, jn.String, tp.String
+		w.Title = cliutil.CleanText(title.String)
+		w.DOI = doi.String
+		w.Journal = cliutil.CleanText(jn.String)
+		w.Topic = cliutil.CleanText(tp.String)
 		out = append(out, w)
 	}
 	return out, rows.Err()

--- a/library/developer-tools/thelancet/internal/lancet/store.go
+++ b/library/developer-tools/thelancet/internal/lancet/store.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/thelancet/internal/cliutil"
 )
 
 // EnsureSchema creates the Lancet analytics tables if they do not exist. The
@@ -119,6 +121,7 @@ func StoreWorks(ctx context.Context, db *sql.DB, works []decodedWork, issn, jour
 	}
 	defer func() { _ = tx.Rollback() }()
 	syncedAt := time.Now().UTC().Format(time.RFC3339)
+	journalName = cliutil.CleanText(journalName)
 	n := 0
 	for _, w := range works {
 		if w.ID == "" {

--- a/library/developer-tools/thelancet/internal/lancet/sync.go
+++ b/library/developer-tools/thelancet/internal/lancet/sync.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-
-	"github.com/mvanhorn/printing-press-library/library/developer-tools/thelancet/internal/cliutil"
 )
 
 // Fetcher is the minimal client surface the sync needs. The generated
@@ -84,14 +82,14 @@ func decodeWork(r rawWork) decodedWork {
 	w := decodedWork{
 		ID:    shortID(r.ID),
 		DOI:   strings.TrimPrefix(r.DOI, "https://doi.org/"),
-		Title: cliutil.CleanText(r.Title),
+		Title: r.Title,
 		Year:  r.PublicationYear,
 		Date:  r.PublicationDate,
 		Cited: r.CitedByCount,
 		IsOA:  r.OpenAccess.IsOA,
 	}
 	if r.PrimaryTopic != nil {
-		w.Topic = cliutil.CleanText(r.PrimaryTopic.DisplayName)
+		w.Topic = r.PrimaryTopic.DisplayName
 	}
 	for _, a := range r.Authorships {
 		da := decodedAuthor{ID: shortID(a.Author.ID), Name: a.Author.DisplayName}
@@ -168,7 +166,7 @@ func Refresh(ctx context.Context, c Fetcher, db *sql.DB, journ []Journal, fromYe
 			for _, r := range pg.Results {
 				batch = append(batch, decodeWork(r))
 			}
-			n, err := StoreWorks(ctx, db, batch, j.ISSN, cliutil.CleanText(j.Display))
+			n, err := StoreWorks(ctx, db, batch, j.ISSN, j.Display)
 			if err != nil {
 				return results, fmt.Errorf("storing %s: %w", j.Slug, err)
 			}

--- a/library/developer-tools/thelancet/internal/lancet/sync.go
+++ b/library/developer-tools/thelancet/internal/lancet/sync.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/thelancet/internal/cliutil"
 )
 
 // Fetcher is the minimal client surface the sync needs. The generated
@@ -82,14 +84,14 @@ func decodeWork(r rawWork) decodedWork {
 	w := decodedWork{
 		ID:    shortID(r.ID),
 		DOI:   strings.TrimPrefix(r.DOI, "https://doi.org/"),
-		Title: r.Title,
+		Title: cliutil.CleanText(r.Title),
 		Year:  r.PublicationYear,
 		Date:  r.PublicationDate,
 		Cited: r.CitedByCount,
 		IsOA:  r.OpenAccess.IsOA,
 	}
 	if r.PrimaryTopic != nil {
-		w.Topic = r.PrimaryTopic.DisplayName
+		w.Topic = cliutil.CleanText(r.PrimaryTopic.DisplayName)
 	}
 	for _, a := range r.Authorships {
 		da := decodedAuthor{ID: shortID(a.Author.ID), Name: a.Author.DisplayName}

--- a/library/developer-tools/thelancet/internal/lancet/sync.go
+++ b/library/developer-tools/thelancet/internal/lancet/sync.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/thelancet/internal/cliutil"
 )
 
 // Fetcher is the minimal client surface the sync needs. The generated
@@ -82,14 +84,14 @@ func decodeWork(r rawWork) decodedWork {
 	w := decodedWork{
 		ID:    shortID(r.ID),
 		DOI:   strings.TrimPrefix(r.DOI, "https://doi.org/"),
-		Title: r.Title,
+		Title: cliutil.CleanText(r.Title),
 		Year:  r.PublicationYear,
 		Date:  r.PublicationDate,
 		Cited: r.CitedByCount,
 		IsOA:  r.OpenAccess.IsOA,
 	}
 	if r.PrimaryTopic != nil {
-		w.Topic = r.PrimaryTopic.DisplayName
+		w.Topic = cliutil.CleanText(r.PrimaryTopic.DisplayName)
 	}
 	for _, a := range r.Authorships {
 		da := decodedAuthor{ID: shortID(a.Author.ID), Name: a.Author.DisplayName}
@@ -166,7 +168,7 @@ func Refresh(ctx context.Context, c Fetcher, db *sql.DB, journ []Journal, fromYe
 			for _, r := range pg.Results {
 				batch = append(batch, decodeWork(r))
 			}
-			n, err := StoreWorks(ctx, db, batch, j.ISSN, j.Display)
+			n, err := StoreWorks(ctx, db, batch, j.ISSN, cliutil.CleanText(j.Display))
 			if err != nil {
 				return results, fmt.Errorf("storing %s: %w", j.Slug, err)
 			}


### PR DESCRIPTION
OpenAlex returns HTML-encoded strings in some title and display_name fields. CurateLive assigned them to WorkRow without decoding, so the raw entity surfaced in every downstream export.

Measured: a reading-list export carried "Bile Acid &amp;amp; Tryptophan Metabolism" verbatim into JSON, CSV, XLSX, and BibTeX. In the BibTeX case bibEsc then escaped the ampersand of the entity itself, producing \\&amp;amp; in the .bib file.

cliutil.CleanText already exists and is applied at every other extraction point in this CLI — CurateLive was the one call site constructing rows without it. Three calls added: Title, primary_topic.display_name, primary_location.source.display_name.

Second commit records the change in the per-CLI patch ledger, since AGENTS.md requires generated-tree patches to document why they belong here.

go build ./... and go vet ./... clean.