### PR TITLE
feat(isitagentready): add is-agentic.com as a second scanner source

### DIFF
--- a/library/developer-tools/isitagentready/.printing-press-patches/isitagentready-multi-scanner-source.json
+++ b/library/developer-tools/isitagentready/.printing-press-patches/isitagentready-multi-scanner-source.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 2,
+  "id": "isitagentready-multi-scanner-source",
+  "applied_at": "2026-08-24",
+  "base_run_id": "20260622-061602-6c74c750",
+  "base_printing_press_version": "4.25.0",
+  "summary": "Added is-agentic.com as a second scanner source: --source flag, provenance on every stored scan, RFC 9457 error mapping, source-aware guards, and the crossref cross-scanner comparison command.",
+  "reason": "Agent-readiness has two independent public scanners and they disagree by construction — isitagentready.com reports a Level 0-5 over five fixed categories, is-agentic.com a score 0-100 over a per-site denominator that excludes non-applicable checks. The generator models one host and one scoring model per CLI, so the second source, its RFC 9457 problem+json error surface, and the deliberately-unmerged cross-scanner view are hand-authored. Every stored scan now carries its source so history, diff, gate, compare, batch and open-advice refuse to mix two incompatible scales instead of silently averaging them.",
+  "files": [
+    "internal/store/store.go",
+    "internal/store/agentic.go",
+    "internal/store/agentic_test.go",
+    "internal/cli/agentic.go",
+    "internal/cli/agentic_render.go",
+    "internal/cli/agentic_test.go",
+    "internal/cli/crossref.go",
+    "internal/cli/crossref_test.go",
+    "internal/cli/root.go",
+    "internal/cli/scanhelpers.go",
+    "internal/cli/check.go",
+    "internal/cli/report.go",
+    "internal/cli/advice.go",
+    "internal/cli/gate.go",
+    "internal/cli/gate_test.go",
+    "internal/cli/history.go",
+    "internal/cli/diff.go",
+    "internal/cli/compare.go",
+    "internal/cli/batch.go",
+    "internal/cli/open_advice.go",
+    "internal/cli/guide.go"
+  ],
+  "call_sites": [
+    "store.FilterSource(",
+    "SourceOrDefault()",
+    "store.BuildCrossRef(",
+    "store.EvaluateAgenticGate(",
+    "classifyAgenticError(",
+    "newAgenticClient("
+  ],
+  "validated_outcome": "Under GOTOOLCHAIN=go1.26.6: gofmt clean, go build, go vet, go test ./... (317 tests) and go test -race all pass; govulncheck reports no vulnerabilities; the public library's verify_skill.py passes all checks. Live dogfood against both hosts confirms the is-agentic 404/400 mapping (exit 3/2, upstream resolution passed through verbatim), cross-source store isolation, the gate threshold guards (exit 2 both ways), and crossref rendering with one scanner missing (exit 0). NOTE: `cli-printing-press publish validate` still fails three checks — manifest schema_version 1, phase5 marker missing source_fingerprint, and a canonical install-section drift in SKILL.md. All three fail IDENTICALLY (same error strings) on the untouched upstream base print, so this amend is validation-neutral; clearing them requires a reprint, not an amend.",
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/4348",
+  "findings_addressed": [
+    "F1",
+    "F2",
+    "F3",
+    "F4",
+    "F5",
+    "F6",
+    "F7",
+    "F8",
+    "F9",
+    "F10",
+    "F11"
+  ],
+  "deferred_to_upstream": [
+    {
+      "feature": "The spec can route to a second host (per-resource and per-endpoint base_url) but cannot describe that host as an independent source: default_rate_limit exists only at spec level, with no per-resource or per-endpoint equivalent, and the spec has no error-model concept at all. The is-agentic client is therefore hand-authored — a second client.Client with BaseURL overridden after construction, its own limiter clamped to the advertised 2 req/s budget, and its own RFC 9457 problem+json classifier mapping 404/400/429 to distinct exit codes.",
+      "reason": "Temporary and structural, not API-specific. Once the Printing Press can declare an additional read-only source with its own rate-limit budget and error model, this hand-authored client and its error mapping should be regenerated from the spec instead of patched back in on every reprint."
+    }
+  ]
+}

--- a/library/developer-tools/isitagentready/.printing-press-patches/isitagentready-multi-scanner-source.json
+++ b/library/developer-tools/isitagentready/.printing-press-patches/isitagentready-multi-scanner-source.json
@@ -4,7 +4,7 @@
   "applied_at": "2026-08-24",
   "base_run_id": "20260622-061602-6c74c750",
   "base_printing_press_version": "4.25.0",
-  "summary": "Added is-agentic.com as a second scanner source: --source flag, provenance on every stored scan, RFC 9457 error mapping, source-aware guards, and the crossref cross-scanner comparison command.",
+  "summary": "Added is-agentic.com as a second scanner source: --source flag, provenance on every stored scan, RFC 9457 error mapping, source-aware guards, a process-wide shared rate limiter for the second host, and the crossref cross-scanner comparison command.",
   "reason": "Agent-readiness has two independent public scanners and they disagree by construction — isitagentready.com reports a Level 0-5 over five fixed categories, is-agentic.com a score 0-100 over a per-site denominator that excludes non-applicable checks. The generator models one host and one scoring model per CLI, so the second source, its RFC 9457 problem+json error surface, and the deliberately-unmerged cross-scanner view are hand-authored. Every stored scan now carries its source so history, diff, gate, compare, batch and open-advice refuse to mix two incompatible scales instead of silently averaging them.",
   "files": [
     "internal/store/store.go",
@@ -18,6 +18,7 @@
     "internal/cli/root.go",
     "internal/cli/scanhelpers.go",
     "internal/cli/check.go",
+    "internal/cli/check_render_test.go",
     "internal/cli/report.go",
     "internal/cli/advice.go",
     "internal/cli/gate.go",
@@ -35,9 +36,11 @@
     "store.BuildCrossRef(",
     "store.EvaluateAgenticGate(",
     "classifyAgenticError(",
-    "newAgenticClient("
+    "newAgenticClient(",
+    "renderScanFor(",
+    "resetAgenticClient("
   ],
-  "validated_outcome": "Under GOTOOLCHAIN=go1.26.6: gofmt clean, go build, go vet, go test ./... (317 tests) and go test -race all pass; govulncheck reports no vulnerabilities; the public library's verify_skill.py passes all checks. Live dogfood against both hosts confirms the is-agentic 404/400 mapping (exit 3/2, upstream resolution passed through verbatim), cross-source store isolation, the gate threshold guards (exit 2 both ways), and crossref rendering with one scanner missing (exit 0). NOTE: `cli-printing-press publish validate` still fails three checks — manifest schema_version 1, phase5 marker missing source_fingerprint, and a canonical install-section drift in SKILL.md. All three fail IDENTICALLY (same error strings) on the untouched upstream base print, so this amend is validation-neutral; clearing them requires a reprint, not an amend.",
+  "validated_outcome": "Under GOTOOLCHAIN=go1.26.7: gofmt clean, go build, go vet, go test ./... (323 tests) and go test -race all pass; govulncheck reports no vulnerabilities; the public library's verify_skill.py passes all checks. Live dogfood against both hosts confirms the is-agentic 404/400 mapping (exit 3/2, upstream resolution passed through verbatim), cross-source store isolation, the gate threshold guards (exit 2 both ways), and crossref rendering with one scanner missing (exit 0). Round 2 (Greptile P1 review) additionally fixed and covered: `check --source is-agentic` in HUMAN mode now renders the native score/issues instead of an all-zero \"Level 0\" summary (store.ParseReport unmarshals the foreign body without error), and every is-agentic request in a process shares ONE client and therefore ONE limiter so the 4-worker compare/batch fan-out cannot exceed the advertised 2 req/s public-report budget. Both regressions are covered by tests proven to fail against the pre-fix code. NOTE: `cli-printing-press publish validate` still fails three checks — manifest schema_version 1, phase5 marker missing source_fingerprint, and a canonical install-section drift in SKILL.md. All three fail IDENTICALLY (same error strings) on the untouched upstream base print, so this amend is validation-neutral; clearing them requires a reprint, not an amend.",
   "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/4348",
   "findings_addressed": [
     "F1",
@@ -54,7 +57,7 @@
   ],
   "deferred_to_upstream": [
     {
-      "feature": "The spec can route to a second host (per-resource and per-endpoint base_url) but cannot describe that host as an independent source: default_rate_limit exists only at spec level, with no per-resource or per-endpoint equivalent, and the spec has no error-model concept at all. The is-agentic client is therefore hand-authored — a second client.Client with BaseURL overridden after construction, its own limiter clamped to the advertised 2 req/s budget, and its own RFC 9457 problem+json classifier mapping 404/400/429 to distinct exit codes.",
+      "feature": "The spec can route to a second host (per-resource and per-endpoint base_url) but cannot describe that host as an independent source: default_rate_limit exists only at spec level, with no per-resource or per-endpoint equivalent, no notion of a rate budget shared process-wide across a fan-out, and no error-model concept at all. The is-agentic client is therefore hand-authored — a single memoized client.Client with BaseURL overridden after construction, one shared limiter clamped to the advertised 2 req/s budget that every concurrent caller queues behind, and its own RFC 9457 problem+json classifier mapping 404/400/429 to distinct exit codes.",
       "reason": "Temporary and structural, not API-specific. Once the Printing Press can declare an additional read-only source with its own rate-limit budget and error model, this hand-authored client and its error mapping should be regenerated from the spec instead of patched back in on every reprint."
     }
   ]

--- a/library/developer-tools/isitagentready/.printing-press.json
+++ b/library/developer-tools/isitagentready/.printing-press.json
@@ -17,7 +17,7 @@
   "spec_checksum": "sha256:e2417feeec64ff103065735945cda29ac932e1fc77203383be67fa7ce551030c",
   "run_id": "20260622-061602-6c74c750",
   "category": "developer-tools",
-  "description": "The terminal scanner for AI-agent readiness: every check the web tool runs, plus copy-paste fixes, CI gating, scan history, and a local store the web UI has no answer for.",
+  "description": "Two agent-readiness scanners in one terminal: every check isitagentready.com and is-agentic.com run, plus copy-paste fixes, CI gating, scan history, and a local store neither web UI has an answer for.",
   "mcp_binary": "isitagentready-pp-mcp",
   "mcp_tool_count": 1,
   "mcp_public_tool_count": 1,
@@ -25,6 +25,11 @@
   "api_version": "0.1.0",
   "auth_type": "none",
   "novel_features": [
+    {
+      "name": "Cross-scanner verdict comparison",
+      "command": "crossref",
+      "description": "Show isitagentready.com's Level 0-5 and is-agentic.com's score 0-100 side by side for one URL, each in its own native scale and never merged, plus an agreement verdict on the four checks that genuinely measure the same thing."
+    },
     {
       "name": "CI readiness gate",
       "command": "gate",

--- a/library/developer-tools/isitagentready/README.md
+++ b/library/developer-tools/isitagentready/README.md
@@ -1,8 +1,10 @@
 # Is It Agent Ready CLI
 
-**The terminal scanner for AI-agent readiness: every check the web tool runs, plus copy-paste fixes, CI gating, scan history, and a local store the web UI has no answer for.**
+**Two agent-readiness scanners in one terminal: every check isitagentready.com and is-agentic.com run, plus copy-paste fixes, CI gating, scan history, and a local store neither web UI has an answer for.**
 
-isitagentready.com gives you a one-shot score in a browser tab with no memory. This CLI turns it into a repeatable loop: check any site, get the prioritized fixes with advice, gate it in CI, diff it over time, compare it to competitors, and batch-scan a whole portfolio, with every scan stored locally so history and open-advice tell you exactly what changed and what is still unfixed.
+isitagentready.com and is-agentic.com each give you a one-shot score in a browser tab with no memory, and neither knows the other exists. This CLI turns both into one repeatable loop: check any site against either scanner, get the prioritized fixes with advice, gate it in CI, diff it over time, compare it to competitors, and batch-scan a whole portfolio — with every scan stored locally and tagged by source, so history and open-advice tell you exactly what changed and what is still unfixed.
+
+The two scanners disagree, and that is the point. isitagentready.com reports a Level 0-5 across five fixed categories; is-agentic.com reports a score 0-100 over a per-site denominator that excludes checks that do not apply. This CLI never averages or rescales them. `crossref` puts both native verdicts side by side and calls agreement only on the four checks that genuinely measure the same thing.
 
 ## Install
 
@@ -187,6 +189,22 @@ These capabilities aren't available in any other tool for this API.
   isitagentready-pp-cli batch urls.txt --rank failing --csv
   ```
 
+### Cross-check both scanners
+- **`crossref`** — Show isitagentready.com's Level 0-5 and is-agentic.com's score 0-100 side by side for one URL, each in its own native scale and never merged, plus an agreement verdict on the four checks that genuinely measure the same thing.
+
+  _Reach for this when one scanner says you are fine and you want a second opinion — without pretending the two scores are the same number._
+
+  ```bash
+  isitagentready-pp-cli crossref https://example.com
+  ```
+- **`--source is-agentic`** — Run any scan-backed command against the second scanner. Every stored scan is tagged with its source, so `history`, `diff`, `gate`, `compare` and `batch` stay inside one scanner's scale instead of silently mixing two.
+
+  _Reach for this to track is-agentic over time the same way you already track isitagentready._
+
+  ```bash
+  isitagentready-pp-cli report https://example.com --source is-agentic
+  ```
+
 ## Recipes
 
 
@@ -229,6 +247,31 @@ isitagentready-pp-cli compare https://example.com https://stripe.com
 ```
 
 Prints a per-standard matrix of which agent-readiness checks each site implements.
+
+### Cross-check a site against both scanners
+
+```bash
+isitagentready-pp-cli crossref https://example.com
+```
+
+Prints isitagentready's Level 0-5 and is-agentic's score 0-100 as two separate native verdicts, then an agreement table for the four checks both scanners actually measure. The two scores are never averaged or rescaled — their denominators differ (five fixed categories vs a per-site set that excludes non-applicable checks). If one scanner has no report for the URL, the other is still printed.
+
+### Track the second scanner over time
+
+```bash
+isitagentready-pp-cli check https://example.com --source is-agentic
+isitagentready-pp-cli history https://example.com --source is-agentic
+```
+
+Every scan is stored with its source, and every read filters to one source, so is-agentic history never mixes with isitagentready history. Omitting `--source` keeps the original isitagentready behavior, including for scans recorded before this feature existed.
+
+### Gate CI on the is-agentic score
+
+```bash
+isitagentready-pp-cli gate https://example.com --source is-agentic --min-score 70
+```
+
+`--min-score` is the is-agentic threshold; `--min-level` is the isitagentready one. Passing the wrong pair (`--min-level` with `--source is-agentic`) is a usage error rather than a silent reinterpretation, because a Level 3 and a score of 70 are not the same claim.
 
 ## Usage
 

--- a/library/developer-tools/isitagentready/README.md
+++ b/library/developer-tools/isitagentready/README.md
@@ -197,7 +197,7 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   isitagentready-pp-cli crossref https://example.com
   ```
-- **`--source is-agentic`** — Run any scan-backed command against the second scanner. Every stored scan is tagged with its source, so `history`, `diff`, `gate`, `compare` and `batch` stay inside one scanner's scale instead of silently mixing two.
+- **`--source is-agentic`** — Run any scan-backed command against the second scanner. Every stored scan is tagged with its source, so `history`, `diff`, `gate`, `compare` and `batch` stay inside one scanner's scale instead of silently mixing two. Every is-agentic request in a run — including the concurrent `compare` and `batch` fan-out — goes through one shared client, so the whole process stays inside the host's advertised 2 requests/second public-report budget instead of racing itself into 429s.
 
   _Reach for this to track is-agentic over time the same way you already track isitagentready._
 
@@ -262,6 +262,8 @@ Prints isitagentready's Level 0-5 and is-agentic's score 0-100 as two separate n
 isitagentready-pp-cli check https://example.com --source is-agentic
 isitagentready-pp-cli history https://example.com --source is-agentic
 ```
+
+With `--source is-agentic`, `check` prints that scanner's own verdict — the score and its label, the essential/recommended tier breakdown, and each non-passing issue with its fix — not an isitagentready level, because the two scales are not the same claim.
 
 Every scan is stored with its source, and every read filters to one source, so is-agentic history never mixes with isitagentready history. Omitting `--source` keeps the original isitagentready behavior, including for scans recorded before this feature existed.
 

--- a/library/developer-tools/isitagentready/SKILL.md
+++ b/library/developer-tools/isitagentready/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-isitagentready
-description: "The terminal scanner for AI-agent readiness: every check the web tool runs, plus copy-paste fixes, CI gating, scan history, and a local store the web UI has no answer for. Trigger phrases: `scan my site for agent readiness`, `is my site agent-ready`, `what's my agent readiness level`, `how do I make my site ready for AI agents`, `fix my site for AI agents`, `check llms.txt and MCP discovery on this site`, `use isitagentready`, `run isitagentready`."
+description: "Two agent-readiness scanners in one terminal: every check isitagentready.com and is-agentic.com run, plus copy-paste fixes, CI gating, scan history, and a local store neither web UI has an answer for. Trigger phrases: `scan my site for agent readiness`, `is my site agent-ready`, `what's my agent readiness level`, `what does is-agentic say about my site`, `cross-check my agent readiness score`, `compare both agent readiness scanners`, `how do I make my site ready for AI agents`, `fix my site for AI agents`, `check llms.txt and MCP discovery on this site`, `use isitagentready`, `run isitagentready`."
 author: "bobe"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"
@@ -37,7 +37,9 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/is
 
 If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
-isitagentready.com gives you a one-shot score in a browser tab with no memory. This CLI turns it into a repeatable loop: check any site, get the prioritized fixes with advice, gate it in CI, diff it over time, compare it to competitors, and batch-scan a whole portfolio, with every scan stored locally so history and open-advice tell you exactly what changed and what is still unfixed.
+isitagentready.com and is-agentic.com each give you a one-shot score in a browser tab with no memory, and neither knows the other exists. This CLI turns both into one repeatable loop: check any site against either scanner, get the prioritized fixes with advice, gate it in CI, diff it over time, compare it to competitors, and batch-scan a whole portfolio — with every scan stored locally and tagged by source, so history and open-advice tell you exactly what changed and what is still unfixed.
+
+The two scanners disagree, and that is the point. isitagentready.com reports a Level 0-5 across five fixed categories; is-agentic.com reports a score 0-100 over a per-site denominator that excludes checks that do not apply. This CLI never averages or rescales them. `crossref` puts both native verdicts side by side and calls agreement only on the four checks that genuinely measure the same thing.
 
 ## When to Use This CLI
 
@@ -103,6 +105,22 @@ These capabilities aren't available in any other tool for this API.
   isitagentready-pp-cli batch urls.txt --rank failing --csv
   ```
 
+### Cross-check both scanners
+- **`crossref`** — Show isitagentready.com's Level 0-5 and is-agentic.com's score 0-100 side by side for one URL, each in its own native scale and never merged, plus an agreement verdict on the four checks that genuinely measure the same thing.
+
+  _Reach for this when one scanner says you are fine and you want a second opinion — without pretending the two scores are the same number._
+
+  ```bash
+  isitagentready-pp-cli crossref https://example.com
+  ```
+- **`--source is-agentic`** — Run any scan-backed command against the second scanner. Every stored scan is tagged with its source, so `history`, `diff`, `gate`, `compare` and `batch` stay inside one scanner's scale instead of silently mixing two.
+
+  _Reach for this to track is-agentic over time the same way you already track isitagentready._
+
+  ```bash
+  isitagentready-pp-cli report https://example.com --source is-agentic
+  ```
+
 ## Command Reference
 
 **scan** — Scan a website for AI-agent readiness
@@ -161,6 +179,31 @@ isitagentready-pp-cli compare https://example.com https://isitagentready.com
 ```
 
 Prints a per-standard matrix of which agent-readiness checks each site implements.
+
+### Cross-check a site against both scanners
+
+```bash
+isitagentready-pp-cli crossref https://example.com
+```
+
+Prints isitagentready's Level 0-5 and is-agentic's score 0-100 as two separate native verdicts, then an agreement table for the four checks both scanners actually measure. The two scores are never averaged or rescaled — their denominators differ (five fixed categories vs a per-site set that excludes non-applicable checks). If one scanner has no report for the URL, the other is still printed.
+
+### Track the second scanner over time
+
+```bash
+isitagentready-pp-cli check https://example.com --source is-agentic
+isitagentready-pp-cli history https://example.com --source is-agentic
+```
+
+Every scan is stored with its source, and every read filters to one source, so is-agentic history never mixes with isitagentready history. Omitting `--source` keeps the original isitagentready behavior, including for scans recorded before this feature existed.
+
+### Gate CI on the is-agentic score
+
+```bash
+isitagentready-pp-cli gate https://example.com --source is-agentic --min-score 70
+```
+
+`--min-score` is the is-agentic threshold; `--min-level` is the isitagentready one. Passing the wrong pair (`--min-level` with `--source is-agentic`) is a usage error rather than a silent reinterpretation, because a Level 3 and a score of 70 are not the same claim.
 
 ## Auth Setup
 

--- a/library/developer-tools/isitagentready/SKILL.md
+++ b/library/developer-tools/isitagentready/SKILL.md
@@ -113,7 +113,7 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   isitagentready-pp-cli crossref https://example.com
   ```
-- **`--source is-agentic`** — Run any scan-backed command against the second scanner. Every stored scan is tagged with its source, so `history`, `diff`, `gate`, `compare` and `batch` stay inside one scanner's scale instead of silently mixing two.
+- **`--source is-agentic`** — Run any scan-backed command against the second scanner. Every stored scan is tagged with its source, so `history`, `diff`, `gate`, `compare` and `batch` stay inside one scanner's scale instead of silently mixing two. Every is-agentic request in a run — including the concurrent `compare` and `batch` fan-out — goes through one shared client, so the whole process stays inside the host's advertised 2 requests/second public-report budget instead of racing itself into 429s.
 
   _Reach for this to track is-agentic over time the same way you already track isitagentready._
 
@@ -194,6 +194,8 @@ Prints isitagentready's Level 0-5 and is-agentic's score 0-100 as two separate n
 isitagentready-pp-cli check https://example.com --source is-agentic
 isitagentready-pp-cli history https://example.com --source is-agentic
 ```
+
+With `--source is-agentic`, `check` prints that scanner's own verdict — the score and its label, the essential/recommended tier breakdown, and each non-passing issue with its fix — not an isitagentready level, because the two scales are not the same claim.
 
 Every scan is stored with its source, and every read filters to one source, so is-agentic history never mixes with isitagentready history. Omitting `--source` keeps the original isitagentready behavior, including for scans recorded before this feature existed.
 

--- a/library/developer-tools/isitagentready/internal/cli/advice.go
+++ b/library/developer-tools/isitagentready/internal/cli/advice.go
@@ -47,6 +47,36 @@ func newAdviceCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			if flags.sourceOrDefault() == store.SourceIsAgentic {
+				rep, err := store.ParseAgenticReport(raw)
+				if err != nil {
+					return err
+				}
+				items := store.AgenticOpenItems(rep)
+				if checkID != "" {
+					var f []store.OpenItem
+					for _, it := range items {
+						if it.Check == checkID {
+							f = append(f, it)
+						}
+					}
+					items = f
+				}
+				if limit > 0 && len(items) > limit {
+					items = items[:limit]
+				}
+				if copyBlock {
+					return renderAgenticAdviceCopy(cmd, rep, items)
+				}
+				if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+					return printJSONFiltered(cmd.OutOrStdout(), agenticAdviceJSON{
+						URL: rep.Target, Score: rep.Score, ScoreLabel: rep.ScoreLabel, ScannedAt: rep.ScannedAt, Fixes: items,
+					}, flags)
+				}
+				return renderAgenticAdvice(cmd, rep, items)
+			}
+
 			rep, err := store.ParseReport(raw)
 			if err != nil {
 				return err

--- a/library/developer-tools/isitagentready/internal/cli/agentic.go
+++ b/library/developer-tools/isitagentready/internal/cli/agentic.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/config"
@@ -24,14 +25,28 @@ const agenticReportPath = "/api/v1/report"
 // `ratelimit-policy: "public-report";q=120;w=60` = 120 requests / 60s = 2 req/s.
 const agenticRateLimit = 2.0
 
-// newAgenticClient returns a client pointed at is-agentic.com. client.Client
-// exports BaseURL and takes no host at construction beyond the config, so the
-// second source needs an override, not a client fork.
+// The is-agentic budget is per-HOST, but a client's limiter is per-CLIENT:
+// client.New builds a fresh cliutil.AdaptiveLimiter every call. Constructing a
+// client per request therefore gave each of the 4 compare/batch fan-out workers
+// its own limiter, so 4 requests could leave at once against a 2 req/s budget —
+// exactly the 429 storm the limiter exists to prevent. Memoize ONE client (and
+// therefore ONE limiter) per process so every worker queues behind one budget.
+//
+// The key covers every setting client.New bakes in. Within a single command run
+// these are fixed, so all fan-out workers share one client; a caller configured
+// differently gets its own rather than silently inheriting another's DryRun /
+// NoCache. Fields are only written under the mutex at construction and never
+// mutated afterwards, so concurrent readers stay race-free.
+var (
+	agenticClientMu     sync.Mutex
+	agenticClientCached *client.Client
+	agenticClientKey    string
+)
+
+// newAgenticClient returns the process-wide client pointed at is-agentic.com.
+// client.Client exports BaseURL and takes no host at construction beyond the
+// config, so the second source needs an override, not a client fork.
 func (f *rootFlags) newAgenticClient() (*client.Client, error) {
-	cfg, err := config.Load(f.configPath)
-	if err != nil {
-		return nil, configErr(err)
-	}
 	// The is-agentic host's public-report budget applies whether or not the
 	// user set --rate-limit: clamp a configured higher rate down, and use the
 	// host budget when none is set.
@@ -39,11 +54,33 @@ func (f *rootFlags) newAgenticClient() (*client.Client, error) {
 	if rl <= 0 || rl > agenticRateLimit {
 		rl = agenticRateLimit
 	}
+	key := fmt.Sprintf("%s|%s|%v|%t|%t", f.configPath, f.timeout, rl, f.dryRun, f.noCache)
+
+	agenticClientMu.Lock()
+	defer agenticClientMu.Unlock()
+	if agenticClientCached != nil && agenticClientKey == key {
+		return agenticClientCached, nil
+	}
+	cfg, err := config.Load(f.configPath)
+	if err != nil {
+		return nil, configErr(err)
+	}
 	c := client.New(cfg, f.timeout, rl)
 	c.BaseURL = agenticBaseURL
 	c.DryRun = f.dryRun
 	c.NoCache = f.noCache
+	agenticClientCached = c
+	agenticClientKey = key
 	return c, nil
+}
+
+// resetAgenticClient drops the memoized client. Tests use it so one test's
+// client (with a test-server BaseURL) cannot leak into another.
+func resetAgenticClient() {
+	agenticClientMu.Lock()
+	defer agenticClientMu.Unlock()
+	agenticClientCached = nil
+	agenticClientKey = ""
 }
 
 // agenticProblem is an RFC 9457 application/problem+json error body.

--- a/library/developer-tools/isitagentready/internal/cli/agentic.go
+++ b/library/developer-tools/isitagentready/internal/cli/agentic.go
@@ -1,0 +1,122 @@
+// Copyright 2026 bobe and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/config"
+)
+
+// agenticBaseURL is the second scanner's host. The generator's spec.yaml models
+// exactly one base_url per CLI, so this second source is hand-authored.
+const agenticBaseURL = "https://is-agentic.com"
+
+// agenticReportPath is READ-ONLY: it returns an already-completed report and
+// never triggers a scan. A never-scanned domain 404s immediately.
+const agenticReportPath = "/api/v1/report"
+
+// agenticRateLimit is the host's advertised public-report budget:
+// `ratelimit-policy: "public-report";q=120;w=60` = 120 requests / 60s = 2 req/s.
+const agenticRateLimit = 2.0
+
+// newAgenticClient returns a client pointed at is-agentic.com. client.Client
+// exports BaseURL and takes no host at construction beyond the config, so the
+// second source needs an override, not a client fork.
+func (f *rootFlags) newAgenticClient() (*client.Client, error) {
+	cfg, err := config.Load(f.configPath)
+	if err != nil {
+		return nil, configErr(err)
+	}
+	// The is-agentic host's public-report budget applies whether or not the
+	// user set --rate-limit: clamp a configured higher rate down, and use the
+	// host budget when none is set.
+	rl := f.rateLimit
+	if rl <= 0 || rl > agenticRateLimit {
+		rl = agenticRateLimit
+	}
+	c := client.New(cfg, f.timeout, rl)
+	c.BaseURL = agenticBaseURL
+	c.DryRun = f.dryRun
+	c.NoCache = f.noCache
+	return c, nil
+}
+
+// agenticProblem is an RFC 9457 application/problem+json error body.
+type agenticProblem struct {
+	Type             string `json:"type"`
+	Title            string `json:"title"`
+	Status           int    `json:"status"`
+	Detail           string `json:"detail"`
+	Instance         string `json:"instance"`
+	Code             string `json:"code"`
+	Resolution       string `json:"resolution"`
+	DocumentationURL string `json:"documentation_url"`
+}
+
+// fetchAgenticReport GETs the completed is-agentic report for url.
+func fetchAgenticReport(ctx context.Context, flags *rootFlags, url string) (json.RawMessage, error) {
+	c, err := flags.newAgenticClient()
+	if err != nil {
+		return nil, err
+	}
+	data, err := c.Get(ctx, agenticReportPath, map[string]string{"url": url})
+	if err != nil {
+		return nil, classifyAgenticError(err, flags)
+	}
+	return data, nil
+}
+
+// classifyAgenticError maps an RFC 9457 problem+json response to a typed CLI
+// error so exit codes stay meaningful:
+//
+//	404 report_not_found -> notFoundErr (3), carrying the upstream `resolution`
+//	                        string verbatim — it names the URL where the user
+//	                        can start the missing scan.
+//	400 invalid_url      -> usageErr (2)
+//	429                  -> rateLimitErr (7), never an empty result: an empty
+//	                        result is indistinguishable from "no data" and
+//	                        silently corrupts downstream queries.
+//
+// Anything else falls through to classifyAPIError.
+func classifyAgenticError(err error, flags *rootFlags) error {
+	var apiErr *client.APIError
+	if !errors.As(err, &apiErr) {
+		return classifyAPIError(err, flags)
+	}
+	var p agenticProblem
+	if json.Unmarshal([]byte(apiErr.Body), &p) != nil {
+		return classifyAPIError(err, flags)
+	}
+	switch {
+	case apiErr.StatusCode == 404 && p.Code == "report_not_found":
+		// The upstream `resolution` names the scan URL the user must run
+		// first; pass it through verbatim, do not paraphrase.
+		msg := p.Detail
+		if p.Resolution != "" {
+			msg = p.Detail + " " + p.Resolution
+		}
+		// No writeAPIErrorEnvelope here: crossref treats this 404 as an
+		// expected outcome, catches it, and still prints the other scanner's
+		// verdict. An envelope written from the classifier would land in the
+		// middle of that JSON document. Envelope emission belongs at the
+		// command boundary, where the error is known to be terminal.
+		return notFoundErr(fmt.Errorf("is-agentic has no completed report for this URL: %s", msg))
+	case apiErr.StatusCode == 400 && p.Code == "invalid_url":
+		msg := p.Detail
+		if p.Resolution != "" {
+			msg = p.Detail + " " + p.Resolution
+		}
+		return usageErr(fmt.Errorf("invalid URL for is-agentic scan: %s", msg))
+	case apiErr.StatusCode == 429:
+		// Never collapse a rate-limit into an empty/no-data result: downstream
+		// queries would silently read it as "no scan exists".
+		return rateLimitErr(fmt.Errorf("is-agentic rate limit reached: %s", p.Detail))
+	default:
+		return classifyAPIError(err, flags)
+	}
+}

--- a/library/developer-tools/isitagentready/internal/cli/agentic_render.go
+++ b/library/developer-tools/isitagentready/internal/cli/agentic_render.go
@@ -1,0 +1,211 @@
+// Copyright 2026 bobe and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/store"
+)
+
+// validAgenticTiers are the only --category/--tier values that make sense for
+// the is-agentic source. is-agentic has two tiers (essential, recommended),
+// not isitagentready's five categories.
+var validAgenticTiers = map[string]string{
+	"essential":   "essential",
+	"recommended": "recommended",
+}
+
+// filterAgenticReport narrows a raw is-agentic report's issues[] by optional
+// tier, failing-only and check id while preserving every other top-level key
+// (score, score_breakdown, scanned_at, ...) so machine output stays complete
+// and honest. When no filter applies, the raw report is returned unchanged.
+func filterAgenticReport(raw json.RawMessage, tier string, onlyFailing bool, checkID string) (json.RawMessage, error) {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return nil, fmt.Errorf("parsing is-agentic report: %w", err)
+	}
+	issuesRaw, ok := top["issues"]
+	if !ok || string(issuesRaw) == "null" {
+		return raw, nil
+	}
+	var issues []store.AgenticIssue
+	if err := json.Unmarshal(issuesRaw, &issues); err != nil {
+		return raw, nil
+	}
+	filtered := make([]store.AgenticIssue, 0, len(issues))
+	for _, iss := range issues {
+		if tier != "" && iss.Tier != tier {
+			continue
+		}
+		if checkID != "" && iss.ID != checkID {
+			continue
+		}
+		if onlyFailing && iss.Result == "pass" {
+			continue
+		}
+		filtered = append(filtered, iss)
+	}
+	b, err := json.Marshal(filtered)
+	if err != nil {
+		return nil, err
+	}
+	top["issues"] = b
+	out, err := json.Marshal(top)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// renderAgenticReport prints the is-agentic report natively for a terminal:
+// score / score_label / eligible_checks, the essential and recommended tier
+// lines (passing/total, earned/available), bonus points, then the non-passing
+// issues grouped by tier. scanned_at is always shown because these reports are
+// cached upstream and can be days old. The issues[] is already filtered by the
+// caller; tier only controls which tier headline lines (and section headers)
+// are shown.
+func renderAgenticReport(cmd *cobra.Command, raw json.RawMessage, tier string) error {
+	out := cmd.OutOrStdout()
+	rep, err := store.ParseAgenticReport(raw)
+	if err != nil {
+		return printOutput(cmd.OutOrStdout(), raw, false)
+	}
+	fmt.Fprintln(out, bold(rep.Target))
+	if rep.ScannedAt != "" {
+		fmt.Fprintf(out, "  scanned %s\n", rep.ScannedAt)
+	}
+	fmt.Fprintf(out, "  Score: %d — %s\n", rep.Score, rep.ScoreLabel)
+	fmt.Fprintf(out, "  Eligible checks: %d\n", rep.EligibleChecks)
+
+	if tier == "" || tier == "essential" {
+		ess := rep.ScoreBreakdown.Essential
+		fmt.Fprintf(out, "  Essential: %d/%d passing, %.1f/%.1f earned\n", ess.Passing, ess.Total, ess.Earned, ess.Available)
+	}
+	if tier == "" || tier == "recommended" {
+		rec := rep.ScoreBreakdown.Recommended
+		fmt.Fprintf(out, "  Recommended: %d/%d passing, %.1f/%.1f earned\n", rec.Passing, rec.Total, rec.Earned, rec.Available)
+	}
+	if tier == "" {
+		fmt.Fprintf(out, "  Bonus: %.1f points, %d positive signals\n", rep.ScoreBreakdown.Bonus.Points, rep.ScoreBreakdown.Bonus.PositiveSignals)
+	}
+
+	// Group the report's (already-filtered) issues by tier, essential first.
+	issues := rep.FailingIssues()
+	byTier := map[string][]store.AgenticIssue{}
+	var order []string
+	for _, iss := range issues {
+		if _, ok := byTier[iss.Tier]; !ok {
+			order = append(order, iss.Tier)
+		}
+		byTier[iss.Tier] = append(byTier[iss.Tier], iss)
+	}
+	// essential always precedes recommended when both are present. The
+	// comparator must be a strict weak ordering: `order[i] == "essential"`
+	// alone returns true for both (i,j) and (j,i) when both are essential,
+	// which violates sort's contract.
+	sort.SliceStable(order, func(i, j int) bool {
+		return order[i] == "essential" && order[j] != "essential"
+	})
+	if len(issues) == 0 {
+		fmt.Fprintln(out, "  No non-passing issues"+(func() string {
+			if tier != "" {
+				return " in this tier"
+			}
+			return ""
+		})())
+		return nil
+	}
+	for _, tr := range order {
+		fmt.Fprintf(out, "\n  %s\n", bold(tierLabel(tr)))
+		for _, iss := range byTier[tr] {
+			mark := red("failed")
+			if iss.Result == "partial" {
+				mark = yellow("partial")
+			}
+			fmt.Fprintf(out, "    %s\t%s\n", mark, iss.ID)
+			desc := iss.Name
+			if iss.Details != "" {
+				desc = desc + " — " + iss.Details
+			}
+			if desc != "" {
+				fmt.Fprintf(out, "        %s\n", desc)
+			}
+			if iss.Recommendation != "" {
+				fmt.Fprintf(out, "        fix: %s\n", iss.Recommendation)
+			}
+		}
+	}
+	return nil
+}
+
+// agenticAdviceJSON is the machine-shape of advice for an is-agentic report: a
+// native score headline plus the fix prompts as OpenItems (their Check/Prompt
+// fields carry is-agentic issue ids / recommendations).
+type agenticAdviceJSON struct {
+	URL        string           `json:"url"`
+	Score      int              `json:"score"`
+	ScoreLabel string           `json:"scoreLabel"`
+	ScannedAt  string           `json:"scannedAt"`
+	Fixes      []store.OpenItem `json:"fixes"`
+}
+
+// renderAgenticAdvice prints is-agentic advice for a terminal: the score
+// headline then one fix per non-passing issue (recommendation as the fix
+// prompt), filtered to the requested check/limit by the caller.
+func renderAgenticAdvice(cmd *cobra.Command, rep *store.AgenticReport, items []store.OpenItem) error {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, bold(rep.Target))
+	if rep.ScannedAt != "" {
+		fmt.Fprintf(out, "  scanned %s\n", rep.ScannedAt)
+	}
+	fmt.Fprintf(out, "  Score %d — %s\n", rep.Score, rep.ScoreLabel)
+	if len(items) == 0 {
+		fmt.Fprintln(out, "  No fixes listed: no non-passing issues in the current filter.")
+		return nil
+	}
+	for i, it := range items {
+		fmt.Fprintf(out, "\n  %d. [%s] %s\n", i+1, it.Check, it.Description)
+		if it.Prompt != "" {
+			fmt.Fprintf(out, "     %s\n", it.Prompt)
+		}
+	}
+	return nil
+}
+
+// renderAgenticAdviceCopy prints is-agentic advice as a plain string ready to
+// paste into a coding agent, mirroring renderAdviceCopy.
+func renderAgenticAdviceCopy(cmd *cobra.Command, rep *store.AgenticReport, items []store.OpenItem) error {
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintf(out, "No outstanding agent-readiness fixes for %s (score %d, %s).\n", rep.Target, rep.Score, rep.ScoreLabel)
+		return nil
+	}
+	fmt.Fprintf(out, "Make %s more AI-agent-ready. It is currently score %d (%s); apply these fixes to improve it:\n",
+		rep.Target, rep.Score, rep.ScoreLabel)
+	for i, it := range items {
+		fmt.Fprintf(out, "\n%d. %s\n%s\n", i+1, it.Description, it.Prompt)
+	}
+	return nil
+}
+
+// tierLabel capitalizes an is-agentic tier name for display. strings.Title is
+// deprecated (and Unicode-word-aware in ways we do not want here), and the tier
+// vocabulary is a closed set of two values.
+func tierLabel(tier string) string {
+	switch tier {
+	case "essential":
+		return "Essential"
+	case "recommended":
+		return "Recommended"
+	case "":
+		return ""
+	default:
+		return strings.ToUpper(tier[:1]) + tier[1:]
+	}
+}

--- a/library/developer-tools/isitagentready/internal/cli/agentic_test.go
+++ b/library/developer-tools/isitagentready/internal/cli/agentic_test.go
@@ -3,10 +3,19 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/cliutil"
 )
 
 // problem404 is the literal upstream application/problem+json body for a
@@ -60,5 +69,123 @@ func TestClassifyAgenticErrorFallback(t *testing.T) {
 	// 500 with unparseable body falls through to classifyAPIError -> apiErr.
 	if got := ExitCode(err); got != 5 {
 		t.Fatalf("ExitCode = %d, want 5 (apiErr fallback), err=%v", got, err)
+	}
+}
+
+// TestAgenticClientIsProcessWideSingleton is the regression test for the
+// fan-out rate-limit bug: newAgenticClient used to construct a fresh
+// client.Client per call, and client.New builds a fresh AdaptiveLimiter each
+// time. Each of the 4 compare/batch fan-out workers therefore got its OWN
+// limiter and all 4 could fire at once against the host's advertised 2 req/s
+// public-report budget.
+//
+// One client == one limiter, so asserting pointer identity across concurrent
+// callers asserts a single shared budget.
+func TestAgenticClientIsProcessWideSingleton(t *testing.T) {
+	seedStore(t)
+	resetAgenticClient()
+	t.Cleanup(resetAgenticClient)
+
+	flags := &rootFlags{timeout: 5 * time.Second, noCache: true}
+
+	const workers = 8
+	got := make([]*client.Client, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			c, err := flags.newAgenticClient()
+			if err != nil {
+				t.Errorf("newAgenticClient: %v", err)
+				return
+			}
+			got[i] = c
+		}(i)
+	}
+	wg.Wait()
+
+	for i, c := range got {
+		if c == nil {
+			t.Fatalf("worker %d got no client", i)
+		}
+		if c != got[0] {
+			t.Fatalf("worker %d got a different client than worker 0: each client carries its own limiter, so the fan-out would not share the 2 req/s budget", i)
+		}
+	}
+	if rate := got[0].RateLimit(); rate != agenticRateLimit {
+		t.Fatalf("shared client rate = %v, want the host budget %v", rate, agenticRateLimit)
+	}
+}
+
+// TestAgenticFanoutSharesOneRateLimit proves the shared limiter actually
+// throttles: a concurrent fan-out of 3 fetchAgenticReport calls must arrive at
+// the host spaced by the 2 req/s budget (500ms apart), not all at once.
+func TestAgenticFanoutSharesOneRateLimit(t *testing.T) {
+	seedStore(t)
+	resetAgenticClient()
+	t.Cleanup(resetAgenticClient)
+
+	var mu sync.Mutex
+	var arrivals []time.Time
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		arrivals = append(arrivals, time.Now())
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"target":%q,"score":50,"score_label":"Partial","scanned_at":"2026-08-20T09:00:00Z"}`,
+			r.URL.Query().Get("url"))
+	}))
+	defer srv.Close()
+
+	flags := &rootFlags{timeout: 30 * time.Second, noCache: true}
+	// Retarget the memoized client at the test server BEFORE any goroutine
+	// starts, so the concurrent fetches below reuse this same client (and its
+	// limiter) rather than racing on the field.
+	c, err := flags.newAgenticClient()
+	if err != nil {
+		t.Fatalf("newAgenticClient: %v", err)
+	}
+	c.BaseURL = srv.URL
+
+	urls := []string{
+		"https://a.example",
+		"https://b.example",
+		"https://c.example",
+	}
+	start := time.Now()
+	results, ferrs := cliutil.FanoutRun(context.Background(), urls,
+		func(u string) string { return u },
+		func(ctx context.Context, u string) (json.RawMessage, error) {
+			return fetchAgenticReport(ctx, flags, u)
+		})
+	elapsed := time.Since(start)
+
+	if len(ferrs) != 0 {
+		t.Fatalf("fan-out errors: %v", ferrs)
+	}
+	if len(results) != len(urls) {
+		t.Fatalf("got %d results, want %d", len(results), len(urls))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(arrivals) != len(urls) {
+		t.Fatalf("host saw %d requests, want %d", len(arrivals), len(urls))
+	}
+	sort.Slice(arrivals, func(i, j int) bool { return arrivals[i].Before(arrivals[j]) })
+
+	// 2 req/s => 500ms between requests. Allow generous scheduler slack; the
+	// bug being guarded against produced gaps near zero, not near 400ms.
+	const minGap = 350 * time.Millisecond
+	for i := 1; i < len(arrivals); i++ {
+		if gap := arrivals[i].Sub(arrivals[i-1]); gap < minGap {
+			t.Fatalf("requests %d and %d arrived %v apart (want >= %v): the fan-out workers are not sharing one limiter",
+				i-1, i, gap, minGap)
+		}
+	}
+	// Two gaps at 500ms => ~1s total; a per-worker limiter finishes near 0s.
+	if elapsed < 2*minGap {
+		t.Fatalf("fan-out finished in %v, too fast for a shared %v req/s budget", elapsed, agenticRateLimit)
 	}
 }

--- a/library/developer-tools/isitagentready/internal/cli/agentic_test.go
+++ b/library/developer-tools/isitagentready/internal/cli/agentic_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 bobe and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/client"
+)
+
+// problem404 is the literal upstream application/problem+json body for a
+// never-scanned domain (verified, do not alter).
+const problem404 = `{"type":"https://is-agentic.com/docs#report-not-found","title":"Completed report not found",
+ "status":404,"detail":"No completed Is Agentic report is stored for this URL.",
+ "instance":"...","code":"report_not_found",
+ "resolution":"Start a scan at https://is-agentic.com/scan/mvanhorn.com, wait for it to complete, and retry this request.",
+ "documentation_url":"https://is-agentic.com/docs#errors"}`
+
+// problem400 is the literal upstream application/problem+json body for an
+// invalid URL.
+const problem400 = `{"type":"https://is-agentic.com/docs#invalid-url","title":"Invalid public URL","status":400,
+ "detail":"Enter a URL to scan.","instance":"...","code":"invalid_url",
+ "resolution":"Pass one public HTTP or HTTPS URL in the required url query parameter.",
+ "documentation_url":"https://is-agentic.com/docs#errors"}`
+
+func TestClassifyAgenticError(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		body     string
+		wantCode int
+		wantSub  string // a substring that must appear verbatim in the message
+	}{
+		{"404 report_not_found", 404, problem404, 3, "Start a scan at https://is-agentic.com/scan/mvanhorn.com, wait for it to complete, and retry this request."},
+		{"400 invalid_url", 400, problem400, 2, "Pass one public HTTP or HTTPS URL in the required url query parameter."},
+		{"429 rate limit", 429, `{"type":"x","title":"Too Many Requests","status":429,"detail":"Rate limit exceeded","code":"rate_limited"}`, 7, "Rate limit exceeded"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			apiErr := &client.APIError{Method: "GET", Path: "/api/v1/report", StatusCode: tc.status, Body: tc.body}
+			err := classifyAgenticError(apiErr, nil)
+			if got := ExitCode(err); got != tc.wantCode {
+				t.Fatalf("ExitCode = %d, want %d (err=%v)", got, tc.wantCode, err)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("message %q does not contain upstream substring %q verbatim", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestClassifyAgenticErrorFallback covers the non-problem+json fallback:
+// when the body does not parse, classifyAgenticError hands off to
+// classifyAPIError so the generic HTTP classification (and its exit code)
+// still applies instead of silently returning a no-data result.
+func TestClassifyAgenticErrorFallback(t *testing.T) {
+	apiErr := &client.APIError{Method: "GET", Path: "/api/v1/report", StatusCode: 500, Body: "not json at all"}
+	err := classifyAgenticError(apiErr, nil)
+	// 500 with unparseable body falls through to classifyAPIError -> apiErr.
+	if got := ExitCode(err); got != 5 {
+		t.Fatalf("ExitCode = %d, want 5 (apiErr fallback), err=%v", got, err)
+	}
+}

--- a/library/developer-tools/isitagentready/internal/cli/batch.go
+++ b/library/developer-tools/isitagentready/internal/cli/batch.go
@@ -72,17 +72,22 @@ func newNovelBatchCmd(flags *rootFlags) *cobra.Command {
 			results, ferrs := cliutil.FanoutRun(ctx, urls,
 				func(u string) string { return u },
 				func(c context.Context, u string) (store.ScanRecord, error) {
-					raw, err := performScan(c, flags, u)
+					raw, err := performScanFor(c, flags, u)
 					if err != nil {
 						return store.ScanRecord{}, err
 					}
-					persistScan(raw)
-					rep, perr := store.ParseReport(raw)
-					if perr != nil {
-						return store.ScanRecord{}, perr
-					}
-					return store.ScanRecord{URL: rep.URL, ScannedAt: rep.ScannedAt, Level: rep.Level, LevelName: rep.LevelName, Raw: raw}, nil
+					persistScanFor(flags, raw)
+					return buildScanRecord(flags, raw)
 				})
+
+			// Surface every per-source failure (429, 404, site error) as a
+			// stderr warning line so none is silently dropped, then fail non-zero
+			// when EVERY scan failed rather than printing an empty leaderboard.
+			cliutil.FanoutReportErrors(cmd.ErrOrStderr(), ferrs)
+			if len(results) == 0 {
+				return apiErr(fmt.Errorf("all %d scan(s) failed; nothing to rank (check rate limits or URL list)", len(urls)))
+			}
+
 			records := make([]store.ScanRecord, 0, len(results))
 			for _, r := range results {
 				records = append(records, r.Value)
@@ -93,19 +98,37 @@ func newNovelBatchCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			ranked := store.RankRecords(records, rank)
+			srcName := flags.sourceOrDefault()
 			rows := make([]map[string]any, 0, len(ranked))
 			for i, r := range ranked {
-				rep, _ := store.ParseReport(r.Raw)
-				failing := 0
-				siteErr := false
-				if rep != nil {
-					failing = len(rep.FailingChecks())
-					siteErr = rep.SiteError != nil
+				row := map[string]any{"rank": i + 1, "url": r.URL, "source": srcName}
+				if srcName == store.SourceIsAgentic {
+					failing := 0
+					if ag, err := store.ParseAgenticReport(r.Raw); err == nil {
+						failing = len(ag.FailingIssues())
+					}
+					score := 0
+					if r.Score != nil {
+						score = *r.Score
+					}
+					row["score"] = score
+					row["scoreLabel"] = r.ScoreLabel
+					row["failing"] = failing
+					row["scannedAt"] = r.ScannedAt // cached upstream; show staleness
+				} else {
+					rep, _ := store.ParseReport(r.Raw)
+					failing := 0
+					siteErr := false
+					if rep != nil {
+						failing = len(rep.FailingChecks())
+						siteErr = rep.SiteError != nil
+					}
+					row["level"] = r.Level
+					row["levelName"] = r.LevelName
+					row["failing"] = failing
+					row["siteError"] = siteErr
 				}
-				rows = append(rows, map[string]any{
-					"rank": i + 1, "url": r.URL, "level": r.Level, "levelName": r.LevelName,
-					"failing": failing, "siteError": siteErr,
-				})
+				rows = append(rows, row)
 			}
 
 			if len(failures) > 0 {

--- a/library/developer-tools/isitagentready/internal/cli/check.go
+++ b/library/developer-tools/isitagentready/internal/cli/check.go
@@ -47,7 +47,7 @@ func newCheckCmd(flags *rootFlags) *cobra.Command {
 
 			var raw json.RawMessage
 			if flags.dataSource == "local" {
-				recs, err := loadStore()
+				recs, err := loadStoreFor(flags)
 				if err != nil {
 					return err
 				}
@@ -59,12 +59,12 @@ func newCheckCmd(flags *rootFlags) *cobra.Command {
 			} else {
 				ctx, cancel := boundCtx(cmd.Context(), flags)
 				defer cancel()
-				data, err := performScan(ctx, flags, url)
+				data, err := performScanFor(ctx, flags, url)
 				if err != nil {
 					return err
 				}
 				raw = data
-				persistScan(raw)
+				persistScanFor(flags, raw)
 			}
 			return renderScan(cmd, flags, raw)
 		},

--- a/library/developer-tools/isitagentready/internal/cli/check_render_test.go
+++ b/library/developer-tools/isitagentready/internal/cli/check_render_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 bobe and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/store"
+)
+
+// agenticRawReport builds a raw is-agentic report body for renderer tests.
+func agenticRawReport(t *testing.T) json.RawMessage {
+	t.Helper()
+	rep := store.AgenticReport{
+		Target:         "https://render-test.example",
+		Score:          73,
+		ScoreLabel:     "Mostly ready",
+		ScannedAt:      "2026-08-20T09:00:00Z",
+		EligibleChecks: 31,
+		ScoreBreakdown: store.AgenticBreakdown{
+			Essential:   store.AgenticTier{Earned: 41.5, Available: 55, Passing: 8, Total: 11},
+			Recommended: store.AgenticTier{Earned: 17.9, Available: 40, Passing: 12, Total: 20},
+			Bonus:       store.AgenticBonus{Points: 3.5, PositiveSignals: 2},
+		},
+		Issues: []store.AgenticIssue{
+			{ID: "llms-txt", Name: "llms.txt present", Tier: "essential", Result: "failed",
+				Details: "no /llms.txt", Recommendation: "publish an llms.txt"},
+			{ID: "mcp-server-card", Name: "MCP server card", Tier: "recommended", Result: "partial"},
+		},
+	}
+	b, err := json.Marshal(rep)
+	if err != nil {
+		t.Fatalf("marshal is-agentic report: %v", err)
+	}
+	return b
+}
+
+// TestRenderScanForRoutesIsAgenticToNativeRenderer is the regression test for
+// `check <url> --source is-agentic` in HUMAN mode. The bug: check passed the
+// is-agentic body to the level-based renderer, and store.ParseReport unmarshals
+// it WITHOUT error into an all-zero Report — so the command printed an empty
+// URL, "Level 0" and zero checks instead of the score and issues.
+//
+// The live dogfood matrix missed this because it only ran `report --source
+// is-agentic`, never `check`. Assert on rendered CONTENT (the real score and a
+// real issue id must appear, "Level 0" must not), not on output length: a
+// length assertion passes happily on the all-zero level summary.
+func TestRenderScanForRoutesIsAgenticToNativeRenderer(t *testing.T) {
+	raw := agenticRawReport(t)
+
+	t.Run("is-agentic human output uses the score renderer", func(t *testing.T) {
+		var buf bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&buf)
+		flags := &rootFlags{source: store.SourceIsAgentic, plain: true}
+		if err := renderScanFor(cmd, flags, raw, true); err != nil {
+			t.Fatalf("renderScanFor: %v", err)
+		}
+		got := buf.String()
+		for _, want := range []string{
+			"https://render-test.example",
+			"Score: 73",
+			"Mostly ready",
+			"Eligible checks: 31",
+			"Essential: 8/11 passing",
+			"llms-txt",            // a real issue id must be listed
+			"mcp-server-card",     // ...including the partial one
+			"publish an llms.txt", // ...and its recommendation
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("is-agentic human output missing %q\n--- got ---\n%s", want, got)
+			}
+		}
+		// The level renderer's fingerprint must be absent entirely. Match on
+		// its literal phrasings, not bare "0 pass" — that substring also
+		// occurs inside the legitimate "12/20 passing" tier line.
+		for _, bad := range []string{"Level 0", "Level ", "neutral (of", "Checks:"} {
+			if strings.Contains(got, bad) {
+				t.Errorf("is-agentic human output leaked level-renderer text %q\n--- got ---\n%s", bad, got)
+			}
+		}
+	})
+
+	t.Run("isitagentready human output still uses the level renderer", func(t *testing.T) {
+		var buf bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&buf)
+		flags := &rootFlags{source: store.SourceIsItAgentReady, plain: true}
+		levelRaw := rawRep("https://level-test.example", "2026-08-20T09:00:00Z", 3,
+			map[string]string{"sitemap": "pass", "llmsTxt": "fail"}, nil)
+		if err := renderScanFor(cmd, flags, levelRaw, true); err != nil {
+			t.Fatalf("renderScanFor: %v", err)
+		}
+		got := buf.String()
+		for _, want := range []string{"https://level-test.example", "Level 3", "1 pass", "1 fail"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("isitagentready human output missing %q\n--- got ---\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("machine output stays raw for both sources", func(t *testing.T) {
+		var buf bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&buf)
+		flags := &rootFlags{source: store.SourceIsAgentic, asJSON: true}
+		if err := renderScanFor(cmd, flags, raw, false); err != nil {
+			t.Fatalf("renderScanFor: %v", err)
+		}
+		var back store.AgenticReport
+		if err := json.Unmarshal(buf.Bytes(), &back); err != nil {
+			t.Fatalf("machine output is not the raw report: %v (%s)", err, buf.String())
+		}
+		if back.Score != 73 || back.Target != "https://render-test.example" {
+			t.Fatalf("machine output lost fields: score=%d target=%q", back.Score, back.Target)
+		}
+	})
+}

--- a/library/developer-tools/isitagentready/internal/cli/compare.go
+++ b/library/developer-tools/isitagentready/internal/cli/compare.go
@@ -56,9 +56,10 @@ func newNovelCompareCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Scan the sites concurrently (each scan is several seconds) so the
-			// matrix returns in roughly one scan's time rather than the sum. The
-			// is-agentic client's limiter already caps concurrency at 2 req/s,
-			// so no extra throttle is needed here.
+			// matrix returns in roughly one scan's time rather than the sum. For
+			// --source is-agentic every worker goes through the one process-wide
+			// client from newAgenticClient, so the four workers share a single
+			// 2 req/s limiter and no extra throttle is needed here.
 			ctx, cancel := boundCtx(cmd.Context(), flags)
 			defer cancel()
 			results, ferrs := cliutil.FanoutRun(ctx, urls,

--- a/library/developer-tools/isitagentready/internal/cli/compare.go
+++ b/library/developer-tools/isitagentready/internal/cli/compare.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -55,25 +56,45 @@ func newNovelCompareCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Scan the sites concurrently (each scan is several seconds) so the
-			// matrix returns in roughly one scan's time rather than the sum.
+			// matrix returns in roughly one scan's time rather than the sum. The
+			// is-agentic client's limiter already caps concurrency at 2 req/s,
+			// so no extra throttle is needed here.
 			ctx, cancel := boundCtx(cmd.Context(), flags)
 			defer cancel()
 			results, ferrs := cliutil.FanoutRun(ctx, urls,
 				func(u string) string { return u },
-				func(c context.Context, u string) (*store.Report, error) {
-					raw, err := resolveReportCtx(c, flags, u)
-					if err != nil {
-						return nil, err
-					}
-					return store.ParseReport(raw)
+				func(c context.Context, u string) (json.RawMessage, error) {
+					return resolveReportCtx(c, flags, u)
 				})
-			for _, fe := range ferrs {
-				fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not scan %s: %v\n", fe.Source, fe.Err)
+			// Surface every per-source failure (429, 404, site error) on stderr
+			// so none is silently dropped from the matrix.
+			cliutil.FanoutReportErrors(cmd.ErrOrStderr(), ferrs)
+
+			if len(results) == 0 {
+				return apiErr(fmt.Errorf("none of the %d site(s) could be scanned", len(urls)))
 			}
+
+			if flags.sourceOrDefault() == store.SourceIsAgentic {
+				reports := make([]*store.AgenticReport, 0, len(results))
+				for _, r := range results {
+					if ag, err := store.ParseAgenticReport(r.Value); err == nil {
+						reports = append(reports, ag)
+					}
+				}
+				if len(reports) == 0 {
+					return apiErr(fmt.Errorf("none of the %d site(s) produced an is-agentic report", len(urls)))
+				}
+				result := store.BuildAgenticCompare(reports)
+				if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+					return printJSONFiltered(cmd.OutOrStdout(), result, flags)
+				}
+				return renderCompare(cmd, result)
+			}
+
 			reports := make([]*store.Report, 0, len(results))
 			for _, r := range results {
-				if r.Value != nil {
-					reports = append(reports, r.Value)
+				if rep, err := store.ParseReport(r.Value); err == nil {
+					reports = append(reports, rep)
 				}
 			}
 			if len(reports) == 0 {
@@ -97,7 +118,11 @@ func renderCompare(cmd *cobra.Command, res store.CompareResult) error {
 	// Header: check column + one column per site (host + level).
 	header := "CHECK"
 	for _, s := range res.Sites {
-		header += "\t" + store.NormalizeURL(s.URL) + " (L" + itoa(s.Level) + ")"
+		if s.Score != nil {
+			header += "\t" + store.NormalizeURL(s.URL) + " (score " + itoa(*s.Score) + ")"
+		} else {
+			header += "\t" + store.NormalizeURL(s.URL) + " (L" + itoa(s.Level) + ")"
+		}
 	}
 	fmt.Fprintln(tw, bold(header))
 

--- a/library/developer-tools/isitagentready/internal/cli/crossref.go
+++ b/library/developer-tools/isitagentready/internal/cli/crossref.go
@@ -1,0 +1,184 @@
+// Copyright 2026 bobe and contributors. Licensed under Apache-2.0. See LICENSE.
+
+// pp:data-source auto
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/cliutil"
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/store"
+)
+
+func newCrossrefCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "crossref <url>",
+		Short: "Show both readiness scanners' native verdicts for one site, side by side",
+		Long: "Fetch (or read from local history) BOTH the isitagentready.com and is-agentic.com\n" +
+			"reports for one site and show them side by side, plus the verdicts for the few\n" +
+			"checks the two scanners genuinely measure the same way. crossref deliberately ignores\n" +
+			"--source: it is by definition both scanners. The two scales are never merged; the\n" +
+			"overlap table is the only place an agree/disagree verdict is possible.\n\n" +
+			"If one scanner has no data (a never-scanned is-agentic domain 404s immediately), crossref\n" +
+			"still prints the scanner that worked and marks the other unavailable with its reason.\n" +
+			"Exit code is 0 unless BOTH scanners failed.",
+		Example: "  isitagentready-pp-cli crossref https://example.com\n" +
+			"  isitagentready-pp-cli crossref https://example.com --agent",
+		Annotations: map[string]string{"pp:no-error-path-probe": "true"},
+		Args:        cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				fmt.Fprintln(cmd.OutOrStdout(), "would show both scanners' verdicts for a URL")
+				return nil
+			}
+			if len(args) == 0 {
+				_ = cmd.Usage()
+				return usageErr(fmt.Errorf("a URL argument is required, e.g. crossref https://example.com"))
+			}
+			url := args[0]
+
+			// Fan out both scanner fetches concurrently. The is-agentic client's
+			// limiter already caps at 2 req/s, so no extra throttle here.
+			type crossJob struct{ source, url string }
+			jobs := []crossJob{
+				{store.SourceIsItAgentReady, url},
+				{store.SourceIsAgentic, url},
+			}
+			ctx, cancel := boundCtx(cmd.Context(), flags)
+			defer cancel()
+			results, ferrs := cliutil.FanoutRun(ctx, jobs,
+				func(j crossJob) string { return j.source },
+				func(c context.Context, j crossJob) (json.RawMessage, error) {
+					return resolveReportCtxForSource(c, flags, j.source, j.url)
+				})
+
+			// Capture each fetch outcome keyed by source.
+			rawBySource := map[string]json.RawMessage{}
+			errBySource := map[string]error{}
+			for _, r := range results {
+				rawBySource[r.Source] = r.Value
+			}
+			for _, fe := range ferrs {
+				errBySource[fe.Source] = fe.Err
+			}
+
+			// Parse each available report; on either 404 (report_not_found is
+			// the expected common case) we still render the other scanner.
+			var iar *store.Report
+			if raw, ok := rawBySource[store.SourceIsItAgentReady]; ok {
+				if rep, err := store.ParseReport(raw); err == nil {
+					iar = rep
+				} else {
+					errBySource[store.SourceIsItAgentReady] = err
+					delete(rawBySource, store.SourceIsItAgentReady)
+				}
+			}
+			var ag *store.AgenticReport
+			if raw, ok := rawBySource[store.SourceIsAgentic]; ok {
+				if rep, err := store.ParseAgenticReport(raw); err == nil {
+					ag = rep
+				} else {
+					errBySource[store.SourceIsAgentic] = err
+					delete(rawBySource, store.SourceIsAgentic)
+				}
+			}
+
+			// Exit non-zero only when BOTH scanners failed; otherwise the
+			// working one is enough to render a useful crossref.
+			if iar == nil && ag == nil {
+				iarErr := "no data"
+				if errBySource[store.SourceIsItAgentReady] != nil {
+					iarErr = errBySource[store.SourceIsItAgentReady].Error()
+				}
+				agErr := "no data"
+				if errBySource[store.SourceIsAgentic] != nil {
+					agErr = errBySource[store.SourceIsAgentic].Error()
+				}
+				return apiErr(fmt.Errorf("both scanners failed for %s: isitagentready (%s); is-agentic (%s)", url, iarErr, agErr))
+			}
+
+			res := store.BuildCrossRef(url, iar, ag)
+
+			// Attach an "unavailable" note per missing scanner so the reason
+			// (including is-agentic's verbatim resolution) survives in JSON too.
+			if _, ok := rawBySource[store.SourceIsItAgentReady]; !ok && errBySource[store.SourceIsItAgentReady] != nil {
+				res.Notes = append(res.Notes, "isitagentready unavailable: "+errBySource[store.SourceIsItAgentReady].Error())
+			}
+			if _, ok := rawBySource[store.SourceIsAgentic]; !ok && errBySource[store.SourceIsAgentic] != nil {
+				res.Notes = append(res.Notes, "is-agentic unavailable: "+errBySource[store.SourceIsAgentic].Error())
+			}
+
+			if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+				return printJSONFiltered(cmd.OutOrStdout(), res, flags)
+			}
+			return renderCrossRef(cmd, res, errBySource)
+		},
+	}
+	return cmd
+}
+
+// renderCrossRef prints the two native verdict blocks, the overlap table, and
+// the notes for a terminal.
+func renderCrossRef(cmd *cobra.Command, res store.CrossRefResult, errBySource map[string]error) error {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, bold(res.URL))
+
+	if res.IsItAgentReady != nil {
+		fmt.Fprintln(out, "\n"+"isitagentready.com (native):")
+		fmt.Fprintf(out, "  level %d — %s\n", res.IsItAgentReady.Level, res.IsItAgentReady.LevelName)
+		fmt.Fprintf(out, "  checks: %d pass, %d fail, %d neutral (of %d)\n", res.IsItAgentReady.Pass, res.IsItAgentReady.Fail, res.IsItAgentReady.Neutral, res.IsItAgentReady.Total)
+		if res.IsItAgentReady.ScannedAt != "" {
+			fmt.Fprintf(out, "  scanned %s\n", res.IsItAgentReady.ScannedAt)
+		}
+		if res.IsItAgentReady.SiteError {
+			fmt.Fprintln(out, "  (site error — the scanner could not fetch the target)")
+		}
+	} else {
+		fmt.Fprintln(out, "\n"+"isitagentready.com (native): unavailable")
+		if e, ok := errBySource[store.SourceIsItAgentReady]; ok && e != nil {
+			fmt.Fprintf(out, "  %s\n", e.Error())
+		}
+	}
+
+	if res.IsAgentic != nil {
+		fmt.Fprintln(out, "\n"+"is-agentic.com (native):")
+		fmt.Fprintf(out, "  score %d — %s\n", res.IsAgentic.Score, res.IsAgentic.ScoreLabel)
+		fmt.Fprintf(out, "  eligible checks: %d\n", res.IsAgentic.EligibleChecks)
+		fmt.Fprintf(out, "  essential: %d/%d passing\n", res.IsAgentic.EssentialPassing, res.IsAgentic.EssentialTotal)
+		fmt.Fprintf(out, "  recommended: %d/%d passing\n", res.IsAgentic.RecommendedPassing, res.IsAgentic.RecommendedTotal)
+		fmt.Fprintf(out, "  bonus: %.1f points\n", res.IsAgentic.BonusPoints)
+		if res.IsAgentic.ScannedAt != "" {
+			fmt.Fprintf(out, "  scanned %s\n", res.IsAgentic.ScannedAt)
+		}
+	} else {
+		fmt.Fprintln(out, "\n"+"is-agentic.com (native): unavailable")
+		if e, ok := errBySource[store.SourceIsAgentic]; ok && e != nil {
+			fmt.Fprintf(out, "  %s\n", e.Error())
+		}
+	}
+
+	fmt.Fprintln(out, "\nOverlap (checks both scanners measure the same way):")
+	tw := newTabWriter(out)
+	fmt.Fprintln(tw, "  LABEL\tISITAGENTREADY\tIS-AGENTIC\tVERDICT")
+	for _, o := range res.Overlap {
+		fmt.Fprintf(tw, "  %s\t%s:%s\t%s:%s\t%s\n",
+			o.Label, o.IsItAgentReadyCheck, o.IsItAgentReadyStatus,
+			o.IsAgenticCheck, o.IsAgenticStatus, o.Verdict)
+	}
+	_ = tw.Flush()
+
+	if len(res.Notes) > 0 {
+		fmt.Fprintln(out, "\nNotes:")
+		for _, n := range res.Notes {
+			fmt.Fprintf(out, "  - %s\n", n)
+		}
+	}
+	return nil
+}

--- a/library/developer-tools/isitagentready/internal/cli/crossref_test.go
+++ b/library/developer-tools/isitagentready/internal/cli/crossref_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 bobe and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/store"
+)
+
+// agenticRecCLI builds an is-agentic ScanRecord for the CLI store (used to seed
+// a crossref where the is-agentic side is present).
+func agenticRecCLI(url, at string, score int, issues [][3]string) store.ScanRecord {
+	ag := &store.AgenticReport{Target: url, Score: score, ScoreLabel: "L", ScannedAt: at}
+	for _, is := range issues {
+		ag.Issues = append(ag.Issues, store.AgenticIssue{ID: is[0], Tier: is[1], Result: is[2]})
+	}
+	b, _ := json.Marshal(ag)
+	return store.ScanRecord{URL: url, Source: store.SourceIsAgentic, ScannedAt: at, Score: &score, Raw: b}
+}
+
+func TestCrossrefWithOneScannerMissing(t *testing.T) {
+	// Seed only the isitagentready side; the is-agentic local lookup 404s.
+	home := seedStore(t, sampleRec(testURL, "2026-06-22T10:00:00Z", 2, map[string]string{"sitemap": "pass"}, nil))
+	out, _, err := runCLI(t, home, "crossref", testURL, "--agent", "--data-source", "local")
+	if err != nil {
+		t.Fatalf("crossref with one scanner missing must exit 0, got %v", err)
+	}
+	var res struct {
+		URL            string         `json:"url"`
+		IsItAgentReady map[string]any `json:"isitagentready"`
+		IsAgentic      map[string]any `json:"isAgentic"`
+		Notes          []string       `json:"notes"`
+	}
+	if e := json.Unmarshal([]byte(out), &res); e != nil {
+		t.Fatalf("not JSON: %v (%s)", e, out)
+	}
+	if res.URL != testURL {
+		t.Fatalf("url=%v", res.URL)
+	}
+	if res.IsItAgentReady == nil {
+		t.Fatalf("isitagentready should be populated, got nil")
+	}
+	if res.IsAgentic != nil {
+		t.Fatalf("isAgentic should be null (no local is-agentic scan), got %v", res.IsAgentic)
+	}
+	// The unavailable reason must be surfaced in notes.
+	found := false
+	for _, n := range res.Notes {
+		if strings.Contains(n, "is-agentic unavailable") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an is-agentic unavailable note, got %v", res.Notes)
+	}
+}
+
+func TestCrossrefWithBothScannersMissing(t *testing.T) {
+	// Empty store + local data-source -> both scanners have no data.
+	home := seedStore(t)
+	_, _, err := runCLI(t, home, "crossref", testURL, "--agent", "--data-source", "local")
+	if err == nil || ExitCode(err) == 0 {
+		t.Fatalf("crossref with both scanners missing must exit non-zero, got %v", err)
+	}
+}
+
+func TestCrossrefHelpWires(t *testing.T) {
+	home := seedStore(t)
+	out, _, err := runCLI(t, home, "crossref", "--help")
+	if err != nil {
+		t.Fatalf("crossref --help error = %v (%s)", err, out)
+	}
+}

--- a/library/developer-tools/isitagentready/internal/cli/diff.go
+++ b/library/developer-tools/isitagentready/internal/cli/diff.go
@@ -46,7 +46,7 @@ func newNovelDiffCmd(flags *rootFlags) *cobra.Command {
 			}
 			url := args[0]
 
-			recs, err := loadStore()
+			recs, err := loadStoreFor(flags)
 			if err != nil {
 				return err
 			}
@@ -63,6 +63,39 @@ func newNovelDiffCmd(flags *rootFlags) *cobra.Command {
 			}
 			fromRec := hist[len(hist)-2]
 			toRec := hist[len(hist)-1]
+
+			if flags.sourceOrDefault() == store.SourceIsAgentic {
+				from, err := store.ParseAgenticReport(fromRec.Raw)
+				if err != nil {
+					return err
+				}
+				to, err := store.ParseAgenticReport(toRec.Raw)
+				if err != nil {
+					return err
+				}
+				transitions := store.DiffAgenticIssues(from, to)
+				shown := transitions
+				if !showAll {
+					shown = shown[:0:0]
+					for _, t := range transitions {
+						if t.Change != "unchanged" {
+							shown = append(shown, t)
+						}
+					}
+				}
+				result := map[string]any{
+					"url":        url,
+					"from":       map[string]any{"scannedAt": fromRec.ScannedAt, "score": from.Score, "scoreLabel": from.ScoreLabel},
+					"to":         map[string]any{"scannedAt": toRec.ScannedAt, "score": to.Score, "scoreLabel": to.ScoreLabel},
+					"scoreDelta": to.Score - from.Score,
+					"changes":    shown,
+				}
+				if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+					return printJSONFiltered(cmd.OutOrStdout(), result, flags)
+				}
+				return renderAgenticDiff(cmd, url, from, to, shown, len(transitions))
+			}
+
 			from, err := store.ParseReport(fromRec.Raw)
 			if err != nil {
 				return err
@@ -122,6 +155,36 @@ func renderDiff(cmd *cobra.Command, url string, from, to *store.Report, shown []
 		case "regressed", "removed":
 			mark = red(t.Change)
 		case "improved", "added":
+			mark = green(t.Change)
+		}
+		fmt.Fprintf(out, "  %-10s %s (%s → %s)\n", mark, t.Check, t.From, t.To)
+	}
+	return nil
+}
+
+// renderAgenticDiff prints an is-agentic diff: a score delta line plus the
+// issue transitions (using AgenticStatus pass/partial/fail values).
+func renderAgenticDiff(cmd *cobra.Command, url string, from, to *store.AgenticReport, shown []store.CheckTransition, total int) error {
+	out := cmd.OutOrStdout()
+	delta := to.Score - from.Score
+	arrow := "="
+	if delta > 0 {
+		arrow = green(fmt.Sprintf("+%d", delta))
+	} else if delta < 0 {
+		arrow = red(fmt.Sprintf("%d", delta))
+	}
+	fmt.Fprintf(out, "%s\n", bold(url))
+	fmt.Fprintf(out, "  score %d → %d (%s)\n", from.Score, to.Score, arrow)
+	if len(shown) == 0 {
+		fmt.Fprintf(out, "  no issue changes across %d checks\n", total)
+		return nil
+	}
+	for _, t := range shown {
+		mark := yellow(t.Change)
+		switch t.Change {
+		case "regressed":
+			mark = red(t.Change)
+		case "improved":
 			mark = green(t.Change)
 		}
 		fmt.Fprintf(out, "  %-10s %s (%s → %s)\n", mark, t.Check, t.From, t.To)

--- a/library/developer-tools/isitagentready/internal/cli/gate.go
+++ b/library/developer-tools/isitagentready/internal/cli/gate.go
@@ -14,14 +14,16 @@ import (
 
 func newNovelGateCmd(flags *rootFlags) *cobra.Command {
 	var minLevel int
+	var minScore int
 	var noRegress bool
 	var strict bool
 
 	cmd := &cobra.Command{
 		Use:   "gate <url>",
 		Short: "Fail a build when a site drops below a target readiness level or a check regresses",
-		Long: "Scan a site and exit non-zero when its readiness level is below --min-level or (with\n" +
-			"--no-regress) when any check that passed in the previous scan now fails. A target\n" +
+		Long: "Scan a site and exit non-zero when its readiness level/score is below --min-level (or\n" +
+			"--min-score for the is-agentic source) or (with --no-regress) when any check that\n" +
+			"passed in the previous scan now fails. A target\n" +
 			"siteError (the scanner could not fetch the site) is reported but does NOT fail the gate\n" +
 			"unless --strict, so a transient target outage does not flap CI. Pair with --agent for a\n" +
 			"machine-readable result on stdout; the exit code is the gate signal.\n\n" +
@@ -52,40 +54,83 @@ func newNovelGateCmd(flags *rootFlags) *cobra.Command {
 			}
 			url := args[0]
 
-			recs, err := loadStore()
+			// The threshold flag must match the active scanner's scale. A
+			// mismatched threshold would be silently reinterpreted, so refuse
+			// it as a usage error (exit 2) instead: is-agentic has no level and
+			// isitagentready has no 0-100 score.
+			src := flags.sourceOrDefault()
+			if cmd.Flags().Changed("min-level") && src == store.SourceIsAgentic {
+				return usageErr(fmt.Errorf("--min-level is a level 0-5 threshold, but --source is-agentic reports a score 0-100 with no level; use --min-score instead"))
+			}
+			if cmd.Flags().Changed("min-score") && src == store.SourceIsItAgentReady {
+				return usageErr(fmt.Errorf("--min-score is a score 0-100 threshold, but --source isitagentready reports a level 0-5 with no score; use --min-level instead"))
+			}
+
+			recs, err := loadStoreFor(flags)
 			if err != nil {
 				return err
 			}
 
-			var current, prev *store.Report
-			if flags.dataSource == "local" {
-				hist := store.HistoryFor(recs, url)
-				if len(hist) == 0 {
-					return notFoundErr(fmt.Errorf("no stored scan for %s; run 'isitagentready-pp-cli check %s' or omit --data-source local", url, url))
+			var res store.GateResult
+			if src == store.SourceIsAgentic {
+				var current, prev *store.AgenticReport
+				if flags.dataSource == "local" {
+					hist := store.HistoryFor(recs, url)
+					if len(hist) == 0 {
+						return notFoundErr(fmt.Errorf("no stored is-agentic scan for %s; run 'isitagentready-pp-cli check %s --source is-agentic' or omit --data-source local", url, url))
+					}
+					if current, err = store.ParseAgenticReport(hist[len(hist)-1].Raw); err != nil {
+						return err
+					}
+					if len(hist) >= 2 {
+						prev, _ = store.ParseAgenticReport(hist[len(hist)-2].Raw)
+					}
+				} else {
+					if rec, ok := store.Latest(recs, url); ok {
+						prev, _ = store.ParseAgenticReport(rec.Raw)
+					}
+					ctx, cancel := boundCtx(cmd.Context(), flags)
+					defer cancel()
+					raw, err := performScanFor(ctx, flags, url)
+					if err != nil {
+						return err
+					}
+					persistScanFor(flags, raw)
+					if current, err = store.ParseAgenticReport(raw); err != nil {
+						return err
+					}
 				}
-				if current, err = store.ParseReport(hist[len(hist)-1].Raw); err != nil {
-					return err
-				}
-				if len(hist) >= 2 {
-					prev, _ = store.ParseReport(hist[len(hist)-2].Raw)
-				}
+				res = store.EvaluateAgenticGate(current, prev, minScore, noRegress)
 			} else {
-				if rec, ok := store.Latest(recs, url); ok {
-					prev, _ = store.ParseReport(rec.Raw)
+				var current, prev *store.Report
+				if flags.dataSource == "local" {
+					hist := store.HistoryFor(recs, url)
+					if len(hist) == 0 {
+						return notFoundErr(fmt.Errorf("no stored scan for %s; run 'isitagentready-pp-cli check %s' or omit --data-source local", url, url))
+					}
+					if current, err = store.ParseReport(hist[len(hist)-1].Raw); err != nil {
+						return err
+					}
+					if len(hist) >= 2 {
+						prev, _ = store.ParseReport(hist[len(hist)-2].Raw)
+					}
+				} else {
+					if rec, ok := store.Latest(recs, url); ok {
+						prev, _ = store.ParseReport(rec.Raw)
+					}
+					ctx, cancel := boundCtx(cmd.Context(), flags)
+					defer cancel()
+					raw, err := performScanFor(ctx, flags, url)
+					if err != nil {
+						return err
+					}
+					persistScanFor(flags, raw)
+					if current, err = store.ParseReport(raw); err != nil {
+						return err
+					}
 				}
-				ctx, cancel := boundCtx(cmd.Context(), flags)
-				defer cancel()
-				raw, err := performScan(ctx, flags, url)
-				if err != nil {
-					return err
-				}
-				persistScan(raw)
-				if current, err = store.ParseReport(raw); err != nil {
-					return err
-				}
+				res = store.EvaluateGate(current, prev, minLevel, noRegress, strict)
 			}
-
-			res := store.EvaluateGate(current, prev, minLevel, noRegress, strict)
 
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				renderGateHuman(cmd, res)
@@ -101,6 +146,7 @@ func newNovelGateCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&minLevel, "min-level", 0, "Fail if the readiness level is below this (0-5; 0 disables the level check)")
+	cmd.Flags().IntVar(&minScore, "min-score", 0, "Fail if the is-agentic score is below this (0-100; 0 disables the score check)")
 	cmd.Flags().BoolVar(&noRegress, "no-regress", false, "Fail if any check that passed in the previous scan now fails")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Also fail when the target site itself is unreachable (siteError)")
 	return cmd
@@ -112,11 +158,15 @@ func renderGateHuman(cmd *cobra.Command, res store.GateResult) {
 	if !res.Pass {
 		verdict = red("FAIL")
 	}
-	fmt.Fprintf(out, "%s  %s  (level %d — %s", verdict, res.URL, res.Level, res.LevelName)
-	if res.MinLevel > 0 {
-		fmt.Fprintf(out, ", min %d", res.MinLevel)
+	if res.Score != nil {
+		fmt.Fprintf(out, "%s  %s  (score %d — %s)\n", verdict, res.URL, *res.Score, res.ScoreLabel)
+	} else {
+		fmt.Fprintf(out, "%s  %s  (level %d — %s", verdict, res.URL, res.Level, res.LevelName)
+		if res.MinLevel > 0 {
+			fmt.Fprintf(out, ", min %d", res.MinLevel)
+		}
+		fmt.Fprintln(out, ")")
 	}
-	fmt.Fprintln(out, ")")
 	for _, r := range res.Reasons {
 		fmt.Fprintf(out, "  - %s\n", r)
 	}

--- a/library/developer-tools/isitagentready/internal/cli/gate_test.go
+++ b/library/developer-tools/isitagentready/internal/cli/gate_test.go
@@ -56,3 +56,31 @@ func TestNovelGateBehavior(t *testing.T) {
 		t.Fatal("gate is missing --min-level or --no-regress")
 	}
 }
+
+// TestGateThresholdSourceGuards enforces the mismatched-threshold refusals:
+// a threshold flag must match the active scanner's scale or gate exits 2 as a
+// usage error rather than silently reinterpreting the value.
+func TestGateThresholdSourceGuards(t *testing.T) {
+	home := seedStore(t)
+	t.Run("--min-level with is-agentic is a usage error", func(t *testing.T) {
+		_, _, err := runCLI(t, home, "gate", testURL, "--min-level", "3", "--source", "is-agentic", "--agent", "--data-source", "local")
+		if err == nil || ExitCode(err) != 2 {
+			t.Fatalf("want usage error exit 2, got %v", err)
+		}
+	})
+	t.Run("--min-score with isitagentready is a usage error", func(t *testing.T) {
+		_, _, err := runCLI(t, home, "gate", testURL, "--min-score", "70", "--agent", "--data-source", "local")
+		if err == nil || ExitCode(err) != 2 {
+			t.Fatalf("want usage error exit 2, got %v", err)
+		}
+	})
+	t.Run("--min-score with is-agentic is allowed", func(t *testing.T) {
+		// With an empty store in local mode this runs past the guard and hits a
+		// missing-scan notFound, NOT a usage error. That proves the guard did not
+		// fire (exit 3, not 2).
+		_, _, err := runCLI(t, home, "gate", testURL, "--min-score", "70", "--source", "is-agentic", "--agent", "--data-source", "local")
+		if err == nil || ExitCode(err) != 3 {
+			t.Fatalf("want notFound exit 3 (guard should not fire), got %v", err)
+		}
+	})
+}

--- a/library/developer-tools/isitagentready/internal/cli/guide.go
+++ b/library/developer-tools/isitagentready/internal/cli/guide.go
@@ -57,7 +57,7 @@ func newGuideCmd(flags *rootFlags) *cobra.Command {
 				return nil
 			}
 
-			recs, err := loadStore()
+			recs, err := loadStoreFor(flags)
 			if err != nil {
 				return err
 			}

--- a/library/developer-tools/isitagentready/internal/cli/history.go
+++ b/library/developer-tools/isitagentready/internal/cli/history.go
@@ -45,13 +45,13 @@ func newNovelHistoryCmd(flags *rootFlags) *cobra.Command {
 			}
 			url := args[0]
 
-			recs, err := loadStore()
+			recs, err := loadStoreFor(flags)
 			if err != nil {
 				return err
 			}
 			hist := store.HistoryFor(recs, url)
 			if len(hist) == 0 {
-				fmt.Fprintf(cmd.ErrOrStderr(), "no scans yet for %s; run: isitagentready-pp-cli check %s\n", url, url)
+				fmt.Fprintf(cmd.ErrOrStderr(), "no %s scans yet for %s; run: isitagentready-pp-cli check %s --source %s\n", flags.sourceOrDefault(), url, url, flags.sourceOrDefault())
 				if flags.asJSON {
 					fmt.Fprintln(cmd.OutOrStdout(), "[]")
 				}
@@ -82,7 +82,16 @@ func renderHistory(cmd *cobra.Command, url string, entries []store.HistoryEntry)
 			when = t.Format("2006-01-02 15:04")
 		}
 		if e.SiteError {
-			fmt.Fprintf(out, "  %s  level %d — %s  %s\n", when, e.Level, e.LevelName, red("(site error)"))
+			fmt.Fprintf(out, "  %s  (site error)\n", when)
+			continue
+		}
+		if e.Score != nil {
+			// is-agentic history rows have a score, not a level.
+			label := fmt.Sprintf("score %d", *e.Score)
+			if e.ScoreLabel != "" {
+				label += " — " + e.ScoreLabel
+			}
+			fmt.Fprintf(out, "  %s  %s\n", when, label)
 		} else {
 			fmt.Fprintf(out, "  %s  level %d — %s\n", when, e.Level, e.LevelName)
 		}

--- a/library/developer-tools/isitagentready/internal/cli/open_advice.go
+++ b/library/developer-tools/isitagentready/internal/cli/open_advice.go
@@ -36,7 +36,7 @@ func newNovelOpenAdviceCmd(flags *rootFlags) *cobra.Command {
 				return usageErr(fmt.Errorf("open-advice reads local scan history only; it has no live equivalent (remove --data-source live)"))
 			}
 
-			recs, err := loadStore()
+			recs, err := loadStoreFor(flags)
 			if err != nil {
 				return err
 			}
@@ -77,7 +77,15 @@ func renderOpenAdvice(cmd *cobra.Command, items []store.OpenItem) error {
 	}
 	for _, url := range order {
 		list := bySite[url]
-		fmt.Fprintf(out, "%s  (level %d — %s, %d open)\n", bold(url), list[0].Level, list[0].LevelName, len(list))
+		if list[0].Score != nil {
+			label := fmt.Sprintf("score %d", *list[0].Score)
+			if list[0].ScoreLabel != "" {
+				label += " — " + list[0].ScoreLabel
+			}
+			fmt.Fprintf(out, "%s  (%s, %d open)\n", bold(url), label, len(list))
+		} else {
+			fmt.Fprintf(out, "%s  (level %d — %s, %d open)\n", bold(url), list[0].Level, list[0].LevelName, len(list))
+		}
 		for _, it := range list {
 			fmt.Fprintf(out, "  %s %s\n", red("[fail]"), it.Check)
 			if it.Description != "" {

--- a/library/developer-tools/isitagentready/internal/cli/report.go
+++ b/library/developer-tools/isitagentready/internal/cli/report.go
@@ -62,6 +62,35 @@ func newReportCmd(flags *rootFlags) *cobra.Command {
 			}
 			url := args[0]
 
+			// is-agentic has a different shape from isitagentready (score over
+			// two tiers instead of a level over five categories), so it renders
+			// natively and --category maps to --tier (essential/recommended).
+			if flags.sourceOrDefault() == store.SourceIsAgentic {
+				tier := ""
+				if category != "" {
+					t, ok := validAgenticTiers[strings.ToLower(strings.TrimSpace(category))]
+					if !ok {
+						return usageErr(fmt.Errorf("--category %q is an isitagentready category; for --source is-agentic use a tier: essential or recommended", category))
+					}
+					tier = t
+				}
+				if profile != "" {
+					return usageErr(fmt.Errorf("--profile is an isitagentready site-type view; it does not apply to --source is-agentic"))
+				}
+				raw, err := resolveReport(cmd, flags, url)
+				if err != nil {
+					return err
+				}
+				filtered, err := filterAgenticReport(raw, tier, onlyFailing, checkID)
+				if err != nil {
+					return err
+				}
+				if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+					return printOutputWithFlags(cmd.OutOrStdout(), filtered, flags)
+				}
+				return renderAgenticReport(cmd, filtered, tier)
+			}
+
 			// Resolve the category filter set (from --category and/or --profile).
 			cats, err := resolveCategoryFilter(category, profile)
 			if err != nil {

--- a/library/developer-tools/isitagentready/internal/cli/root.go
+++ b/library/developer-tools/isitagentready/internal/cli/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -43,6 +44,7 @@ type rootFlags struct {
 	timeout             time.Duration
 	rateLimit           float64
 	dataSource          string
+	source              string
 	freshnessMeta       any
 
 	// deliverBuf captures command output when --deliver is set to a
@@ -181,6 +183,8 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)")
 	rootCmd.PersistentFlags().BoolVar(&flags.allowPartialFailure, "allow-partial-failure", false, "Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit")
 	rootCmd.PersistentFlags().StringVar(&flags.dataSource, "data-source", "auto", "Data source for read commands: auto (live with local fallback), live (API only), local (synced data only)")
+	rootCmd.PersistentFlags().StringVar(&flags.source, "source", store.SourceIsItAgentReady,
+		"Scanner source: isitagentready (Level 0-5) or is-agentic (score 0-100). The two use different scales and are never merged; see 'crossref'.")
 	rootCmd.PersistentFlags().StringVar(&flags.profileName, "profile", "", "Apply values from a saved profile (see 'isitagentready-pp-cli profile list')")
 	rootCmd.PersistentFlags().StringVar(&flags.deliverSpec, "deliver", "", "Route output to a sink: stdout (default), file:<path>, webhook:<url>")
 	rootCmd.PersistentFlags().Float64Var(&flags.rateLimit, "rate-limit", 0, "Max requests per second (0 to disable)")
@@ -239,6 +243,12 @@ See README.md or the bundled SKILL.md for recipes.`,
 		default:
 			return fmt.Errorf("invalid --data-source value %q: must be auto, live, or local", flags.dataSource)
 		}
+		switch flags.source {
+		case store.SourceIsItAgentReady, store.SourceIsAgentic:
+			// valid
+		default:
+			return fmt.Errorf("invalid --source value %q: must be %s", flags.source, strings.Join(store.ValidSources(), " or "))
+		}
 		return nil
 	}
 	rootCmd.AddCommand(newDoctorCmd(flags))
@@ -253,6 +263,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newNovelGateCmd(flags))
 	rootCmd.AddCommand(newNovelHistoryCmd(flags))
 	rootCmd.AddCommand(newNovelOpenAdviceCmd(flags))
+	rootCmd.AddCommand(newCrossrefCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newScanPromotedCmd(flags))
 	rootCmd.AddCommand(newCheckCmd(flags))

--- a/library/developer-tools/isitagentready/internal/cli/scanhelpers.go
+++ b/library/developer-tools/isitagentready/internal/cli/scanhelpers.go
@@ -262,9 +262,34 @@ func resolveReportCtx(ctx context.Context, flags *rootFlags, url string) (json.R
 // renderScan prints a scan report: raw JSON (with --select/--compact) for
 // machine output, or a human summary for a terminal.
 func renderScan(cmd *cobra.Command, flags *rootFlags, raw json.RawMessage) error {
-	if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+	return renderScanFor(cmd, flags, raw, wantsHumanTable(cmd.OutOrStdout(), flags))
+}
+
+// renderScanFor is renderScan with the human/machine decision passed in, and
+// with the human renderer chosen by --source.
+//
+// An is-agentic report shares no fields with an isitagentready one, and
+// store.ParseReport unmarshals it WITHOUT error into an all-zero Report — so
+// routing it through the level renderer printed an empty URL, "Level 0" and
+// zero checks instead of the real score and issues. Dispatch on the source
+// before rendering, the same way report/crossref already do.
+//
+// human is a parameter rather than a recomputed wantsHumanTable call so tests
+// can exercise the terminal path: wantsHumanTable gates it behind isTerminal,
+// which is false for the buffer a test renders into.
+func renderScanFor(cmd *cobra.Command, flags *rootFlags, raw json.RawMessage, human bool) error {
+	if !human {
 		return printOutputWithFlags(cmd.OutOrStdout(), raw, flags)
 	}
+	if flags.sourceOrDefault() == store.SourceIsAgentic {
+		// tier "" — check has no --category/--tier filter, so show both tiers.
+		return renderAgenticReport(cmd, raw, "")
+	}
+	return renderScanLevels(cmd, flags, raw)
+}
+
+// renderScanLevels prints the isitagentready level-based human summary.
+func renderScanLevels(cmd *cobra.Command, flags *rootFlags, raw json.RawMessage) error {
 	rep, err := store.ParseReport(raw)
 	if err != nil {
 		return printOutputWithFlags(cmd.OutOrStdout(), raw, flags)

--- a/library/developer-tools/isitagentready/internal/cli/scanhelpers.go
+++ b/library/developer-tools/isitagentready/internal/cli/scanhelpers.go
@@ -49,23 +49,6 @@ func performScan(ctx context.Context, flags *rootFlags, url string) (json.RawMes
 	return data, nil
 }
 
-// persistScan parses a raw report and appends it to the local scan store. A
-// store write failure is a warning, not fatal: the scan is still useful.
-func persistScan(raw json.RawMessage) {
-	rep, err := store.ParseReport(raw)
-	if err != nil {
-		return
-	}
-	path, err := store.DefaultPath()
-	if err != nil {
-		return
-	}
-	rec := store.ScanRecord{URL: rep.URL, ScannedAt: rep.ScannedAt, Level: rep.Level, LevelName: rep.LevelName, Raw: raw}
-	if err := store.Append(path, rec); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not save scan to local history: %v\n", err)
-	}
-}
-
 // mustJSON marshals v, falling back to an empty array on error so callers can
 // pass the result straight to printOutputWithFlags.
 func mustJSON(v any) json.RawMessage {
@@ -85,6 +68,109 @@ func loadStore() ([]store.ScanRecord, error) {
 	return store.Load(path)
 }
 
+// sourceOrDefault returns the active scanner, defaulting to isitagentready.
+// newRootCmd's StringVar registration normally fills flags.source in, but a
+// rootFlags built directly (tests, or any future caller that bypasses the
+// Cobra wiring) would leave it empty — and an empty source silently filters
+// the whole scan store to nothing. Default here rather than fail open.
+func (f *rootFlags) sourceOrDefault() string {
+	if f.source == "" {
+		return store.SourceIsItAgentReady
+	}
+	return f.source
+}
+
+// performScanFor fetches a report from the source selected by --source.
+func performScanFor(ctx context.Context, flags *rootFlags, url string) (json.RawMessage, error) {
+	return performScanForSource(ctx, flags, flags.sourceOrDefault(), url)
+}
+
+// performScanForSource fetches a report from an explicit source, decoupled from
+// --source. crossref uses it to fetch BOTH scanners for one URL.
+func performScanForSource(ctx context.Context, flags *rootFlags, source, url string) (json.RawMessage, error) {
+	switch source {
+	case store.SourceIsAgentic:
+		return fetchAgenticReport(ctx, flags, url)
+	default: // isitagentready
+		return performScan(ctx, flags, url)
+	}
+}
+
+// persistScanFor appends a scan to the local store with its provenance, parsing
+// per source so each scanner's headline lands in the right field.
+func persistScanFor(flags *rootFlags, raw json.RawMessage) {
+	persistScanForSource(flags, flags.sourceOrDefault(), raw)
+}
+
+func persistScanForSource(flags *rootFlags, source string, raw json.RawMessage) {
+	path, err := store.DefaultPath()
+	if err != nil {
+		return
+	}
+	switch source {
+	case store.SourceIsAgentic:
+		rep, err := store.ParseAgenticReport(raw)
+		if err != nil {
+			return
+		}
+		score := rep.Score // local so the pointer is stable
+		rec := store.ScanRecord{
+			URL:        rep.Target,
+			Source:     store.SourceIsAgentic,
+			ScannedAt:  rep.ScannedAt,
+			Score:      &score,
+			ScoreLabel: rep.ScoreLabel,
+			Raw:        raw,
+		}
+		if err := store.Append(path, rec); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not save scan to local history: %v\n", err)
+		}
+	default: // isitagentready — mirrors persistScan but labels the source
+		rep, err := store.ParseReport(raw)
+		if err != nil {
+			return
+		}
+		rec := store.ScanRecord{URL: rep.URL, Source: store.SourceIsItAgentReady, ScannedAt: rep.ScannedAt, Level: rep.Level, LevelName: rep.LevelName, Raw: raw}
+		if err := store.Append(path, rec); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not save scan to local history: %v\n", err)
+		}
+	}
+}
+
+// loadStoreFor reads the local store filtered to the active --source, so no
+// command can compare two scanners' incompatible numbers.
+func loadStoreFor(flags *rootFlags) ([]store.ScanRecord, error) {
+	return loadStoreForSource(flags, flags.sourceOrDefault())
+}
+
+func loadStoreForSource(flags *rootFlags, source string) ([]store.ScanRecord, error) {
+	recs, err := loadStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.FilterSource(recs, source), nil
+}
+
+// buildScanRecord parses a raw report into a persisted ScanRecord with the
+// correct headline for its source: level fields for isitagentready, score
+// fields for is-agentic. Used by batch to build its fan-out rows carrying the
+// right provenance.
+func buildScanRecord(flags *rootFlags, raw json.RawMessage) (store.ScanRecord, error) {
+	if flags.sourceOrDefault() == store.SourceIsAgentic {
+		rep, err := store.ParseAgenticReport(raw)
+		if err != nil {
+			return store.ScanRecord{}, err
+		}
+		score := rep.Score
+		return store.ScanRecord{URL: rep.Target, Source: store.SourceIsAgentic, ScannedAt: rep.ScannedAt, Score: &score, ScoreLabel: rep.ScoreLabel, Raw: raw}, nil
+	}
+	rep, err := store.ParseReport(raw)
+	if err != nil {
+		return store.ScanRecord{}, err
+	}
+	return store.ScanRecord{URL: rep.URL, Source: store.SourceIsItAgentReady, ScannedAt: rep.ScannedAt, Level: rep.Level, LevelName: rep.LevelName, Raw: raw}, nil
+}
+
 // resolveReport returns a raw report for url according to the --data-source
 // flag, bounding the work with the root --timeout. Used by view commands
 // (report, advice) so they do not re-scan on every call.
@@ -94,6 +180,45 @@ func resolveReport(cmd *cobra.Command, flags *rootFlags, url string) (json.RawMe
 	return resolveReportCtx(ctx, flags, url)
 }
 
+// resolveReportCtxForSource is resolveReportCtx with an explicit source instead
+// of flags.source. crossref uses it to resolve BOTH scanners for one URL the
+// same way the single-source commands resolve one (live / local / auto).
+func resolveReportCtxForSource(ctx context.Context, flags *rootFlags, source, url string) (json.RawMessage, error) {
+	switch flags.dataSource {
+	case "live":
+		raw, err := performScanForSource(ctx, flags, source, url)
+		if err != nil {
+			return nil, err
+		}
+		persistScanForSource(flags, source, raw)
+		return raw, nil
+	case "local":
+		recs, err := loadStoreForSource(flags, source)
+		if err != nil {
+			return nil, err
+		}
+		rec, ok := store.Latest(recs, url)
+		if !ok {
+			return nil, notFoundErr(fmt.Errorf("no stored %s scan for %s; run 'isitagentready-pp-cli check %s --source %s' first", source, url, url, source))
+		}
+		return rec.Raw, nil
+	default: // auto
+		recs, err := loadStoreForSource(flags, source)
+		if err != nil {
+			return nil, err
+		}
+		if rec, ok := store.Latest(recs, url); ok {
+			return rec.Raw, nil
+		}
+		raw, err := performScanForSource(ctx, flags, source, url)
+		if err != nil {
+			return nil, err
+		}
+		persistScanForSource(flags, source, raw)
+		return raw, nil
+	}
+}
+
 // resolveReportCtx is resolveReport with an explicit context so callers that
 // fan out (compare) can share one bounded context: live forces a fresh scan,
 // local reads the latest stored scan (and errors if none), auto reads the
@@ -101,35 +226,35 @@ func resolveReport(cmd *cobra.Command, flags *rootFlags, url string) (json.RawMe
 func resolveReportCtx(ctx context.Context, flags *rootFlags, url string) (json.RawMessage, error) {
 	switch flags.dataSource {
 	case "live":
-		raw, err := performScan(ctx, flags, url)
+		raw, err := performScanFor(ctx, flags, url)
 		if err != nil {
 			return nil, err
 		}
-		persistScan(raw)
+		persistScanFor(flags, raw)
 		return raw, nil
 	case "local":
-		recs, err := loadStore()
+		recs, err := loadStoreFor(flags)
 		if err != nil {
 			return nil, err
 		}
 		rec, ok := store.Latest(recs, url)
 		if !ok {
-			return nil, notFoundErr(fmt.Errorf("no stored scan for %s; run 'isitagentready-pp-cli check %s' first", url, url))
+			return nil, notFoundErr(fmt.Errorf("no stored %s scan for %s; run 'isitagentready-pp-cli check %s --source %s' first", flags.sourceOrDefault(), url, url, flags.sourceOrDefault()))
 		}
 		return rec.Raw, nil
 	default: // auto
-		recs, err := loadStore()
+		recs, err := loadStoreFor(flags)
 		if err != nil {
 			return nil, err
 		}
 		if rec, ok := store.Latest(recs, url); ok {
 			return rec.Raw, nil
 		}
-		raw, err := performScan(ctx, flags, url)
+		raw, err := performScanFor(ctx, flags, url)
 		if err != nil {
 			return nil, err
 		}
-		persistScan(raw)
+		persistScanFor(flags, raw)
 		return raw, nil
 	}
 }

--- a/library/developer-tools/isitagentready/internal/store/agentic.go
+++ b/library/developer-tools/isitagentready/internal/store/agentic.go
@@ -1,0 +1,342 @@
+// Copyright 2026 bobe and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/cliutil"
+)
+
+// AgenticReport is the parsed shape of a GET /api/v1/report response from the
+// is-agentic.com scanner. Unlike isitagentready's fixed Level 0-5, this scanner
+// reports a score 0-100 over a per-site floating denominator
+// (eligible_checks), which is why the two scales are never merged.
+type AgenticReport struct {
+	Target         string           `json:"target"`
+	DisplayTarget  string           `json:"display_target"`
+	ReportURL      string           `json:"report_url"`
+	Score          int              `json:"score"`
+	ScoreLabel     string           `json:"score_label"`
+	ScannedAt      string           `json:"scanned_at"`
+	EligibleChecks int              `json:"eligible_checks"`
+	ScoreBreakdown AgenticBreakdown `json:"score_breakdown"`
+	Issues         []AgenticIssue   `json:"issues"`
+}
+
+// AgenticTier is one score_breakdown tier (essential or recommended). Earned
+// and Available are floats — the API reports 63.5 / 17.9, not whole numbers.
+type AgenticTier struct {
+	Earned    float64 `json:"earned"`
+	Available float64 `json:"available"`
+	Passing   int     `json:"passing"`
+	Total     int     `json:"total"`
+}
+
+// AgenticBonus carries the bonus-tier points; Points is a float like the
+// other tiers.
+type AgenticBonus struct {
+	Points          float64 `json:"points"`
+	PositiveSignals int     `json:"positive_signals"`
+}
+
+// AgenticBreakdown groups the essential, recommended, and bonus tiers.
+type AgenticBreakdown struct {
+	Essential   AgenticTier  `json:"essential"`
+	Recommended AgenticTier  `json:"recommended"`
+	Bonus       AgenticBonus `json:"bonus"`
+}
+
+// AgenticIssue is one check the scanner evaluated, but issues[] carries ONLY
+// non-passing checks (result is "failed" or "partial"); a check absent from
+// issues[] is passing.
+type AgenticIssue struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Tier           string `json:"tier"`
+	Result         string `json:"result"`
+	Details        string `json:"details"`
+	Recommendation string `json:"recommendation"`
+}
+
+// ParseAgenticReport decodes a raw GET /api/v1/report response.
+func ParseAgenticReport(raw json.RawMessage) (*AgenticReport, error) {
+	var r AgenticReport
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("parsing is-agentic report: %w", err)
+	}
+	return &r, nil
+}
+
+// AgenticStatus returns a normalized status for one is-agentic check id:
+// "pass", "partial" or "fail".
+//
+// is-agentic's issues[] carries ONLY non-passing checks. Verified against
+// score_breakdown on three sites — the expected non-passing count
+// (essential.total-essential.passing)+(recommended.total-recommended.passing)
+// matched len(issues) exactly every time:
+//
+//	vercel.com  essential 8/11  recommended 17/22  -> 8 expected,  8 issues
+//	stripe.com  essential 6/11  recommended 11/21  -> 15 expected, 15 issues
+//	sqlite.org  essential 2/7   recommended 3/11   -> 13 expected, 13 issues
+//
+// So an id absent from issues[] is passing. The same numbers show the tier
+// totals themselves vary per site, which is the floating denominator that
+// makes the two scanners' scores incomparable.
+func (r *AgenticReport) AgenticStatus(id string) string {
+	for _, iss := range r.Issues {
+		if iss.ID == id {
+			switch iss.Result {
+			case "partial":
+				return "partial"
+			default:
+				return "fail"
+			}
+		}
+	}
+	return "pass"
+}
+
+// FailingIssues returns the issues whose result is not passing, sorted by tier
+// (essential first) then id.
+func (r *AgenticReport) FailingIssues() []AgenticIssue {
+	rank := map[string]int{"essential": 0, "recommended": 1}
+	out := make([]AgenticIssue, 0, len(r.Issues))
+	for _, iss := range r.Issues {
+		if iss.Result == "pass" {
+			continue
+		}
+		out = append(out, iss)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		ri, rj := rank[out[i].Tier], rank[out[j].Tier]
+		if ri != rj {
+			return ri < rj
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// AgenticOpenItems maps every non-passing issue into the shared OpenItem advice
+// shape. issues[].recommendation is a copy-paste fix prompt, directly analogous
+// to isitagentready's nextLevel.requirements[].prompt, so `advice` and
+// `open-advice` render both scanners through one code path.
+func AgenticOpenItems(r *AgenticReport) []OpenItem {
+	score := r.Score // local copy so &score stays stable (never the loop var)
+	out := make([]OpenItem, 0, len(r.Issues))
+	for _, iss := range r.FailingIssues() {
+		desc := iss.Name
+		if iss.Details != "" {
+			desc = iss.Name + " — " + iss.Details
+		}
+		out = append(out, OpenItem{
+			URL:         r.Target,
+			Source:      SourceIsAgentic,
+			Score:       &score,
+			ScoreLabel:  r.ScoreLabel,
+			Check:       iss.ID,
+			Description: desc,
+			Prompt:      iss.Recommendation,
+		})
+	}
+	return out
+}
+
+// CrossCheck pairs one isitagentready check id with the is-agentic check id
+// that measures the same thing.
+type CrossCheck struct {
+	IsItAgentReady string
+	IsAgentic      string
+	Label          string
+}
+
+// CrossCheckPairs is a deliberately conservative overlap table. It was derived
+// from the real id sets of both scanners: isitagentready's 20 ids across five
+// categories, and 26 is-agentic ids observed by probing seven sites. Only these
+// four pairs measure the same property, so only these four can carry an
+// agree/disagree verdict.
+//
+// Deliberately EXCLUDED near-misses — do not "fix" these omissions:
+//   - apiCatalog vs openapi-spec: apiCatalog is RFC 9727 .well-known/api-catalog,
+//     a catalog *of* APIs ("API Catalog found with 2 APIs listed"); openapi-spec
+//     is the OpenAPI document itself. A site can publish either without the other.
+//   - robotsTxtAiRules vs bot-detection: robots.txt AI directives are not WAF blocking.
+//   - robotsTxt vs agent-crawler-reachability: reachability is strictly broader.
+//   - oauthProtectedResource vs scoped-permissions: RFC 9728 metadata is not scope granularity.
+var CrossCheckPairs = []CrossCheck{
+	{"sitemap", "sitemap", "Sitemap published"},
+	{"markdownNegotiation", "markdown-negotiation-vary", "Markdown content negotiation"},
+	{"mcpServerCard", "mcp-server", "MCP server manifest"},
+	{"oauthDiscovery", "oauth-support", "OAuth 2.0 discovery"},
+}
+
+// CrossRefIsItAgentReady is isitagentready.com's native verdict.
+type CrossRefIsItAgentReady struct {
+	Level     int    `json:"level"`
+	LevelName string `json:"levelName"`
+	Pass      int    `json:"pass"`
+	Fail      int    `json:"fail"`
+	Neutral   int    `json:"neutral"`
+	Total     int    `json:"total"`
+	ScannedAt string `json:"scannedAt"`
+	SiteError bool   `json:"siteError,omitempty"`
+}
+
+// CrossRefIsAgentic is is-agentic.com's native verdict. EligibleChecks is a
+// per-site floating denominator, which is why the two scores are never merged.
+type CrossRefIsAgentic struct {
+	Score              int     `json:"score"`
+	ScoreLabel         string  `json:"scoreLabel"`
+	EligibleChecks     int     `json:"eligibleChecks"`
+	EssentialPassing   int     `json:"essentialPassing"`
+	EssentialTotal     int     `json:"essentialTotal"`
+	RecommendedPassing int     `json:"recommendedPassing"`
+	RecommendedTotal   int     `json:"recommendedTotal"`
+	BonusPoints        float64 `json:"bonusPoints"`
+	ScannedAt          string  `json:"scannedAt"`
+}
+
+// CrossRefAgreement is one genuinely-overlapping check seen by both scanners.
+type CrossRefAgreement struct {
+	Label                string `json:"label"`
+	IsItAgentReadyCheck  string `json:"isitagentreadyCheck"`
+	IsAgenticCheck       string `json:"isAgenticCheck"`
+	IsItAgentReadyStatus string `json:"isitagentreadyStatus"`
+	IsAgenticStatus      string `json:"isAgenticStatus"`
+	Verdict              string `json:"verdict"` // agree | partial | disagree | unknown
+}
+
+// CrossRefResult is both scanners' native verdicts side by side plus the
+// overlap table. It deliberately carries NO merged or rescaled score.
+type CrossRefResult struct {
+	URL            string                  `json:"url"`
+	IsItAgentReady *CrossRefIsItAgentReady `json:"isitagentready"`
+	IsAgentic      *CrossRefIsAgentic      `json:"isAgentic"`
+	Overlap        []CrossRefAgreement     `json:"overlap"`
+	Notes          []string                `json:"notes"`
+}
+
+// BuildCrossRef assembles both native verdicts and the overlap verdicts.
+// Either report may be nil (that scanner had no data); the corresponding
+// pointer is then nil and every overlap verdict is "unknown".
+func BuildCrossRef(url string, iar *Report, ag *AgenticReport) CrossRefResult {
+	res := CrossRefResult{URL: url, Overlap: []CrossRefAgreement{}}
+	if iar == nil && ag == nil {
+		return res
+	}
+	var iarStatus func(string) string
+	var agStatus func(string) string
+	if iar != nil {
+		pass, fail, neutral, total := iar.Counts()
+		cr := &CrossRefIsItAgentReady{
+			Level: iar.Level, LevelName: iar.LevelName,
+			Pass: pass, Fail: fail, Neutral: neutral, Total: total,
+			ScannedAt: iar.ScannedAt,
+		}
+		if iar.SiteError != nil {
+			cr.SiteError = true
+		}
+		res.IsItAgentReady = cr
+		st := iar.statusMap()
+		iarStatus = func(id string) string {
+			s, ok := st[id]
+			if !ok {
+				return "-"
+			}
+			return s
+		}
+	}
+	if ag != nil {
+		cr := &CrossRefIsAgentic{
+			Score: ag.Score, ScoreLabel: ag.ScoreLabel, EligibleChecks: ag.EligibleChecks,
+			EssentialPassing:   ag.ScoreBreakdown.Essential.Passing,
+			EssentialTotal:     ag.ScoreBreakdown.Essential.Total,
+			RecommendedPassing: ag.ScoreBreakdown.Recommended.Passing,
+			RecommendedTotal:   ag.ScoreBreakdown.Recommended.Total,
+			BonusPoints:        ag.ScoreBreakdown.Bonus.Points,
+			ScannedAt:          ag.ScannedAt,
+		}
+		res.IsAgentic = cr
+		agStatus = func(id string) string { return ag.AgenticStatus(id) }
+	}
+
+	for _, pair := range CrossCheckPairs {
+		iarS := "-"
+		if iarStatus != nil {
+			iarS = iarStatus(pair.IsItAgentReady)
+		}
+		agS := "-"
+		if agStatus != nil {
+			agS = agStatus(pair.IsAgentic)
+		}
+		verdict := "unknown"
+		if iarS != "-" && agS != "-" {
+			verdict = crossVerdict(iarS, agS)
+		}
+		res.Overlap = append(res.Overlap, CrossRefAgreement{
+			Label:                pair.Label,
+			IsItAgentReadyCheck:  pair.IsItAgentReady,
+			IsAgenticCheck:       pair.IsAgentic,
+			IsItAgentReadyStatus: iarS,
+			IsAgenticStatus:      agS,
+			Verdict:              verdict,
+		})
+	}
+
+	// Always state the two scales are not comparable: they use different
+	// denominators (fixed 5-category set vs per-site eligible checks), so only
+	// the listed overlapping checks can carry a verdict.
+	res.Notes = append(res.Notes, "isitagentready reports a Level 0-5 over five fixed categories; is-agentic reports a score 0-100 over a per-site floating denominator. The two scales are not comparable and are never merged; only the listed overlapping checks carry an agree/disagree verdict.")
+
+	// Staleness guard: is-agentic reports can be arbitrarily old (sqlite.org
+	// was 2 days stale). When the two scans are far apart in time, flag it so a
+	// disagreement is not misread as a live regression.
+	if iar != nil && ag != nil && iar.ScannedAt != "" && ag.ScannedAt != "" {
+		ti := cliutil.ParseStoredTime(iar.ScannedAt)
+		ta := cliutil.ParseStoredTime(ag.ScannedAt)
+		if !ti.IsZero() && !ta.IsZero() {
+			// Absolute gap: either scanner can be the stale one. is-agentic
+			// serves cached reports (sqlite.org was 2 days old) and the local
+			// isitagentready scan can equally be the older of the two.
+			diff := ti.Sub(ta)
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > 24*time.Hour {
+				res.Notes = append(res.Notes, fmt.Sprintf("the two scans are %s apart (isitagentready %s, is-agentic %s); they may disagree simply because they describe different points in time.", diff.Round(time.Hour), iar.ScannedAt, ag.ScannedAt))
+			}
+		}
+	}
+	return res
+}
+
+// crossVerdict ranks each side — pass=2, neutral/partial=1, fail=0 — then:
+// equal rank -> agree; difference of 1 -> partial; difference of 2 -> disagree.
+func crossVerdict(iarStatus, agStatus string) string {
+	rank := func(s string) int {
+		switch s {
+		case "pass":
+			return 2
+		case "neutral", "partial":
+			return 1
+		default: // fail
+			return 0
+		}
+	}
+	d := rank(iarStatus) - rank(agStatus)
+	if d < 0 {
+		d = -d
+	}
+	switch d {
+	case 0:
+		return "agree"
+	case 1:
+		return "partial"
+	default:
+		return "disagree"
+	}
+}

--- a/library/developer-tools/isitagentready/internal/store/agentic_test.go
+++ b/library/developer-tools/isitagentready/internal/store/agentic_test.go
@@ -1,0 +1,376 @@
+// Copyright 2026 bobe and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// vercelBody is the literal upstream is-agentic.com report body for vercel.com
+// (verified, do not alter). The float Earned/Available/Points fields are the
+// shape bug most likely to slip — 63.5 / 17.9 / 5 must decode as float64.
+const vercelBody = `{"score":86,"score_label":"Strong technical baseline","eligible_checks":33,
+ "score_breakdown":{
+   "essential":{"earned":63.5,"available":80,"passing":8,"total":11},
+   "recommended":{"earned":17.9,"available":20,"passing":17,"total":22},
+   "bonus":{"points":5,"positive_signals":38}},
+ "issues":[{"id":"agent-friendly-404","name":"Agent-friendly 404s","tier":"essential",
+            "result":"failed","details":"...","recommendation":"..."}]}`
+
+func TestParseAgenticReportFloats(t *testing.T) {
+	r, err := ParseAgenticReport(json.RawMessage(vercelBody))
+	if err != nil {
+		t.Fatalf("ParseAgenticReport: %v", err)
+	}
+	if r.Score != 86 || r.ScoreLabel != "Strong technical baseline" || r.EligibleChecks != 33 {
+		t.Fatalf("headline = %d/%q/%d", r.Score, r.ScoreLabel, r.EligibleChecks)
+	}
+	if r.ScoreBreakdown.Essential.Earned != 63.5 {
+		t.Fatalf("essential.earned = %v, want 63.5 (float)", r.ScoreBreakdown.Essential.Earned)
+	}
+	if r.ScoreBreakdown.Recommended.Earned != 17.9 {
+		t.Fatalf("recommended.earned = %v, want 17.9 (float)", r.ScoreBreakdown.Recommended.Earned)
+	}
+	if r.ScoreBreakdown.Bonus.Points != 5 {
+		t.Fatalf("bonus.points = %v, want 5 (float)", r.ScoreBreakdown.Bonus.Points)
+	}
+	if r.ScoreBreakdown.Essential.Passing != 8 || r.ScoreBreakdown.Essential.Total != 11 {
+		t.Fatalf("essential counts = %d/%d", r.ScoreBreakdown.Essential.Passing, r.ScoreBreakdown.Essential.Total)
+	}
+	if r.ScoreBreakdown.Essential.Available != 80 {
+		t.Fatalf("essential.available = %v, want 80", r.ScoreBreakdown.Essential.Available)
+	}
+}
+
+func TestAgenticStatus(t *testing.T) {
+	body := `{"score":50,"score_label":"x","eligible_checks":3,"scanned_at":"2026-06-22T10:00:00Z",
+	 "score_breakdown":{},
+	 "issues":[
+	   {"id":"a","name":"a","tier":"essential","result":"failed","details":"","recommendation":"fix a"},
+	   {"id":"b","name":"b","tier":"recommended","result":"partial","details":"","recommendation":"fix b"}]}`
+	r, err := ParseAgenticReport(json.RawMessage(body))
+	if err != nil {
+		t.Fatalf("ParseAgenticReport: %v", err)
+	}
+	if got := r.AgenticStatus("a"); got != "fail" {
+		t.Fatalf("AgenticStatus(a) = %q, want fail", got)
+	}
+	if got := r.AgenticStatus("b"); got != "partial" {
+		t.Fatalf("AgenticStatus(b) = %q, want partial", got)
+	}
+	if got := r.AgenticStatus("c"); got != "pass" {
+		t.Fatalf("AgenticStatus(c) absent = %q, want pass", got)
+	}
+}
+
+func TestAgenticOpenItems(t *testing.T) {
+	body := `{"target":"https://vercel.com","score_label":"Strong technical baseline","score":86,"eligible_checks":33,
+	 "score_breakdown":{},"issues":[
+	   {"id":"agent-friendly-404","name":"Agent-friendly 404s","tier":"essential","result":"failed","details":"no 404 page","recommendation":"Add an agent-friendly 404"},
+	   {"id":"mcp-server","name":"MCP server","tier":"recommended","result":"partial","details":"","recommendation":"Expose an MCP server"}]}`
+	r, err := ParseAgenticReport(json.RawMessage(body))
+	if err != nil {
+		t.Fatalf("ParseAgenticReport: %v", err)
+	}
+	items := AgenticOpenItems(r)
+	if len(items) != 2 {
+		t.Fatalf("AgenticOpenItems = %d items, want 2", len(items))
+	}
+	for _, it := range items {
+		if it.Source != SourceIsAgentic {
+			t.Fatalf("Source = %q, want is-agentic", it.Source)
+		}
+		if it.Score == nil || *it.Score != 86 {
+			t.Fatalf("Score = %v, want 86", it.Score)
+		}
+		if it.ScoreLabel != "Strong technical baseline" {
+			t.Fatalf("ScoreLabel = %q", it.ScoreLabel)
+		}
+		if it.Level != 0 || it.LevelName != "" {
+			t.Fatalf("is-agentic must leave Level 0/empty, got %d/%q", it.Level, it.LevelName)
+		}
+	}
+	if items[0].Check != "agent-friendly-404" || items[0].Prompt != "Add an agent-friendly 404" {
+		t.Fatalf("item[0] = %+v", items[0])
+	}
+	if items[0].Description != "Agent-friendly 404s — no 404 page" {
+		t.Fatalf("Description with details = %q", items[0].Description)
+	}
+	if items[1].Check != "mcp-server" || items[1].Description != "MCP server" {
+		t.Fatalf("item[1] = %+v", items[1])
+	}
+}
+
+func TestFailingIssuesSorted(t *testing.T) {
+	body := `{"target":"x","score":10,"score_label":"x","eligible_checks":2,"score_breakdown":{},
+	 "issues":[
+	   {"id":"z","tier":"recommended","result":"failed"},
+	   {"id":"a","tier":"essential","result":"failed"},
+	   {"id":"p","tier":"essential","result":"pass"}]}`
+	r, err := ParseAgenticReport(json.RawMessage(body))
+	if err != nil {
+		t.Fatalf("ParseAgenticReport: %v", err)
+	}
+	issues := r.FailingIssues()
+	if len(issues) != 2 {
+		t.Fatalf("FailingIssues = %d, want 2 (pass excluded)", len(issues))
+	}
+	if issues[0].ID != "a" || issues[1].ID != "z" {
+		t.Fatalf("FailingIssues order = %s,%s; want essential-then-id", issues[0].ID, issues[1].ID)
+	}
+}
+
+func TestBuildCrossRefVerdicts(t *testing.T) {
+	mkIar := func(statuses map[string]string) *Report {
+		rep, _ := ParseReport(rawReport("https://x.com", "2026-06-22T10:00:00Z", 2, "L", statuses, nil))
+		return rep
+	}
+	mkAg := func(m map[string]string, scannedAt string) *AgenticReport {
+		ag := &AgenticReport{Target: "https://x.com", Score: 50, ScoreLabel: "x", ScannedAt: scannedAt}
+		for id, res := range m {
+			ag.Issues = append(ag.Issues, AgenticIssue{ID: id, Tier: "essential", Result: res})
+		}
+		return ag
+	}
+
+	cases := []struct {
+		name    string
+		iar     *Report
+		ag      *AgenticReport
+		label   string // cross-pair label we assert on
+		verdict string
+	}{
+		// sitemap: iar pass (2), ag fail (0) -> diff 2 -> disagree
+		{"disagree", mkIar(map[string]string{"sitemap": "pass"}), mkAg(map[string]string{"sitemap": "failed"}, "2026-06-22T10:00:00Z"), "Sitemap published", "disagree"},
+		// markdownNegotiation: iar neutral (1), ag pass (2) -> diff 1 -> partial
+		{"partial", mkIar(map[string]string{"markdownNegotiation": "neutral"}), mkAg(map[string]string{"markdown-negotiation-vary": "pass"}, "2026-06-22T10:00:00Z"), "Markdown content negotiation", "partial"},
+		// mcpServerCard: iar pass (2), ag partial (1) -> diff 1 -> partial
+		{"partial2", mkIar(map[string]string{"mcpServerCard": "pass"}), mkAg(map[string]string{"mcp-server": "partial"}, "2026-06-22T10:00:00Z"), "MCP server manifest", "partial"},
+		// oauthDiscovery: iar fail (0), ag fail (0) -> diff 0 -> agree
+		{"agree", mkIar(map[string]string{"oauthDiscovery": "fail"}), mkAg(map[string]string{"oauth-support": "failed"}, "2026-06-22T10:00:00Z"), "OAuth 2.0 discovery", "agree"},
+		// mcpServerCard: iar lacks the check (so its status is "-") while ag
+		// has the pair -> the is-agentic side has data but isitagentready does
+		// not, so verdict is unknown.
+		{"unknown", mkIar(map[string]string{"sitemap": "pass"}), mkAg(map[string]string{"mcp-server": "failed"}, "2026-06-22T10:00:00Z"), "MCP server manifest", "unknown"},
+		// ag nil -> all unknown
+		{"ag-nil", mkIar(map[string]string{"sitemap": "pass"}), nil, "Sitemap published", "unknown"},
+		// iar nil -> all unknown
+		{"iar-nil", nil, mkAg(map[string]string{"sitemap": "failed"}, "2026-06-22T10:00:00Z"), "Sitemap published", "unknown"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := BuildCrossRef("https://x.com", c.iar, c.ag)
+			for _, o := range res.Overlap {
+				if o.Label == c.label {
+					if o.Verdict != c.verdict {
+						t.Fatalf("verdict for %q = %q, want %q (statuses %q / %q)", o.Label, o.Verdict, c.verdict, o.IsItAgentReadyStatus, o.IsAgenticStatus)
+					}
+					return
+				}
+			}
+			t.Fatalf("overlap pair %q not found in %+v", c.label, res.Overlap)
+		})
+	}
+}
+
+func TestBuildCrossRefNotes(t *testing.T) {
+	iar, _ := ParseReport(rawReport("https://x.com", "2026-06-22T10:00:00Z", 2, "L", map[string]string{"sitemap": "pass"}, nil))
+	ag := &AgenticReport{Target: "https://x.com", Score: 50, ScoreLabel: "x", ScannedAt: "2026-06-20T10:00:00Z"}
+	res := BuildCrossRef("https://x.com", iar, ag)
+
+	joined := strings.Join(res.Notes, "\n")
+	// The not-comparable note must always be present and must actually name
+	// why the two scales differ, not merely be a long string.
+	for _, want := range []string{"Level 0-5", "score 0-100", "never merged"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("scale note missing %q; notes = %q", want, res.Notes)
+		}
+	}
+	// 2026-06-22 vs 2026-06-20 = 48h apart -> staleness note naming the gap.
+	if !strings.Contains(joined, "48h") {
+		t.Fatalf("expected a staleness note naming the 48h gap, got %q", res.Notes)
+	}
+}
+
+// TestBuildCrossRefNotesFreshNoStaleness pins the negative case: scans close in
+// time must NOT produce a staleness note, otherwise the note is noise.
+func TestBuildCrossRefNotesFreshNoStaleness(t *testing.T) {
+	iar, _ := ParseReport(rawReport("https://x.com", "2026-06-22T10:00:00Z", 2, "L", map[string]string{"sitemap": "pass"}, nil))
+	ag := &AgenticReport{Target: "https://x.com", Score: 50, ScoreLabel: "x", ScannedAt: "2026-06-22T12:00:00Z"}
+	res := BuildCrossRef("https://x.com", iar, ag)
+	for _, n := range res.Notes {
+		if strings.Contains(n, "apart") {
+			t.Fatalf("did not expect a staleness note for a 2h gap, got %q", n)
+		}
+	}
+}
+
+// TestBuildCrossRefStalenessIsBidirectional pins that an is-agentic report
+// NEWER than the isitagentready one still trips the staleness note — the gap
+// matters in both directions.
+func TestBuildCrossRefStalenessIsBidirectional(t *testing.T) {
+	iar, _ := ParseReport(rawReport("https://x.com", "2026-06-20T10:00:00Z", 2, "L", map[string]string{"sitemap": "pass"}, nil))
+	ag := &AgenticReport{Target: "https://x.com", Score: 50, ScoreLabel: "x", ScannedAt: "2026-06-22T10:00:00Z"}
+	res := BuildCrossRef("https://x.com", iar, ag)
+	if !strings.Contains(strings.Join(res.Notes, "\n"), "48h") {
+		t.Fatalf("expected a staleness note when is-agentic is the newer scan, got %q", res.Notes)
+	}
+}
+
+func TestFilterSourceAndSourceOrDefault(t *testing.T) {
+	recs := []ScanRecord{
+		{URL: "https://old.com", ScannedAt: "t", Level: 2, LevelName: "L", Raw: json.RawMessage(`{}`), Source: ""}, // pre-amend
+		{URL: "https://ag.com", Source: SourceIsAgentic, ScannedAt: "t", Score: intPtr(70), Raw: json.RawMessage(`{}`)},
+	}
+	iar := FilterSource(recs, SourceIsItAgentReady)
+	if len(iar) != 1 || NormalizeURL(iar[0].URL) != "old.com" {
+		t.Fatalf("isitagentready filter = %+v", iar)
+	}
+	ag := FilterSource(recs, SourceIsAgentic)
+	if len(ag) != 1 || NormalizeURL(ag[0].URL) != "ag.com" {
+		t.Fatalf("is-agentic filter = %+v", ag)
+	}
+	// SourceOrDefault backfills empty to isitagentready.
+	if recs[0].SourceOrDefault() != SourceIsItAgentReady {
+		t.Fatalf("SourceOrDefault empty = %q", recs[0].SourceOrDefault())
+	}
+	if recs[1].SourceOrDefault() != SourceIsAgentic {
+		t.Fatalf("SourceOrDefault is-agentic = %q", recs[1].SourceOrDefault())
+	}
+}
+
+func intPtr(v int) *int { return &v }
+
+func TestAssertSameSource(t *testing.T) {
+	a := ScanRecord{URL: "a", Source: SourceIsItAgentReady}
+	b := ScanRecord{URL: "b", Source: SourceIsItAgentReady}
+	if err := AssertSameSource(a, b); err != nil {
+		t.Fatalf("same source errored: %v", err)
+	}
+	c := ScanRecord{URL: "c", Source: SourceIsAgentic}
+	if err := AssertSameSource(a, c); err == nil {
+		t.Fatalf("different sources did not error")
+	}
+}
+
+// agenticRec builds an is-agentic ScanRecord for store-level ranking tests.
+func agenticRec(url, at string, score int, issues []struct {
+	ID, Tier, Result string
+}) ScanRecord {
+	ag := &AgenticReport{Target: url, Score: score, ScoreLabel: "L", ScannedAt: at}
+	for _, is := range issues {
+		ag.Issues = append(ag.Issues, AgenticIssue{ID: is.ID, Tier: is.Tier, Result: is.Result})
+	}
+	b, _ := json.Marshal(ag)
+	return ScanRecord{URL: url, Source: SourceIsAgentic, ScannedAt: at, Score: &score, Raw: b}
+}
+
+func TestEvaluateAgenticGate(t *testing.T) {
+	mk := func(score int, issues ...AgenticIssue) *AgenticReport {
+		return &AgenticReport{Target: "https://x.com", Score: score, ScoreLabel: "x", Issues: issues}
+	}
+	t.Run("below score fails", func(t *testing.T) {
+		res := EvaluateAgenticGate(mk(50), nil, 60, false)
+		if res.Pass {
+			t.Fatalf("expected fail for score 50 < min 60, got %+v", res)
+		}
+		if res.Level != 0 {
+			t.Fatalf("is-agentic gate must leave Level 0, got %d", res.Level)
+		}
+		if res.Score == nil || *res.Score != 50 {
+			t.Fatalf("Score = %v, want 50", res.Score)
+		}
+	})
+	t.Run("meets score passes", func(t *testing.T) {
+		res := EvaluateAgenticGate(mk(80), nil, 60, false)
+		if !res.Pass {
+			t.Fatalf("expected pass, got %+v", res)
+		}
+	})
+	t.Run("no-regress catches a passing->failing check", func(t *testing.T) {
+		// prev has no "x" issue -> passing. latest has "x" failed -> regressed.
+		prev := mk(70)
+		latest := mk(70, AgenticIssue{ID: "x", Tier: "essential", Result: "failed"})
+		res := EvaluateAgenticGate(latest, prev, 0, true)
+		if res.Pass {
+			t.Fatalf("expected fail under no-regress, got %+v", res)
+		}
+		if len(res.Regressions) != 1 || res.Regressions[0] != "x" {
+			t.Fatalf("Regressions = %v, want [x]", res.Regressions)
+		}
+	})
+	t.Run("no-regress ignores an improving check", func(t *testing.T) {
+		prev := mk(70, AgenticIssue{ID: "x", Tier: "essential", Result: "failed"})
+		latest := mk(80) // x now absent -> passing
+		res := EvaluateAgenticGate(latest, prev, 0, true)
+		if !res.Pass {
+			t.Fatalf("expected pass (x improved), got %+v", res)
+		}
+	})
+}
+
+func TestDiffAgenticIssues(t *testing.T) {
+	fromNoIssues := &AgenticReport{Target: "u", Issues: nil}
+	fromFail := &AgenticReport{Target: "u", Issues: []AgenticIssue{{ID: "x", Tier: "essential", Result: "failed"}}}
+	toPass := &AgenticReport{Target: "u", Issues: nil}
+
+	// failed -> absent: x goes from failing to passing -> improved.
+	tr := DiffAgenticIssues(fromFail, toPass)
+	foundImproved := false
+	for _, c := range tr {
+		if c.Check == "x" && c.Change == "improved" {
+			foundImproved = true
+		}
+	}
+	if !foundImproved {
+		t.Fatalf("expected x improved (failed -> absent), got %+v", tr)
+	}
+
+	// absent -> failed: x goes from passing to failing -> regressed.
+	tr2 := DiffAgenticIssues(fromNoIssues, fromFail)
+	foundRegressed := false
+	for _, c := range tr2 {
+		if c.Check == "x" && c.Change == "regressed" {
+			foundRegressed = true
+		}
+	}
+	if !foundRegressed {
+		t.Fatalf("expected x regressed (absent -> failed), got %+v", tr2)
+	}
+}
+
+func TestRankRecordsAgenticByScore(t *testing.T) {
+	recs := []ScanRecord{
+		agenticRec("https://mid.example", "t", 60, nil),
+		agenticRec("https://bad.example", "t", 40, nil),
+		agenticRec("https://good.example", "t", 80, nil),
+	}
+	ranked := RankRecords(recs, "level") // "level" maps to score asc worst-first for agentic
+	if ranked[0].URL != "https://bad.example" || ranked[1].URL != "https://mid.example" || ranked[2].URL != "https://good.example" {
+		t.Fatalf("RankRecords(agentic, level) order = %v, %v, %v; want bad, mid, good",
+			ranked[0].URL, ranked[1].URL, ranked[2].URL)
+	}
+}
+
+func TestRankRecordsAgenticByFailing(t *testing.T) {
+	// bad has 2 non-passing, mid 1, good 0.
+	mkIss := func(ids []string) []struct{ ID, Tier, Result string } {
+		var out []struct{ ID, Tier, Result string }
+		for _, id := range ids {
+			out = append(out, struct{ ID, Tier, Result string }{id, "essential", "failed"})
+		}
+		return out
+	}
+	recs := []ScanRecord{
+		agenticRec("https://mid.example", "t", 60, mkIss([]string{"a"})),
+		agenticRec("https://good.example", "t", 90, nil),
+		agenticRec("https://bad.example", "t", 40, mkIss([]string{"a", "b"})),
+	}
+	ranked := RankRecords(recs, "failing")
+	if ranked[0].URL != "https://bad.example" || ranked[1].URL != "https://mid.example" || ranked[2].URL != "https://good.example" {
+		t.Fatalf("RankRecords(agentic, failing) order = %v, %v, %v",
+			ranked[0].URL, ranked[1].URL, ranked[2].URL)
+	}
+}

--- a/library/developer-tools/isitagentready/internal/store/store.go
+++ b/library/developer-tools/isitagentready/internal/store/store.go
@@ -25,6 +25,17 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/developer-tools/isitagentready/internal/cliutil"
 )
 
+// Scanner sources. isitagentready.com reports a Level 0-5 across five fixed
+// categories; is-agentic.com reports a score 0-100 over a per-site floating
+// denominator. The two scales are never merged — see the crossref command.
+const (
+	SourceIsItAgentReady = "isitagentready"
+	SourceIsAgentic      = "is-agentic"
+)
+
+// ValidSources lists every scanner source the CLI can read, in flag-help order.
+func ValidSources() []string { return []string{SourceIsItAgentReady, SourceIsAgentic} }
+
 // storeMu guards the JSONL store so concurrent scans (e.g. compare's parallel
 // fan-out) cannot interleave a write with another write or read within this
 // process. Append takes the write lock; Load takes the read lock.
@@ -33,11 +44,21 @@ var storeMu sync.RWMutex
 // ScanRecord is one persisted scan: one line in the JSONL store. Raw holds the
 // full upstream report so any command can reconstruct any view offline.
 type ScanRecord struct {
-	URL       string          `json:"url"`
-	ScannedAt string          `json:"scannedAt"`
-	Level     int             `json:"level"`
-	LevelName string          `json:"levelName"`
-	Raw       json.RawMessage `json:"raw"`
+	URL string `json:"url"`
+	// Source is the scanner that produced this record. Empty on every line
+	// written before the multi-scanner amend; SourceOrDefault backfills those
+	// to SourceIsItAgentReady so old history keeps its meaning without a
+	// migration pass over the JSONL store.
+	Source    string `json:"source,omitempty"`
+	ScannedAt string `json:"scannedAt"`
+	Level     int    `json:"level"`
+	LevelName string `json:"levelName"`
+	// Score and ScoreLabel carry the is-agentic headline. They are pointers /
+	// omitempty because they are meaningless for isitagentready records —
+	// unlike Level, where 0 is a real readiness level and must never be elided.
+	Score      *int            `json:"score,omitempty"`
+	ScoreLabel string          `json:"scoreLabel,omitempty"`
+	Raw        json.RawMessage `json:"raw"`
 }
 
 // Report is the parsed shape of a POST /api/scan response.
@@ -96,6 +117,39 @@ func ParseReport(raw json.RawMessage) (*Report, error) {
 		return nil, fmt.Errorf("parsing scan report: %w", err)
 	}
 	return &r, nil
+}
+
+// SourceOrDefault returns the record's scanner, backfilling the pre-amend
+// default for JSONL lines written before Source existed.
+func (r ScanRecord) SourceOrDefault() string {
+	if r.Source == "" {
+		return SourceIsItAgentReady
+	}
+	return r.Source
+}
+
+// FilterSource returns only the records produced by one scanner. Every command
+// that reads the store must filter through this before any comparison, ranking
+// or diff, so two scanners' incompatible numbers can never mix.
+func FilterSource(recs []ScanRecord, source string) []ScanRecord {
+	var out []ScanRecord
+	for _, r := range recs {
+		if r.SourceOrDefault() == source {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// AssertSameSource errors when two records come from different scanners. Belt
+// and braces for the two-record paths (diff, gate baseline) on top of
+// FilterSource.
+func AssertSameSource(a, b ScanRecord) error {
+	as, bs := a.SourceOrDefault(), b.SourceOrDefault()
+	if as != bs {
+		return fmt.Errorf("records come from different scanners: %s and %s; they use incompatible scales and cannot be compared", as, bs)
+	}
+	return nil
 }
 
 // CheckRef is a flattened check with its category and id.
@@ -371,10 +425,15 @@ func regressedChecks(from, to *Report) []string {
 
 // GateResult is the outcome of a CI gate evaluation.
 type GateResult struct {
-	Pass        bool     `json:"pass"`
-	URL         string   `json:"url"`
-	Level       int      `json:"level"`
-	LevelName   string   `json:"levelName"`
+	Pass      bool   `json:"pass"`
+	URL       string `json:"url"`
+	Level     int    `json:"level"`
+	LevelName string `json:"levelName"`
+	// Score and ScoreLabel carry the is-agentic headline when the gate ran
+	// against that source; omitempty keeps them out of isitagentready gate JSON
+	// where they are meaningless (there, Level is the honest headline).
+	Score       *int     `json:"score,omitempty"`
+	ScoreLabel  string   `json:"scoreLabel,omitempty"`
 	MinLevel    int      `json:"minLevel"`
 	SiteError   bool     `json:"siteError"`
 	Regressions []string `json:"regressions,omitempty"`
@@ -417,11 +476,97 @@ func EvaluateGate(latest, prev *Report, minLevel int, noRegress, strict bool) Ga
 	return res
 }
 
+// EvaluateAgenticGate is the is-agentic counterpart to EvaluateGate. It fails
+// when the site's score is below minScore and, with noRegress, when a check
+// that was passing in the previous report is now failing or partial. is-agentic
+// has no level (its GateResult.Level is always 0); the honest headline is
+// carried in Score/ScoreLabel so the JSON stays truthful for both sources.
+func EvaluateAgenticGate(latest, prev *AgenticReport, minScore int, noRegress bool) GateResult {
+	score := latest.Score
+	res := GateResult{Pass: true, URL: latest.Target, Level: 0, Score: &score, ScoreLabel: latest.ScoreLabel}
+	if minScore > 0 && latest.Score < minScore {
+		res.Pass = false
+		res.Reasons = append(res.Reasons, fmt.Sprintf("score %d is below the required minimum %d", latest.Score, minScore))
+	}
+	if noRegress && prev != nil {
+		if regr := agenticRegressed(prev, latest); len(regr) > 0 {
+			res.Pass = false
+			res.Regressions = regr
+			res.Reasons = append(res.Reasons, fmt.Sprintf("%d check(s) regressed since the last scan: %s", len(regr), strings.Join(regr, ", ")))
+		}
+	}
+	if res.Pass && len(res.Reasons) == 0 {
+		if minScore > 0 {
+			res.Reasons = append(res.Reasons, fmt.Sprintf("score %d meets the required minimum %d", latest.Score, minScore))
+		} else {
+			res.Reasons = append(res.Reasons, "scan completed; no gate condition failed")
+		}
+	}
+	return res
+}
+
+// agenticRegressed returns the is-agentic issue ids that went from passing in
+// prev to non-passing (failed or partial) in latest, over the union of both
+// reports' issue ids.
+func agenticRegressed(prev, latest *AgenticReport) []string {
+	var out []string
+	for _, tr := range DiffAgenticIssues(prev, latest) {
+		if tr.Change == "regressed" && tr.From == "pass" {
+			out = append(out, tr.Check)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// DiffAgenticIssues compares two is-agentic reports over the union of their
+// issue ids, using AgenticStatus for each side. Because an id absent from a
+// report's issues[] is passing, a failed -> absent transition ranks as
+// improved (fail -> pass) and absent -> failed ranks as regressed (pass ->
+// fail). Transitions share the same change vocabulary as DiffChecks.
+
+func DiffAgenticIssues(from, to *AgenticReport) []CheckTransition {
+	seen := map[string]bool{}
+	var ids []string
+	for _, iss := range from.Issues {
+		if !seen[iss.ID] {
+			seen[iss.ID] = true
+			ids = append(ids, iss.ID)
+		}
+	}
+	for _, iss := range to.Issues {
+		if !seen[iss.ID] {
+			seen[iss.ID] = true
+			ids = append(ids, iss.ID)
+		}
+	}
+	sort.Strings(ids)
+	out := make([]CheckTransition, 0, len(ids))
+	for _, id := range ids {
+		f := from.AgenticStatus(id)
+		t := to.AgenticStatus(id)
+		var change string
+		switch {
+		case statusRank(t) < statusRank(f):
+			change = "regressed"
+		case statusRank(t) > statusRank(f):
+			change = "improved"
+		default:
+			change = "unchanged"
+		}
+		out = append(out, CheckTransition{Check: id, From: f, To: t, Change: change})
+	}
+	return out
+}
+
 // OpenItem is one still-open fix across the portfolio.
 type OpenItem struct {
 	URL         string `json:"url"`
+	Source      string `json:"source"`
 	Level       int    `json:"level"`
 	LevelName   string `json:"levelName"`
+	Score       *int   `json:"score,omitempty"`
+	ScoreLabel  string `json:"scoreLabel,omitempty"`
 	Check       string `json:"check"`
 	Description string `json:"description"`
 	Prompt      string `json:"prompt"`
@@ -437,23 +582,41 @@ func OpenAdvice(latestPerURL []ScanRecord, filterURL, filterCheck string) []Open
 		if filterURL != "" && !MatchURL(rec.URL, filterURL) {
 			continue
 		}
-		rep, err := ParseReport(rec.Raw)
-		if err != nil {
-			continue
-		}
-		for _, req := range rep.NextLevel.Requirements {
-			if filterCheck != "" && req.Check != filterCheck {
+		switch rec.SourceOrDefault() {
+		case SourceIsAgentic:
+			ag, err := ParseAgenticReport(rec.Raw)
+			if err != nil {
 				continue
 			}
-			out = append(out, OpenItem{
-				URL:         rep.URL,
-				Level:       rep.Level,
-				LevelName:   rep.LevelName,
-				Check:       req.Check,
-				Description: req.Description,
-				Prompt:      req.Prompt,
-				SkillURL:    req.SkillURL,
-			})
+			for _, item := range AgenticOpenItems(ag) {
+				if filterURL != "" && !MatchURL(item.URL, filterURL) {
+					continue
+				}
+				if filterCheck != "" && item.Check != filterCheck {
+					continue
+				}
+				out = append(out, item)
+			}
+		default: // SourceIsItAgentReady (including pre-amend backfill)
+			rep, err := ParseReport(rec.Raw)
+			if err != nil {
+				continue
+			}
+			for _, req := range rep.NextLevel.Requirements {
+				if filterCheck != "" && req.Check != filterCheck {
+					continue
+				}
+				out = append(out, OpenItem{
+					URL:         rep.URL,
+					Source:      SourceIsItAgentReady,
+					Level:       rep.Level,
+					LevelName:   rep.LevelName,
+					Check:       req.Check,
+					Description: req.Description,
+					Prompt:      req.Prompt,
+					SkillURL:    req.SkillURL,
+				})
+			}
 		}
 	}
 	return out
@@ -472,6 +635,16 @@ func failingCount(rec ScanRecord) int {
 // count (desc); any other value ranks by level (asc).
 func RankRecords(recs []ScanRecord, by string) []ScanRecord {
 	out := append([]ScanRecord(nil), recs...)
+	if len(out) == 0 {
+		return out
+	}
+	// A batch run is single-source because the store read is filtered by
+	// --source, so branch on the first record's backing scanner. is-agentic has
+	// no level: its Level is always 0, so Level ranking would collapse every
+	// site to a tie — rank by score (worst first) instead.
+	if out[0].SourceOrDefault() == SourceIsAgentic {
+		return rankAgentic(out, by)
+	}
 	if by == "failing" {
 		fc := map[string]int{}
 		for _, r := range out {
@@ -495,13 +668,52 @@ func RankRecords(recs []ScanRecord, by string) []ScanRecord {
 	return out
 }
 
+// rankAgentic ranks is-agentic records worst-first. The default ("level" maps
+// to score) ranks by score ascending so the lowest score leads; "failing"
+// ranks by non-passing issue count descending.
+func rankAgentic(recs []ScanRecord, by string) []ScanRecord {
+	score := map[string]int{}
+	nonPass := map[string]int{}
+	for _, r := range recs {
+		k := NormalizeURL(r.URL)
+		if ag, err := ParseAgenticReport(r.Raw); err == nil {
+			score[k] = ag.Score
+			nonPass[k] = len(ag.FailingIssues())
+		}
+	}
+	if by == "failing" {
+		sort.SliceStable(recs, func(i, j int) bool {
+			fi, fj := nonPass[NormalizeURL(recs[i].URL)], nonPass[NormalizeURL(recs[j].URL)]
+			if fi != fj {
+				return fi > fj
+			}
+			return score[NormalizeURL(recs[i].URL)] < score[NormalizeURL(recs[j].URL)]
+		})
+		return recs
+	}
+	// default: rank by score ascending (worst first), then URL.
+	sort.SliceStable(recs, func(i, j int) bool {
+		si, sj := score[NormalizeURL(recs[i].URL)], score[NormalizeURL(recs[j].URL)]
+		if si != sj {
+			return si < sj
+		}
+		return NormalizeURL(recs[i].URL) < NormalizeURL(recs[j].URL)
+	})
+	return recs
+}
+
 // HistoryEntry is one row of a URL's readiness timeline.
 type HistoryEntry struct {
-	ScannedAt string            `json:"scannedAt"`
-	Level     int               `json:"level"`
-	LevelName string            `json:"levelName"`
-	SiteError bool              `json:"siteError,omitempty"`
-	Flips     []CheckTransition `json:"flips,omitempty"`
+	ScannedAt string `json:"scannedAt"`
+	Level     int    `json:"level"`
+	LevelName string `json:"levelName"`
+	// Score/ScoreLabel carry the is-agentic headline for is-agentic history
+	// rows, where there is no level. omitempty keeps them out of isitagentready
+	// rows (there Level is the honest headline).
+	Score      *int              `json:"score,omitempty"`
+	ScoreLabel string            `json:"scoreLabel,omitempty"`
+	SiteError  bool              `json:"siteError,omitempty"`
+	Flips      []CheckTransition `json:"flips,omitempty"`
 }
 
 // BuildHistory turns an ascending history into timeline entries, computing the
@@ -509,26 +721,50 @@ type HistoryEntry struct {
 // check when non-empty.
 func BuildHistory(history []ScanRecord, filterCheck string) []HistoryEntry {
 	out := make([]HistoryEntry, 0, len(history))
-	var prev *Report
+	var prevR *Report
+	var prevA *AgenticReport
 	for _, rec := range history {
-		rep, err := ParseReport(rec.Raw)
-		if err != nil {
-			continue
-		}
-		entry := HistoryEntry{ScannedAt: rec.ScannedAt, Level: rep.Level, LevelName: rep.LevelName, SiteError: rep.SiteError != nil}
-		if prev != nil && prev.SiteError == nil && rep.SiteError == nil {
-			for _, tr := range DiffChecks(prev, rep) {
-				if tr.Change == "unchanged" {
-					continue
-				}
-				if filterCheck != "" && tr.Check != filterCheck {
-					continue
-				}
-				entry.Flips = append(entry.Flips, tr)
+		switch rec.SourceOrDefault() {
+		case SourceIsAgentic:
+			ag, err := ParseAgenticReport(rec.Raw)
+			if err != nil {
+				continue
 			}
+			sc := ag.Score
+			entry := HistoryEntry{ScannedAt: rec.ScannedAt, Score: &sc, ScoreLabel: ag.ScoreLabel}
+			if prevA != nil {
+				for _, tr := range DiffAgenticIssues(prevA, ag) {
+					if tr.Change == "unchanged" {
+						continue
+					}
+					if filterCheck != "" && tr.Check != filterCheck {
+						continue
+					}
+					entry.Flips = append(entry.Flips, tr)
+				}
+			}
+			out = append(out, entry)
+			prevA, prevR = ag, nil
+		default: // SourceIsItAgentReady (including pre-amend backfill)
+			rep, err := ParseReport(rec.Raw)
+			if err != nil {
+				continue
+			}
+			entry := HistoryEntry{ScannedAt: rec.ScannedAt, Level: rep.Level, LevelName: rep.LevelName, SiteError: rep.SiteError != nil}
+			if prevR != nil && prevR.SiteError == nil && rep.SiteError == nil {
+				for _, tr := range DiffChecks(prevR, rep) {
+					if tr.Change == "unchanged" {
+						continue
+					}
+					if filterCheck != "" && tr.Check != filterCheck {
+						continue
+					}
+					entry.Flips = append(entry.Flips, tr)
+				}
+			}
+			out = append(out, entry)
+			prevR, prevA = rep, nil
 		}
-		out = append(out, entry)
-		prev = rep
 	}
 	return out
 }
@@ -538,7 +774,11 @@ type CompareSite struct {
 	URL       string `json:"url"`
 	Level     int    `json:"level"`
 	LevelName string `json:"levelName"`
-	SiteError bool   `json:"siteError,omitempty"`
+	// Score/ScoreLabel carry the is-agentic headline for agentic compare rows
+	// where there is no level; omitempty keeps them out of isitagentready rows.
+	Score      *int   `json:"score,omitempty"`
+	ScoreLabel string `json:"scoreLabel,omitempty"`
+	SiteError  bool   `json:"siteError,omitempty"`
 }
 
 // CompareRow is one check's status across the compared sites.
@@ -586,6 +826,50 @@ func BuildCompare(reports []*Report) CompareResult {
 			} else {
 				row.Statuses[NormalizeURL(rep.URL)] = "-"
 			}
+		}
+		res.Checks = append(res.Checks, row)
+	}
+	return res
+}
+
+// BuildAgenticCompare builds the same check-by-check matrix shape as
+// BuildCompare but for is-agentic reports: one site per report, one row per
+// issue id (the union of all reports' ids), each site's cell its AgenticStatus,
+// and the issue's tier (essential/recommended) used as the Category column so
+// the shared matrix renderer works unchanged.
+func BuildAgenticCompare(reports []*AgenticReport) CompareResult {
+	res := CompareResult{}
+	category := map[string]string{}
+	seen := map[string]bool{}
+	var checkIDs []string
+	for _, rep := range reports {
+		if rep == nil {
+			continue
+		}
+		sc := rep.Score
+		res.Sites = append(res.Sites, CompareSite{URL: rep.Target, Level: 0, Score: &sc, ScoreLabel: rep.ScoreLabel})
+		for _, iss := range rep.Issues {
+			if !seen[iss.ID] {
+				seen[iss.ID] = true
+				checkIDs = append(checkIDs, iss.ID)
+				category[iss.ID] = iss.Tier
+			}
+		}
+	}
+	// Match BuildCompare's canonical order: group by tier, then id.
+	sort.SliceStable(checkIDs, func(i, j int) bool {
+		if category[checkIDs[i]] != category[checkIDs[j]] {
+			return category[checkIDs[i]] < category[checkIDs[j]]
+		}
+		return checkIDs[i] < checkIDs[j]
+	})
+	for _, id := range checkIDs {
+		row := CompareRow{Check: id, Category: category[id], Statuses: map[string]string{}}
+		for _, rep := range reports {
+			if rep == nil {
+				continue
+			}
+			row.Statuses[NormalizeURL(rep.Target)] = rep.AgenticStatus(id)
 		}
 		res.Checks = append(res.Checks, row)
 	}


### PR DESCRIPTION
## Summary

`isitagentready-pp-cli` now reads **two** independent agent-readiness scanners instead of one. `is-agentic.com` joins `isitagentready.com` behind a `--source` flag, every stored scan carries its provenance, and a new `crossref` command puts both verdicts side by side.

The two scanners disagree by construction, and the CLI never hides that. isitagentready.com reports a **Level 0-5** over five fixed categories; is-agentic.com reports a **score 0-100** over a per-site denominator that excludes checks that do not apply to the site. These are not the same claim, so nothing here averages, rescales, or normalizes one into the other. Every read filters to one source, and the surfaces that compare two records refuse to run across sources rather than silently producing a meaningless number.

## Published CLI Metadata

**API:** `isitagentready` | **Category:** `developer-tools` | **Press version:** `4.25.0`
**Spec:** `spec.yaml` (`spec_format: internal`)  
**Required env:** none (`auth_type: none`; both scanners are public read-only endpoints)

This is an **amend to an already-published CLI**, not a new print or a reprint. `.printing-press.json` is edited in place (description + one `novel_features` entry); the CLI tree is not replaced. Per `AGENTS.md`, the code-level customization is catalogued in `.printing-press-patches/isitagentready-multi-scanner-source.json`.

## What Changed

25 files, +2358 / -146. Every path is inside `library/developer-tools/isitagentready/`.

| ID | Type | What |
|----|------|------|
| F1 | feature | `ScanRecord.Source` + `Score`/`ScoreLabel`; `SourceOrDefault()` backfills `isitagentready` so pre-existing JSONL lines keep their meaning with no migration |
| F2 | feature | Second `client.Client` for `https://is-agentic.com` — one memoized instance per process, so its rate limiter is shared by every caller |
| F3 | feature | RFC 9457 `application/problem+json` error mapping (404 / 400 / 429) |
| F4 | bug | Source-aware guards: `history`, `diff`, `gate`, `compare`, `batch`, `open-advice` can no longer mix two incompatible scales |
| F5 | feature | `--source isitagentready\|is-agentic` as a persistent root flag, validated once in `PersistentPreRunE` |
| F6 | feature | `crossref` — both native verdicts plus a genuine-overlap agreement table |
| F7 | feature | `issues[].recommendation` mapped into the existing advice surface |
| F8 | bug | Bounded is-agentic fan-out; a 429 surfaces as a typed rate-limit error (exit 7) instead of empty results |
| F9 | docs | README / SKILL.md / manifest description updated to the multi-scanner identity |
| F10 | docs | `.printing-press.json` `novel_features` gains the `crossref` entry |
| F11 | docs | Second source recorded in `.printing-press-patches/`, with `upstream_issue` |

### Design decisions

**Provenance lives on the record.** `ScanRecord` gains `Source`, `Score` and `ScoreLabel`. `Level`/`LevelName` stay non-`omitempty` — level 0 is a real readiness level and must not vanish from JSON output.

**The two scales are never merged.**

| | isitagentready.com | is-agentic.com |
|---|---|---|
| Headline | Level 0-5 + `levelName` | Score 0-100 + `score_label` |
| Grouping | 5 fixed categories | essential / recommended / bonus |
| Non-applicable checks | counted neutral | excluded from `eligible_checks` |
| Denominator | fixed | floating (33 on vercel.com, 18 on sqlite.org) |

**Guards refuse rather than mix.** Every store read filters to the active source first (`store.FilterSource`), so cross-source records can never reach `DiffChecks` or `EvaluateGate`. `store.AssertSameSource` is a second check on the two-record paths. `gate --min-level` under `--source is-agentic` is a **usage error**, not a silent reinterpretation; `--min-score` is its is-agentic counterpart and is a usage error under `--source isitagentready`.

**The overlap table is deliberately conservative.** Derived from the real check-id sets of both scanners (20 ids across 5 categories for isitagentready, 26 ids observed by read-only probing for is-agentic), only four pairs measure the same thing:

| isitagentready | is-agentic | what both measure |
|---|---|---|
| `sitemap` | `sitemap` | sitemap published |
| `markdownNegotiation` | `markdown-negotiation-vary` | markdown content negotiation |
| `mcpServerCard` | `mcp-server` | MCP server manifest |
| `oauthDiscovery` | `oauth-support` | OAuth 2.0 discovery |

Near-misses are excluded on purpose and the reasoning is recorded in code so a later reader does not "fix" the omission — e.g. `apiCatalog` is RFC 9727 `.well-known/api-catalog`, a catalog *of* APIs, while `openapi-spec` is the OpenAPI document itself; a site can publish either without the other.

**Read-only and rate-limit aware.** `GET /api/v1/report?url=` never triggers a scan. No browser transport, no scan POST, no sidecar. The advertised budget `ratelimit-policy: "public-report";q=120;w=60` is 2 req/s, so the is-agentic client clamps its limiter accordingly. Because `client.New` builds a *fresh* limiter on every call, the budget is only real if the client is not rebuilt per request: `newAgenticClient` therefore memoizes one client per process, keyed on the settings baked in at construction. `compare`/`batch` stay at the default 4 workers, and all four queue behind that single limiter rather than each holding its own.

**`issues[]` carries only non-passing checks**, so an id absent from it is passing. Verified against `score_breakdown` on three sites, where the expected non-passing count matched `len(issues)` exactly every time:

| site | essential | recommended | expected | `len(issues)` |
|---|---|---|---|---|
| vercel.com | 8/11 | 17/22 | 8 | 8 |
| stripe.com | 6/11 | 11/21 | 15 | 15 |
| sqlite.org | 2/7 | 3/11 | 13 | 13 |

The same table shows tier totals themselves vary per site (11/22, 11/21, 7/11) — independent confirmation of the floating denominator. `score_breakdown.*.earned` and `.bonus.points` are floats (63.5, 17.9, 5), so the Go structs use `float64`.

### Not touched, deliberately

`registry.json`, `cli-skills/pp-*/SKILL.md`, `CHANGELOG.md` and `.printing-press-release.json` are all outside this diff, per the generated-artifact and release-ledger rules in `AGENTS.md`.

## CLI Shape

```bash
$ isitagentready-pp-cli --help
Available Commands:
  advice        Show the prioritized, copy-paste fixes to reach the next readiness level
  batch         Scan a list of URLs (file or stdin), store each, and rank worst-first
  check         Scan a site for AI-agent readiness and save the result
  compare       Compare which agent standards several sites implement, side by side
  crossref      Show both readiness scanners' native verdicts for one site, side by side
  diff          Diff a site's two most recent scans (what regressed, fixed, or changed)
  doctor        Check CLI health
  gate          Fail a build when a site drops below a target readiness level or a check regresses
  guide         Fetch and print the SKILL.md fix guide for a check
  history       Show a site's readiness level across past scans and which checks flipped
  open-advice   List every still-failing check across all your scanned sites with its fix prompt
  report        Show the detailed per-check breakdown of a site's scan
  scan          Scan a URL; returns readiness level (0-5), per-check results across 5 categories
  ...

Flags:
      --source string   Scanner source: isitagentready (Level 0-5) or is-agentic (score 0-100).
                        The two use different scales and are never merged; see 'crossref'.
                        (default "isitagentready")
```

`crossref` is the new command; `--source` is the new persistent flag. Everything else is unchanged.

## What This CLI Does

Scans a website for AI-agent readiness — whether agents can discover, read, and act on it — and turns the verdict into something you can work with from a terminal: copy-paste fixes for each failing check, a CI gate that fails a build on regression, scan history and diffs in a local store, and side-by-side comparison across sites.

With this change it reads two scanners rather than one. `--source` picks which scanner answers a given command; `crossref` shows both verdicts for a URL without merging their incompatible scales.

## Manuscripts

Unchanged from the original publish (this is an amend, not a reprint):

- [Research Brief](./library/developer-tools/isitagentready/.manuscripts/20260622-061602-6c74c750/research/)
- [Shipcheck Results](./library/developer-tools/isitagentready/.manuscripts/20260622-061602-6c74c750/proofs/)

## Validation

All run under `GOTOOLCHAIN=go1.26.7` from `library/developer-tools/isitagentready/`.

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/developer-tools/isitagentready/` — all checks passed
- [x] `go build ./...` — pass
- [x] `go vet ./...` — pass
- [x] `go test ./...` — **323 passed** (300 on the base print; 317 before the review round); `go test -race ./...` also 323 passed
- [x] `govulncheck ./...` — no vulnerabilities
- [ ] `go run ./tools/generate-skills/main.go` — **intentionally not run.** `library/**/SKILL.md` did change, but its output is `cli-skills/pp-isitagentready/SKILL.md`, which `AGENTS.md` and `verify-library-conventions.yml` both forbid in a PR diff. The post-merge `generate-skills.yml` owns that mirror.
- [x] `git diff --check` — clean
- [x] `gofmt` — clean

**Documentation checkpoint: PASS.** Every new user-facing surface ships docs in this PR — `crossref` and `--source` have Unique Capabilities entries plus cookbook recipes in both `README.md` and `SKILL.md`, and the manifest `novel_features` entry matches.

**Live dogfood** against both hosts, with the binary built from this tree:

| case | result |
|---|---|
| `report <known> --source is-agentic --data-source live` | 200, score 86, `eligible_checks` 33, full `issues[]` |
| `report <never-scanned> --source is-agentic` | exit 3, upstream `resolution` passed through verbatim |
| `report notaurl --source is-agentic` | exit 2, carries upstream `detail` + `resolution` |
| `--source bogus` | rejected: `invalid --source value "bogus": must be isitagentready or is-agentic` |
| is-agentic scan, then `--source isitagentready --data-source local` | exit 3 — the is-agentic record is correctly invisible to the isitagentready read |
| stored JSONL line | `source="is-agentic" score=86 level=0` |
| `crossref` with one scanner missing | exit 0, other scanner still rendered |
| `check <known> --source is-agentic` **in a terminal** | score 86 / `Strong technical baseline`, tier breakdown, and real issue ids (`agent-friendly-404`, `rate-limit-headers`) — no `Level 0` |
| `compare` over 6 URLs `--source is-agentic --data-source live` | exit 0, 6/6 scored, **zero 429s**, 2.7s — consistent with 5 gaps at one shared 2 req/s budget |
| `batch` over 5 URLs `--source is-agentic --data-source live` | exit 0, 5/5 ranked, **zero 429s**, 2.2s |

### On `publish validate`

`cli-printing-press publish validate` fails three checks on this tree: manifest `schema_version` 1, phase5 marker missing `source_fingerprint`, and a canonical install-section drift in `SKILL.md`.

**All three fail identically — byte-identical error strings — on the untouched `upstream/main` base print**, verified by validating a `git archive upstream/main` extraction side by side. Zero checks changed state, so this amend is validation-neutral. Clearing them requires a reprint, not an amend.

## Review round 2 — Greptile P1 findings

Both P1 findings were assessed as genuine and fixed in `7a08f0c`.

**1. Is-agentic response used the wrong renderer** (`internal/cli/check.go`). `check <url> --source is-agentic` in human mode passed the is-agentic body to the level-based `renderScan` path. `store.ParseReport` unmarshals that foreign shape *without error* into an all-zero `Report`, so the command printed an empty URL, `Level 0` and zero checks instead of the score and issues. `renderScan` now dispatches on `--source` and routes is-agentic to `renderAgenticReport` — the native renderer `report`/`crossref` already use.

Root cause of the miss: the live dogfood matrix exercised `report --source is-agentic` but never `check --source is-agentic` in human mode, and `wantsHumanTable` gates that path behind `isTerminal`, which is false for the buffer tests render into. The human/machine decision therefore moved into `renderScanFor` as a parameter so a test can reach the terminal path. The regression test asserts on rendered **content** — the real score value, real issue ids, and the absence of `Level 0` — not on output length, which would have passed against the all-zero summary.

**2. Fan-out bypassed the shared rate limit** (`internal/cli/agentic.go`). `client.New` builds a fresh `AdaptiveLimiter` on every call, so a client-per-request gave each of the four `compare`/`batch` workers its own limiter and let four requests leave at once against the 2 req/s budget. `newAgenticClient` now memoizes one client — and therefore one limiter — per process, keyed on the settings `client.New` bakes in, so a differently-configured caller gets its own rather than silently inheriting another's `DryRun`/`NoCache`. Fields are written only under the mutex at construction and never mutated after, so concurrent readers stay race-free (`go test -race` clean). The stale `compare.go` comment that claimed this already held is corrected, as is the corresponding sentence in this PR body.

Covered by two tests: a singleton-identity assertion across 8 concurrent callers, and a live spacing test that fans out 3 `fetchAgenticReport` calls at an `httptest` server and asserts the observed arrivals are spaced by the shared budget. Both were verified to **fail** against the pre-fix code before being kept.

## Gaps / Follow-Up

**Deferred upstream — tracked at [mvanhorn/cli-printing-press#4348](https://github.com/mvanhorn/cli-printing-press/issues/4348).** The Printing Press supports per-resource and per-endpoint `base_url` overrides, so *routing* to a second host is already covered. It does not cover the rest of what makes a second source independent: `default_rate_limit` exists only at spec level (`internal/spec/spec.go:312`) with no per-resource equivalent, and the spec has no error-model concept at all. So the is-agentic client is hand-authored — a memoized `client.Client` with `BaseURL` overridden, one shared limiter clamped to the advertised 2 req/s that every concurrent caller queues behind, and its own RFC 9457 classifier. Once the press can declare additional read-only sources with their own budget and error model, this should be regenerated from the spec rather than patched back in on every reprint. Recorded as `deferred_to_upstream` + `upstream_issue` in the patch record.

**Not fixed here — exit code on a bad `--source`.** It exits **1**, not the conventional **2** for a usage error. This is not a regression: the pre-existing `--data-source` flag behaves identically. The cause is generator-level — validation errors returned from `PersistentPreRunE` never flow through `usageErr()`, because `Execute()`'s `isCobraUsageError` wrap only recognizes Cobra/pflag's own pre-RunE error shapes. Fixing only `--source` would leave two sibling flags on the same command disagreeing about exit codes, which is worse than a consistent shared quirk. It belongs in a generator retro, not in this amend.

**Known drift, not touched.** The root command's `Short`/`Long` in `internal/cli/root.go` still carries the original single-scanner description and its Highlights list omits `crossref`, while the manifest `description` and `novel_features` were updated. Both are generator-populated surfaces derived from the spec; hand-editing the generated root help in an amend risks diverging further from the next print. Happy to align them in this PR if maintainers prefer that over waiting for a reprint.

