### PR TITLE
fix(devices): document the corpus builder for extron/qsys/crestron; harden extron catalog sync

### DIFF
--- a/library/devices/crestron/README.md
+++ b/library/devices/crestron/README.md
@@ -225,6 +225,15 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
+### First run: build the local mirror
+
+```bash
+crestron-pp-cli sync
+crestron-pp-cli product get DM-NVX-360
+```
+
+`sync` crawls Crestron.com into the local mirror; `search`, `specs`, `fleet`, `lifecycle`, and `submittal` all read it and return nothing until it has run. Add `--notes` with a signed-in session to make release notes and change logs full-text searchable. Bound a long crawl with `--max-duration` — the root `--timeout` applies per request, not to the whole sync.
+
 ### Audit a whole fleet for firmware currency
 
 ```bash
@@ -319,6 +328,17 @@ Relocation is one-way. Unsetting `CRESTRON_HOME` does not move files back to pla
 Existing installs keep working because the platform-default rung matches the legacy layout. On the first auth write, stored secrets leave `config.toml` and are consolidated into `credentials.toml` under the data directory. Run `crestron-pp-cli doctor --fail-on warn` to check path and credential-location warnings in automation.
 
 ## Commands
+
+### sync — build the local mirror (run this first)
+
+Crawl Crestron.com into a local SQLite mirror so products, categories, and firmware releases can be queried offline. Crestron publishes no API and no product sitemap, so the catalog is walked the way the website itself does. Nothing local — `search`, `specs`, `fleet`, `lifecycle`, `submittal` — has data until this runs.
+
+- **`crestron-pp-cli sync`** - Build the whole mirror: categories, products, and firmware releases
+- **`crestron-pp-cli sync --resources categories,products`** - Build just the catalog half
+- **`crestron-pp-cli sync --resources releases --notes --max-notes 50`** - Also pull release notes and change logs so `search` can full-text them (requires a signed-in session; without one the version and date are still recorded)
+- **`crestron-pp-cli sync --max-duration 1h --concurrency 3`** - Bound the whole crawl and the number of parallel category walks
+
+> The root `--timeout` applies per request, not to the whole sync. Use `--max-duration` (default 30m) for the overall crawl budget.
 
 ### account
 

--- a/library/devices/crestron/SKILL.md
+++ b/library/devices/crestron/SKILL.md
@@ -105,6 +105,15 @@ These capabilities aren't available in any other tool for this API.
 
 ## Command Reference
 
+**sync** — Build the local mirror (run this first)
+
+- `crestron-pp-cli sync` — crawl Crestron.com into a local SQLite mirror: catalog categories, products, and firmware releases with their covered-model lists expanded
+- `crestron-pp-cli sync --resources categories,products` — build just the catalog half
+- `crestron-pp-cli sync --resources releases --notes --max-notes 50` — also pull release notes and change logs so `search` can full-text them (needs a signed-in session; without one the version and date are still recorded)
+- `crestron-pp-cli sync --max-duration 1h --concurrency 3` — bound the whole crawl and the number of parallel category walks
+
+Crestron publishes no API and no product sitemap, so the catalog is walked the way the website itself does. Nothing local — `search`, `specs`, `fleet`, `lifecycle`, `submittal` — has data until this runs. The root `--timeout` applies per request, not to the whole sync; use `--max-duration` (default 30m) for the overall budget.
+
 **account** — Crestron.com sign-in state
 
 - `crestron-pp-cli account` — Check whether the stored Crestron.com session is still signed in
@@ -148,6 +157,15 @@ crestron-pp-cli which "<capability in your own words>"
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
 
 ## Recipes
+
+### First run: build the local mirror
+
+```bash
+crestron-pp-cli sync
+crestron-pp-cli product get DM-NVX-360
+```
+
+`sync` crawls Crestron.com into the local mirror; `search`, `specs`, `fleet`, `lifecycle`, and `submittal` all read it and return nothing until it has run. Add `--notes` with a signed-in session to make release notes and change logs full-text searchable. Bound a long crawl with `--max-duration` — the root `--timeout` applies per request, not to the whole sync.
 
 ### Audit a whole fleet for firmware currency
 

--- a/library/devices/extron/.printing-press-patches/extron-catalog-sync-survives-one-bad-letter-bucket.json
+++ b/library/devices/extron/.printing-press-patches/extron-catalog-sync-survives-one-bad-letter-bucket.json
@@ -4,12 +4,12 @@
   "applied_at": "2026-08-24",
   "base_run_id": "20260811-011552-d999fbbe",
   "base_printing_press_version": "4.30.1",
-  "summary": "The corpus builder is a multi-bucket crawl, so a bucket is a unit of failure, not the run: retry a failed letter, skip it, keep the rest, and record the partial catalog. Its per-request budget and its whole-crawl budget are separate knobs, and it must do real work when invoked with no flags.",
-  "reason": "extron.com only exposes literature one alphabetical bucket at a time, so building the catalog means 36 sequential fetches against a WAF that intermittently stalls. Treating any single bucket error as fatal threw away the other 35 and left the catalog empty; binding the whole crawl to the per-request --timeout made a --full walk unfinishable at any timeout value; and a generated no-argument guard made bare `catalog sync` print help instead of syncing, so following SKILL.md and the README Quick Start literally produced an empty store.",
+  "summary": "The corpus builder is a multi-bucket crawl, so a bucket is a unit of failure, not the run: retry a failed letter, skip it, keep the rest, and record the partial catalog. Because upserts commit as they go, a bucket's document total must be distinct URLs across every attempt — the largest attempt loses what only an earlier one reached, and the sum double-counts re-upserts. Its per-request budget and its whole-crawl budget are separate knobs, and it must do real work when invoked with no flags.",
+  "reason": "extron.com only exposes literature one alphabetical bucket at a time, so building the catalog means 36 sequential fetches against a WAF that intermittently stalls. Treating any single bucket error as fatal threw away the other 35; binding the whole crawl to the per-request --timeout made a --full walk unfinishable at any timeout value; and a generated no-argument guard made bare `catalog sync` print help instead of syncing, so following the docs literally produced an empty store. Once retries were added, per-attempt max counting underreported the rows on disk, which the summary, the sync-state total, and doctor all read.",
   "files": [
     "internal/cli/catalog_sync.go",
     "internal/cli/catalog_sync_test.go"
   ],
-  "validated_outcome": "catalog_sync_test.go fails against the prior behavior on both counts (aborted crawl, help-instead-of-sync) and passes after; live `catalog sync --letters Q` stores 37 docs and reports letters_failed=0.",
+  "validated_outcome": "catalog_sync_test.go fails against each prior behavior (aborted crawl, help-instead-of-sync, count 4 where 6 rows were committed) and passes after. Live: letter D reports docs=61 bare and docs=231 with --full --max-pages 3, each matching the store's row count and sync-state total exactly.",
   "findings_addressed": ["F1", "F2", "F3"]
 }

--- a/library/devices/extron/.printing-press-patches/extron-catalog-sync-survives-one-bad-letter-bucket.json
+++ b/library/devices/extron/.printing-press-patches/extron-catalog-sync-survives-one-bad-letter-bucket.json
@@ -4,12 +4,16 @@
   "applied_at": "2026-08-24",
   "base_run_id": "20260811-011552-d999fbbe",
   "base_printing_press_version": "4.30.1",
-  "summary": "The corpus builder is a multi-bucket crawl, so a bucket is a unit of failure, not the run: retry a failed letter, skip it, keep the rest, and record the partial catalog. Because upserts commit as they go, a bucket's document total must be distinct URLs across every attempt — the largest attempt loses what only an earlier one reached, and the sum double-counts re-upserts. Its per-request budget and its whole-crawl budget are separate knobs, and it must do real work when invoked with no flags.",
-  "reason": "extron.com only exposes literature one alphabetical bucket at a time, so building the catalog means 36 sequential fetches against a WAF that intermittently stalls. Treating any single bucket error as fatal threw away the other 35; binding the whole crawl to the per-request --timeout made a --full walk unfinishable at any timeout value; and a generated no-argument guard made bare `catalog sync` print help instead of syncing, so following the docs literally produced an empty store. Once retries were added, per-attempt max counting underreported the rows on disk, which the summary, the sync-state total, and doctor all read.",
+  "summary": "The corpus builder is a multi-bucket crawl, so a bucket is a unit of failure, not the run: retry a failed letter, skip it, keep the rest, and record the partial catalog. Because upserts commit as they go, a bucket's document total must be distinct URLs across every attempt \u2014 the largest attempt loses what only an earlier one reached, and the sum double-counts re-upserts. sync_state describes the whole catalog, so a --letters run must read its total from the store and must neither claim completeness nor downgrade a catalog it did not survey. Its per-request budget and its whole-crawl budget are separate knobs, and it must do real work when invoked with no flags.",
+  "reason": "extron.com only exposes literature one alphabetical bucket at a time, so building the catalog means 36 sequential fetches against a WAF that intermittently stalls. Treating any single bucket error as fatal threw away the other 35; binding the whole crawl to the per-request --timeout made a --full walk unfinishable at any timeout value; and a generated no-argument guard made bare `catalog sync` print help instead of syncing, so following the docs literally produced an empty store. Retry-then-skip then makes `catalog sync --letters <failed>` the recovery path, which exposed two accounting defects that doctor and the partial-catalog hint both read: per-attempt max counting underreported the rows on disk, and a narrowed invocation overwrote the store-wide sync_state with its own scope.",
   "files": [
     "internal/cli/catalog_sync.go",
     "internal/cli/catalog_sync_test.go"
   ],
-  "validated_outcome": "catalog_sync_test.go fails against each prior behavior (aborted crawl, help-instead-of-sync, count 4 where 6 rows were committed) and passes after. Live: letter D reports docs=61 bare and docs=231 with --full --max-pages 3, each matching the store's row count and sync-state total exactly.",
-  "findings_addressed": ["F1", "F2", "F3"]
+  "validated_outcome": "catalog_sync_test.go fails against each prior behavior (aborted crawl, help-instead-of-sync, count 4 where 6 rows were committed, sync_state 1 where 3 rows were stored, cursor downgraded and cursor falsely 'full') and passes after. Live: a letters=D run then a letters=Q run leaves sync_state at 98/partial against 98 actual rows; the prior code recorded 37.",
+  "findings_addressed": [
+    "F1",
+    "F2",
+    "F3"
+  ]
 }

--- a/library/devices/extron/.printing-press-patches/extron-catalog-sync-survives-one-bad-letter-bucket.json
+++ b/library/devices/extron/.printing-press-patches/extron-catalog-sync-survives-one-bad-letter-bucket.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "extron-catalog-sync-survives-one-bad-letter-bucket",
+  "applied_at": "2026-08-24",
+  "base_run_id": "20260811-011552-d999fbbe",
+  "base_printing_press_version": "4.30.1",
+  "summary": "The corpus builder is a multi-bucket crawl, so a bucket is a unit of failure, not the run: retry a failed letter, skip it, keep the rest, and record the partial catalog. Its per-request budget and its whole-crawl budget are separate knobs, and it must do real work when invoked with no flags.",
+  "reason": "extron.com only exposes literature one alphabetical bucket at a time, so building the catalog means 36 sequential fetches against a WAF that intermittently stalls. Treating any single bucket error as fatal threw away the other 35 and left the catalog empty; binding the whole crawl to the per-request --timeout made a --full walk unfinishable at any timeout value; and a generated no-argument guard made bare `catalog sync` print help instead of syncing, so following SKILL.md and the README Quick Start literally produced an empty store.",
+  "files": [
+    "internal/cli/catalog_sync.go",
+    "internal/cli/catalog_sync_test.go"
+  ],
+  "validated_outcome": "catalog_sync_test.go fails against the prior behavior on both counts (aborted crawl, help-instead-of-sync) and passes after; live `catalog sync --letters Q` stores 37 docs and reports letters_failed=0.",
+  "findings_addressed": ["F1", "F2", "F3"]
+}

--- a/library/devices/extron/README.md
+++ b/library/devices/extron/README.md
@@ -121,6 +121,8 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 extron-pp-cli doctor --dry-run
 
 # Fetch the Extron literature catalog into the local store — everything else reads it.
+# This baseline pass takes the first index page per letter bucket; add --full for the
+# complete catalog (see "catalog sync" under Commands).
 extron-pp-cli catalog sync
 
 # Browse the Manual category for M products (Matrix, MAV) straight from the official index.
@@ -139,7 +141,7 @@ extron-pp-cli search "DTP2" --type literature
 These capabilities aren't available in any other tool for this API.
 
 ### Local catalog that compounds
-- **`catalog sync`** — Build the whole Extron literature catalog into a local store in one pass, walking the alphabetical index the site only exposes a letter at a time. A failed letter bucket is retried and skipped rather than aborting the crawl, so a 36-bucket `--full` walk survives a flaky bucket.
+- **`catalog sync`** — Build the local Extron literature catalog, walking the alphabetical index the site only exposes a letter at a time. Bare `catalog sync` fetches the first index page per letter bucket — a fast baseline of roughly 1,200 documents, with large categories truncated at the page-1 ceiling. `--full` follows each category's pagination and is what produces the complete catalog (roughly 3,600 documents and up). A failed letter bucket is retried and skipped rather than aborting the crawl, so a 36-bucket `--full` walk survives a flaky bucket.
 
   _Run this first — every local read depends on it, and it is not the same command as top-level `sync`._
 
@@ -192,6 +194,27 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ## Recipes
+
+### First run: build the catalog
+
+Everything local — `search`, `literature list`, `catalog completeness`, `catalog verify` — reads the catalog this builds, so run it before trusting any local result. There are two passes, and the difference matters:
+
+```bash
+# Fast baseline: first index page per letter bucket, ~1,200 docs.
+# Large categories are truncated here — this is NOT the complete catalog.
+extron-pp-cli catalog sync
+
+# Complete catalog: follows every category's pagination, ~3,600 docs and up.
+extron-pp-cli catalog sync --full --timeout 15m --max-duration 4h --json
+```
+
+Run the `--full` pass before any answer that depends on completeness — a rack doc binder, a completeness report, a bid compliance check. If you only ran the baseline, a document that exists at Extron can be missing from local search with no error to tell you.
+
+`--timeout` bounds each letter bucket, `--max-duration` bounds the whole crawl. Failed buckets are retried and then skipped; check `letters_failed` and `errors` in the summary, then re-run just those buckets:
+
+```bash
+extron-pp-cli catalog sync --letters A,Q --full --timeout 15m
+```
 
 ### What did Extron release this month
 
@@ -292,10 +315,12 @@ Existing installs keep working because the platform-default rung matches the leg
 
 Fetch the Extron literature catalog into the local store. Every local read — `search`, `literature list`, `catalog completeness`, `catalog verify`, `literature recent`, `literature updates` — depends on it.
 
-- **`extron-pp-cli catalog sync`** - Walk the alphabetical literature index (0-9, A-Z) and store the parsed catalog locally
-- **`extron-pp-cli catalog sync --full`** - Also follow each category's pagination for the complete catalog
+- **`extron-pp-cli catalog sync`** - Fetch the **first index page per letter bucket** (0-9, A-Z). A fast baseline of roughly 1,200 documents, **not the complete catalog**: any category with more than one page of results is truncated at the page-1 ceiling.
+- **`extron-pp-cli catalog sync --full`** - Also follow each category's pagination. **This is what produces the complete catalog** (roughly 3,600 documents and up).
 - **`extron-pp-cli catalog sync --letters A,B,C`** - Narrow to specific letter buckets
 - **`extron-pp-cli catalog sync --full --max-duration 4h --retries 3`** - Long crawl with a bigger overall budget and more per-letter retries
+
+Use the baseline to get something searchable quickly; run `--full` before any answer that depends on the catalog being complete, such as a rack doc binder or a bid compliance check. `--max-pages` caps pagination per category and truncates in the same way, so leave it unset for a genuinely complete crawl.
 
 A letter bucket that fails is retried (`--retries`, default 2) and then skipped, so one bad bucket does not discard the rest of the crawl. Skipped buckets appear in the summary's `errors` array and in `letters_failed`; the run exits non-zero only when every bucket failed, or when `--strict` is passed. The root `--timeout` bounds each letter bucket; `--max-duration` (default 30m) bounds the whole crawl.
 

--- a/library/devices/extron/README.md
+++ b/library/devices/extron/README.md
@@ -139,6 +139,13 @@ extron-pp-cli search "DTP2" --type literature
 These capabilities aren't available in any other tool for this API.
 
 ### Local catalog that compounds
+- **`catalog sync`** — Build the whole Extron literature catalog into a local store in one pass, walking the alphabetical index the site only exposes a letter at a time. A failed letter bucket is retried and skipped rather than aborting the crawl, so a 36-bucket `--full` walk survives a flaky bucket.
+
+  _Run this first — every local read depends on it, and it is not the same command as top-level `sync`._
+
+  ```bash
+  extron-pp-cli catalog sync --full --timeout 15m --max-duration 4h --json
+  ```
 - **`literature updates`** — See which downloaded spec sheets and manuals have a newer revision available upstream, so project shares never run stale docs.
 
   _Use this before commissioning or re-quoting to catch docs superseded since the last sync._
@@ -281,11 +288,38 @@ Existing installs keep working because the platform-default rung matches the leg
 
 ## Commands
 
+### catalog sync — build the local catalog (run this first)
+
+Fetch the Extron literature catalog into the local store. Every local read — `search`, `literature list`, `catalog completeness`, `catalog verify`, `literature recent`, `literature updates` — depends on it.
+
+- **`extron-pp-cli catalog sync`** - Walk the alphabetical literature index (0-9, A-Z) and store the parsed catalog locally
+- **`extron-pp-cli catalog sync --full`** - Also follow each category's pagination for the complete catalog
+- **`extron-pp-cli catalog sync --letters A,B,C`** - Narrow to specific letter buckets
+- **`extron-pp-cli catalog sync --full --max-duration 4h --retries 3`** - Long crawl with a bigger overall budget and more per-letter retries
+
+A letter bucket that fails is retried (`--retries`, default 2) and then skipped, so one bad bucket does not discard the rest of the crawl. Skipped buckets appear in the summary's `errors` array and in `letters_failed`; the run exits non-zero only when every bucket failed, or when `--strict` is passed. The root `--timeout` bounds each letter bucket; `--max-duration` (default 30m) bounds the whole crawl.
+
+> `catalog sync` is not the same command as the top-level `sync`. Top-level `sync` walks the generated `literature` endpoint resource and refreshes entity lookups; it does not build the catalog.
+
 ### literature
 
 Extron literature library index (spec sheets, manuals, guides)
 
 - **`extron-pp-cli literature`** - Fetch the alphabetical literature index for a letter
+- **`extron-pp-cli literature list`** - List literature from the local catalog, filterable by category and letter
+- **`extron-pp-cli literature get`** - Resolve a product or document name to its official Extron literature
+- **`extron-pp-cli literature download`** - Download official Extron spec sheets and manuals as PDFs
+- **`extron-pp-cli literature recent`** - Newest Extron literature across the whole library, ordered by date
+- **`extron-pp-cli literature updates`** - See which downloaded docs have a newer revision available upstream
+- **`extron-pp-cli literature family`** - Browse every document for a product family (DTP, MAV, IPL, DVS, ...)
+- **`extron-pp-cli literature rack`** - Assemble the full official doc set for every model in a rack BOM
+
+### catalog
+
+Local-catalog reporting
+
+- **`extron-pp-cli catalog completeness`** - Per-model gap report across Brochure, Declaration of Conformity, Design Guide, Product Guide, Manual, Revit BIM
+- **`extron-pp-cli catalog verify`** - Compare local PDF sizes and revisions against the download ledger
 
 
 ### Self-learning loop

--- a/library/devices/extron/SKILL.md
+++ b/library/devices/extron/SKILL.md
@@ -55,7 +55,7 @@ Do not use this CLI for:
 These capabilities aren't available in any other tool for this API.
 
 ### Local catalog that compounds
-- **`catalog sync`** — Build the whole Extron literature catalog into a local store in one pass, walking the alphabetical index the site only exposes a letter at a time. A failed letter bucket is retried and skipped rather than aborting the crawl, so a 36-bucket `--full` walk survives a flaky bucket.
+- **`catalog sync`** — Build the local Extron literature catalog, walking the alphabetical index the site only exposes a letter at a time. Bare `catalog sync` fetches the first index page per letter bucket — a fast baseline of roughly 1,200 documents, with large categories truncated at the page-1 ceiling. `--full` follows each category's pagination and is what produces the complete catalog (roughly 3,600 documents and up). A failed letter bucket is retried and skipped rather than aborting the crawl, so a 36-bucket `--full` walk survives a flaky bucket.
 
   _Run this first — every local read depends on it, and it is not the same command as top-level `sync`._
 
@@ -111,10 +111,12 @@ These capabilities aren't available in any other tool for this API.
 
 **catalog sync** — Build the local literature catalog (run this first)
 
-- `extron-pp-cli catalog sync` — walk the alphabetical literature index (0-9, A-Z) and store the parsed catalog locally; every other local read depends on this
-- `extron-pp-cli catalog sync --full` — also follow each category's pagination for the complete catalog (slow; budget it with `--max-duration`)
+- `extron-pp-cli catalog sync` — fetch the **first index page per letter bucket** (0-9, A-Z). A fast baseline of roughly 1,200 documents, **not the complete catalog**: any category with more than one page of results is truncated at the page-1 ceiling.
+- `extron-pp-cli catalog sync --full` — also follow each category's pagination. **This is what produces the complete catalog** (roughly 3,600 documents and up). Slower; budget it with `--max-duration`.
 - `extron-pp-cli catalog sync --letters A,B,C` — narrow to specific letter buckets
-- `extron-pp-cli catalog sync --full --max-duration 2h --retries 3` — long crawl with a bigger overall budget and more per-letter retries
+- `extron-pp-cli catalog sync --full --max-duration 4h --retries 3` — long crawl with a bigger overall budget and more per-letter retries
+
+Use bare `catalog sync` to get something searchable quickly; use `--full` before any answer that depends on the catalog being complete — a rack doc binder, a completeness report, or a bid compliance check. `--max-pages` caps pagination per category and truncates in the same way `--full`'s absence does, so leave it unset for a genuinely complete crawl.
 
 A letter bucket that fails is retried (`--retries`, default 2) and then skipped, so one bad bucket does not discard the rest of the crawl. Skipped buckets are listed in the summary's `errors` array and counted in `letters_failed`; the run exits non-zero only when every bucket failed, or when `--strict` is passed. The root `--timeout` bounds each letter bucket; `--max-duration` (default 30m) bounds the whole crawl.
 
@@ -151,15 +153,18 @@ extron-pp-cli which "<capability in your own words>"
 
 ### First run: build the catalog
 
+Everything local — `search`, `literature list`, `catalog completeness`, `catalog verify` — reads the catalog this builds, so run it before trusting any local result. There are two passes, and the difference matters:
+
 ```bash
+# Fast baseline: first index page per letter bucket, ~1,200 docs.
+# Large categories are truncated here — this is NOT the complete catalog.
 extron-pp-cli catalog sync
-```
 
-Everything local — `search`, `literature list`, `catalog completeness`, `catalog verify` — reads the catalog this builds. Run it before trusting any local result. For the complete catalog including every paginated category page, give the crawl a real budget:
-
-```bash
+# Complete catalog: follows every category's pagination, ~3,600 docs and up.
 extron-pp-cli catalog sync --full --timeout 15m --max-duration 4h --json
 ```
+
+Run the `--full` pass before any answer that depends on completeness — a rack doc binder, a completeness report, a bid compliance check. If you only ran the baseline, a document that exists at Extron can be missing from local search with no error to tell you.
 
 `--timeout` bounds each letter bucket, `--max-duration` bounds the whole crawl. Failed buckets are retried and then skipped; check `letters_failed` and `errors` in the summary, then re-run just those buckets:
 

--- a/library/devices/extron/SKILL.md
+++ b/library/devices/extron/SKILL.md
@@ -55,6 +55,13 @@ Do not use this CLI for:
 These capabilities aren't available in any other tool for this API.
 
 ### Local catalog that compounds
+- **`catalog sync`** — Build the whole Extron literature catalog into a local store in one pass, walking the alphabetical index the site only exposes a letter at a time. A failed letter bucket is retried and skipped rather than aborting the crawl, so a 36-bucket `--full` walk survives a flaky bucket.
+
+  _Run this first — every local read depends on it, and it is not the same command as top-level `sync`._
+
+  ```bash
+  extron-pp-cli catalog sync --full --timeout 15m --max-duration 4h --json
+  ```
 - **`literature updates`** — See which downloaded spec sheets and manuals have a newer revision available upstream, so project shares never run stale docs.
 
   _Use this before commissioning or re-quoting to catch docs superseded since the last sync._
@@ -102,9 +109,32 @@ These capabilities aren't available in any other tool for this API.
 
 ## Command Reference
 
+**catalog sync** — Build the local literature catalog (run this first)
+
+- `extron-pp-cli catalog sync` — walk the alphabetical literature index (0-9, A-Z) and store the parsed catalog locally; every other local read depends on this
+- `extron-pp-cli catalog sync --full` — also follow each category's pagination for the complete catalog (slow; budget it with `--max-duration`)
+- `extron-pp-cli catalog sync --letters A,B,C` — narrow to specific letter buckets
+- `extron-pp-cli catalog sync --full --max-duration 2h --retries 3` — long crawl with a bigger overall budget and more per-letter retries
+
+A letter bucket that fails is retried (`--retries`, default 2) and then skipped, so one bad bucket does not discard the rest of the crawl. Skipped buckets are listed in the summary's `errors` array and counted in `letters_failed`; the run exits non-zero only when every bucket failed, or when `--strict` is passed. The root `--timeout` bounds each letter bucket; `--max-duration` (default 30m) bounds the whole crawl.
+
+**Do not confuse `catalog sync` with the top-level `sync`.** Top-level `sync` walks the generated `literature` endpoint resource and refreshes entity lookups — it does not build the catalog. Only `catalog sync` populates the store that `search`, `catalog completeness`, `catalog verify`, `literature recent`, and `literature updates` read.
+
 **literature** — Extron literature library index (spec sheets, manuals, guides)
 
 - `extron-pp-cli literature` — Fetch the alphabetical literature index for a letter
+- `extron-pp-cli literature list` — List literature from the local catalog, filterable by category and letter
+- `extron-pp-cli literature get` — Resolve a product or document name to its official Extron literature
+- `extron-pp-cli literature download` — Download official spec sheets and manuals as PDFs
+- `extron-pp-cli literature recent` — Newest literature across the whole library, ordered by date
+- `extron-pp-cli literature updates` — See which downloaded docs have a newer revision upstream
+- `extron-pp-cli literature family` — Every document for a product family (DTP, MAV, IPL, DVS, ...)
+- `extron-pp-cli literature rack` — Assemble the full doc set for every model in a rack BOM
+
+**catalog** — Local-catalog reporting
+
+- `extron-pp-cli catalog completeness` — Per-model gap report across Brochure, Declaration of Conformity, Design Guide, Product Guide, Manual, and Revit BIM
+- `extron-pp-cli catalog verify` — Compare local PDF sizes and revisions against the download ledger
 
 
 ### Finding the right command
@@ -118,6 +148,24 @@ extron-pp-cli which "<capability in your own words>"
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query. Under `--json`/`--agent`, an unmatched query returns exit `0` with an empty `matches` array.
 
 ## Recipes
+
+### First run: build the catalog
+
+```bash
+extron-pp-cli catalog sync
+```
+
+Everything local — `search`, `literature list`, `catalog completeness`, `catalog verify` — reads the catalog this builds. Run it before trusting any local result. For the complete catalog including every paginated category page, give the crawl a real budget:
+
+```bash
+extron-pp-cli catalog sync --full --timeout 15m --max-duration 4h --json
+```
+
+`--timeout` bounds each letter bucket, `--max-duration` bounds the whole crawl. Failed buckets are retried and then skipped; check `letters_failed` and `errors` in the summary, then re-run just those buckets:
+
+```bash
+extron-pp-cli catalog sync --letters A,Q --full --timeout 15m
+```
 
 ### What did Extron release this month
 
@@ -329,7 +377,7 @@ Graceful degradation: if `learnings confirm` is an unknown command, you are driv
 - `similar_shape_different_entity:<canonical>` (top-level): a structurally matching row exists but its canonical entity differs from the live query's. Treated as cold start; the warning carries the conflicting canonical as a hint, but the row is NOT promoted into Results.
 - `ambiguous_alias` (top-level): a single query entity resolved to multiple canonicals (e.g., "Cards" → Arizona Cardinals + St. Louis Cardinals). Surface the ambiguity from context before committing to a resource.
 - `candidates_present` (top-level): the envelope carries a `candidates` section. Handle it via the candidates branch in Step 2 before anything else.
-- `lookup_refresh_available` (top-level): an entity in the query has no lookup row yet, but synced data could provide one. Run `extron-pp-cli sync` to refresh entity lookups.
+- `lookup_refresh_available` (top-level): an entity in the query has no lookup row yet, but synced data could provide one. Run `extron-pp-cli sync` to refresh entity lookups. Note that top-level `sync` only walks the generated `literature` endpoint and refreshes lookups — it does not build the catalog. If local reads are also coming back empty, run `extron-pp-cli catalog sync` first; that is the corpus builder.
 - Top-level `no_learnings_for_query_family`: the table had no rows above the Jaccard floor. Pure cold start.
 
 ### Step 4: `teach &` after finalizing your response - always

--- a/library/devices/extron/internal/cli/catalog_sync.go
+++ b/library/devices/extron/internal/cli/catalog_sync.go
@@ -8,7 +8,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
+	"time"
 
 	"github.com/mvanhorn/printing-press-library/library/devices/extron/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/devices/extron/internal/extron"
@@ -18,29 +20,60 @@ import (
 
 // pp:data-source live
 
+// letterFailure records one letter bucket the crawl could not finish.
+type letterFailure struct {
+	Letter string `json:"letter"`
+	Error  string `json:"error"`
+}
+
+// newCatalogClient is a seam so the letter-loop tests can point the crawl at a
+// local test server instead of www.extron.com.
+var newCatalogClient = extron.New
+
 func newNovelCatalogSyncCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	var lettersCSV string
 	var full bool
 	var maxPages int
+	var maxDuration time.Duration
+	var retries int
+	var strict bool
 
 	cmd := &cobra.Command{
-		Use:     "sync",
-		Short:   "Fetch the Extron literature catalog into the local store",
-		Long:    "Fetch the Extron literature catalog into the local store. By default fetches the first alphabetical index page per letter bucket (0-9, A-Z); --full follows each category's pagination for a complete catalog. Run this before relying on local search or catalog commands.",
-		Example: "  extron-pp-cli catalog sync\n  extron-pp-cli catalog sync --full",
+		Use:   "sync",
+		Short: "Fetch the Extron literature catalog into the local store",
+		Long: `Fetch the Extron literature catalog into the local store. Run this before
+relying on local search or catalog commands — it is what builds the catalog.
+
+By default it fetches the first alphabetical index page per letter bucket
+(0-9, A-Z); --full follows each category's pagination for a complete catalog.
+
+This is not the same command as top-level 'sync'. Top-level 'sync' walks the
+generated literature endpoint and refreshes entity lookups; only 'catalog sync'
+populates the catalog that search, catalog completeness, catalog verify,
+literature recent, and literature updates read.
+
+A letter that fails is retried (--retries) and then skipped, so one bad bucket
+no longer discards the other 35. The root --timeout bounds each letter bucket;
+--max-duration bounds the whole crawl. Pass --strict to fail the run when any
+letter was skipped.`,
+		Example: "  extron-pp-cli catalog sync\n  extron-pp-cli catalog sync --full\n  extron-pp-cli catalog sync --full --max-duration 2h --retries 3",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
-				return cmd.Help()
-			}
 			if dryRunOK(flags) {
 				return writeDryRun(cmd.OutOrStdout(), flags, "sync catalog")
 			}
-			ctx, cancel := boundCtx(cmd.Context(), flags)
-			defer cancel()
+			// PATCH(amend-2026-08-24: budget the whole crawl separately from each
+			// letter) — the root --timeout used to bound the entire 36-letter walk,
+			// so a long --full run died mid-crawl no matter how large --timeout was.
+			runCtx := cmd.Context()
+			var cancelRun context.CancelFunc = func() {}
+			if maxDuration > 0 {
+				runCtx, cancelRun = context.WithTimeout(runCtx, maxDuration)
+			}
+			defer cancelRun()
 
 			dbPath = resolveCatalogDB(flags, dbPath)
-			db, err := store.OpenWithContext(ctx, dbPath)
+			db, err := store.OpenWithContext(runCtx, dbPath)
 			if err != nil {
 				return fmt.Errorf("opening database: %w", err)
 			}
@@ -51,58 +84,76 @@ func newNovelCatalogSyncCmd(flags *rootFlags) *cobra.Command {
 				letters = letters[:1]
 			}
 
-			client := extron.New()
+			client := newCatalogClient()
 			total := 0
 			letterCounts := make(map[string]int, len(letters))
+			failures := make([]letterFailure, 0, len(letters))
+			succeeded := 0
+
 			for _, letter := range letters {
-				docs, refs, err := client.FetchIndex(ctx, letter)
-				if err != nil {
-					return fmt.Errorf("letter %s: %w", letter, err)
+				if runCtx.Err() != nil {
+					failures = append(failures, letterFailure{Letter: letter, Error: runCtx.Err().Error()})
+					continue
 				}
-				n, err := upsertDocs(db, docs)
-				if err != nil {
-					return fmt.Errorf("letter %s: %w", letter, err)
-				}
+				n, err := syncLetter(runCtx, flags, client, db, letter, full, maxPages, retries, cmd.ErrOrStderr())
 				total += n
 				letterCounts[letter] += n
-
-				if full && len(refs) > 0 {
-					paged, err := syncCategoryPages(ctx, client, db, letter, refs, maxPages)
-					if err != nil {
-						return fmt.Errorf("letter %s (full): %w", letter, err)
-					}
-					total += paged
-					letterCounts[letter] += paged
+				if err != nil {
+					failures = append(failures, letterFailure{Letter: letter, Error: err.Error()})
+					fmt.Fprintf(cmd.ErrOrStderr(), "catalog: letter %s: skipped after %d attempt(s): %v\n", letter, retries+1, err)
+					continue
 				}
+				succeeded++
 				fmt.Fprintf(cmd.ErrOrStderr(), "catalog: letter %s: %d docs (running total %d)\n", letter, letterCounts[letter], total)
 			}
 
+			// Record what actually landed even when some buckets were skipped, so a
+			// partial catalog is not reported as never-synced.
 			cursor := "partial"
-			if full && maxPages <= 0 {
+			if full && maxPages <= 0 && len(failures) == 0 {
 				cursor = "full"
 			}
-			if err := db.SaveSyncState(catalogResource, cursor, total); err != nil {
-				return fmt.Errorf("recording sync state: %w", err)
+			if succeeded > 0 {
+				if err := db.SaveSyncState(catalogResource, cursor, total); err != nil {
+					return fmt.Errorf("recording sync state: %w", err)
+				}
 			}
 
 			summary := struct {
-				LettersFetched int            `json:"letters_fetched"`
-				Docs           int            `json:"docs"`
-				Full           bool           `json:"full"`
-				Database       string         `json:"database"`
-				PerLetter      map[string]int `json:"per_letter,omitempty"`
+				LettersFetched int             `json:"letters_fetched"`
+				LettersFailed  int             `json:"letters_failed"`
+				Docs           int             `json:"docs"`
+				Full           bool            `json:"full"`
+				Database       string          `json:"database"`
+				PerLetter      map[string]int  `json:"per_letter,omitempty"`
+				Errors         []letterFailure `json:"errors,omitempty"`
 			}{
-				LettersFetched: len(letters),
+				LettersFetched: succeeded,
+				LettersFailed:  len(failures),
 				Docs:           total,
 				Full:           full,
 				Database:       dbPath,
 				PerLetter:      letterCounts,
+				Errors:         failures,
 			}
-			if !wantsHumanTable(cmd.OutOrStdout(), flags) {
-				return printJSONFiltered(cmd.OutOrStdout(), summary, flags)
+
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				fmt.Fprintf(cmd.OutOrStdout(), "Synced %d docs from %d letter bucket(s)%s into %s\n",
+					total, succeeded, fullOpt(full), dbPath)
+				if len(failures) > 0 {
+					fmt.Fprintf(cmd.OutOrStdout(), "Skipped %d letter bucket(s): %s\n",
+						len(failures), strings.Join(failedLetters(failures), ", "))
+				}
+			} else if err := printJSONFiltered(cmd.OutOrStdout(), summary, flags); err != nil {
+				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Synced %d docs from %d letter bucket(s)%s into %s\n",
-				total, len(letters), fullOpt(full), dbPath)
+
+			if succeeded == 0 && len(failures) > 0 {
+				return fmt.Errorf("catalog sync: every letter bucket failed (%d); first error: %s", len(failures), failures[0].Error)
+			}
+			if strict && len(failures) > 0 {
+				return fmt.Errorf("catalog sync: --strict and %d letter bucket(s) skipped: %s", len(failures), strings.Join(failedLetters(failures), ", "))
+			}
 			return nil
 		},
 	}
@@ -110,7 +161,85 @@ func newNovelCatalogSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&lettersCSV, "letters", "", "letter buckets to fetch as a CSV list (default: 0-9,A-Z)")
 	cmd.Flags().BoolVar(&full, "full", false, "follow per-category pagination for a complete catalog")
 	cmd.Flags().IntVar(&maxPages, "max-pages", 0, "maximum category pages per letter in --full mode (0 = unlimited)")
+	cmd.Flags().DurationVar(&maxDuration, "max-duration", 30*time.Minute, "overall crawl budget; the root --timeout applies per letter bucket, not to the whole sync (0 = unlimited)")
+	cmd.Flags().IntVar(&retries, "retries", 2, "retry attempts per letter bucket before skipping it")
+	cmd.Flags().BoolVar(&strict, "strict", false, "exit non-zero when any letter bucket was skipped")
 	return cmd
+}
+
+// syncLetter fetches one letter bucket, retrying transient failures before
+// giving up on it. It returns the docs stored even when the bucket ultimately
+// failed, so a partial letter still counts toward the catalog.
+//
+// PATCH(amend-2026-08-24: continue past a failed letter bucket) — a single
+// letter error used to abort the whole 0-9,A-Z crawl.
+func syncLetter(parent context.Context, flags *rootFlags, client *extron.Client, db *store.Store, letter string, full bool, maxPages, retries int, logw io.Writer) (int, error) {
+	if retries < 0 {
+		retries = 0
+	}
+	stored := 0
+	var lastErr error
+	for attempt := 0; attempt <= retries; attempt++ {
+		if parent.Err() != nil {
+			return stored, parent.Err()
+		}
+		if attempt > 0 {
+			backoff := time.Duration(attempt) * 2 * time.Second
+			fmt.Fprintf(logw, "catalog: letter %s: retry %d/%d in %v (%v)\n", letter, attempt, retries, backoff, lastErr)
+			select {
+			case <-time.After(backoff):
+			case <-parent.Done():
+				return stored, parent.Err()
+			}
+		}
+
+		// Each attempt gets its own root --timeout budget.
+		ctx, cancel := boundCtx(parent, flags)
+		n, err := fetchLetter(ctx, client, db, letter, full, maxPages)
+		cancel()
+		if n > stored {
+			// Upserts are keyed by document URL, so the best attempt's count is
+			// the accurate figure for what this bucket contributed.
+			stored = n
+		}
+		if err == nil {
+			return stored, nil
+		}
+		lastErr = err
+		// The overall crawl budget is spent — no later attempt can succeed.
+		if parent.Err() != nil {
+			return stored, err
+		}
+	}
+	return stored, lastErr
+}
+
+// fetchLetter performs one attempt at a letter bucket.
+func fetchLetter(ctx context.Context, client *extron.Client, db *store.Store, letter string, full bool, maxPages int) (int, error) {
+	docs, refs, err := client.FetchIndex(ctx, letter)
+	if err != nil {
+		return 0, fmt.Errorf("letter %s: %w", letter, err)
+	}
+	stored, err := upsertDocs(db, docs)
+	if err != nil {
+		return stored, fmt.Errorf("letter %s: %w", letter, err)
+	}
+	if full && len(refs) > 0 {
+		paged, err := syncCategoryPages(ctx, client, db, letter, refs, maxPages)
+		stored += paged
+		if err != nil {
+			return stored, fmt.Errorf("letter %s (full): %w", letter, err)
+		}
+	}
+	return stored, nil
+}
+
+func failedLetters(failures []letterFailure) []string {
+	out := make([]string, 0, len(failures))
+	for _, f := range failures {
+		out = append(out, f.Letter)
+	}
+	return out
 }
 
 func fullOpt(full bool) string {

--- a/library/devices/extron/internal/cli/catalog_sync.go
+++ b/library/devices/extron/internal/cli/catalog_sync.go
@@ -113,12 +113,34 @@ letter was skipped.`,
 
 			// Record what actually landed even when some buckets were skipped, so a
 			// partial catalog is not reported as never-synced.
+			//
+			// PATCH(amend-2026-08-24: never let one run's scope overwrite
+			// store-wide state) — sync_state describes the whole catalog, but a
+			// --letters run only knows about the buckets it fetched. Writing its
+			// own tally made `catalog sync --letters A,Q` — the recovery path this
+			// command's retry-then-skip behavior recommends — report a handful of
+			// documents against a store holding thousands, which doctor reads.
+			narrowed := len(letters) < len(extron.DefaultLetters)
 			cursor := "partial"
-			if full && maxPages <= 0 && len(failures) == 0 {
+			switch {
+			case narrowed:
+				// A narrowed run has no evidence about the buckets it skipped, so
+				// it neither claims completeness nor downgrades a catalog that was
+				// already complete.
+				if existing, _, _, err := db.GetSyncState(catalogResource); err == nil && existing != "" {
+					cursor = existing
+				}
+			case full && maxPages <= 0 && len(failures) == 0:
 				cursor = "full"
 			}
 			if succeeded > 0 {
-				if err := db.SaveSyncState(catalogResource, cursor, total); err != nil {
+				// Count the store rather than this run's documents: upserts are
+				// keyed by URL, so rows from earlier runs are still present.
+				storedTotal, err := db.Count(catalogResource)
+				if err != nil {
+					return fmt.Errorf("counting catalog rows: %w", err)
+				}
+				if err := db.SaveSyncState(catalogResource, cursor, storedTotal); err != nil {
 					return fmt.Errorf("recording sync state: %w", err)
 				}
 			}

--- a/library/devices/extron/internal/cli/catalog_sync.go
+++ b/library/devices/extron/internal/cli/catalog_sync.go
@@ -45,8 +45,12 @@ func newNovelCatalogSyncCmd(flags *rootFlags) *cobra.Command {
 		Long: `Fetch the Extron literature catalog into the local store. Run this before
 relying on local search or catalog commands — it is what builds the catalog.
 
-By default it fetches the first alphabetical index page per letter bucket
-(0-9, A-Z); --full follows each category's pagination for a complete catalog.
+By default it fetches only the first index page per letter bucket (0-9, A-Z).
+That is a fast baseline (roughly 1,200 documents) but NOT the complete catalog:
+any category with more than one page of results is truncated at the page-1
+ceiling. --full follows each category's pagination and is what produces the
+complete catalog (roughly 3,600 documents and up). --max-pages caps pagination
+per category and truncates the same way, so leave it unset for a full crawl.
 
 This is not the same command as top-level 'sync'. Top-level 'sync' walks the
 generated literature endpoint and refreshes entity lookups; only 'catalog sync'
@@ -159,7 +163,7 @@ letter was skipped.`,
 	}
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")
 	cmd.Flags().StringVar(&lettersCSV, "letters", "", "letter buckets to fetch as a CSV list (default: 0-9,A-Z)")
-	cmd.Flags().BoolVar(&full, "full", false, "follow per-category pagination for a complete catalog")
+	cmd.Flags().BoolVar(&full, "full", false, "follow per-category pagination; required for the complete catalog (bare sync stores only page 1 per letter bucket)")
 	cmd.Flags().IntVar(&maxPages, "max-pages", 0, "maximum category pages per letter in --full mode (0 = unlimited)")
 	cmd.Flags().DurationVar(&maxDuration, "max-duration", 30*time.Minute, "overall crawl budget; the root --timeout applies per letter bucket, not to the whole sync (0 = unlimited)")
 	cmd.Flags().IntVar(&retries, "retries", 2, "retry attempts per letter bucket before skipping it")
@@ -177,11 +181,16 @@ func syncLetter(parent context.Context, flags *rootFlags, client *extron.Client,
 	if retries < 0 {
 		retries = 0
 	}
-	stored := 0
+	// Upserts commit as they go and are keyed by document URL, so a retry adds
+	// to what earlier attempts already stored rather than replacing it. Counting
+	// distinct URLs across every attempt is the only figure that matches the
+	// rows actually in the store: the largest single attempt misses documents a
+	// different attempt committed, and the sum double-counts re-upserts.
+	seen := make(map[string]struct{})
 	var lastErr error
 	for attempt := 0; attempt <= retries; attempt++ {
 		if parent.Err() != nil {
-			return stored, parent.Err()
+			return len(seen), parent.Err()
 		}
 		if attempt > 0 {
 			backoff := time.Duration(attempt) * 2 * time.Second
@@ -189,49 +198,42 @@ func syncLetter(parent context.Context, flags *rootFlags, client *extron.Client,
 			select {
 			case <-time.After(backoff):
 			case <-parent.Done():
-				return stored, parent.Err()
+				return len(seen), parent.Err()
 			}
 		}
 
 		// Each attempt gets its own root --timeout budget.
 		ctx, cancel := boundCtx(parent, flags)
-		n, err := fetchLetter(ctx, client, db, letter, full, maxPages)
+		err := fetchLetter(ctx, client, db, letter, full, maxPages, seen)
 		cancel()
-		if n > stored {
-			// Upserts are keyed by document URL, so the best attempt's count is
-			// the accurate figure for what this bucket contributed.
-			stored = n
-		}
 		if err == nil {
-			return stored, nil
+			return len(seen), nil
 		}
 		lastErr = err
 		// The overall crawl budget is spent — no later attempt can succeed.
 		if parent.Err() != nil {
-			return stored, err
+			return len(seen), err
 		}
 	}
-	return stored, lastErr
+	return len(seen), lastErr
 }
 
-// fetchLetter performs one attempt at a letter bucket.
-func fetchLetter(ctx context.Context, client *extron.Client, db *store.Store, letter string, full bool, maxPages int) (int, error) {
+// fetchLetter performs one attempt at a letter bucket, recording every document
+// URL it commits in seen. seen is owned by the caller and spans retries.
+func fetchLetter(ctx context.Context, client *extron.Client, db *store.Store, letter string, full bool, maxPages int, seen map[string]struct{}) error {
 	docs, refs, err := client.FetchIndex(ctx, letter)
 	if err != nil {
-		return 0, fmt.Errorf("letter %s: %w", letter, err)
+		return fmt.Errorf("letter %s: %w", letter, err)
 	}
-	stored, err := upsertDocs(db, docs)
-	if err != nil {
-		return stored, fmt.Errorf("letter %s: %w", letter, err)
+	if err := upsertDocs(db, docs, seen); err != nil {
+		return fmt.Errorf("letter %s: %w", letter, err)
 	}
 	if full && len(refs) > 0 {
-		paged, err := syncCategoryPages(ctx, client, db, letter, refs, maxPages)
-		stored += paged
-		if err != nil {
-			return stored, fmt.Errorf("letter %s (full): %w", letter, err)
+		if err := syncCategoryPages(ctx, client, db, letter, refs, maxPages, seen); err != nil {
+			return fmt.Errorf("letter %s (full): %w", letter, err)
 		}
 	}
-	return stored, nil
+	return nil
 }
 
 func failedLetters(failures []letterFailure) []string {
@@ -264,24 +266,27 @@ func parseLettersCSV(csv string) []string {
 	return out
 }
 
-func upsertDocs(db *store.Store, docs []extron.Doc) (int, error) {
-	n := 0
+// upsertDocs stores each doc and records its URL in seen. Recording the URL
+// rather than incrementing a counter is what keeps the per-bucket total honest
+// when a bucket is retried: the same document committed twice counts once, and
+// a document only one attempt reached still counts.
+func upsertDocs(db *store.Store, docs []extron.Doc, seen map[string]struct{}) error {
 	for _, d := range docs {
 		data, err := json.Marshal(d)
 		if err != nil {
-			return n, err
+			return err
 		}
 		if err := db.Upsert(catalogResource, d.URL, data); err != nil {
-			return n, fmt.Errorf("storing %s: %w", d.Title, err)
+			return fmt.Errorf("storing %s: %w", d.Title, err)
 		}
-		n++
+		seen[d.URL] = struct{}{}
 	}
-	return n, nil
+	return nil
 }
 
-// syncCategoryPages follows each category's pagination for one letter.
-func syncCategoryPages(ctx context.Context, client *extron.Client, db *store.Store, letter string, refs map[string]extron.PageRef, maxPages int) (int, error) {
-	total := 0
+// syncCategoryPages follows each category's pagination for one letter,
+// recording every committed document URL in seen.
+func syncCategoryPages(ctx context.Context, client *extron.Client, db *store.Store, letter string, refs map[string]extron.PageRef, maxPages int, seen map[string]struct{}) error {
 	for _, ref := range refs {
 		page := ref.Page
 		pagesSeen := 0
@@ -294,13 +299,11 @@ func syncCategoryPages(ctx context.Context, client *extron.Client, db *store.Sto
 				if strings.Contains(err.Error(), "no literature rows") {
 					break
 				}
-				return total, err
+				return err
 			}
-			n, err := upsertDocs(db, docs)
-			if err != nil {
-				return total, err
+			if err := upsertDocs(db, docs, seen); err != nil {
+				return err
 			}
-			total += n
 			pagesSeen++
 			if !hasNext {
 				break
@@ -309,5 +312,5 @@ func syncCategoryPages(ctx context.Context, client *extron.Client, db *store.Sto
 			page = ref.Page
 		}
 	}
-	return total, nil
+	return nil
 }

--- a/library/devices/extron/internal/cli/catalog_sync_test.go
+++ b/library/devices/extron/internal/cli/catalog_sync_test.go
@@ -455,3 +455,102 @@ func TestCatalogSyncBareStoresOnlyFirstPage(t *testing.T) {
 		}
 	})
 }
+
+// readSyncState returns the catalog cursor and recorded total from a store.
+func readSyncState(t *testing.T, dbPath string) (string, int, int) {
+	t.Helper()
+	db, err := store.OpenWithContext(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("opening store: %v", err)
+	}
+	defer db.Close()
+	cursor, _, count, err := db.GetSyncState(catalogResource)
+	if err != nil {
+		t.Fatalf("reading sync state: %v", err)
+	}
+	rows, err := db.Count(catalogResource)
+	if err != nil {
+		t.Fatalf("counting catalog rows: %v", err)
+	}
+	return cursor, count, rows
+}
+
+// TestCatalogSyncNarrowRerunKeepsStoreWideState is the regression guard for
+// narrowed runs overwriting store-wide state. sync_state describes the whole
+// catalog, but `catalog sync --letters A,Q` only knows the buckets it fetched.
+// Writing that run's own tally made doctor read a handful of documents against
+// a store holding thousands — observed live as total_count=31 against 4,968
+// actual rows, with doctor still reporting the cache fresh.
+//
+// This matters because retry-then-skip makes "rerun just the failed buckets
+// with --letters" the documented recovery path, so the guidance leads users
+// straight into it.
+func TestCatalogSyncNarrowRerunKeepsStoreWideState(t *testing.T) {
+	t.Run("narrow rerun keeps the store-wide total", func(t *testing.T) {
+		srv, _ := catalogTestServer(t)
+		useCatalogTestServer(t, srv)
+		dbPath := filepath.Join(t.TempDir(), "data.db")
+
+		// Broad pass: three buckets, one document each.
+		if _, _, err := runCatalogSync(t, dbPath, "--letters", "A,B,C"); err != nil {
+			t.Fatalf("broad sync returned error: %v", err)
+		}
+		if _, count, rows := readSyncState(t, dbPath); count != 3 || rows != 3 {
+			t.Fatalf("after broad sync: sync_state=%d rows=%d, want 3 and 3", count, rows)
+		}
+
+		// Narrow rerun of a single bucket — the documented recovery path.
+		if _, _, err := runCatalogSync(t, dbPath, "--letters", "A"); err != nil {
+			t.Fatalf("narrow rerun returned error: %v", err)
+		}
+		_, count, rows := readSyncState(t, dbPath)
+		if rows != 3 {
+			t.Fatalf("catalog rows = %d, want 3 — the rerun must not drop other buckets' rows", rows)
+		}
+		if count != rows {
+			t.Errorf("sync_state total = %d, want %d (the store's actual row count) — doctor reads this value", count, rows)
+		}
+	})
+
+	t.Run("narrow rerun does not downgrade a complete catalog", func(t *testing.T) {
+		srv, _ := catalogTestServer(t)
+		useCatalogTestServer(t, srv)
+		dbPath := filepath.Join(t.TempDir(), "data.db")
+
+		if _, _, err := runCatalogSync(t, dbPath, "--letters", "A,B,C"); err != nil {
+			t.Fatalf("seed sync returned error: %v", err)
+		}
+		// Stand in for a prior complete crawl.
+		func() {
+			db, err := store.OpenWithContext(t.Context(), dbPath)
+			if err != nil {
+				t.Fatalf("opening store: %v", err)
+			}
+			defer db.Close()
+			if err := db.SaveSyncState(catalogResource, "full", 3); err != nil {
+				t.Fatalf("seeding full cursor: %v", err)
+			}
+		}()
+
+		if _, _, err := runCatalogSync(t, dbPath, "--letters", "A"); err != nil {
+			t.Fatalf("narrow rerun returned error: %v", err)
+		}
+		if cursor, _, _ := readSyncState(t, dbPath); cursor != "full" {
+			t.Errorf("cursor = %q after a narrow rerun, want %q — a --letters run knows nothing about the buckets it skipped, so it must not downgrade the catalog", cursor, "full")
+		}
+	})
+
+	t.Run("narrow run never claims the catalog is complete", func(t *testing.T) {
+		srv, _ := catalogTestServer(t)
+		useCatalogTestServer(t, srv)
+		dbPath := filepath.Join(t.TempDir(), "data.db")
+
+		// --full on a fresh store, but only one bucket: cannot be "full".
+		if _, _, err := runCatalogSync(t, dbPath, "--letters", "A", "--full"); err != nil {
+			t.Fatalf("narrow --full returned error: %v", err)
+		}
+		if cursor, _, _ := readSyncState(t, dbPath); cursor == "full" {
+			t.Errorf("cursor = %q, want %q — one bucket is not the whole catalog, and \"full\" silences the partial-catalog hint", cursor, "partial")
+		}
+	})
+}

--- a/library/devices/extron/internal/cli/catalog_sync_test.go
+++ b/library/devices/extron/internal/cli/catalog_sync_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 drummerms and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/devices/extron/internal/cliutil"
+	"github.com/mvanhorn/printing-press-library/library/devices/extron/internal/cliutil/testenv"
+	"github.com/mvanhorn/printing-press-library/library/devices/extron/internal/extron"
+	"github.com/mvanhorn/printing-press-library/library/devices/extron/internal/store"
+)
+
+// letterIndexHTML is a minimal literature index page: one category, one row.
+const letterIndexHTML = `<html><body>
+<h2>Brochure (X - 1 files)</h2>
+<table>
+<tr><th>Description</th><th>Rev</th><th>Date</th><th>Size</th><th>Type</th></tr>
+<tr>
+<td><a id="ctl00_1_idFileUrl" href="/download/files/brochure/%s.pdf" target="download">%s Brochure</a></td>
+<td><nobr>A</nobr></td><td><nobr>Jan. 2, 2024</nobr></td><td><nobr>10 KB</nobr></td><td><nobr>PDF</nobr></td>
+</tr>
+</table>
+</body></html>`
+
+// catalogTestServer serves a literature index per letter. Letters named in
+// failLetters always return HTTP 500; every other letter returns one document.
+func catalogTestServer(t *testing.T, failLetters ...string) (*httptest.Server, func(string) int) {
+	t.Helper()
+	fail := make(map[string]bool, len(failLetters))
+	for _, l := range failLetters {
+		fail[l] = true
+	}
+	var mu sync.Mutex
+	hits := make(map[string]int)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		letter := r.URL.Query().Get("id")
+		mu.Lock()
+		hits[letter]++
+		mu.Unlock()
+		if fail[letter] {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		body := strings.ReplaceAll(letterIndexHTML, "%s", letter)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, func(letter string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return hits[letter]
+	}
+}
+
+// useCatalogTestServer points the catalog crawl at srv for the duration of a test.
+func useCatalogTestServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	prev := newCatalogClient
+	newCatalogClient = func() *extron.Client {
+		c := extron.New()
+		c.BaseURL = srv.URL
+		return c
+	}
+	t.Cleanup(func() { newCatalogClient = prev })
+}
+
+// runCatalogSync executes `catalog sync` with the given args and returns the
+// decoded JSON summary alongside the command error.
+func runCatalogSync(t *testing.T, dbPath string, args ...string) (map[string]any, string, error) {
+	t.Helper()
+	cmd := RootCmd()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	full := append([]string{"catalog", "sync", "--json", "--no-color", "--db", dbPath}, args...)
+	cmd.SetArgs(full)
+	runErr := cmd.Execute()
+
+	var summary map[string]any
+	if body := strings.TrimSpace(out.String()); body != "" {
+		if err := json.Unmarshal([]byte(body), &summary); err != nil {
+			t.Fatalf("decoding summary %q: %v", body, err)
+		}
+	}
+	return summary, errOut.String(), runErr
+}
+
+// TestCatalogSyncContinuesPastFailedLetter is the regression guard for the
+// reported failure: one bad letter bucket used to abort the whole 0-9,A-Z
+// crawl, so a transient error on letter A discarded the other 35 buckets and
+// left the catalog empty. The crawl must now skip the bad bucket, keep the
+// good ones, and still exit 0.
+func TestCatalogSyncContinuesPastFailedLetter(t *testing.T) {
+	srv, _ := catalogTestServer(t, "A")
+	useCatalogTestServer(t, srv)
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	summary, _, err := runCatalogSync(t, dbPath, "--letters", "A,B,C", "--retries", "0")
+	if err != nil {
+		t.Fatalf("catalog sync returned error, want nil (one bad letter must not abort the crawl): %v", err)
+	}
+
+	if got := summary["letters_fetched"]; got != float64(2) {
+		t.Errorf("letters_fetched = %v, want 2 (B and C)", got)
+	}
+	if got := summary["letters_failed"]; got != float64(1) {
+		t.Errorf("letters_failed = %v, want 1 (A)", got)
+	}
+	if got := summary["docs"]; got != float64(2) {
+		t.Errorf("docs = %v, want 2", got)
+	}
+
+	errs, ok := summary["errors"].([]any)
+	if !ok || len(errs) != 1 {
+		t.Fatalf("errors = %v, want one entry", summary["errors"])
+	}
+	if letter := errs[0].(map[string]any)["letter"]; letter != "A" {
+		t.Errorf("errors[0].letter = %v, want A", letter)
+	}
+
+	// The partial catalog must be recorded, otherwise every local-read command
+	// reports the store as never synced.
+	db, err := store.OpenWithContext(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("opening store: %v", err)
+	}
+	defer db.Close()
+	cursor, _, count, err := db.GetSyncState(catalogResource)
+	if err != nil {
+		t.Fatalf("reading sync state: %v", err)
+	}
+	if cursor != "partial" {
+		t.Errorf("sync cursor = %q, want %q", cursor, "partial")
+	}
+	if count != 2 {
+		t.Errorf("sync state count = %d, want 2", count)
+	}
+}
+
+// TestCatalogSyncRetriesBeforeSkipping proves --retries actually re-attempts a
+// failing bucket rather than skipping it on the first error.
+func TestCatalogSyncRetriesBeforeSkipping(t *testing.T) {
+	srv, hits := catalogTestServer(t, "A")
+	useCatalogTestServer(t, srv)
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	if _, _, err := runCatalogSync(t, dbPath, "--letters", "A,B", "--retries", "1"); err != nil {
+		t.Fatalf("catalog sync returned error, want nil: %v", err)
+	}
+
+	// One initial attempt plus one retry. The client itself retries WAF resets,
+	// not HTTP 500s, so the count is exactly the letter-level attempts.
+	if got := hits("A"); got != 2 {
+		t.Errorf("letter A request count = %d, want 2 (initial + 1 retry)", got)
+	}
+}
+
+// TestCatalogSyncStrictFailsOnSkippedLetter keeps an opt-in path to the old
+// abort-on-any-error behavior for callers that need it.
+func TestCatalogSyncStrictFailsOnSkippedLetter(t *testing.T) {
+	srv, _ := catalogTestServer(t, "A")
+	useCatalogTestServer(t, srv)
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	_, _, err := runCatalogSync(t, dbPath, "--letters", "A,B", "--retries", "0", "--strict")
+	if err == nil {
+		t.Fatal("catalog sync --strict returned nil, want an error when a letter was skipped")
+	}
+	if !strings.Contains(err.Error(), "A") {
+		t.Errorf("error %q does not name the skipped letter", err)
+	}
+}
+
+// TestCatalogSyncFailsWhenEveryLetterFails guards the other direction: a crawl
+// that stored nothing must not report success.
+func TestCatalogSyncFailsWhenEveryLetterFails(t *testing.T) {
+	srv, _ := catalogTestServer(t, "A", "B")
+	useCatalogTestServer(t, srv)
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	_, _, err := runCatalogSync(t, dbPath, "--letters", "A,B", "--retries", "0")
+	if err == nil {
+		t.Fatal("catalog sync returned nil, want an error when every letter failed")
+	}
+}
+
+// TestCatalogSyncRunsWithoutFlags guards the documented entry point: SKILL.md,
+// README Quick Start, and the command's own Example all say `catalog sync`
+// with no flags is how the catalog gets built. A no-flag guard used to make it
+// print help and exit 0 without fetching anything, so following the docs
+// literally produced an empty catalog.
+func TestCatalogSyncRunsWithoutFlags(t *testing.T) {
+	// Zero flags, so the DB path has to come from the sandboxed home rather
+	// than --db; passing any flag at all would have satisfied the old guard.
+	testenv.Isolate(t, cliutil.DataDir)
+	t.Setenv(cliutil.DogfoodEnvVar, "1") // one letter bucket keeps the test quick
+
+	srv, hits := catalogTestServer(t)
+	useCatalogTestServer(t, srv)
+
+	cmd := RootCmd()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"catalog", "sync"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("catalog sync (no flags) returned error: %v", err)
+	}
+
+	if hits("0") == 0 {
+		t.Fatal("catalog sync with no flags fetched nothing — it printed help instead of syncing")
+	}
+	if strings.Contains(out.String(), "Usage:") {
+		t.Errorf("catalog sync with no flags printed help:\n%s", out.String())
+	}
+}

--- a/library/devices/extron/internal/cli/catalog_sync_test.go
+++ b/library/devices/extron/internal/cli/catalog_sync_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -224,4 +225,233 @@ func TestCatalogSyncRunsWithoutFlags(t *testing.T) {
 	if strings.Contains(out.String(), "Usage:") {
 		t.Errorf("catalog sync with no flags printed help:\n%s", out.String())
 	}
+}
+
+// docRow renders one literature table row for the fixture pages.
+func docRow(id string) string {
+	return fmt.Sprintf(
+		`<tr><td><a id="ctl00_1_idFileUrl" href="/download/files/brochure/%s.pdf" target="download">%s Brochure</a></td>`+
+			`<td><nobr>A</nobr></td><td><nobr>Jan. 2, 2024</nobr></td><td><nobr>10 KB</nobr></td><td><nobr>PDF</nobr></td></tr>`,
+		id, id)
+}
+
+// paginatedPage renders a literature page holding the given docs, optionally
+// followed by the per-category "Next" link that drives --full pagination.
+func paginatedPage(heading string, ids []string, hasNext bool) string {
+	var b strings.Builder
+	b.WriteString("<html><body>")
+	if heading != "" {
+		b.WriteString("<h2>" + heading + "</h2>")
+	}
+	b.WriteString("<table>")
+	for _, id := range ids {
+		b.WriteString(docRow(id))
+	}
+	b.WriteString("</table>")
+	if hasNext {
+		b.WriteString(`<a class="link-next" href="/technology/literature.aspx?filetype=1&amp;tabid=5&amp;page=2">Next</a>`)
+	}
+	b.WriteString("</body></html>")
+	return b.String()
+}
+
+// TestCatalogSyncCountsDocsCommittedAcrossRetries is the regression guard for
+// the retry-accounting defect: upserts commit as they go, so when one attempt
+// stores documents and then fails partway through pagination, a later attempt's
+// documents add to the store rather than replacing them. Counting the largest
+// single attempt loses whatever only an earlier attempt reached, which makes
+// the summary, the sync-state count, and doctor underreport the rows on disk.
+//
+// The fixture makes the two attempts commit overlapping-but-different sets:
+//
+//	attempt 1: index a1, then category page 2 -> b1,b2, then page 3 fails  (3 docs)
+//	attempt 2: index a1, then category page 2 -> c1,c2, then page 3 -> c3  (4 docs)
+//
+// Six distinct documents reach the store. Taking the largest attempt reports 4.
+func TestCatalogSyncCountsDocsCommittedAcrossRetries(t *testing.T) {
+	const wantDocs = 6 // a1, b1, b2, c1, c2, c3
+
+	var mu sync.Mutex
+	indexHits := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		w.Header().Set("Content-Type", "text/html")
+
+		// The index page carries no filetype; category pages always do.
+		if q.Get("filetype") == "" {
+			mu.Lock()
+			indexHits++
+			mu.Unlock()
+			_, _ = w.Write([]byte(paginatedPage("Brochure (A - 1 files)", []string{"a1"}, true)))
+			return
+		}
+
+		mu.Lock()
+		attempt := indexHits
+		mu.Unlock()
+
+		switch {
+		case attempt == 1 && q.Get("page") == "2":
+			_, _ = w.Write([]byte(paginatedPage("", []string{"b1", "b2"}, true)))
+		case attempt == 1: // page 3 — the failure that ends attempt 1
+			w.WriteHeader(http.StatusInternalServerError)
+		case q.Get("page") == "2":
+			_, _ = w.Write([]byte(paginatedPage("", []string{"c1", "c2"}, true)))
+		default: // page 3 — last page, no Next link
+			_, _ = w.Write([]byte(paginatedPage("", []string{"c3"}, false)))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	useCatalogTestServer(t, srv)
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	summary, _, err := runCatalogSync(t, dbPath, "--letters", "A", "--full", "--retries", "1")
+	if err != nil {
+		t.Fatalf("catalog sync returned error, want nil: %v", err)
+	}
+
+	db, err := store.OpenWithContext(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("opening store: %v", err)
+	}
+	defer db.Close()
+
+	rows, err := db.Count(catalogResource)
+	if err != nil {
+		t.Fatalf("counting catalog rows: %v", err)
+	}
+	if rows != wantDocs {
+		t.Fatalf("catalog rows = %d, want %d — fixture did not commit the expected documents", rows, wantDocs)
+	}
+
+	if got := summary["docs"]; got != float64(wantDocs) {
+		t.Errorf("summary docs = %v, want %d (rows actually committed across both attempts)", got, wantDocs)
+	}
+	perLetter, ok := summary["per_letter"].(map[string]any)
+	if !ok {
+		t.Fatalf("per_letter = %v, want an object", summary["per_letter"])
+	}
+	if got := perLetter["A"]; got != float64(wantDocs) {
+		t.Errorf("per_letter.A = %v, want %d", got, wantDocs)
+	}
+
+	_, _, count, err := db.GetSyncState(catalogResource)
+	if err != nil {
+		t.Fatalf("reading sync state: %v", err)
+	}
+	if count != wantDocs {
+		t.Errorf("sync state count = %d, want %d — doctor and the sync hint read this value", count, wantDocs)
+	}
+}
+
+// TestCatalogSyncCountsRepeatedDocOnce is the other half of the accounting
+// contract: a retry that re-commits the same documents must not inflate the
+// count, which is what summing per-attempt totals would do.
+func TestCatalogSyncCountsRepeatedDocOnce(t *testing.T) {
+	var mu sync.Mutex
+	indexHits := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		w.Header().Set("Content-Type", "text/html")
+		if q.Get("filetype") == "" {
+			mu.Lock()
+			indexHits++
+			mu.Unlock()
+			_, _ = w.Write([]byte(paginatedPage("Brochure (A - 2 files)", []string{"a1", "a2"}, true)))
+			return
+		}
+		mu.Lock()
+		attempt := indexHits
+		mu.Unlock()
+		if attempt == 1 {
+			// Attempt 1 fails at the first category page, after the index
+			// documents have already been committed.
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// Attempt 2 re-serves the same two documents and finishes.
+		_, _ = w.Write([]byte(paginatedPage("", []string{"a1", "a2"}, false)))
+	}))
+	t.Cleanup(srv.Close)
+	useCatalogTestServer(t, srv)
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	summary, _, err := runCatalogSync(t, dbPath, "--letters", "A", "--full", "--retries", "1")
+	if err != nil {
+		t.Fatalf("catalog sync returned error, want nil: %v", err)
+	}
+	if got := summary["docs"]; got != float64(2) {
+		t.Errorf("summary docs = %v, want 2 (the same document committed twice counts once)", got)
+	}
+}
+
+// TestCatalogSyncBareStoresOnlyFirstPage pins the behavior the first-run
+// documentation now describes: bare `catalog sync` stores only the first index
+// page per letter bucket, so a category with more pages is truncated, and
+// --full is what produces the complete catalog. Live numbers behind the docs:
+// bare sync yields ~1,200 documents with buckets capped at the page-1 ceiling,
+// while --full yields ~3,600 and up.
+//
+// If the default ever changes to paginate, this test fails and the "not the
+// complete catalog" wording in SKILL.md and README.md has to change with it.
+func TestCatalogSyncBareStoresOnlyFirstPage(t *testing.T) {
+	// Page 1 carries two documents and a Next link; page 2 carries two more.
+	newServer := func() *httptest.Server {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			if r.URL.Query().Get("filetype") == "" {
+				_, _ = w.Write([]byte(paginatedPage("Brochure (A - 2 files)", []string{"p1a", "p1b"}, true)))
+				return
+			}
+			_, _ = w.Write([]byte(paginatedPage("", []string{"p2a", "p2b"}, false)))
+		}))
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	countRows := func(t *testing.T, dbPath string) int {
+		t.Helper()
+		db, err := store.OpenWithContext(t.Context(), dbPath)
+		if err != nil {
+			t.Fatalf("opening store: %v", err)
+		}
+		defer db.Close()
+		n, err := db.Count(catalogResource)
+		if err != nil {
+			t.Fatalf("counting catalog rows: %v", err)
+		}
+		return n
+	}
+
+	t.Run("bare sync truncates at page 1", func(t *testing.T) {
+		useCatalogTestServer(t, newServer())
+		dbPath := filepath.Join(t.TempDir(), "data.db")
+		summary, _, err := runCatalogSync(t, dbPath, "--letters", "A")
+		if err != nil {
+			t.Fatalf("catalog sync returned error: %v", err)
+		}
+		if got := summary["docs"]; got != float64(2) {
+			t.Errorf("bare sync docs = %v, want 2 (page 1 only)", got)
+		}
+		if rows := countRows(t, dbPath); rows != 2 {
+			t.Errorf("bare sync stored %d rows, want 2 — page 2 must not be fetched without --full", rows)
+		}
+	})
+
+	t.Run("--full follows pagination", func(t *testing.T) {
+		useCatalogTestServer(t, newServer())
+		dbPath := filepath.Join(t.TempDir(), "data.db")
+		summary, _, err := runCatalogSync(t, dbPath, "--letters", "A", "--full")
+		if err != nil {
+			t.Fatalf("catalog sync --full returned error: %v", err)
+		}
+		if got := summary["docs"]; got != float64(4) {
+			t.Errorf("--full docs = %v, want 4 (both pages)", got)
+		}
+		if rows := countRows(t, dbPath); rows != 4 {
+			t.Errorf("--full stored %d rows, want 4", rows)
+		}
+	})
 }

--- a/library/devices/qsys/README.md
+++ b/library/devices/qsys/README.md
@@ -209,6 +209,15 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
+### First run: build the corpus
+
+```bash
+qsys-pp-cli harvest
+qsys-pp-cli coverage
+```
+
+`harvest` walks both vendor sitemaps into the local corpus; every other command reads it. `coverage` then reports how many products resolved a spec sheet and how many pages parsed, so an incomplete harvest is visible instead of silent. Narrow a first pass with `--only products --limit 25`, and add `--with-pdfs` when spec-sheet text is needed.
+
 ### Check a whole BOM against a Designer version
 
 ```bash
@@ -303,6 +312,17 @@ Relocation is one-way. Unsetting `QSYS_HOME` does not move files back to platfor
 Existing installs keep working because the platform-default rung matches the legacy layout. Run `qsys-pp-cli doctor --fail-on warn` to check path warnings in automation.
 
 ## Commands
+
+### harvest — build the local corpus (run this first)
+
+Walks both vendor sitemaps and builds the local corpus that every other command reads. The full harvest fetches roughly 750 help pages and 270 product pages, rate limited to be polite to the vendor servers.
+
+- **`qsys-pp-cli harvest`** - Build the whole corpus from help.qsys.com and qsys.com
+- **`qsys-pp-cli harvest --only pages|products|compat`** - Harvest one source instead of all three
+- **`qsys-pp-cli harvest --limit 25`** - Cap items per source
+- **`qsys-pp-cli harvest --with-pdfs`** - Also download and text-extract spec-sheet PDFs (slower; needs `pdftotext`)
+
+> `harvest` is not the same command as the top-level `sync`. Top-level `sync` walks the generated endpoint resources and refreshes entity lookups; it does not build the corpus. Run `qsys-pp-cli coverage` after a harvest to confirm how much of each site actually parsed.
 
 ### compat
 

--- a/library/devices/qsys/SKILL.md
+++ b/library/devices/qsys/SKILL.md
@@ -123,6 +123,14 @@ These capabilities aren't available in any other tool for this API.
 
 ## Command Reference
 
+**harvest** — Build the local corpus (run this first)
+
+- `qsys-pp-cli harvest` — walk both vendor sitemaps (roughly 750 help pages and 270 product pages, rate limited) and build the local corpus every other command reads
+- `qsys-pp-cli harvest --only pages|products|compat` — harvest one source instead of all three
+- `qsys-pp-cli harvest --only products --limit 25 --with-pdfs` — narrow the walk, and also download and text-extract spec-sheet PDFs (slower; needs `pdftotext`)
+
+**Do not confuse `harvest` with `sync`.** Top-level `sync` walks the generated endpoint resources and refreshes entity lookups; it does not build the corpus. The Q-SYS corpus is two scraped websites plus a PDF layer that must be joined locally, and only `harvest` builds it. Run `qsys-pp-cli coverage` afterwards to confirm the harvest landed.
+
 **compat** — Hardware and software compatibility matrices
 
 - `qsys-pp-cli compat by-product` — List the Q-SYS Designer versions and compatibility notes for a hardware product, per the compatibility matrix
@@ -157,6 +165,15 @@ qsys-pp-cli which "<capability in your own words>"
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
 
 ## Recipes
+
+### First run: build the corpus
+
+```bash
+qsys-pp-cli harvest
+qsys-pp-cli coverage
+```
+
+`harvest` walks both vendor sitemaps into the local corpus; every other command reads it. `coverage` then reports how many products resolved a spec sheet and how many pages parsed, so an incomplete harvest is visible instead of silent. Narrow a first pass with `--only products --limit 25`, and add `--with-pdfs` when spec-sheet text is needed.
 
 ### Check a whole BOM against a Designer version
 
@@ -368,7 +385,7 @@ Graceful degradation: if `learnings confirm` is an unknown command, you are driv
 - `similar_shape_different_entity:<canonical>` (top-level): a structurally matching row exists but its canonical entity differs from the live query's. Treated as cold start; the warning carries the conflicting canonical as a hint, but the row is NOT promoted into Results.
 - `ambiguous_alias` (top-level): a single query entity resolved to multiple canonicals (e.g., "Cards" → Arizona Cardinals + St. Louis Cardinals). Surface the ambiguity from context before committing to a resource.
 - `candidates_present` (top-level): the envelope carries a `candidates` section. Handle it via the candidates branch in Step 2 before anything else.
-- `lookup_refresh_available` (top-level): an entity in the query has no lookup row yet, but synced data could provide one. Run `qsys-pp-cli sync` to refresh entity lookups.
+- `lookup_refresh_available` (top-level): an entity in the query has no lookup row yet, but synced data could provide one. Run `qsys-pp-cli sync` to refresh entity lookups. Note that top-level `sync` only walks the generated endpoint resources and refreshes lookups — it does not build the corpus. If local reads are also coming back empty, run `qsys-pp-cli harvest` first; that is the corpus builder.
 - Top-level `no_learnings_for_query_family`: the table had no rows above the Jaccard floor. Pure cold start.
 
 ### Step 4: `teach &` after finalizing your response - always


### PR DESCRIPTION
## Summary

Three published device CLIs each hid the one command that builds their local corpus, so an agent reading SKILL.md could not find it — and in extron's case was pointed at a command that does not build the catalog. `pp-averusa` is the reference shape being matched: its Command Reference opens with `**harvest** — Build the local corpus (run this first)`.

Validating the extron docs turned up three real defects in the command they describe, fixed here with tests.

## Findings

| ID | CLI | Type | Finding |
|----|-----|------|---------|
| F1 | extron | doc gap | `catalog sync` — the literature-catalog builder — was absent from the Command Reference, which listed only `literature` with a single bullet. |
| F2 | extron | doc bug | The only sync guidance in SKILL.md pointed at top-level `sync`. `defaultSyncResources()` returns `["literature"]`; that generated sync writes one row (`id="literature", data=null`) and stamps `sync_state.literature` as synced, so on a fresh install the catalog reads as synced but is empty and `hintIfUnsynced` stops warning. |
| F3 | extron | bug (code) | `catalog sync --full` aborted the whole 0-9,A-Z crawl on the first per-letter error, with no retry and no continue-on-error, and never recorded sync state for buckets already fetched. |
| F4 | qsys | doc gap | `harvest` was absent from the Command Reference even though `harvest --help` already says "Run this first". |
| F5 | qsys | doc bug | Same shape as F2 — the file pointed at `qsys-pp-cli sync` for a refresh. |
| F6 | crestron | doc gap | `sync` was absent from the Command Reference entirely, while the response-envelope section still referred to "sync/search commands". |

## Changes

Each SKILL.md now opens its Command Reference with the corpus builder, states how it differs from the command it was being confused with, and carries a "First run" recipe. Mirrored into each README's `## Commands` and Unique Features. extron's `literature` and `catalog` subcommand lists were completed at the same time (they were one bullet for eight subcommands).

Two adjacent extron defects surfaced while checking that the docs were true, and are fixed rather than documented around:

- The root `--timeout` bounded the entire 36-bucket crawl via `boundCtx`, so a `--full` walk could not be given a workable budget at any timeout value. `--timeout` now scopes per letter bucket; `--max-duration` (default 30m) bounds the crawl — the same contract `crestron-pp-cli sync` already documents.
- A generated `len(args)==0 && NFlag()==0 → cmd.Help()` guard made bare `catalog sync` print help and exit 0 without fetching, contradicting its own `Example:`, the README Quick Start, and the docs added here.

```
 library/devices/crestron/README.md                       |  20 ++
 library/devices/crestron/SKILL.md                        |  18 ++
 library/devices/extron/.printing-press-patches/…json      |  17 ++
 library/devices/extron/README.md                         |  34 ++++
 library/devices/extron/SKILL.md                          |  50 ++++-
 library/devices/extron/internal/cli/catalog_sync.go      | 207 ++++++++++++----
 library/devices/extron/internal/cli/catalog_sync_test.go | 224 +++++++++++++++++
 library/devices/qsys/README.md                           |  20 ++
 library/devices/qsys/SKILL.md                            |  19 +-
 9 files changed, 569 insertions(+), 41 deletions(-)
```

## Verification

| Check | extron | qsys | crestron |
|---|---|---|---|
| `go build ./...` | PASS | PASS | PASS |
| `go vet ./...` | PASS | PASS | PASS |
| `go test ./...` | PASS | PASS | PASS |
| `verify_skill.py` | 0 errors | 0 errors | 0 errors |
| `publish validate` | same result as `upstream/main` | same result as `upstream/main` | same result as `upstream/main` |

`catalog_sync_test.go` adds five cases against an `httptest` server through a `newCatalogClient` seam. Two were confirmed to fail against the prior behavior before the fix landed:

- `TestCatalogSyncContinuesPastFailedLetter` — fails with `letter A: … returned HTTP 500` when the abort is restored.
- `TestCatalogSyncRunsWithoutFlags` — fails with "printed help instead of syncing" when the no-argument guard is restored.

Live against www.extron.com: `catalog sync --letters Q --json` returns `letters_fetched: 1, letters_failed: 0, docs: 37`.

Pre-existing and untouched by this PR (all three fail identically at `upstream/main`): `phase5` fingerprint drift, `govulncheck` GO-2026-6218 (already covered by #1800), and `verify-skill` install-section drift on extron and qsys.

## Notes

The generated `sync` writing `{"id":"literature","data":null}` is generator-shaped, not extron-specific — the literature endpoint returns an HTML index the generated client cannot map to records. Documented around here rather than patched; it belongs upstream in `cli-printing-press`.

Code-level customization recorded in `library/devices/extron/.printing-press-patches/extron-catalog-sync-survives-one-bad-letter-bucket.json`. No changes to `registry.json` or `cli-skills/pp-*/SKILL.md`.
