### PR TITLE
chore: gitignore raw live-dogfood transcript in manuscript proofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,12 @@ Thumbs.db
 # canonical archive; raw .log files are local-only generation/dogfood output.
 library/**/.manuscripts/**/proofs/*.log
 
+# Raw live-dogfood transcript — samples real live-API response bodies
+# (account data, private repo/org names, source diffs). Never canonical
+# evidence; phase5-acceptance.json (metadata-only) is the safe artifact.
+# See #4319.
+library/**/.manuscripts/**/proofs/publish-live-gate.json
+
 # Local Git worktrees
 .worktrees/
 


### PR DESCRIPTION
## Summary

Adds a `.gitignore` entry for `publish-live-gate.json` under any CLI's `.manuscripts/**/proofs/`, matching the existing pattern for raw `.log` dogfood output right above it.

## Why

`publish-live-gate.json` is the raw `dogfood --live --json` transcript written during `/printing-press-publish`'s Step 4.5 ("Live End-to-End Gate"). It samples real live-API response bodies into each test's `output_sample` field by design — useful for local review, but this file lives under a CLI's own `.manuscripts/` tree, which `publish package` bundles into the public PR without distinguishing "safe metadata" from "raw live-account dump."

This surfaced concretely on the `jules` CLI's publish PR (#1794): a real account's private org/repo names, an internal branch name, and a proprietary source-code diff ended up committed to a public fork before being caught and force-pushed away.

`phase5-acceptance.json` (also written by Step 4.5, via `--write-acceptance`) is unaffected — it's metadata-only (pass/fail counts, schema version, source-file hashes) and stays tracked as the canonical proof artifact.

## Scope

This is a backstop, not the root-cause fix. The actual fix belongs in `printing-press-publish`'s Step 4.5, which should stop writing this transcript under `.manuscripts/` in the first place — tracked separately as #4319. This `.gitignore` entry protects:

- CLIs printed/published before that fix lands
- any operator running an unpatched copy of the publish skill

## Related issues

- #4319 — the root-cause fix (Step 4.5 should not write the raw transcript into a manuscript path at all)
