### PR TITLE
fix(scientific-consensus): count inconclusive works in controversies

### DIFF
--- a/library/other/scientific-consensus/.printing-press-patches/controversies-counts-inconclusive-as-a-fourth-stance.json
+++ b/library/other/scientific-consensus/.printing-press-patches/controversies-counts-inconclusive-as-a-fourth-stance.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "controversies-counts-inconclusive-as-a-fourth-stance",
+  "applied_at": "2026-08-30",
+  "base_run_id": "20260620-165352-e55cec69",
+  "base_printing_press_version": "4.24.0",
+  "summary": "The controversies command must report all four stances the engine can return, so supporting + refuting + mixed + inconclusive always equals the study_count printed beside them. Inconclusive gets its own counter rather than being folded into mixed: the two are distinct engine outcomes — mixed means conflicting directional signals, inconclusive means no directional signal at all — and collapsing them would report an absence of evidence as a conflict of evidence. The controversy score keeps its denominator of supporting + refuting only, so inconclusive works are reported but never scored and no previous score or contested verdict moves. consensus.go is the shape being matched, field order and rendered wording included.",
+  "reason": "study_count was len(works) while the tally switch handled only three of the four stance values, so every inconclusive work vanished from the counters and from the JSON entirely — a large fraction of a real corpus, present in no field and unexplained by the numbers shown.",
+  "files": [
+    "internal/cli/controversies.go",
+    "internal/cli/controversies_test.go"
+  ],
+  "validated_outcome": "Over a fixture carrying all four stances (5/3/2/4): the four JSON counts sum to study_count, and controversy_score is pinned literally at 0.75 with contested true — the values the pre-change code produced for the same fixture. Mutation-checked: dropping the new case or zeroing the counter fails the sum assertion; adding Inconclusive to the score's directional denominator fails the pinned score at 0.5."
+}

--- a/library/other/scientific-consensus/internal/cli/controversies.go
+++ b/library/other/scientific-consensus/internal/cli/controversies.go
@@ -15,6 +15,7 @@ type controversyOutput struct {
 	Supporting       int         `json:"supporting"`
 	Refuting         int         `json:"refuting"`
 	Mixed            int         `json:"mixed"`
+	Inconclusive     int         `json:"inconclusive"`
 	ControversyScore float64     `json:"controversy_score"` // 0 (settled) .. 1 (highly contested)
 	Contested        bool        `json:"contested"`
 	SupportingSide   []workBrief `json:"supporting_side"`
@@ -69,40 +70,54 @@ func newNovelControversiesCmd(flags *rootFlags) *cobra.Command {
 			_, stances := scoreWorks(ctx, works, query)
 			prog.done()
 
-			out := controversyOutput{Query: query, StudyCount: len(works)}
-			for _, s := range stances {
-				switch s.Stance {
-				case scengine.StanceSupporting:
-					out.Supporting++
-				case scengine.StanceRefuting:
-					out.Refuting++
-				case scengine.StanceMixed:
-					out.Mixed++
-				}
-			}
-			directional := out.Supporting + out.Refuting
-			if directional > 0 {
-				minor := out.Supporting
-				if out.Refuting < minor {
-					minor = out.Refuting
-				}
-				// 2*minority/total => 1.0 when evenly split, 0 when one-sided.
-				out.ControversyScore = round2f(2 * float64(minor) / float64(directional))
-			}
-			out.Contested = out.ControversyScore >= 0.5 && directional >= 4
-			out.SupportingSide = topByStance(stances, scengine.StanceSupporting, 3)
-			out.RefutingSide = topByStance(stances, scengine.StanceRefuting, 3)
-			if len(works) == 0 {
-				out.Note = "no works found; try a broader query"
-			} else if directional < 4 {
-				out.Note = "too few directional studies to assess controversy reliably"
-			}
+			out := tallyControversy(query, len(works), stances)
 			return emit(cmd, flags, out, func(w io.Writer) { renderControversy(w, out) })
 		},
 	}
 	cmd.Flags().IntVar(&limit, "limit", 50, "number of works to analyze (max 200)")
 	cmd.Flags().BoolVar(&enrich, "enrich", true, "enrich classification with PubMed publication types")
 	return cmd
+}
+
+// tallyControversy turns the per-work stances into the command's output
+// shape: the four stance counters, the controversy score, and the top works
+// on each side. Split out of RunE so the tally and the score can be exercised
+// from tests without a network client. studyCount is passed separately
+// because it is the size of the retrieved corpus, which the caller owns.
+func tallyControversy(query string, studyCount int, stances []workStance) controversyOutput {
+	out := controversyOutput{Query: query, StudyCount: studyCount}
+	for _, s := range stances {
+		switch s.Stance {
+		case scengine.StanceSupporting:
+			out.Supporting++
+		case scengine.StanceRefuting:
+			out.Refuting++
+		case scengine.StanceMixed:
+			out.Mixed++
+		case scengine.StanceInconclusive:
+			out.Inconclusive++
+		}
+	}
+	// Inconclusive works carry no directional signal, so they are reported
+	// but deliberately excluded from the score's denominator.
+	directional := out.Supporting + out.Refuting
+	if directional > 0 {
+		minor := out.Supporting
+		if out.Refuting < minor {
+			minor = out.Refuting
+		}
+		// 2*minority/total => 1.0 when evenly split, 0 when one-sided.
+		out.ControversyScore = round2f(2 * float64(minor) / float64(directional))
+	}
+	out.Contested = out.ControversyScore >= 0.5 && directional >= 4
+	out.SupportingSide = topByStance(stances, scengine.StanceSupporting, 3)
+	out.RefutingSide = topByStance(stances, scengine.StanceRefuting, 3)
+	if studyCount == 0 {
+		out.Note = "no works found; try a broader query"
+	} else if directional < 4 {
+		out.Note = "too few directional studies to assess controversy reliably"
+	}
+	return out
 }
 
 func renderControversy(w io.Writer, o controversyOutput) {
@@ -112,7 +127,8 @@ func renderControversy(w io.Writer, o controversyOutput) {
 		verdict = "CONTESTED"
 	}
 	fmt.Fprintf(w, "  Controversy score: %.2f  (%s)\n", o.ControversyScore, verdict)
-	fmt.Fprintf(w, "  Studies: %d  (support %d / refute %d / mixed %d)\n\n", o.StudyCount, o.Supporting, o.Refuting, o.Mixed)
+	fmt.Fprintf(w, "  Studies: %d  (support %d / refute %d / mixed %d / inconclusive %d)\n\n",
+		o.StudyCount, o.Supporting, o.Refuting, o.Mixed, o.Inconclusive)
 	if len(o.SupportingSide) > 0 {
 		fmt.Fprintln(w, "  Supporting side:")
 		for _, b := range o.SupportingSide {

--- a/library/other/scientific-consensus/internal/cli/controversies_test.go
+++ b/library/other/scientific-consensus/internal/cli/controversies_test.go
@@ -3,8 +3,106 @@
 
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/other/scientific-consensus/internal/scengine"
+)
 
 func TestNovelControversiesCommandTODO(t *testing.T) {
 	t.Skip("TODO: implement table-driven tests for controversies")
+}
+
+// fourStanceFixture is a corpus carrying every stance the engine can return:
+// 5 supporting, 3 refuting, 2 mixed, 4 inconclusive. The stances are set
+// literally rather than classified from text so the tally under test is not
+// coupled to the classifier's heuristics.
+func fourStanceFixture() []workStance {
+	stances := []workStance{}
+	add := func(st scengine.Stance, n int) {
+		for i := 0; i < n; i++ {
+			stances = append(stances, workStance{
+				Work:   scWork{ID: string(st) + string(rune('1'+i)), Title: string(st) + " study", Year: 2021, CitedBy: 10 + i},
+				Stance: st, Confidence: 0.6,
+			})
+		}
+	}
+	add(scengine.StanceSupporting, 5)
+	add(scengine.StanceRefuting, 3)
+	add(scengine.StanceMixed, 2)
+	add(scengine.StanceInconclusive, 4)
+	return stances
+}
+
+// TestControversiesCountsCoverEveryWork is the counter: with all four stances
+// present, the four JSON counts must account for the whole corpus. Before
+// inconclusive was counted, four of these fourteen works appeared in no field
+// at all.
+func TestControversiesCountsCoverEveryWork(t *testing.T) {
+	stances := fourStanceFixture()
+	raw, err := json.Marshal(tallyControversy("sweeteners weight gain", len(stances), stances))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got struct {
+		StudyCount   int `json:"study_count"`
+		Supporting   int `json:"supporting"`
+		Refuting     int `json:"refuting"`
+		Mixed        int `json:"mixed"`
+		Inconclusive int `json:"inconclusive"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	sum := got.Supporting + got.Refuting + got.Mixed + got.Inconclusive
+	if sum != got.StudyCount {
+		t.Errorf("counts sum to %d, want study_count %d (support %d / refute %d / mixed %d / inconclusive %d)",
+			sum, got.StudyCount, got.Supporting, got.Refuting, got.Mixed, got.Inconclusive)
+	}
+	if got.Inconclusive != 4 {
+		t.Errorf("inconclusive = %d, want 4", got.Inconclusive)
+	}
+}
+
+// TestControversiesScoreIgnoresInconclusive pins the score and the contested
+// verdict to the values the pre-change code produced for this fixture:
+// 5 supporting and 3 refuting give 2*3/8 = 0.75. Inconclusive works must stay
+// out of the denominator, so any change that folds them in fails here.
+func TestControversiesScoreIgnoresInconclusive(t *testing.T) {
+	stances := fourStanceFixture()
+	out := tallyControversy("sweeteners weight gain", len(stances), stances)
+	if out.ControversyScore != 0.75 {
+		t.Errorf("controversy_score = %v, want 0.75", out.ControversyScore)
+	}
+	if !out.Contested {
+		t.Error("contested = false, want true")
+	}
+}
+
+// TestControversiesTextBreakdownSums asserts the rendered breakdown adds up to
+// the Studies figure printed on the same line.
+func TestControversiesTextBreakdownSums(t *testing.T) {
+	stances := fourStanceFixture()
+	var buf bytes.Buffer
+	renderControversy(&buf, tallyControversy("sweeteners weight gain", len(stances), stances))
+	var total, s, r, m, inc int
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if !strings.Contains(line, "Studies:") {
+			continue
+		}
+		if _, err := fmt.Sscanf(strings.TrimSpace(line),
+			"Studies: %d  (support %d / refute %d / mixed %d / inconclusive %d)", &total, &s, &r, &m, &inc); err != nil {
+			t.Fatalf("unexpected Studies line %q: %v", line, err)
+		}
+	}
+	if total == 0 {
+		t.Fatalf("no Studies line in output:\n%s", buf.String())
+	}
+	if s+r+m+inc != total {
+		t.Errorf("printed breakdown sums to %d, want Studies %d", s+r+m+inc, total)
+	}
 }


### PR DESCRIPTION
## What

`controversies` prints `study_count` beside supporting / refuting / mixed,
and those three never sum to it. `StudyCount` is `len(works)`, but the tally
switch handled three of the four values `scengine` can return —
`StanceInconclusive` fell through it silently and appeared in no counter and
in no field of the JSON.

This adds the fourth counter, matching what `consensus` already does.

## The defect, on a live run

Query "artificial sweeteners cause weight gain":

```
study_count 28  ·  supporting 2  ·  refuting 8  ·  mixed 0

```

Eighteen works — 64% of the corpus — unaccounted for, with nothing in the output explaining where they went.

## Why it matters beyond arithmetic

`StanceInconclusive` is defined at `internal/scengine/stance.go:18` and returned at `:188` with confidence 0.2. It is one of the four values `llm_stance.go:160` accepts, and `internal/cli/consensus.go` already carries `Inconclusive int` and renders `(support %d / refute %d / mixed %d / inconclusive %d)`.

Both commands read the same engine and the same enum. Only `controversies` kept three slots for four outcomes.

## How common is it

Every one of the 13 archived corpora under `internal/scengine/testdata/corpora/` contains inconclusive works, between 12% and 50%:

| corpus | study_count | s | r | m | inconclusive | % |
|---|---|---|---|---|---|---|
| cellphones | 31 | 5 | 14 | 1 | 11 | 35% |
| coffee | 11 | 0 | 6 | 1 | 4 | 36% |
| meditation | 10 | 5 | 0 | 1 | 4 | 40% |
| melatonin | 19 | 13 | 1 | 2 | 3 | 16% |
| omega3 | 62 | 44 | 0 | 0 | 18 | 29% |
| probiotics | 9 | 6 | 0 | 0 | 3 | 33% |
| redmeat_run1 | 11 | 5 | 4 | 0 | 2 | 18% |
| redmeat_run2 | 11 | 5 | 4 | 0 | 2 | 18% |
| saffron | 12 | 6 | 0 | 0 | 6 | 50% |
| sweeteners | 7 | 0 | 5 | 0 | 2 | 29% |
| vaccines | 37 | 1 | 17 | 1 | 18 | 49% |
| vitaminc | 49 | 34 | 4 | 5 | 6 | 12% |
| vitamind | 26 | 18 | 0 | 1 | 7 | 27% |

**These are consensus exports.** No archived controversies corpus exists, so they measure how large the silence is, not whether the defect exists — that is structural and visible in the source. Stating this plainly rather than implying corpus coverage this change does not have.

## Why a separate counter rather than folding into `mixed`

They are distinct engine outcomes. `mixed` means conflicting directional signals; `inconclusive` means no directional signal at all. Collapsing them would report an absence of evidence as a conflict of evidence.

## The score is deliberately unchanged

`directional` stays `Supporting + Refuting`. A work with no directional signal cannot make a literature contested, so inconclusive works are now reported but still never scored. **No previous score or contested verdict moves.**

A test pins the score literally (0.75, contested true on the fixture) so a later change cannot quietly rewrite past verdicts.

## One deviation worth flagging

The tally was extracted from `RunE` into `tallyControversy()` **byte-for-byte**. It sat inside the command's closure, reachable only after a network fetch, so none of the mutations below could have been detected without the split. `studyCount` is passed in rather than derived from `len(stances)`: it is the size of the retrieved corpus and the caller owns it.

## Mutation testing

| mutation | expected | result |
|---|---|---|
| delete the new `case` | sum assertion fails | 10 vs 14 ✓ |
| force `out.Inconclusive = 0` | sum assertion fails | 0 vs 14 ✓ |
| add `Inconclusive` to the score's denominator | pinned score fails | 0.5 vs 0.75 ✓ |

The third is the guard this change most needed — it is what proves the score is genuinely pinned.

## Not in scope

`controversies_test.go` was a 10-line `TODO` placeholder. It is **left in place**: filling the command's test gap is a separate change and does not belong in a counter fix.

## Checks

- `go test ./... -count=1` — all packages pass
- `go vet ./...` clean
- `gofmt -l` clean on the staged LF copies of both changed files
- `.printing-press-patches` entry added (1408 chars)