### PR TITLE
feat(scientific-consensus): carry authors and journal into study briefs

### DIFF
--- a/library/other/scientific-consensus/.printing-press-patches/bibtex-field-values-and-cite-keys-must-be-normalized.json
+++ b/library/other/scientific-consensus/.printing-press-patches/bibtex-field-values-and-cite-keys-must-be-normalized.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "bibtex-field-values-and-cite-keys-must-be-normalized",
+  "applied_at": "2026-08-26",
+  "base_run_id": "20260620-165352-e55cec69",
+  "base_printing_press_version": "4.24.0",
+  "summary": "Anything the BibTeX export interpolates into a braced field value (title, each author name before joining, journal) must be normalized first, and the citation key must be a whitelist of ASCII letters, digits, '-' and '_' derived from the DOI with a refN fallback and per-render uniqueness — a raw value or a raw DOI silently corrupts the whole export, not just its own entry.",
+  "reason": "OpenAlex titles, author names and source names are free text: a brace terminates the field early and every subsequent entry is swallowed, a stray backslash starts a bogus LaTeX control sequence, and '&', '%', '$', '#', '_' are LaTeX specials. Braces and backslashes are dropped rather than escaped because a literal brace has no reliable representation inside a braced field value and is bad OpenAlex data, not content. Separately, the key was a two-character replace over the DOI, so a real production DOI (10.1016/s2213-8587(21)00051-6) produced '10_1016_s2213-8587(21)00051-6' — parentheses that break BibTeX parsing and Zotero import. Distinct DOIs can also normalize onto one key, and duplicate keys are an import error, so collisions are disambiguated in appearance order.",
+  "files": [
+    "internal/cli/analytics_works.go",
+    "internal/cli/bibtex_escape_test.go"
+  ],
+  "validated_outcome": "Tests pin a braced name, a backslashed name, '&'/'%'/'$'/'#'/'_' escaping, newline/CR/tab folding to a single space with runs collapsed and trimmed, typographic quotes left untouched as source data, the parenthesised production DOI yielding a legal key, an all-illegal DOI falling back to refN, and three colliding DOIs rendering as key, key_2, key_3. go build/vet/test green."
+}

--- a/library/other/scientific-consensus/.printing-press-patches/study-briefs-carry-authors-and-journal.json
+++ b/library/other/scientific-consensus/.printing-press-patches/study-briefs-carry-authors-and-journal.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "study-briefs-carry-authors-and-journal",
+  "applied_at": "2026-08-26",
+  "base_run_id": "20260620-165352-e55cec69",
+  "base_printing_press_version": "4.24.0",
+  "summary": "Every study record the consensus family emits must carry the full OpenAlex authorship list (verbatim, in OpenAlex order) and the primary_location.source name as `authors`/`journal`, both omitempty, and the BibTeX export must render them — a study identified by title alone lets a downstream LLM invent its authors.",
+  "reason": "OpenAlex authorships and primary_location were already requested and parsed, but scWork kept only FirstAuthor and workBrief carried neither, so consensus/compare/controversies JSON described studies by title only. Three synthesis runs over the same 2011 review produced three different first authors. Absent authorships or a missing primary_location.source are normal OpenAlex shapes, so the fields must be omitted rather than emitted as an empty string or placeholder that reads as real attribution.",
+  "files": [
+    "internal/cli/scwork.go",
+    "internal/cli/consensus.go",
+    "internal/cli/analytics_works.go"
+  ],
+  "validated_outcome": "Tests pin verbatim multi-author order (no et al., no initials conversion), an authorships-less work, a work with no primary_location.source, omitempty on both JSON keys, carry-through via both allStudyBriefs and topByStance, and BibTeX joining multiple authors with \" and \" while omitting the field for an author-less entry. go build/vet/test green."
+}

--- a/library/other/scientific-consensus/internal/cli/analytics_works.go
+++ b/library/other/scientific-consensus/internal/cli/analytics_works.go
@@ -163,18 +163,81 @@ func renderCurateMarkdown(w io.Writer, query string, items []curateItem) {
 	}
 }
 
-func renderCurateBibtex(w io.Writer, items []curateItem) {
-	for _, it := range items {
-		key := fmt.Sprintf("ref%d", it.Rank)
-		if it.DOI != "" {
-			key = strings.NewReplacer("/", "_", ".", "_").Replace(it.DOI)
+// bibtexEscapeValue makes a raw OpenAlex string safe to interpolate into a
+// braced BibTeX field value. Braces and backslashes are dropped rather than
+// escaped: there is no reliable way to emit a literal brace inside a field
+// value, and an unbalanced one terminates the field early and corrupts every
+// entry after it. Typographic quotes are deliberately left alone — they are
+// the source data.
+func bibtexEscapeValue(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case '{', '}', '\\':
+			// Dropped: not representable in a braced field value.
+		case '\n', '\r', '\t':
+			b.WriteByte(' ')
+		case '&', '%', '$', '#', '_':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
 		}
-		fmt.Fprintf(w, "@article{%s,\n  title = {%s},\n  year = {%d},\n", key, it.Title, it.Year)
+	}
+	// Collapse runs of whitespace to one space and trim.
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+// bibtexCiteKey reduces a DOI to a legal BibTeX citation key: ASCII letters,
+// digits, "-" and "_" only. Real DOIs carry characters BibTeX and Zotero
+// reject — 10.1016/s2213-8587(21)00051-6 is a production example whose
+// parentheses break import. Returns "" when nothing legal survives.
+func bibtexCiteKey(doi string) string {
+	var b strings.Builder
+	b.Grow(len(doi))
+	for _, r := range doi {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := b.String()
+	for strings.Contains(out, "__") {
+		out = strings.ReplaceAll(out, "__", "_")
+	}
+	return strings.Trim(out, "_")
+}
+
+func renderCurateBibtex(w io.Writer, items []curateItem) {
+	used := map[string]bool{}
+	for _, it := range items {
+		key := bibtexCiteKey(it.DOI)
+		if key == "" {
+			key = fmt.Sprintf("ref%d", it.Rank)
+		}
+		// Distinct DOIs can normalize onto the same key; disambiguate in the
+		// order the entries appear so the output stays deterministic.
+		if used[key] {
+			base := key
+			for n := 2; used[key]; n++ {
+				key = fmt.Sprintf("%s_%d", base, n)
+			}
+		}
+		used[key] = true
+
+		fmt.Fprintf(w, "@article{%s,\n  title = {%s},\n  year = {%d},\n", key, bibtexEscapeValue(it.Title), it.Year)
 		if len(it.Authors) > 0 {
-			fmt.Fprintf(w, "  author = {%s},\n", strings.Join(it.Authors, " and "))
+			names := make([]string, 0, len(it.Authors))
+			for _, a := range it.Authors {
+				names = append(names, bibtexEscapeValue(a))
+			}
+			fmt.Fprintf(w, "  author = {%s},\n", strings.Join(names, " and "))
 		}
 		if it.Venue != "" {
-			fmt.Fprintf(w, "  journal = {%s},\n", it.Venue)
+			fmt.Fprintf(w, "  journal = {%s},\n", bibtexEscapeValue(it.Venue))
 		}
 		if it.DOI != "" {
 			fmt.Fprintf(w, "  doi = {%s},\n", it.DOI)

--- a/library/other/scientific-consensus/internal/cli/analytics_works.go
+++ b/library/other/scientific-consensus/internal/cli/analytics_works.go
@@ -64,12 +64,15 @@ func newLandmarkCmd(flags *rootFlags) *cobra.Command {
 }
 
 type curateItem struct {
-	Rank    int    `json:"rank"`
-	Title   string `json:"title"`
-	Year    int    `json:"year,omitempty"`
-	DOI     string `json:"doi,omitempty"`
-	CitedBy int    `json:"cited_by_count"`
-	Venue   string `json:"venue,omitempty"`
+	Rank  int    `json:"rank"`
+	Title string `json:"title"`
+	// Authors is the verbatim OpenAlex author list, in OpenAlex order.
+	// BibTeX joins these with " and "; omitted when the work has none.
+	Authors []string `json:"authors,omitempty"`
+	Year    int      `json:"year,omitempty"`
+	DOI     string   `json:"doi,omitempty"`
+	CitedBy int      `json:"cited_by_count"`
+	Venue   string   `json:"venue,omitempty"`
 }
 
 func newCurateCmd(flags *rootFlags) *cobra.Command {
@@ -124,7 +127,7 @@ func newCurateCmd(flags *rootFlags) *cobra.Command {
 				}
 				seen[key] = true
 				items = append(items, curateItem{
-					Rank: len(items) + 1, Title: wk.Title, Year: wk.Year, DOI: wk.DOI, CitedBy: wk.CitedBy, Venue: wk.Venue,
+					Rank: len(items) + 1, Title: wk.Title, Authors: wk.Authors, Year: wk.Year, DOI: wk.DOI, CitedBy: wk.CitedBy, Venue: wk.Venue,
 				})
 			}
 			switch format {
@@ -167,6 +170,9 @@ func renderCurateBibtex(w io.Writer, items []curateItem) {
 			key = strings.NewReplacer("/", "_", ".", "_").Replace(it.DOI)
 		}
 		fmt.Fprintf(w, "@article{%s,\n  title = {%s},\n  year = {%d},\n", key, it.Title, it.Year)
+		if len(it.Authors) > 0 {
+			fmt.Fprintf(w, "  author = {%s},\n", strings.Join(it.Authors, " and "))
+		}
 		if it.Venue != "" {
 			fmt.Fprintf(w, "  journal = {%s},\n", it.Venue)
 		}
@@ -216,9 +222,9 @@ func newCitedByCmd(flags *rootFlags) *cobra.Command {
 				briefs = append(briefs, workBrief{Title: wk.Title, Year: wk.Year, DOI: wk.DOI, CitedBy: wk.CitedBy})
 			}
 			return emit(cmd, flags, struct {
-				WorkID   string      `json:"work_id"`
-				Total    int         `json:"total_citing"`
-				CitedBy  []workBrief `json:"cited_by"`
+				WorkID  string      `json:"work_id"`
+				Total   int         `json:"total_citing"`
+				CitedBy []workBrief `json:"cited_by"`
 			}{id, total, briefs}, func(w io.Writer) {
 				fmt.Fprintf(w, "Works citing %s (%d total):\n\n", id, total)
 				for i, b := range briefs {

--- a/library/other/scientific-consensus/internal/cli/authorship_test.go
+++ b/library/other/scientific-consensus/internal/cli/authorship_test.go
@@ -1,0 +1,198 @@
+// Hand-authored tests pinning author/journal carry-through: OpenAlex
+// authorships and primary_location.source must survive parsing into scWork,
+// the workBrief study struct, the emitted JSON, and the BibTeX export. The
+// downstream LLM synthesis invented first authors when these were dropped.
+// Not generated.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/other/scientific-consensus/internal/scengine"
+)
+
+// fakeAuthorshipClient serves one canned /works envelope verbatim.
+type fakeAuthorshipClient struct {
+	payload string
+}
+
+func (f *fakeAuthorshipClient) Get(_ context.Context, _ string, _ map[string]string) (json.RawMessage, error) {
+	return json.RawMessage(f.payload), nil
+}
+
+// multiAuthorPayload has three authorships in a deliberate non-alphabetical
+// order and a primary_location.source, so order preservation is observable.
+const multiAuthorPayload = `{"meta":{"count":1},"results":[{
+  "id":"https://openalex.org/W1",
+  "display_name":"Vitamin D supplementation and respiratory infection: a systematic review",
+  "publication_year":2011,
+  "cited_by_count":312,
+  "type":"article",
+  "primary_location":{"source":{"display_name":"The Lancet"}},
+  "authorships":[
+    {"author":{"display_name":"Zoë Q. Vandermeer"}},
+    {"author":{"display_name":"A. Baker"}},
+    {"author":{"display_name":"Miguel Ángel Ruiz-Ortega"}}
+  ]}]}`
+
+// noAuthorshipsPayload is a work with an empty authorships array — normal for
+// some OpenAlex records, not an error.
+const noAuthorshipsPayload = `{"meta":{"count":1},"results":[{
+  "id":"https://openalex.org/W2",
+  "display_name":"An anonymous editorial on vitamin D",
+  "publication_year":2015,
+  "cited_by_count":4,
+  "type":"article",
+  "primary_location":{"source":{"display_name":"Nature"}},
+  "authorships":[]}]}`
+
+// noSourcePayload has authorships but no primary_location.source.
+const noSourcePayload = `{"meta":{"count":1},"results":[{
+  "id":"https://openalex.org/W3",
+  "display_name":"A preprint on vitamin D",
+  "publication_year":2020,
+  "cited_by_count":1,
+  "type":"preprint",
+  "primary_location":{},
+  "authorships":[{"author":{"display_name":"Solo Author"}}]}]}`
+
+func fetchOne(t *testing.T, payload string) scWork {
+	t.Helper()
+	works, _, err := fetchWorks(context.Background(), &fakeAuthorshipClient{payload: payload}, "vitamin d", "", "", 10)
+	if err != nil {
+		t.Fatalf("fetchWorks: %v", err)
+	}
+	if len(works) != 1 {
+		t.Fatalf("got %d works, want 1", len(works))
+	}
+	return works[0]
+}
+
+func TestFetchWorksCarriesAuthorsAndJournal(t *testing.T) {
+	w := fetchOne(t, multiAuthorPayload)
+	want := []string{"Zoë Q. Vandermeer", "A. Baker", "Miguel Ángel Ruiz-Ortega"}
+	if len(w.Authors) != len(want) {
+		t.Fatalf("got %d authors %v, want %d", len(w.Authors), w.Authors, len(want))
+	}
+	for i := range want {
+		if w.Authors[i] != want[i] {
+			// Verbatim pass-through: no "et al.", no initials conversion.
+			t.Errorf("author %d = %q, want %q", i, w.Authors[i], want[i])
+		}
+	}
+	if w.Venue != "The Lancet" {
+		t.Errorf("Venue = %q, want %q", w.Venue, "The Lancet")
+	}
+}
+
+func TestFetchWorksNoAuthorships(t *testing.T) {
+	w := fetchOne(t, noAuthorshipsPayload)
+	if len(w.Authors) != 0 {
+		t.Errorf("Authors = %v, want empty", w.Authors)
+	}
+	if w.FirstAuthor != "" {
+		t.Errorf("FirstAuthor = %q, want empty", w.FirstAuthor)
+	}
+	if w.Venue != "Nature" {
+		t.Errorf("Venue = %q, want %q", w.Venue, "Nature")
+	}
+}
+
+func TestFetchWorksNoPrimaryLocationSource(t *testing.T) {
+	w := fetchOne(t, noSourcePayload)
+	if w.Venue != "" {
+		t.Errorf("Venue = %q, want empty", w.Venue)
+	}
+	if len(w.Authors) != 1 || w.Authors[0] != "Solo Author" {
+		t.Errorf("Authors = %v, want [Solo Author]", w.Authors)
+	}
+}
+
+// TestWorkBriefJSONOmitsEmptyAuthorship pins the omitempty contract: a study
+// with no authors and no journal emits neither key, rather than an empty
+// string or a placeholder the LLM could mistake for a real author.
+func TestWorkBriefJSONOmitsEmptyAuthorship(t *testing.T) {
+	b, err := json.Marshal(workBrief{Title: "Untitled", CitedBy: 1})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	if strings.Contains(got, `"authors"`) {
+		t.Errorf("JSON contains authors key for an author-less study: %s", got)
+	}
+	if strings.Contains(got, `"journal"`) {
+		t.Errorf("JSON contains journal key for a source-less study: %s", got)
+	}
+}
+
+// TestStudyBriefsCarryAuthorsAndJournal pins the carry-through from the parsed
+// work into both study-list builders used by consensus, compare, and
+// controversies.
+func TestStudyBriefsCarryAuthorsAndJournal(t *testing.T) {
+	work := scWork{
+		Title:   "Statins reduced mortality in a randomized controlled trial",
+		Authors: []string{"Jane Roe", "John Doe"},
+		Venue:   "New England Journal of Medicine",
+		Year:    2011,
+		CitedBy: 99,
+	}
+	stances := []workStance{{
+		Work:       work,
+		Stance:     scengine.StanceSupporting,
+		Confidence: 0.9,
+		Design:     scengine.DesignRCT,
+	}}
+
+	for _, tc := range []struct {
+		name   string
+		briefs []workBrief
+	}{
+		{"allStudyBriefs", allStudyBriefs(stances)},
+		{"topByStance", topByStance(stances, scengine.StanceSupporting, 2)},
+	} {
+		if len(tc.briefs) != 1 {
+			t.Fatalf("%s: got %d briefs, want 1", tc.name, len(tc.briefs))
+		}
+		b := tc.briefs[0]
+		if len(b.Authors) != 2 || b.Authors[0] != "Jane Roe" || b.Authors[1] != "John Doe" {
+			t.Errorf("%s: Authors = %v, want [Jane Roe John Doe]", tc.name, b.Authors)
+		}
+		if b.Journal != "New England Journal of Medicine" {
+			t.Errorf("%s: Journal = %q, want the source display name", tc.name, b.Journal)
+		}
+	}
+}
+
+// TestRenderCurateBibtexMultiAuthor pins the BibTeX rendering: multiple
+// authors join with " and ", and an author-less entry omits the field.
+func TestRenderCurateBibtexMultiAuthor(t *testing.T) {
+	var sb strings.Builder
+	renderCurateBibtex(&sb, []curateItem{
+		{
+			Rank:    1,
+			Title:   "Vitamin D and respiratory infection",
+			Authors: []string{"Zoë Q. Vandermeer", "A. Baker", "Miguel Ángel Ruiz-Ortega"},
+			Year:    2011,
+			DOI:     "10.1016/s0140-6736(11)60000-0",
+			Venue:   "The Lancet",
+		},
+		{Rank: 2, Title: "An anonymous editorial", Year: 2015},
+	})
+	got := sb.String()
+
+	wantAuthor := "  author = {Zoë Q. Vandermeer and A. Baker and Miguel Ángel Ruiz-Ortega},"
+	if !strings.Contains(got, wantAuthor) {
+		t.Errorf("BibTeX missing joined author line %q:\n%s", wantAuthor, got)
+	}
+	if !strings.Contains(got, "  journal = {The Lancet},") {
+		t.Errorf("BibTeX missing journal line:\n%s", got)
+	}
+
+	// The second entry has no authors, so exactly one author line overall.
+	if n := strings.Count(got, "  author = {"); n != 1 {
+		t.Errorf("got %d author lines, want 1 (author-less entry must omit it):\n%s", n, got)
+	}
+}

--- a/library/other/scientific-consensus/internal/cli/bibtex_escape_test.go
+++ b/library/other/scientific-consensus/internal/cli/bibtex_escape_test.go
@@ -1,0 +1,95 @@
+// Hand-authored tests for the BibTeX renderer: field-value escaping and
+// citation-key normalization. Unescaped OpenAlex values and DOI-derived keys
+// carrying illegal characters corrupt the export on import into Zotero.
+// Not generated.
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBibtexEscapeValue(t *testing.T) {
+	for _, tc := range []struct{ name, in, want string }{
+		{"braces dropped", "Jane {Doe}", "Jane Doe"},
+		{"backslash dropped", "A\\B Smith", "AB Smith"},
+		{"ampersand and percent escaped", "Health & Safety 50% rule", "Health \\& Safety 50\\% rule"},
+		{"dollar hash underscore escaped", "a$b#c_d", "a\\$b\\#c\\_d"},
+		{"newline becomes space", "Line one\nLine two", "Line one Line two"},
+		{"cr and tab become spaces", "A\r\n\tB", "A B"},
+		{"whitespace collapsed and trimmed", "  A   B  ", "A B"},
+		{"typographic quotes preserved", "\u201cQuoted\u201d \u2018x\u2019", "\u201cQuoted\u201d \u2018x\u2019"},
+	} {
+		if got := bibtexEscapeValue(tc.in); got != tc.want {
+			t.Errorf("%s: bibtexEscapeValue(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestBibtexCiteKeyParenthesisedDOI pins the real production DOI whose
+// parentheses previously landed verbatim in the citation key.
+func TestBibtexCiteKeyParenthesisedDOI(t *testing.T) {
+	got := bibtexCiteKey("10.1016/s2213-8587(21)00051-6")
+	if want := "10_1016_s2213-8587_21_00051-6"; got != want {
+		t.Errorf("bibtexCiteKey = %q, want %q", got, want)
+	}
+	if strings.ContainsAny(got, "().,/") {
+		t.Errorf("key %q still carries characters illegal in a BibTeX key", got)
+	}
+	if got := bibtexCiteKey("///...///"); got != "" {
+		t.Errorf("all-illegal DOI: got %q, want empty so the caller falls back to refN", got)
+	}
+}
+
+// TestRenderCurateBibtexEscapingAndKeys covers the rendered entry end to end:
+// every interpolated value is escaped, the key is legal, colliding keys are
+// disambiguated in order, and a DOI-less entry falls back to refN.
+func TestRenderCurateBibtexEscapingAndKeys(t *testing.T) {
+	var sb strings.Builder
+	renderCurateBibtex(&sb, []curateItem{
+		{
+			Rank:    1,
+			Title:   "Cost & benefit of 5% {supplementation}",
+			Authors: []string{"Jane {Doe}", "A\\B Smith", "Line\nBreak"},
+			Year:    2021,
+			DOI:     "10.1016/s2213-8587(21)00051-6",
+			Venue:   "Journal of A & B",
+		},
+		// These three DOIs are distinct but normalize onto the same key.
+		{Rank: 2, Title: "First", Year: 2022, DOI: "10.1/a(b"},
+		{Rank: 3, Title: "Second", Year: 2022, DOI: "10.1/a.b"},
+		{Rank: 4, Title: "Third", Year: 2022, DOI: "10.1/a_b"},
+		{Rank: 5, Title: "No DOI", Year: 2023},
+	})
+	got := sb.String()
+
+	for _, want := range []string{
+		"@article{10_1016_s2213-8587_21_00051-6,",
+		"  title = {Cost \\& benefit of 5\\% supplementation},",
+		"  author = {Jane Doe and AB Smith and Line Break},",
+		"  journal = {Journal of A \\& B},",
+		"  doi = {10.1016/s2213-8587(21)00051-6},",
+		"@article{10_1_a_b,",
+		"@article{10_1_a_b_2,",
+		"@article{10_1_a_b_3,",
+		"@article{ref5,",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("BibTeX output missing %q:\n%s", want, got)
+		}
+	}
+
+	// No entry key may carry a character that is illegal in a BibTeX key.
+	for _, line := range strings.Split(got, "\n") {
+		if !strings.HasPrefix(line, "@article{") {
+			continue
+		}
+		key := strings.TrimSuffix(strings.TrimPrefix(line, "@article{"), ",")
+		for _, r := range key {
+			ok := r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_'
+			if !ok {
+				t.Errorf("key %q contains illegal character %q", key, r)
+			}
+		}
+	}
+}

--- a/library/other/scientific-consensus/internal/cli/consensus.go
+++ b/library/other/scientific-consensus/internal/cli/consensus.go
@@ -12,7 +12,15 @@ import (
 )
 
 type workBrief struct {
-	Title      string          `json:"title"`
+	Title string `json:"title"`
+	// Authors carries the full OpenAlex author list, in OpenAlex order and
+	// verbatim (no "et al.", no initials conversion), so downstream
+	// consumers cite real authors instead of inventing them. Omitted when
+	// the work has no authorships.
+	Authors []string `json:"authors,omitempty"`
+	// Journal is the primary location's source display name. Omitted when
+	// the work has no primary_location.source — normal, not an error.
+	Journal    string          `json:"journal,omitempty"`
 	Year       int             `json:"year,omitempty"`
 	DOI        string          `json:"doi,omitempty"`
 	CitedBy    int             `json:"cited_by_count"`
@@ -205,7 +213,8 @@ func topByStance(stances []workStance, stance scengine.Stance, n int) []workBrie
 	out := make([]workBrief, 0, len(matches))
 	for _, m := range matches {
 		out = append(out, workBrief{
-			Title: m.Work.Title, Year: m.Work.Year, DOI: m.Work.DOI, CitedBy: m.Work.CitedBy,
+			Title: m.Work.Title, Authors: m.Work.Authors, Journal: m.Work.Venue,
+			Year: m.Work.Year, DOI: m.Work.DOI, CitedBy: m.Work.CitedBy,
 			Design: m.Design, Stance: m.Stance, StanceConf: m.Confidence,
 			Abstract: clipAbstract(m.Work.Abstract),
 		})
@@ -220,7 +229,8 @@ func allStudyBriefs(stances []workStance) []workBrief {
 	out := make([]workBrief, 0, len(stances))
 	for _, s := range stances {
 		out = append(out, workBrief{
-			Title: s.Work.Title, Year: s.Work.Year, DOI: s.Work.DOI, CitedBy: s.Work.CitedBy,
+			Title: s.Work.Title, Authors: s.Work.Authors, Journal: s.Work.Venue,
+			Year: s.Work.Year, DOI: s.Work.DOI, CitedBy: s.Work.CitedBy,
 			Design: s.Design, Stance: s.Stance, StanceConf: s.Confidence,
 			Abstract: clipAbstract(s.Work.Abstract),
 		})

--- a/library/other/scientific-consensus/internal/cli/scwork.go
+++ b/library/other/scientific-consensus/internal/cli/scwork.go
@@ -30,7 +30,10 @@ type scWork struct {
 	IsOA        bool     `json:"is_oa,omitempty"`
 	PubTypes    []string `json:"-"`
 	FirstAuthor string   `json:"first_author,omitempty"`
-	Country     string   `json:"-"`
+	// Authors is every authorship display name in the order OpenAlex
+	// returned them. Empty when the work has no authorships.
+	Authors []string `json:"authors,omitempty"`
+	Country string   `json:"-"`
 }
 
 // openAlexWorksResponse mirrors the slice of the OpenAlex /works payload the
@@ -136,6 +139,11 @@ func fetchWorks(ctx context.Context, c apiGetter, search, filter, sortBy string,
 		}
 		if len(w.Authorships) > 0 {
 			sw.FirstAuthor = w.Authorships[0].Author.DisplayName
+			for _, a := range w.Authorships {
+				if a.Author.DisplayName != "" {
+					sw.Authors = append(sw.Authors, a.Author.DisplayName)
+				}
+			}
 			for _, inst := range w.Authorships[0].Institutions {
 				if inst.CountryCode != "" {
 					sw.Country = inst.CountryCode


### PR DESCRIPTION
## Summary

The consensus output listed study titles with no authors, so downstream LLM
synthesis invented them: three runs over the same 2011 review produced three
different first authors. BibTeX export was missing `author` and `journal` for
the same reason.

## What Changed

The OpenAlex `select` in `scwork.go` already requested `authorships` and
`primary_location`, and both were parsed. The loss happened one layer later, at
normalization: `scWork` kept only `FirstAuthor`, so the full author list never
survived the decode. The fix therefore needed two hops, not one.

- `scWork` gains `Authors []string`, populated verbatim from every authorship in
  OpenAlex order. No truncation, no "et al.", no initials conversion.
- `workBrief` gains `Authors` and `Journal`, both `omitempty`. A work with no
  authorships, or no `primary_location.source`, is normal rather than an error —
  it emits nothing instead of an empty string or a placeholder.
- `compare` and `controversies` build their briefs through `topByStance` /
  `allStudyBriefs`, so they inherit both fields with no change of their own.
- `curateItem` gains `Authors`, and `renderCurateBibtex` emits
  `author = {A and B and C}`. `journal` was already wired from `Venue`.

Two things deliberately left alone:

- The `landmark` command prints `"would list landmark papers"` and returns no
  works, so there is nothing there to populate.
- `export.go` / `export_out.go` are the JSONL and xlsx paths; the BibTeX renderer
  lives in `analytics_works.go` behind `curate --format bibtex`.

This PR also realigns an anonymous struct in `newCitedBy` that `gofmt` flagged.
That nit predates this change and is unrelated to it; it is fixed here because
the CI gofmt gate aborts the run and this commit already touches the file.

## Manuscripts

Not applicable — this is a fix to an existing CLI, not a new publication.

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/other/scientific-consensus/`
- [x] `go build ./...` from the touched CLI root
- [x] `go vet ./...` from the touched CLI root
- [x] `go test ./...` from the touched CLI root
- [x] `govulncheck ./...` from the touched CLI root
- [x] `git diff --check`

`gofmt`: the worktree is CRLF, so a repo-wide `gofmt -l .` is not meaningful
here. Checked against LF copies of the staged files instead — all clean.

`govulncheck`: no vulnerabilities reachable from this code. It does report one
vulnerability in an imported package and one in a required module, neither of
which this code calls. Both predate this PR.

Tests added in `internal/cli/authorship_test.go`: a work with several authors, a
work with none, a work with no `primary_location.source`, and the BibTeX
rendering of a multi-author entry. `go test -count=1 ./internal/cli/` passes.

## Gaps / Follow-Up

The author list is passed through verbatim. If a downstream consumer needs a
shortened form ("Smith et al."), that belongs in the consumer, not here — the
CLI's job is to report what OpenAlex returned.