### PR TITLE
fix(scientific-consensus): make each gap finding name the sample it read

### DIFF
--- a/library/other/scientific-consensus/.printing-press-patches/gap-findings-name-their-sample.json
+++ b/library/other/scientific-consensus/.printing-press-patches/gap-findings-name-their-sample.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "gap-findings-name-their-sample",
+  "applied_at": "2026-08-29",
+  "base_run_id": "20260620-165352-e55cec69",
+  "base_printing_press_version": "4.24.0",
+  "summary": "Each gap finding names the sample it read. gaps looks at the works one relevance-ranked page returned, so a finding drawn from that page is a fact about those works and must not be worded as a fact about the literature.",
+  "reason": "Three of the four findings read the sample rather than the query: missing-strong-designs its designs, stale-evidence its years, understudied-population its text. Only thin-literature is safe, because it counts total matches. Measured on one claim, gaps reported a latest year of 2022 from 100 works while consensus reported 2018 from 20 — one literature, two numbers, and a reader acting on either would look for a gap the sample invented. The well-covered message needed the same treatment, being the strongest claim of the set. Re-sorting a second query by publication_date was tried and rejected: sorted by date, OpenAlex full-text search returns the newest work matching any term, so stale-evidence would stop firing entirely.",
+  "files": [
+    "internal/cli/gaps.go"
+  ],
+  "validated_outcome": "Wording only: the same findings fire under the same conditions, the JSON field names and output shape are unchanged, and go build, go vet and the full test suite are green. The counts quoted in each message come from len(works), which is the sample the command actually read."
+}

--- a/library/other/scientific-consensus/internal/cli/gaps.go
+++ b/library/other/scientific-consensus/internal/cli/gaps.go
@@ -107,13 +107,13 @@ func newNovelGapsCmd(flags *rootFlags) *cobra.Command {
 			// Finding: no strong designs.
 			if !out.HasRCT {
 				out.Findings = append(out.Findings, gapFinding{Kind: "missing-strong-designs",
-					Detail: "no randomized trials, systematic reviews, or meta-analyses among the analyzed works — evidence rests on weaker designs"})
+					Detail: fmt.Sprintf("none of the %d most relevant works is a randomized trial, systematic review, or meta-analysis; works outside that sample were not examined", len(works))})
 			}
 			// Finding: stale evidence.
 			thisYear := time.Now().Year()
 			if out.LatestYear > 0 && thisYear-out.LatestYear >= 4 {
 				out.Findings = append(out.Findings, gapFinding{Kind: "stale-evidence",
-					Detail: fmt.Sprintf("most recent analyzed study is from %d (%d+ years old) — replication / updates may be missing", out.LatestYear, thisYear-out.LatestYear)})
+					Detail: fmt.Sprintf("none of the %d most relevant works is newer than %d (%d+ years); that is a property of this sample, not of the literature — a newer study ranking lower on relevance would not appear here", len(works), out.LatestYear, thisYear-out.LatestYear)})
 			}
 			// Finding: thin volume.
 			if total < 50 {
@@ -124,12 +124,12 @@ func newNovelGapsCmd(flags *rootFlags) *cobra.Command {
 			for _, label := range sortedProbeLabels() {
 				if !reMatch(populationProbes[label], hay) {
 					out.Findings = append(out.Findings, gapFinding{Kind: "understudied-population",
-						Detail: "little or no coverage of " + label})
+						Detail: fmt.Sprintf("%s is not mentioned in any of the %d most relevant works; that is where the probe looked, and nowhere else", label, len(works))})
 				}
 			}
 			if len(out.Findings) == 0 {
 				out.Findings = append(out.Findings, gapFinding{Kind: "well-covered",
-					Detail: "no obvious gaps detected: strong designs present, recent, and reasonably broad"})
+					Detail: fmt.Sprintf("no gaps found in the %d most relevant works: strong designs present, recent, and reasonably broad. Absence of a gap here is not evidence there is none", len(works))})
 			}
 			return emit(cmd, flags, out, func(w io.Writer) { renderGaps(w, out) })
 		},


### PR DESCRIPTION
## Summary

The gap findings state properties of the literature while measuring a sample.

`gaps` fetches by `relevance_score:desc` and reads the first 100 of what can be
120,000 matches, so *"most recent analyzed study is from 2022"* is a fact about
those 100 works, not about the field.

Four lines of wording. Not a CLI publish: no new package, no manifest, no
manuscripts.

## The measurement

On *"vitamin C prevents the common cold"*:

| command | works read | reports latest year |
|---|---|---|
| `gaps` | 100 | **2022** |
| `consensus` | 20 | **2018** |

Same claim, same sort. Two numbers, one literature. A reader acting on the
first would conclude there has been no work since 2022 and go looking for a gap
the sample invented.

## Which findings share this

| finding | reads | sample-bound |
|---|---|---|
| `missing-strong-designs` | the sample's designs | yes |
| `stale-evidence` | the sample's years | yes |
| `understudied-population` | the sample's text | yes |
| `thin-literature` | `total` matches | **no** |

`thin-literature` is safe because it counts what the query matched, not what was
retrieved. The `well-covered` message needed the same treatment — *"no obvious
gaps detected"* is as strong a claim as any of them, and the one most likely to
be trusted.

Each now names the sample it read, and `stale-evidence` says outright that a
newer study ranking lower on relevance would not appear.

## Re-sorting by date, measured and rejected

The obvious fix is a second query sorted by `publication_date:desc`. On this
claim that returns five 2026 papers about SGLT2 inhibitors, tau seeding, YouTube
recovery interviews, gene therapy and meteorology.

OpenAlex full-text search sorted by date returns the newest *anything*, so
`stale-evidence` would never fire again — worse than the current state, not
better.

The sampling limit is not fixable from inside this command. Saying so is.

## Validation

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -count=1 ./...` — all packages ok
- [x] `gofmt` on an LF copy — clean

No behaviour change: the same findings fire under the same conditions, and only
the wording differs.