### PR TITLE
feat(scientific-consensus): give the pyramid's example a DOI and a year

### DIFF
--- a/library/other/scientific-consensus/.printing-press-patches/pyramid-exemplar-carries-identifiers.json
+++ b/library/other/scientific-consensus/.printing-press-patches/pyramid-exemplar-carries-identifiers.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "pyramid-exemplar-carries-identifiers",
+  "applied_at": "2026-08-29",
+  "base_run_id": "20260620-165352-e55cec69",
+  "base_printing_press_version": "4.24.0",
+  "summary": "The evidence pyramid's exemplar carries example_doi and example_year alongside example, and all three are read from one scWork in a single assignment. The classification pass lives in classifyForPyramid rather than inline in RunE, so that guarantee has something to hold it.",
+  "reason": "A title on its own cannot be looked up. A client that renders the exemplar as a citation produces one that resolves to nothing, and the work is already in hand where the exemplar is chosen — the loop held the whole struct and kept one field of it. The fields must stay in one assignment rather than being collected in separate passes: they are rendered together as a single reference, so a title paired with another work's DOI is not a cosmetic defect but a pointer to the wrong paper. classifyForPyramid is deliberately separate from classifyWorks in scwork.go, which classifies and nothing else; gaps is its only caller and would have to discard two return values to share this one. The text renderer is left alone — it shows counts and a bar, and widening it is a separate decision from what the JSON carries.",
+  "files": [
+    "internal/cli/evidence.go",
+    "internal/cli/evidence_example_test.go"
+  ],
+  "validated_outcome": "Three tests assert the pairing, the selection rule (first work seen at each design) and the pubtype count, each verified by mutation: sourcing the DOI or the year from a different work fails the pairing test, and keeping the last work at a design instead of the first fails the selection test. An earlier version of the test rebuilt the loop rather than calling it, and passed all three mutations; it was replaced. Both new fields are omitempty, since a zero-count level has no exemplar and a work may legitimately have no DOI."
+}

--- a/library/other/scientific-consensus/internal/cli/evidence.go
+++ b/library/other/scientific-consensus/internal/cli/evidence.go
@@ -10,11 +10,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// exemplarWork is the one work the pyramid names for a design level. The three
+// fields are filled from a single scWork in one assignment, never assembled
+// from separate lookups: a client renders a citation from all three at once,
+// so a title paired with another work's DOI would resolve to the wrong paper
+// while looking complete.
+type exemplarWork struct {
+	title string
+	doi   string
+	year  int
+}
+
 type evidenceLevel struct {
-	Design  scengine.Design `json:"design"`
-	Count   int             `json:"count"`
-	Pct     float64         `json:"pct"`
-	Example string          `json:"example,omitempty"`
+	Design scengine.Design `json:"design"`
+	Count  int             `json:"count"`
+	Pct    float64         `json:"pct"`
+	// Example names one work at this level so a reader can check the
+	// classification instead of taking the count on trust. ExampleDOI and
+	// ExampleYear come with it because a title alone cannot be looked up:
+	// a client rendering a citation from this response would produce one
+	// that resolves to nothing. All three are omitempty — a level with a
+	// zero count has no exemplar, and a work can legitimately have no DOI.
+	Example     string `json:"example,omitempty"`
+	ExampleDOI  string `json:"example_doi,omitempty"`
+	ExampleYear int    `json:"example_year,omitempty"`
 }
 
 type evidenceOutput struct {
@@ -71,21 +90,8 @@ func newNovelEvidenceCmd(flags *rootFlags) *cobra.Command {
 				enrichPubTypes(ctx, works, 50)
 			}
 
-			cs := make([]scengine.Classification, len(works))
-			byPub := 0
-			exemplar := map[scengine.Design]string{}
 			prog := newProgress(flags, "classifying", len(works))
-			for i, wk := range works {
-				cls := scengine.ClassifyDesign(wk.Title, wk.Abstract, wk.Type, wk.PubTypes)
-				cs[i] = cls
-				if cls.Method == scengine.MethodPubMedPubType {
-					byPub++
-				}
-				if _, ok := exemplar[cls.Design]; !ok {
-					exemplar[cls.Design] = wk.Title
-				}
-				prog.update(i + 1)
-			}
+			cs, byPub, exemplar := classifyForPyramid(works, func(done int) { prog.update(done) })
 			prog.done()
 			levels := scengine.Pyramid(cs)
 			out := evidenceOutput{
@@ -98,7 +104,10 @@ func newNovelEvidenceCmd(flags *rootFlags) *cobra.Command {
 					pct = float64(lvl.Count) * 100 / float64(len(works))
 				}
 				out.Pyramid = append(out.Pyramid, evidenceLevel{
-					Design: lvl.Design, Count: lvl.Count, Pct: round1(pct), Example: exemplar[lvl.Design],
+					Design: lvl.Design, Count: lvl.Count, Pct: round1(pct),
+					Example:     exemplar[lvl.Design].title,
+					ExampleDOI:  exemplar[lvl.Design].doi,
+					ExampleYear: exemplar[lvl.Design].year,
 				})
 			}
 			if len(works) == 0 {
@@ -131,6 +140,42 @@ func renderEvidence(w io.Writer, o evidenceOutput) {
 	if o.Note != "" {
 		fmt.Fprintf(w, "\n  Note: %s\n", o.Note)
 	}
+}
+
+// classifyForPyramid runs the design classifier over every work and returns
+// three results of one pass: the per-work classifications, how many of them
+// came from a publisher-supplied publication type rather than a title
+// heuristic, and one exemplar per design. It is separate from classifyWorks
+// in scwork.go, which classifies and nothing else: gaps needs only the
+// classifications, and would have to discard two return values to use this.
+//
+// The exemplar is the FIRST work seen at each design, and it is copied out of
+// that one scWork in a single assignment. Splitting the pass — collecting
+// titles here and looking DOIs up afterwards — is what this function exists to
+// prevent: the three fields travel together to a client that renders them as
+// one citation, so a mismatch is not a cosmetic defect but a reference to the
+// wrong paper.
+//
+// onProgress is called with the number of works finished; it is a callback
+// rather than a *progress so a test can drive this without a terminal.
+func classifyForPyramid(works []scWork, onProgress func(done int)) ([]scengine.Classification, int, map[scengine.Design]exemplarWork) {
+	cs := make([]scengine.Classification, len(works))
+	byPub := 0
+	exemplar := map[scengine.Design]exemplarWork{}
+	for i, wk := range works {
+		cls := scengine.ClassifyDesign(wk.Title, wk.Abstract, wk.Type, wk.PubTypes)
+		cs[i] = cls
+		if cls.Method == scengine.MethodPubMedPubType {
+			byPub++
+		}
+		if _, ok := exemplar[cls.Design]; !ok {
+			exemplar[cls.Design] = exemplarWork{title: wk.Title, doi: wk.DOI, year: wk.Year}
+		}
+		if onProgress != nil {
+			onProgress(i + 1)
+		}
+	}
+	return cs, byPub, exemplar
 }
 
 func round1(v float64) float64 {

--- a/library/other/scientific-consensus/internal/cli/evidence_example_test.go
+++ b/library/other/scientific-consensus/internal/cli/evidence_example_test.go
@@ -1,0 +1,104 @@
+// Hand-authored test for the evidence pyramid's exemplar. The pyramid names one
+// work per design level and reports its DOI and year alongside; this pins that
+// the three come from the same work. A client renders a citation from all three
+// at once, so a title paired with another work's DOI resolves to the wrong
+// paper while looking complete. Calls classifyForPyramid directly rather than
+// reproducing its loop, so a change to the real code is what the assertions
+// see. Not generated.
+package cli
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/other/scientific-consensus/internal/scengine"
+)
+
+// TestClassifyForPyramidExemplarIsOneWork is the assertion the change exists
+// for. The two fixtures classify to different design levels and carry DOIs and
+// years that are individually plausible against either title, so a swap is
+// caught by the pairing rather than by one value looking obviously wrong.
+func TestClassifyForPyramidExemplarIsOneWork(t *testing.T) {
+	works := []scWork{
+		{
+			Title:    "A meta-analysis of melatonin for shift work sleep disorder",
+			DOI:      "10.1000/meta.2019",
+			Year:     2019,
+			Type:     "review",
+			PubTypes: []string{"Meta-Analysis"},
+		},
+		{
+			Title:    "Randomised controlled trial of melatonin timing in rotating shift workers",
+			DOI:      "10.1000/rct.2011",
+			Year:     2011,
+			Type:     "article",
+			PubTypes: []string{"Randomized Controlled Trial"},
+		},
+	}
+
+	_, _, exemplar := classifyForPyramid(works, nil)
+
+	// Index the fixtures by title so each assertion asks the question a citation
+	// asks: given this name, is the rest of the row this work's?
+	want := map[string]scWork{}
+	for _, w := range works {
+		want[w.Title] = w
+	}
+
+	if len(exemplar) == 0 {
+		t.Fatal("no exemplar recorded for any design")
+	}
+	for design, ex := range exemplar {
+		w, ok := want[ex.title]
+		if !ok {
+			t.Errorf("%s: exemplar title %q is not one of the fixtures", design, ex.title)
+			continue
+		}
+		if ex.doi != w.DOI {
+			t.Errorf("%s: exemplar %q has doi %q, want %q — the DOI came from a different work",
+				design, ex.title, ex.doi, w.DOI)
+		}
+		if ex.year != w.Year {
+			t.Errorf("%s: exemplar %q has year %d, want %d — the year came from a different work",
+				design, ex.title, ex.year, w.Year)
+		}
+	}
+}
+
+// TestClassifyForPyramidKeepsFirstAtEachDesign pins the selection rule itself.
+// Two works of the same design must not overwrite each other, or the reported
+// example would depend on result ordering the caller cannot see.
+func TestClassifyForPyramidKeepsFirstAtEachDesign(t *testing.T) {
+	works := []scWork{
+		{Title: "First RCT", DOI: "10.1000/first", Year: 2001, Type: "article", PubTypes: []string{"Randomized Controlled Trial"}},
+		{Title: "Second RCT", DOI: "10.1000/second", Year: 2002, Type: "article", PubTypes: []string{"Randomized Controlled Trial"}},
+	}
+
+	_, _, exemplar := classifyForPyramid(works, nil)
+
+	ex, ok := exemplar[scengine.DesignRCT]
+	if !ok {
+		t.Fatalf("no exemplar for the RCT level; got %v", exemplar)
+	}
+	if ex.title != "First RCT" {
+		t.Errorf("exemplar title = %q, want the first work seen at this design", ex.title)
+	}
+	if ex.doi != "10.1000/first" {
+		t.Errorf("exemplar doi = %q, want the first work's", ex.doi)
+	}
+}
+
+// TestClassifyForPyramidCountsPubTypeClassifications pins the second return
+// value, which the UI shows as how much of the pyramid rests on publisher
+// metadata rather than a title guess.
+func TestClassifyForPyramidCountsPubTypeClassifications(t *testing.T) {
+	works := []scWork{
+		{Title: "Typed by the publisher", Type: "article", PubTypes: []string{"Randomized Controlled Trial"}},
+		{Title: "Nothing here identifies a design", Type: "article"},
+	}
+
+	_, byPub, _ := classifyForPyramid(works, nil)
+
+	if byPub != 1 {
+		t.Errorf("byPub = %d, want 1 — only the first fixture carries a publication type", byPub)
+	}
+}


### PR DESCRIPTION
## Summary

The evidence pyramid names one work per design level. It named the title and
stopped there, which is not enough to act on: a client rendering that name as
a citation produces one that resolves to nothing.

`example_doi` and `example_year` now come out of the same `scWork` in the same
assignment. Both `omitempty` — a zero-count level has no exemplar, and a work
may legitimately have no DOI.

Not a CLI publish: no new package, no manifest, no manuscripts.

## Why the fields must travel together

They are rendered as one reference. A title paired with another work's DOI is
not a cosmetic defect — it is a pointer to the wrong paper, and it looks
complete while being wrong.

That is why the classification loop moves out of `RunE` into
`classifyForPyramid`: the three fields are filled from one `scWork` in one
statement, and a test can assert it directly instead of rebuilding the loop and
asserting against its own copy.

It is deliberately not the existing `classifyWorks` in `scwork.go`. That one
classifies and nothing else; `gaps`, its only caller, would have to discard two
return values to share this one.

## What Changed

| commit | |
|---|---|
| `6e680248` | the two fields, `classifyForPyramid`, three tests |
| `32ae9e83` | ledger entry |

## Validation

- [x] `go build ./...` — clean
- [x] `go test -count=1 ./...` — all packages ok
- [x] `gofmt` on an LF copy of both touched files — clean
- [x] mutation-checked, three ways:

| mutation | fails |
|---|---|
| DOI sourced from a different work | `TestClassifyForPyramidExemplarIsOneWork` |
| year sourced from a different work | `TestClassifyForPyramidExemplarIsOneWork` |
| keep the last work at a design, not the first | `TestClassifyForPyramidKeepsFirstAtEachDesign` |

An earlier version of the test rebuilt the loop itself rather than calling it.
It passed all three mutations. It was replaced rather than kept alongside — a
test that cannot fail is worse than no test, because it reads as coverage.

## Gaps / Follow-up

The text renderer is unchanged. `renderEvidence` shows counts and a bar and has
never shown the exemplar; widening it is a separate decision from what the JSON
carries, and this PR does not make it.

`classified_by_pubtype` was already in the response and is untouched here, but
it is worth knowing when reading a pyramid: it does not grow with the result
set. On `melatonin supplementation improves sleep quality in shift workers` it
reports 34 works typed at `--limit 55` and 34 again at `--limit 100`, so a
larger limit dilutes the percentages rather than sharpening them.