### PR TITLE
chore: drop leftover apify audit JSON

### DIFF
--- a/library/developer-tools/dndbeyond/apify-actor-audit-report.json
+++ b/library/developer-tools/dndbeyond/apify-actor-audit-report.json
@@ -1,8 +1,0 @@
-{
-  "dir": "\u003ccli-dir\u003e\\cli-neutral",
-  "verdict": "pass",
-  "actors": null,
-  "issues": [
-    "no Apify actor references found, skipping"
-  ]
-}

--- a/library/developer-tools/is-agentic/apify-actor-audit-report.json
+++ b/library/developer-tools/is-agentic/apify-actor-audit-report.json
@@ -1,9 +1,0 @@
-{
-  "dir": "\u003ccli-dir\u003e/is-agentic-pp-cli",
-  "research_dir": "\u003ccli-dir\u003e/20260824-224824-d2043dea",
-  "verdict": "pass",
-  "actors": null,
-  "issues": [
-    "no Apify actor references found, skipping"
-  ]
-}

--- a/library/health/carol-bike/apify-actor-audit-report.json
+++ b/library/health/carol-bike/apify-actor-audit-report.json
@@ -1,9 +1,0 @@
-{
-  "dir": "\u003ccli-dir\u003e/carol-bike-pp-cli",
-  "research_dir": "\u003ccli-dir\u003e/20260825-194050",
-  "verdict": "pass",
-  "actors": null,
-  "issues": [
-    "no Apify actor references found, skipping"
-  ]
-}


### PR DESCRIPTION
Drops `apify-actor-audit-report.json` from carol-bike, is-agentic, and dndbeyond. That file shouldn't ship; it landed on main with #1819 / #1810 / #1809 after the origin leftover follow-ups were closed.