### PR TITLE
docs(openrouter-image): document prerequisites and uninstall steps

### DIFF
--- a/library/ai/openrouter-image/README.md
+++ b/library/ai/openrouter-image/README.md
@@ -160,13 +160,21 @@ How you remove the skill depends on how it was installed:
 
 ### Local data (optional)
 
-Remove saved credentials and local state (sync cache, cost ledger, learnings). The commands below remove the default locations:
+Remove saved credentials and local state (sync cache, cost ledger, learnings). The commands below remove the default locations.
+
+On Unix:
 
 ```bash
 rm -rf "$HOME/.config/openrouter-image-pp-cli" \
        "$HOME/.local/share/openrouter-image-pp-cli" \
        "$HOME/.local/state/openrouter-image-pp-cli" \
        "$HOME/.cache/openrouter-image-pp-cli"
+```
+
+On Windows (PowerShell):
+
+```powershell
+Remove-Item -Recurse -Force "$env:USERPROFILE\.config\openrouter-image-pp-cli", "$env:USERPROFILE\.local\share\openrouter-image-pp-cli", "$env:USERPROFILE\.local\state\openrouter-image-pp-cli", "$env:USERPROFILE\.cache\openrouter-image-pp-cli"
 ```
 
 If you relocated storage via `--home`, `OPENROUTER_IMAGE_HOME`, an XDG override (`XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`), or a per-kind override (`OPENROUTER_IMAGE_CONFIG_DIR`, `OPENROUTER_IMAGE_DATA_DIR`, `OPENROUTER_IMAGE_STATE_DIR`, `OPENROUTER_IMAGE_CACHE_DIR`), the files live under those locations instead. Run `openrouter-image-pp-cli doctor` (or `openrouter-image-pp-cli agent-context --pretty` for the resolved paths) to see where each kind currently resolves before deleting; when using `--home`, pass the same `--home <dir>` flag to that command.

--- a/library/ai/openrouter-image/README.md
+++ b/library/ai/openrouter-image/README.md
@@ -169,7 +169,7 @@ rm -rf "$HOME/.config/openrouter-image-pp-cli" \
        "$HOME/.cache/openrouter-image-pp-cli"
 ```
 
-If you relocated storage via `--home`, `OPENROUTER_IMAGE_HOME`, or a per-kind override (`OPENROUTER_IMAGE_CONFIG_DIR`, `OPENROUTER_IMAGE_DATA_DIR`, `OPENROUTER_IMAGE_STATE_DIR`, `OPENROUTER_IMAGE_CACHE_DIR`), the files live under those locations instead. Run `openrouter-image-pp-cli doctor` (or `openrouter-image-pp-cli agent-context --pretty` for the resolved paths) to see where each kind currently resolves before deleting; when using `--home`, pass the same `--home <dir>` flag to that command.
+If you relocated storage via `--home`, `OPENROUTER_IMAGE_HOME`, an XDG override (`XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`), or a per-kind override (`OPENROUTER_IMAGE_CONFIG_DIR`, `OPENROUTER_IMAGE_DATA_DIR`, `OPENROUTER_IMAGE_STATE_DIR`, `OPENROUTER_IMAGE_CACHE_DIR`), the files live under those locations instead. Run `openrouter-image-pp-cli doctor` (or `openrouter-image-pp-cli agent-context --pretty` for the resolved paths) to see where each kind currently resolves before deleting; when using `--home`, pass the same `--home <dir>` flag to that command.
 
 ## Authentication
 

--- a/library/ai/openrouter-image/README.md
+++ b/library/ai/openrouter-image/README.md
@@ -171,7 +171,35 @@ rm -rf "$HOME/.config/openrouter-image-pp-cli" \
 
 ## Authentication
 
-Set OPENROUTER_API_KEY in your environment. The key is read per command; nothing is persisted to disk. Run `openrouter-image-pp-cli doctor` to verify setup.
+You need an OpenRouter API key. Get one at [openrouter.ai/keys](https://openrouter.ai/keys).
+
+### Permanent (saved to disk, survives restarts)
+
+```bash
+openrouter-image-pp-cli auth set-token YOUR_TOKEN_HERE
+```
+
+Verify it's saved:
+
+```bash
+openrouter-image-pp-cli auth status
+```
+
+### Temporary (current session only)
+
+```bash
+export OPENROUTER_API_KEY="YOUR_TOKEN_HERE"
+```
+
+This lasts until you close the terminal. Good for testing or one-off commands.
+
+### Verify everything works
+
+```bash
+openrouter-image-pp-cli doctor
+```
+
+Checks your credentials, config, and API connectivity. To remove saved credentials: `openrouter-image-pp-cli auth logout`.
 
 ## Quick Start
 

--- a/library/ai/openrouter-image/README.md
+++ b/library/ai/openrouter-image/README.md
@@ -10,6 +10,11 @@ Created by [@neal-kyle](https://github.com/neal-kyle).
 
 ## Install
 
+### Prerequisites
+
+- **Node.js** (any current LTS) — required for the npx installer below.
+- **Go 1.26.5 or newer** — only needed for the [Go fallback](#without-node-go-fallback) install or building from source. Not needed for the npx or pre-built binary paths.
+
 The recommended path installs both the `openrouter-image-pp-cli` binary and the `pp-openrouter-image` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
@@ -121,6 +126,48 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 ```
 
 </details>
+
+## Uninstall
+
+### CLI binary
+
+Remove the binary from the install location:
+
+```bash
+rm "$HOME/.local/bin/openrouter-image-pp-cli"
+```
+
+On Windows, delete `%LOCALAPPDATA%\Programs\PrintingPress\bin\openrouter-image-pp-cli.exe`.
+
+### Agent skill
+
+How you remove the skill depends on how it was installed:
+
+- **Via `hermes skills install`** (or another agent's equivalent): uninstall normally:
+
+  ```bash
+  hermes skills uninstall pp-openrouter-image
+  ```
+
+- **Via the npx installer** (`npx ... install openrouter-image`): the skill is registered as a local skill (symlinked into `~/.agents/skills/`), which `hermes skills uninstall` refuses to remove with "not a hub-installed skill (may be a builtin)". Delete it manually:
+
+  ```bash
+  rm "$HOME/.hermes/skills/pp-openrouter-image"      # symlink
+  rm -rf "$HOME/.agents/skills/pp-openrouter-image"  # shared skill target
+  ```
+
+  Remove an npx-installed skill first if you plan to reinstall via `hermes skills install`, otherwise the install is blocked with "Unsafe install path".
+
+### Local data (optional)
+
+Remove saved credentials and local state (sync cache, cost ledger, learnings):
+
+```bash
+rm -rf "$HOME/.config/openrouter-image-pp-cli" \
+       "$HOME/.local/share/openrouter-image-pp-cli" \
+       "$HOME/.local/state/openrouter-image-pp-cli" \
+       "$HOME/.cache/openrouter-image-pp-cli"
+```
 
 ## Authentication
 

--- a/library/ai/openrouter-image/README.md
+++ b/library/ai/openrouter-image/README.md
@@ -12,8 +12,8 @@ Created by [@neal-kyle](https://github.com/neal-kyle).
 
 ### Prerequisites
 
-- **Node.js** (any current LTS) — required for the npx installer below.
-- **Go 1.26.5 or newer** — only needed for the [Go fallback](#without-node-go-fallback) install or building from source. Not needed for the npx or pre-built binary paths.
+- **Node.js** (any current LTS) — required to run the npx installer below.
+- **Go 1.26.5 or newer** — required by the npx installer (it compiles the CLI via `go install`) and by the [Go fallback](#without-node-go-fallback) / source builds. The only paths that skip Go are `--skill-only` (installs the skill without the binary) and the [pre-built binary](#pre-built-binary) download.
 
 The recommended path installs both the `openrouter-image-pp-cli` binary and the `pp-openrouter-image` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
@@ -160,7 +160,7 @@ How you remove the skill depends on how it was installed:
 
 ### Local data (optional)
 
-Remove saved credentials and local state (sync cache, cost ledger, learnings):
+Remove saved credentials and local state (sync cache, cost ledger, learnings). The commands below remove the default locations:
 
 ```bash
 rm -rf "$HOME/.config/openrouter-image-pp-cli" \
@@ -168,6 +168,8 @@ rm -rf "$HOME/.config/openrouter-image-pp-cli" \
        "$HOME/.local/state/openrouter-image-pp-cli" \
        "$HOME/.cache/openrouter-image-pp-cli"
 ```
+
+If you relocated storage via `OPENROUTER_IMAGE_HOME` or a per-kind override (`OPENROUTER_IMAGE_CONFIG_DIR`, `OPENROUTER_IMAGE_DATA_DIR`, `OPENROUTER_IMAGE_STATE_DIR`, `OPENROUTER_IMAGE_CACHE_DIR`), the files live under those locations instead. Run `openrouter-image-pp-cli doctor` (or `openrouter-image-pp-cli agent-context --pretty` for the resolved paths) to see where each kind currently resolves before deleting.
 
 ## Authentication
 

--- a/library/ai/openrouter-image/README.md
+++ b/library/ai/openrouter-image/README.md
@@ -169,7 +169,7 @@ rm -rf "$HOME/.config/openrouter-image-pp-cli" \
        "$HOME/.cache/openrouter-image-pp-cli"
 ```
 
-If you relocated storage via `OPENROUTER_IMAGE_HOME` or a per-kind override (`OPENROUTER_IMAGE_CONFIG_DIR`, `OPENROUTER_IMAGE_DATA_DIR`, `OPENROUTER_IMAGE_STATE_DIR`, `OPENROUTER_IMAGE_CACHE_DIR`), the files live under those locations instead. Run `openrouter-image-pp-cli doctor` (or `openrouter-image-pp-cli agent-context --pretty` for the resolved paths) to see where each kind currently resolves before deleting.
+If you relocated storage via `--home`, `OPENROUTER_IMAGE_HOME`, or a per-kind override (`OPENROUTER_IMAGE_CONFIG_DIR`, `OPENROUTER_IMAGE_DATA_DIR`, `OPENROUTER_IMAGE_STATE_DIR`, `OPENROUTER_IMAGE_CACHE_DIR`), the files live under those locations instead. Run `openrouter-image-pp-cli doctor` (or `openrouter-image-pp-cli agent-context --pretty` for the resolved paths) to see where each kind currently resolves before deleting; when using `--home`, pass the same `--home <dir>` flag to that command.
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

Clean-slate test of the openrouter-image install flow (uninstall -> reinstall -> verify) surfaced gaps in `library/ai/openrouter-image/README.md`:

1. **No prerequisites documented.** The npx installer requires Node.js; the Go fallback requires Go 1.26.5+. The README mentioned neither up front.
2. **No uninstall docs, and the two install paths uninstall differently.** `hermes skills install` produces a skill that `hermes skills uninstall` removes cleanly, but the npx installer (`npx ... install openrouter-image`) registers the skill as a *local* skill (symlinked into `~/.agents/skills/`), which `hermes skills uninstall` refuses to remove with "not a hub-installed skill (may be a builtin)". It must be deleted by hand. The stale local copy also blocks a later `hermes skills install` with "Unsafe install path" until removed.
3. **Authentication section omitted the auth commands.** It only mentioned the `OPENROUTER_API_KEY` env var and claimed nothing is persisted. The CLI ships a full auth family (`set-token`, `status`, `setup`, `logout`); the permanent `auth set-token` path was undocumented.

## Changes

- **`### Prerequisites`** at the top of `## Install`: Node.js (npx installer) and Go 1.26.5+ (Go fallback / source builds only).
- **`## Uninstall`** section (placed after the generated install sections, before `## Authentication`):
  - CLI binary removal for Unix and Windows
  - Skill removal for both install paths, with the exact error and manual `rm` commands for the npx-installed case
  - Note about the "Unsafe install path" conflict when reinstalling via `hermes skills install`
  - Optional local-data cleanup (config/data/state/cache dirs)
- **`## Authentication`** rewritten: permanent (`auth set-token`), temporary (env var), `auth status` / `auth setup` / `auth logout`, and `doctor` verification.

## Verification

- Ran the full uninstall -> reinstall -> verify loop on Linux with the actual commands: npx install (binary + skill), `hermes skills install` fallback, `hermes skills uninstall`, and the manual removal for the npx-installed skill. Every command and error message in the new docs was observed live.
- Auth commands (`auth set-token`, `auth status`, `auth setup`) verified against the installed binary.
- Only `library/ai/openrouter-image/README.md` changed. No generated blocks touched: `## Uninstall` sits after the `<!-- pp-hermes-install-anchor -->` block, so `sweep-canonical` regeneration leaves it intact.

## Checklist

- [x] Single CLI scope (`openrouter-image`)
- [x] Hand-maintained sections only, generated install block untouched
- [x] Changes verified against the live CLI