### PR TITLE
fix(texas-roadhouse): keep guest PII off argv and correct waitlist docs

### DIFF
--- a/library/food-and-dining/texas-roadhouse/.manuscripts/20260829-221218/research/2026-08-29-221218-feat-texas-roadhouse-pp-cli-absorb-manifest.md
+++ b/library/food-and-dining/texas-roadhouse/.manuscripts/20260829-221218/research/2026-08-29-221218-feat-texas-roadhouse-pp-cli-absorb-manifest.md
@@ -7,7 +7,7 @@
 | Nearby store lookup | Sniffed `GET /api/stores/near` | Return stores with `extref`; waitlist paths use extref, not internal id. |
 | Quote by party size | Sniffed `GET /waitlist/{extref}/quote` | Expose `MinQuote` / `MaxQuote` buckets 1–6 so submit can send `WaitMinutes`. |
 | Join waitlist | Sniffed `POST /waitlist/{extref}/submit` | Require email, party size ≤ 6, `WaitMinutes` from quote MinQuote. Live POST only with `--yes`. |
-| Check-in (HERE) | Sniffed `POST /waitlist/{extref}/checkin` | Mark the party HERE at the host stand. Live POST only with `--yes`. |
+| Check-in (HERE) | Sniffed `POST /waitlist/{extref}/checkin` | Mark the party HERE after the guest texts HERE once everyone has arrived (REMOVE to leave). Not a host-stand visit. Live POST only with `--yes`. |
 | Cancel request | Sniffed `POST /waitlist/cancel` | Body `waitlistRequestId` is a JSON number; `siteId` is extref. Live POST only with `--yes`. |
 
 ## Transcendence

--- a/library/food-and-dining/texas-roadhouse/.manuscripts/20260829-221218/research/2026-08-29-221218-feat-texas-roadhouse-pp-cli-brief.md
+++ b/library/food-and-dining/texas-roadhouse/.manuscripts/20260829-221218/research/2026-08-29-221218-feat-texas-roadhouse-pp-cli-brief.md
@@ -6,7 +6,7 @@ generated_at: 2026-08-29
 
 # Texas Roadhouse CLI Brief
 
-Waitlist CLI for Texas Roadhouse call-ahead seating. Find a nearby store, read the quote, join the list, check in at the host stand, or cancel.
+Waitlist CLI for Texas Roadhouse call-ahead seating. Find a nearby store, read the quote, join the list, check in when the guest texts HERE, or cancel.
 
 ## API Identity
 
@@ -36,7 +36,7 @@ Internal spec derived from a sanitized browser sniff of `www.texasroadhouse.com`
 1. Geocode a named place (`mapbox`), list nearby stores (`stores --lat --long`), quote each extref.
 2. Present stores. Stop. Wait for the human to name one store and a party size (1–6).
 3. Dry-run submit. Live join only with `--yes`.
-4. Status while waiting. Check-in (HERE) at the host stand only with `--yes`.
+4. Status while waiting. Check-in (guest texts HERE once everyone has arrived; REMOVE to leave) only with `--yes`. Not a host-stand visit.
 5. Cancel only with `--yes`. `waitlistRequestId` stays a JSON number.
 
 ## Safety

--- a/library/food-and-dining/texas-roadhouse/.manuscripts/20260829-221218/research/2026-08-29-221218-novel-features-brainstorm.md
+++ b/library/food-and-dining/texas-roadhouse/.manuscripts/20260829-221218/research/2026-08-29-221218-novel-features-brainstorm.md
@@ -25,7 +25,7 @@ Sanitized sniffed-waitlist facts that a reprint must keep. No customer PII, toke
 
 `texasroadhouse checkin <extref>` posts to `/api/texasroadhouse/waitlist/{extref}/checkin`.
 
-- Marks the party HERE at the host stand.
+- Marks the party HERE after the guest texts HERE once everyone has arrived (REMOVE to leave). Not a host-stand visit.
 - Live check-in requires `--yes`.
 
 ## Quote MinQuote lookup

--- a/library/food-and-dining/texas-roadhouse/.manuscripts/20260829-221218/research/texas-roadhouse-spec.yaml
+++ b/library/food-and-dining/texas-roadhouse/.manuscripts/20260829-221218/research/texas-roadhouse-spec.yaml
@@ -302,7 +302,7 @@ resources:
             checkin:
                 method: POST
                 path: /api/texasroadhouse/waitlist/{waitlist_id}/checkin
-                description: Check in once the party is at the host stand. Do not fire without a yes.
+                description: Mark the party HERE after the guest texts HERE once everyone has arrived (text REMOVE to leave). Not a host-stand visit. Do not fire without a yes.
                 params:
                     - name: waitlist_id
                       type: string

--- a/library/food-and-dining/texas-roadhouse/.printing-press-patches/waitlist-pii-stdin-and-here-checkin.json
+++ b/library/food-and-dining/texas-roadhouse/.printing-press-patches/waitlist-pii-stdin-and-here-checkin.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 2,
+  "id": "waitlist-pii-stdin-and-here-checkin",
+  "applied_at": "2026-08-30",
+  "base_run_id": "20260829-221218",
+  "base_printing_press_version": "4.31.2",
+  "summary": "Guest name/email/phone default to stdin or a prompt (never argv); dry-run and logs redact them; check-in is HERE/REMOVE, not a host-stand visit; 404s point at stores/quote; Cloudflare-challenge 403 is a distinct error.",
+  "reason": "Argv PII leaks through shell history and ps. The waitlist HERE text is the check-in signal. Generated first-command and troubleshooting copy advertised a fake mapbox id and a nonexistent list command.",
+  "files": [
+    "internal/cli/texasroadhouse_pii.go",
+    "internal/cli/texasroadhouse_pii_test.go",
+    "internal/cli/texasroadhouse_errors.go",
+    "internal/cli/texasroadhouse_submit.go",
+    "internal/cli/texasroadhouse_checkin.go",
+    "internal/cli/texasroadhouse_confirm_test.go",
+    "internal/cli/helpers.go",
+    "internal/cli/root.go",
+    "internal/learn/journal.go",
+    "internal/mcp/tools.go",
+    "tools-manifest.json",
+    "spec.yaml"
+  ],
+  "validated_outcome": "Submit with --email-address/--first-name refuses; --stdin --dry-run redacts guest fields; 404 hint names stores/get-quote; Cloudflare Just a moment 403 uses the challenge hint."
+}

--- a/library/food-and-dining/texas-roadhouse/.printing-press.json
+++ b/library/food-and-dining/texas-roadhouse/.printing-press.json
@@ -50,7 +50,7 @@
     {
       "name": "Sniffed waitlist check-in",
       "command": "texasroadhouse checkin",
-      "description": "Check in at the host stand via sniffed POST /waitlist/{extref}/checkin (no public API)."
+      "description": "Mark the party HERE after the guest texts HERE once everyone has arrived (REMOVE to leave) via sniffed POST /waitlist/{extref}/checkin. Not a host-stand visit."
     },
     {
       "name": "Quote MinQuote lookup",

--- a/library/food-and-dining/texas-roadhouse/AGENTS.md
+++ b/library/food-and-dining/texas-roadhouse/AGENTS.md
@@ -33,6 +33,8 @@ texas-roadhouse-pp-cli <command> --dry-run --agent
 
 When a command requires confirmation, pass `--yes` explicitly only after the target, arguments, and side effects are clear. `--agent` does not imply `--yes`.
 
+Guest first name, last name, email, and phone must not appear on argv flags. Pass stdin JSON (or use the interactive prompt). `--dry-run` redacts those fields. Check-in is the guest texting HERE once everyone has arrived (REMOVE to leave), not a host-stand visit.
+
 ## Novel Command Data Sources
 
 Every hand-written novel command must declare its strategy in a Go line comment:

--- a/library/food-and-dining/texas-roadhouse/README.md
+++ b/library/food-and-dining/texas-roadhouse/README.md
@@ -2,6 +2,14 @@
 
 Waitlist CLI for Texas Roadhouse. Find a nearby store, read the quote, join and leave the list.
 
+This is an **unofficial** tool. It is **not affiliated with or endorsed by** Texas Roadhouse, Inc. It talks to **sniffed unofficial endpoints** (no public API). Those endpoints can change or break without notice. Use is subject to the [Texas Roadhouse website terms](https://www.texasroadhouse.com).
+
+**PII / consent:** joining a waitlist sends the guest's first name, last name, email, and phone to Texas Roadhouse. Get the guest's consent first. Do not put that identity on argv flags (shell history / `ps` leak). Pass stdin JSON, or use the interactive prompt.
+
+**Local retention:** successful waitlist responses may be written to the local SQLite store under the resolved data dir.
+
+**Last verified:** live-tested late Aug 2026. Naked HTTP gets Cloudflare 403; this CLI uses Chrome-compatible transport. A Cloudflare-challenge error means the origin returned `cf-mitigated` / "Just a moment" instead of the waitlist API — run `texas-roadhouse-pp-cli doctor`.
+
 Learn more at [Texas Roadhouse](https://www.texasroadhouse.com).
 
 ## Install
@@ -123,7 +131,8 @@ This checks your configuration.
 ### 3. Try Your First Command
 
 ```bash
-texas-roadhouse-pp-cli mapbox mock-value
+texas-roadhouse-pp-cli stores --lat 36.643 --long -93.218 --limit 4
+texas-roadhouse-pp-cli texasroadhouse get-quote 901
 ```
 
 ## Usage
@@ -197,13 +206,15 @@ Operations on near
 
 Operations on test
 
+Before `submit`, confirm: unofficial sniffed endpoints; guest consented to send name/email/phone; PII stays on stdin or a prompt (never argv); local store may retain the response; live join/check-in/cancel need `--yes`.
+
 - **`texas-roadhouse-pp-cli texasroadhouse cancel`** - Cancel a waitlist request. Live cancel requires `--yes`; `--dry-run` previews without POSTing.
-- **`texas-roadhouse-pp-cli texasroadhouse checkin`** - Check in once the party is at the host stand. Live check-in requires `--yes`; `--dry-run` previews without POSTing.
+- **`texas-roadhouse-pp-cli texasroadhouse checkin`** - Mark the party HERE after the guest texts HERE once everyone has arrived (text REMOVE to leave). Not a host-stand visit. Live check-in requires `--yes`; `--dry-run` previews without POSTing.
 - **`texas-roadhouse-pp-cli texasroadhouse get-quote`** - GET /api/texasroadhouse/waitlist/{waitlist_id}/quote
 - **`texas-roadhouse-pp-cli texasroadhouse get-settings`** - GET /api/texasroadhouse/waitlist/{waitlist_id}/settings
 - **`texas-roadhouse-pp-cli texasroadhouse get-status`** - GET waitlist request status. Query clientid=texasroadhouse.
 - **`texas-roadhouse-pp-cli texasroadhouse get-test`** - GET /api/texasroadhouse/waitlist/{waitlist_id}/test
-- **`texas-roadhouse-pp-cli texasroadhouse submit`** - Join a store waitlist. Live join requires `--yes`; `--dry-run` previews without POSTing.
+- **`texas-roadhouse-pp-cli texasroadhouse submit`** - Join a store waitlist. Guest PII comes from stdin JSON or a prompt, never argv flags. Live join requires `--yes`; `--dry-run` previews a redacted body without POSTing.
 
 
 ### Self-learning loop
@@ -227,25 +238,25 @@ The local store's schema version stamp is one-way: once this version of `texas-r
 
 ```bash
 # Human-readable table (default in terminal, JSON when piped)
-texas-roadhouse-pp-cli mapbox mock-value
+texas-roadhouse-pp-cli stores --lat 36.643 --long -93.218 --limit 4
 
 # JSON for scripting and agents
-texas-roadhouse-pp-cli mapbox mock-value --json
+texas-roadhouse-pp-cli texasroadhouse get-quote 901 --json
 # Filter to specific fields
-texas-roadhouse-pp-cli mapbox mock-value --json --select bbox,center,context
+texas-roadhouse-pp-cli stores --lat 36.643 --long -93.218 --limit 4 --json --select name,extref,city,distance
 
 # Dry run — show the request without sending
-texas-roadhouse-pp-cli mapbox mock-value --dry-run
+texas-roadhouse-pp-cli texasroadhouse get-quote 901 --dry-run
 
 # Agent mode — JSON + compact + no prompts in one flag
-texas-roadhouse-pp-cli mapbox mock-value --agent
+texas-roadhouse-pp-cli stores --lat 36.643 --long -93.218 --limit 4 --agent
 ```
 
 ## Agent Usage
 
 This CLI is designed for AI agent consumption:
 
-- **Non-interactive** - never prompts, every input is a flag
+- **Non-interactive** - `--agent` never prompts; guest name/email/phone belong on stdin JSON, not argv flags
 - **Pipeable** - `--json` output to stdout, errors to stderr
 - **Filterable** - `--select <field>[,<field>...]` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
@@ -273,8 +284,13 @@ Static request headers can be configured under `headers`; per-command header ove
 
 ## Troubleshooting
 **Not found errors (exit code 3)**
-- Check the resource ID is correct
-- Run the `list` command to see available items
+- Check the store `extref` (not the internal store id)
+- Look up stores with `stores --lat <lat> --long <long>` and quotes with `texasroadhouse get-quote <extref>`
+- This CLI has no `list` command
+
+**Cloudflare challenge (HTTP 403)**
+- Naked HTTP gets Cloudflare 403. This CLI uses Chrome-compatible transport (live-tested late Aug 2026)
+- If the error names a Cloudflare challenge (`cf-mitigated` / Just a moment), the origin returned the interstitial instead of the waitlist API. Run `texas-roadhouse-pp-cli doctor`
 
 ## HTTP Transport
 

--- a/library/food-and-dining/texas-roadhouse/SKILL.md
+++ b/library/food-and-dining/texas-roadhouse/SKILL.md
@@ -14,6 +14,16 @@ metadata:
 
 # Texas Roadhouse - call ahead seating
 
+This is an **unofficial** skill. It is **not affiliated with or endorsed by** Texas Roadhouse, Inc. The CLI talks to **sniffed unofficial endpoints** (no public API). Those endpoints can change or break without notice. Use is subject to Texas Roadhouse website terms.
+
+**PII / consent:** joining a waitlist sends the guest's first name, last name, email, and phone. Get consent first. Never put that identity on argv flags. Agents pass stdin JSON. `--dry-run` redacts PII. Live `submit` / `checkin` / `cancel` require `--yes`.
+
+**Local retention:** successful waitlist responses may be written to the local SQLite store.
+
+**Check-in:** the guest texts HERE once everyone has arrived (text REMOVE to leave). This is not a host-stand visit.
+
+**Last verified:** live-tested late Aug 2026. Naked HTTP gets Cloudflare 403; the CLI uses Chrome-compatible transport. A Cloudflare-challenge error means `cf-mitigated` / "Just a moment" instead of the API — run `texas-roadhouse-pp-cli doctor`.
+
 ## Prerequisites: Install the CLI
 
 This skill drives the `texas-roadhouse-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
@@ -59,12 +69,12 @@ This CLI was generated with browser-observed traffic context.
 **texasroadhouse** — Operations on test
 
 - `texas-roadhouse-pp-cli texasroadhouse cancel` — Cancel a waitlist request. Live cancel requires `--yes`; `--dry-run` previews without POSTing.
-- `texas-roadhouse-pp-cli texasroadhouse checkin` — Check in once the party is at the host stand. Live check-in requires `--yes`; `--dry-run` previews without POSTing.
+- `texas-roadhouse-pp-cli texasroadhouse checkin` — Mark the party HERE after the guest texts HERE once everyone has arrived (text REMOVE to leave). Not a host-stand visit. Live check-in requires `--yes`; `--dry-run` previews without POSTing.
 - `texas-roadhouse-pp-cli texasroadhouse get-quote` — GET /api/texasroadhouse/waitlist/{waitlist_id}/quote
 - `texas-roadhouse-pp-cli texasroadhouse get-settings` — GET /api/texasroadhouse/waitlist/{waitlist_id}/settings
 - `texas-roadhouse-pp-cli texasroadhouse get-status` — GET waitlist request status. Query clientid=texasroadhouse.
 - `texas-roadhouse-pp-cli texasroadhouse get-test` — GET /api/texasroadhouse/waitlist/{waitlist_id}/test
-- `texas-roadhouse-pp-cli texasroadhouse submit` — Join a store waitlist. Live join requires `--yes`; `--dry-run` previews without POSTing.
+- `texas-roadhouse-pp-cli texasroadhouse submit` — Join a store waitlist. Guest PII comes from stdin JSON or a prompt, never argv flags. Live join requires `--yes`; `--dry-run` previews a redacted body without POSTing.
 
 
 ### Finding the right command
@@ -91,11 +101,11 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
-  texas-roadhouse-pp-cli mapbox mock-value --agent --select bbox,center,context
+  texas-roadhouse-pp-cli stores --lat 36.643 --long -93.218 --limit 4 --agent --select name,extref,city,distance
   ```
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available
-- **Non-interactive** — never prompts, every input is a flag
+- **Non-interactive** — `--agent` never prompts; guest name/email/phone belong on stdin JSON, not argv flags
 - **Explicit confirmation** — `--agent` does not imply `--yes`; pass `--yes` separately only after the target, arguments, and side effects are clear
 - **Explicit retries** — use `--idempotent` only when an already-existing create should count as success
 
@@ -363,7 +373,7 @@ A profile is a saved set of flag values, reused across invocations. Use it when 
 
 ```
 texas-roadhouse-pp-cli profile save briefing --json
-texas-roadhouse-pp-cli --profile briefing mapbox mock-value
+texas-roadhouse-pp-cli --profile briefing stores --lat 36.643 --long -93.218 --limit 4
 texas-roadhouse-pp-cli profile list --json
 texas-roadhouse-pp-cli profile show briefing
 texas-roadhouse-pp-cli profile delete briefing --yes
@@ -394,7 +404,14 @@ When a human wants on a Texas Roadhouse waitlist:
 3. `stores --lat … --long … --limit 4 --radius 80`. Use each store's `extref` as `waitlist_id`, not the internal `id`.
 4. `texasroadhouse get-quote <extref>` for those four.
 5. **STOP.** Present 3–4 stores with name, street address, city, distance, and wait. Wait for the human to name one store and a party size (1–6).
-6. Dry-run `submit` only after that pick. Live `submit` only after an explicit yes. Email is required. VIP Club stays off.
+6. Repeat the disclosures (unofficial / sniffed endpoints / PII consent / local retention / ToS). Dry-run `submit --stdin` only after that pick. Guest name, email, and phone go in stdin JSON — never argv flags:
+
+   ```bash
+   printf '%s\n' '{"EmailAddress":"<email>","FirstName":"<first>","LastName":"<last>","PrimaryPhoneAreaCode":"<area>","PrimaryPhoneNumber":"<number>","PartySize":2,"WaitMinutes":10}' \
+     | texas-roadhouse-pp-cli texasroadhouse submit 901 --stdin --dry-run
+   ```
+
+   Live `submit` only after an explicit yes (`--yes`). VIP Club stays off. The guest later texts HERE once everyone has arrived (REMOVE to leave); `checkin` is that HERE mark, not a host-stand visit, and still needs `--yes`.
 
 ### How to present the options (every harness)
 

--- a/library/food-and-dining/texas-roadhouse/internal/cli/helpers.go
+++ b/library/food-and-dining/texas-roadhouse/internal/cli/helpers.go
@@ -615,10 +615,9 @@ func classifyAPIErrorOnly(err error) error {
 			"\n      See API docs: https://www.texasroadhouse.com"+
 			"\n      Run 'texas-roadhouse-pp-cli doctor' to check auth status.", err))
 	case strings.Contains(msg, "HTTP 403"):
-		return authErr(fmt.Errorf("%w\nhint: permission denied. This API is configured without credentials, so the service may be blocking the request by rate limit, geography, bot protection, or endpoint policy."+
-			"\n      Run 'texas-roadhouse-pp-cli doctor' to check connectivity.", err))
+		return classifyWaitlistHTTP403(err)
 	case strings.Contains(msg, "HTTP 404"):
-		return notFoundErr(fmt.Errorf("%w\nhint: resource not found. Run the 'list' command to see available items", err))
+		return classifyWaitlistHTTP404(err)
 	case strings.Contains(msg, "HTTP 429"):
 		return rateLimitErr(err)
 	default:

--- a/library/food-and-dining/texas-roadhouse/internal/cli/root.go
+++ b/library/food-and-dining/texas-roadhouse/internal/cli/root.go
@@ -216,11 +216,17 @@ func isCobraUsageError(err error) bool {
 func newRootCmd(flags *rootFlags) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "texas-roadhouse-pp-cli",
-		Short: "Manage texas-roadhouse resources via the texas-roadhouse API",
-		Long: `Manage texas-roadhouse resources via the texas-roadhouse API.
+		Short: "Unofficial Texas Roadhouse waitlist CLI (not affiliated)",
+		Long: `Unofficial Texas Roadhouse waitlist CLI. Not affiliated with or endorsed by Texas Roadhouse, Inc.
+
+This talks to sniffed unofficial endpoints (no public API). Endpoints can change or break without notice. Use is subject to Texas Roadhouse website terms.
+
+Guest first name, last name, email, and phone must not be passed as argv flags. Default is stdin JSON or an interactive prompt. Live submit, check-in (guest texts HERE once everyone has arrived; REMOVE to leave), and cancel require --yes. --dry-run redacts PII.
+
+Last verified late Aug 2026: naked HTTP gets Cloudflare 403; this CLI uses Chrome-compatible transport.
 
 Add --agent to any command for JSON output + non-interactive mode.
-Run 'texas-roadhouse-pp-cli doctor' to verify auth and connectivity.`,
+Run 'texas-roadhouse-pp-cli doctor' to verify connectivity.`,
 		SilenceUsage: true,
 		Version:      version,
 	}

--- a/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_checkin.go
+++ b/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_checkin.go
@@ -17,7 +17,7 @@ func newTexasroadhouseCheckinCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:         "checkin <waitlist_id>",
-		Short:       "Check in once the party is at the host stand. Live check-in requires --yes; --dry-run previews without POSTing.",
+		Short:       "Mark the party HERE after the guest texts HERE once everyone has arrived (text REMOVE to leave). Not a host-stand visit. Live check-in requires --yes; --dry-run previews without POSTing.",
 		Example:     "  texas-roadhouse-pp-cli texasroadhouse checkin 550e8400-e29b-41d4-a716-446655440000",
 		Annotations: map[string]string{"pp:endpoint": "texasroadhouse.checkin", "pp:method": "POST", "pp:path": "/api/texasroadhouse/waitlist/{waitlist_id}/checkin"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_confirm_test.go
+++ b/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_confirm_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,13 +13,17 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/food-and-dining/texas-roadhouse/internal/client"
 )
 
+const submitGuestStdinJSON = `{"EmailAddress":"guest@example.test","FirstName":"Test","LastName":"User","PrimaryPhoneAreaCode":"555","PrimaryPhoneNumber":"555-0100","PartySize":2,"WaitMinutes":10}`
+
 func waitlistMutationCases() []struct {
-	name string
-	args []string
+	name  string
+	args  []string
+	stdin string
 } {
 	return []struct {
-		name string
-		args []string
+		name  string
+		args  []string
+		stdin string
 	}{
 		{
 			name: "checkin",
@@ -29,20 +34,23 @@ func waitlistMutationCases() []struct {
 			args: []string{"texasroadhouse", "cancel", "--waitlist-request-id", "1", "--site-id", "218", "--no-learn"},
 		},
 		{
-			name: "submit",
-			args: []string{
-				"texasroadhouse", "submit", "218",
-				"--email-address", "guest@example.test",
-				"--first-name", "Test",
-				"--last-name", "User",
-				"--primary-phone-area-code", "555",
-				"--primary-phone-number", "555-0100",
-				"--party-size", "2",
-				"--wait-minutes", "10",
-				"--no-learn",
-			},
+			name:  "submit",
+			args:  []string{"texasroadhouse", "submit", "218", "--stdin", "--no-learn"},
+			stdin: submitGuestStdinJSON,
 		},
 	}
+}
+
+func runRootArgsWithStdin(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	rootCmd := RootCmd()
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetIn(strings.NewReader(stdin))
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	return stdout.String(), stderr.String(), err
 }
 
 func TestWaitlistMutationsRefuseWithoutYes(t *testing.T) {
@@ -50,7 +58,7 @@ func TestWaitlistMutationsRefuseWithoutYes(t *testing.T) {
 	for _, tc := range waitlistMutationCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			args := append(append([]string{}, tc.args...), "--agent")
-			_, stderr, err := runRootArgs(t, args...)
+			_, stderr, err := runRootArgsWithStdin(t, tc.stdin, args...)
 			if err == nil {
 				t.Fatalf("expected refuse without --yes, stderr=%q", stderr)
 			}
@@ -78,7 +86,7 @@ func TestWaitlistMutationsDryRunDoesNotPost(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			posts.Store(0)
 			args := append(append([]string{}, tc.args...), "--dry-run", "--agent")
-			_, stderr, err := runRootArgs(t, args...)
+			_, stderr, err := runRootArgsWithStdin(t, tc.stdin, args...)
 			if err != nil {
 				t.Fatalf("dry-run should succeed: %v (stderr=%q)", err, stderr)
 			}
@@ -106,7 +114,7 @@ func TestWaitlistMutationsYesPosts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			posts.Store(0)
 			args := append(append([]string{}, tc.args...), "--yes", "--agent")
-			_, stderr, err := runRootArgs(t, args...)
+			_, stderr, err := runRootArgsWithStdin(t, tc.stdin, args...)
 			if err != nil {
 				t.Fatalf("--yes should POST: %v (stderr=%q)", err, stderr)
 			}

--- a/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_errors.go
+++ b/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_errors.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Thomas McCormick and contributors. Licensed under Apache-2.0. See LICENSE.
+// PATCH(waitlist-pii-stdin-and-here-checkin): Cloudflare-challenge 403 + no fake list command.
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+const cloudflareChallengeHint = "Cloudflare challenge. Naked HTTP gets HTTP 403; this CLI uses Chrome-compatible transport (live-tested late Aug 2026). If this persists, the origin returned a challenge page (cf-mitigated / Just a moment) instead of the waitlist API. Run 'texas-roadhouse-pp-cli doctor'."
+
+const notFoundStoresHint = "resource not found. This CLI has no list command; look up stores with 'stores --lat <lat> --long <long>' and quotes with 'texasroadhouse get-quote <extref>'."
+
+// LooksLikeCloudflareChallenge reports a Cloudflare interstitial or
+// cf-mitigated 403, as opposed to a generic permission denial.
+func LooksLikeCloudflareChallenge(msg string) bool {
+	lower := strings.ToLower(msg)
+	if !strings.Contains(lower, "403") {
+		return false
+	}
+	return strings.Contains(lower, "cloudflare") ||
+		strings.Contains(lower, "cf-mitigated") ||
+		strings.Contains(lower, "just a moment") ||
+		strings.Contains(lower, "challenges.cloudflare.com") ||
+		(strings.Contains(lower, "attention required") && strings.Contains(lower, "cloudflare"))
+}
+
+func classifyWaitlistHTTP403(err error) error {
+	if err == nil {
+		return nil
+	}
+	if LooksLikeCloudflareChallenge(err.Error()) {
+		return authErr(fmt.Errorf("%w\nhint: %s", err, cloudflareChallengeHint))
+	}
+	return authErr(fmt.Errorf("%w\nhint: permission denied. This API is configured without credentials, so the service may be blocking the request by rate limit, geography, bot protection, or endpoint policy."+
+		"\n      Run 'texas-roadhouse-pp-cli doctor' to check connectivity.", err))
+}
+
+func classifyWaitlistHTTP404(err error) error {
+	return notFoundErr(fmt.Errorf("%w\nhint: %s", err, notFoundStoresHint))
+}
+
+// CloudflareChallengeToolMessage is the MCP-facing form of the same 403 hint.
+func CloudflareChallengeToolMessage(msg string) string {
+	return "Cloudflare challenge: " + msg + "\nhint: " + cloudflareChallengeHint
+}

--- a/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_pii.go
+++ b/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_pii.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Thomas McCormick and contributors. Licensed under Apache-2.0. See LICENSE.
+// PATCH(waitlist-pii-stdin-and-here-checkin): guest name/email/phone stay off argv.
+
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// waitlistPIIFlagNames are argv flags that leak guest identity into shell
+// history and `ps`. Submit must not take these as the default input path.
+var waitlistPIIFlagNames = []string{
+	"email-address",
+	"first-name",
+	"last-name",
+	"primary-phone-area-code",
+	"primary-phone-number",
+	"primary-phone-extension",
+}
+
+var waitlistPIIBodyKeys = []string{
+	"EmailAddress",
+	"FirstName",
+	"LastName",
+	"PrimaryPhoneAreaCode",
+	"PrimaryPhoneNumber",
+	"PrimaryPhoneExtension",
+}
+
+const waitlistPIIRedacted = "<redacted>"
+
+const waitlistPIIArgvErr = "guest first name, last name, email, and phone must not be passed as argv flags (shell history / ps leak); pass stdin JSON or use an interactive prompt"
+
+const waitlistPIIStdinErr = "guest PII is required on stdin JSON (agents) or an interactive prompt; do not pass name, email, or phone as flags"
+
+// rejectWaitlistPIIFlags refuses PII on argv even when the flags still exist
+// for help compatibility. The values must never become the submit body.
+func rejectWaitlistPIIFlags(cmd *cobra.Command) error {
+	if cmd == nil {
+		return nil
+	}
+	for _, name := range waitlistPIIFlagNames {
+		if cmd.Flags().Changed(name) {
+			return usageErr(fmt.Errorf("%s", waitlistPIIArgvErr))
+		}
+	}
+	return nil
+}
+
+// redactWaitlistPII copies body and replaces guest identity fields. Used for
+// --dry-run display and logs so a preview cannot leak name/email/phone.
+func redactWaitlistPII(body map[string]any) map[string]any {
+	out := make(map[string]any, len(body))
+	for k, v := range body {
+		out[k] = v
+	}
+	for _, key := range waitlistPIIBodyKeys {
+		if _, ok := out[key]; ok {
+			out[key] = waitlistPIIRedacted
+		}
+	}
+	return out
+}
+
+func waitlistPIIPlaceholderBody() map[string]any {
+	return map[string]any{
+		"EmailAddress":         waitlistPIIRedacted,
+		"FirstName":            waitlistPIIRedacted,
+		"LastName":             waitlistPIIRedacted,
+		"PrimaryPhoneAreaCode": waitlistPIIRedacted,
+		"PrimaryPhoneNumber":   waitlistPIIRedacted,
+	}
+}
+
+func waitlistHasGuestPII(body map[string]any) bool {
+	for _, key := range []string{"EmailAddress", "FirstName", "LastName", "PrimaryPhoneAreaCode", "PrimaryPhoneNumber"} {
+		if waitlistNonEmpty(body[key]) {
+			return true
+		}
+	}
+	return false
+}
+
+func waitlistNonEmpty(v any) bool {
+	if v == nil {
+		return false
+	}
+	s := strings.TrimSpace(fmt.Sprint(v))
+	return s != "" && s != "<nil>"
+}
+
+func mergeWaitlistJSON(dst map[string]any, src map[string]any) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}
+
+// readWaitlistStdinJSON reads a guest/submit object from cmd.InOrStdin().
+func readWaitlistStdinJSON(r io.Reader) (map[string]any, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading stdin: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil, nil
+	}
+	var jsonBody map[string]any
+	if err := json.Unmarshal(data, &jsonBody); err != nil {
+		return nil, fmt.Errorf("parsing stdin JSON: %w", err)
+	}
+	return jsonBody, nil
+}
+
+func isTerminalReader(r io.Reader) bool {
+	if f, ok := r.(*os.File); ok {
+		return isTerminal(f)
+	}
+	return false
+}
+
+func waitlistInteractiveAllowed(flags *rootFlags, in io.Reader) bool {
+	if flags != nil && (flags.agent || flags.noInput) {
+		return false
+	}
+	return isTerminalReader(in)
+}
+
+func promptWaitlistGuestPII(in io.Reader, errOut io.Writer) (map[string]any, error) {
+	reader := bufio.NewReader(in)
+	ask := func(label string) (string, error) {
+		fmt.Fprintf(errOut, "%s: ", label)
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return "", err
+		}
+		return strings.TrimSpace(line), nil
+	}
+	first, err := ask("First name")
+	if err != nil {
+		return nil, err
+	}
+	last, err := ask("Last name")
+	if err != nil {
+		return nil, err
+	}
+	email, err := ask("Email")
+	if err != nil {
+		return nil, err
+	}
+	area, err := ask("Phone area code (3 digits)")
+	if err != nil {
+		return nil, err
+	}
+	number, err := ask("Phone number (xxx-xxxx)")
+	if err != nil {
+		return nil, err
+	}
+	body := map[string]any{
+		"EmailAddress":         email,
+		"FirstName":            first,
+		"LastName":             last,
+		"PrimaryPhoneAreaCode": area,
+		"PrimaryPhoneNumber":   number,
+	}
+	if !waitlistHasGuestPII(body) {
+		return nil, usageErr(fmt.Errorf("%s", waitlistPIIStdinErr))
+	}
+	return body, nil
+}
+
+// collectWaitlistGuestPII loads guest identity from stdin JSON or an
+// interactive prompt. Argv flags are never the source.
+func collectWaitlistGuestPII(cmd *cobra.Command, flags *rootFlags, stdinBody bool) (map[string]any, error) {
+	if err := rejectWaitlistPIIFlags(cmd); err != nil {
+		return nil, err
+	}
+	in := io.Reader(os.Stdin)
+	errOut := io.Writer(os.Stderr)
+	if cmd != nil {
+		in = cmd.InOrStdin()
+		errOut = cmd.ErrOrStderr()
+	}
+
+	// Piped or --stdin JSON is the agent path.
+	if stdinBody || !isTerminalReader(in) {
+		parsed, err := readWaitlistStdinJSON(in)
+		if err != nil {
+			return nil, err
+		}
+		if parsed != nil {
+			return parsed, nil
+		}
+	}
+	if flags != nil && flags.dryRun && !stdinBody {
+		return waitlistPIIPlaceholderBody(), nil
+	}
+	if waitlistInteractiveAllowed(flags, in) {
+		return promptWaitlistGuestPII(in, errOut)
+	}
+	if flags != nil && flags.dryRun {
+		return waitlistPIIPlaceholderBody(), nil
+	}
+	return nil, usageErr(fmt.Errorf("%s", waitlistPIIStdinErr))
+}
+
+func applyWaitlistNonPIIFlags(cmd *cobra.Command, body map[string]any, isSmoking bool, partySize float64, waitMinutes int, platform string, phoneType int) {
+	if cmd.Flags().Changed("is-smoking") {
+		body["IsSmoking"] = isSmoking
+	}
+	if cmd.Flags().Changed("party-size") || partySize != 0 {
+		body["PartySize"] = partySize
+	}
+	if cmd.Flags().Changed("wait-minutes") || waitMinutes != 0 {
+		body["WaitMinutes"] = waitMinutes
+	}
+	if cmd.Flags().Changed("platform") || platform != "" {
+		body["Platform"] = platform
+	}
+	if cmd.Flags().Changed("primary-phone-type") || phoneType != 0 {
+		body["PrimaryPhoneType"] = phoneType
+	}
+}
+
+func requireWaitlistSubmitFields(body map[string]any, dryRun bool) error {
+	if dryRun {
+		return nil
+	}
+	for _, key := range []string{"EmailAddress", "FirstName", "LastName", "PrimaryPhoneAreaCode", "PrimaryPhoneNumber"} {
+		if !waitlistNonEmpty(body[key]) || fmt.Sprint(body[key]) == waitlistPIIRedacted {
+			return usageErr(fmt.Errorf("%s", waitlistPIIStdinErr))
+		}
+	}
+	if !waitlistNonEmpty(body["PartySize"]) {
+		return usageErr(fmt.Errorf("required flag %q not set (or include PartySize in stdin JSON)", "party-size"))
+	}
+	if !waitlistNonEmpty(body["WaitMinutes"]) {
+		return usageErr(fmt.Errorf("required flag %q not set (or include WaitMinutes in stdin JSON)", "wait-minutes"))
+	}
+	return nil
+}

--- a/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_pii_test.go
+++ b/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_pii_test.go
@@ -3,9 +3,30 @@
 package cli
 
 import (
+	"io"
+	"os"
 	"strings"
 	"testing"
 )
+
+func captureOSStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+	fn()
+	_ = w.Close()
+	out, err := io.ReadAll(r)
+	_ = r.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
 
 func TestRejectWaitlistPIIFlags(t *testing.T) {
 	withTempLearnHome(t)
@@ -28,22 +49,44 @@ func TestRejectWaitlistPIIFlags(t *testing.T) {
 	}
 }
 
+func TestRedactWaitlistPII(t *testing.T) {
+	got := redactWaitlistPII(map[string]any{
+		"EmailAddress":         "guest@example.test",
+		"FirstName":            "Test",
+		"LastName":             "User",
+		"PrimaryPhoneAreaCode": "555",
+		"PrimaryPhoneNumber":   "555-0100",
+		"PartySize":            2,
+		"WaitMinutes":          10,
+	})
+	for _, key := range []string{"EmailAddress", "FirstName", "LastName", "PrimaryPhoneAreaCode", "PrimaryPhoneNumber"} {
+		if got[key] != waitlistPIIRedacted {
+			t.Fatalf("%s = %v, want %s", key, got[key], waitlistPIIRedacted)
+		}
+	}
+	if got["PartySize"] != 2 || got["WaitMinutes"] != 10 {
+		t.Fatalf("non-PII fields were changed: %#v", got)
+	}
+}
+
 func TestSubmitDryRunRedactsPII(t *testing.T) {
 	withTempLearnHome(t)
-	_, stderr, err := runRootArgsWithStdin(t, submitGuestStdinJSON,
-		"texasroadhouse", "submit", "218",
-		"--stdin", "--dry-run", "--agent", "--no-learn",
-	)
-	if err != nil {
-		t.Fatalf("dry-run submit: %v (stderr=%q)", err, stderr)
-	}
-	leaks := []string{"guest@example.test", "555-0100", `"Test"`, `"User"`}
+	stderr := captureOSStderr(t, func() {
+		_, _, err := runRootArgsWithStdin(t, submitGuestStdinJSON,
+			"texasroadhouse", "submit", "218",
+			"--stdin", "--dry-run", "--agent", "--no-learn",
+		)
+		if err != nil {
+			t.Fatalf("dry-run submit: %v", err)
+		}
+	})
+	leaks := []string{"guest@example.test", "555-0100"}
 	for _, leak := range leaks {
 		if strings.Contains(stderr, leak) {
 			t.Fatalf("dry-run stderr leaked %q: %s", leak, stderr)
 		}
 	}
-	if !strings.Contains(stderr, waitlistPIIRedacted) {
+	if !strings.Contains(stderr, "redacted") {
 		t.Fatalf("dry-run stderr should redact PII, got %q", stderr)
 	}
 }

--- a/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_pii_test.go
+++ b/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_pii_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Thomas McCormick and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRejectWaitlistPIIFlags(t *testing.T) {
+	withTempLearnHome(t)
+	_, _, err := runRootArgs(t,
+		"texasroadhouse", "submit", "218",
+		"--email-address", "guest@example.test",
+		"--first-name", "Test",
+		"--last-name", "User",
+		"--primary-phone-area-code", "555",
+		"--primary-phone-number", "555-0100",
+		"--party-size", "2",
+		"--wait-minutes", "10",
+		"--dry-run", "--agent", "--no-learn",
+	)
+	if err == nil {
+		t.Fatal("expected argv PII flags to be refused")
+	}
+	if !strings.Contains(err.Error(), "must not be passed as argv flags") {
+		t.Fatalf("error = %v, want argv PII refusal", err)
+	}
+}
+
+func TestSubmitDryRunRedactsPII(t *testing.T) {
+	withTempLearnHome(t)
+	_, stderr, err := runRootArgsWithStdin(t, submitGuestStdinJSON,
+		"texasroadhouse", "submit", "218",
+		"--stdin", "--dry-run", "--agent", "--no-learn",
+	)
+	if err != nil {
+		t.Fatalf("dry-run submit: %v (stderr=%q)", err, stderr)
+	}
+	leaks := []string{"guest@example.test", "555-0100", `"Test"`, `"User"`}
+	for _, leak := range leaks {
+		if strings.Contains(stderr, leak) {
+			t.Fatalf("dry-run stderr leaked %q: %s", leak, stderr)
+		}
+	}
+	if !strings.Contains(stderr, waitlistPIIRedacted) {
+		t.Fatalf("dry-run stderr should redact PII, got %q", stderr)
+	}
+}
+
+func TestLooksLikeCloudflareChallenge(t *testing.T) {
+	if !LooksLikeCloudflareChallenge("GET /api/stores/near returned HTTP 403: HTML error page (1200 bytes): Just a moment") {
+		t.Fatal("expected Just a moment 403 to classify as Cloudflare")
+	}
+	if !LooksLikeCloudflareChallenge("GET /x returned HTTP 403: cf-mitigated: challenge") {
+		t.Fatal("expected cf-mitigated 403 to classify as Cloudflare")
+	}
+	if LooksLikeCloudflareChallenge("GET /x returned HTTP 403: permission denied") {
+		t.Fatal("generic 403 should not be a Cloudflare challenge")
+	}
+}
+
+func TestClassifyWaitlistHTTP404OmitsListCommand(t *testing.T) {
+	err := classifyAPIErrorOnly(fmtWaitlistAPIError("GET /api/stores/near returned HTTP 404: missing"))
+	if err == nil {
+		t.Fatal("expected 404 error")
+	}
+	if strings.Contains(err.Error(), "list' command") || strings.Contains(err.Error(), "list command to see") {
+		t.Fatalf("404 hint still mentions list command: %v", err)
+	}
+	if !strings.Contains(err.Error(), "stores") || !strings.Contains(err.Error(), "get-quote") {
+		t.Fatalf("404 hint should point at stores/get-quote: %v", err)
+	}
+}
+
+func TestClassifyWaitlistHTTP403Cloudflare(t *testing.T) {
+	err := classifyAPIErrorOnly(fmtWaitlistAPIError("GET /api/stores/near returned HTTP 403: HTML error page (800 bytes): Just a moment"))
+	if err == nil {
+		t.Fatal("expected 403 error")
+	}
+	if !strings.Contains(err.Error(), "Cloudflare challenge") {
+		t.Fatalf("403 Cloudflare hint missing: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Chrome-compatible") {
+		t.Fatalf("403 should mention Chrome-compatible transport: %v", err)
+	}
+}
+
+func fmtWaitlistAPIError(msg string) error {
+	return &simpleError{msg: msg}
+}
+
+type simpleError struct{ msg string }
+
+func (e *simpleError) Error() string { return e.msg }

--- a/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_submit.go
+++ b/library/food-and-dining/texas-roadhouse/internal/cli/texasroadhouse_submit.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -27,9 +26,9 @@ func newTexasroadhouseSubmitCmd(flags *rootFlags) *cobra.Command {
 	var stdinBody bool
 
 	cmd := &cobra.Command{
-		Use:         "submit <waitlist_id>",
-		Short:       "Join a store waitlist. Live join requires --yes; --dry-run previews without POSTing.",
-		Example:     "  texas-roadhouse-pp-cli texasroadhouse submit 550e8400-e29b-41d4-a716-446655440000 --email-address 123 Test St, Anytown, ST 12345",
+		Use:   "submit <waitlist_id>",
+		Short: "Join a store waitlist. Guest PII comes from stdin JSON or a prompt, never argv flags. Live join requires --yes; --dry-run previews a redacted body without POSTing.",
+		Example: "  printf '%s\\n' '{\"EmailAddress\":\"<email>\",\"FirstName\":\"<first>\",\"LastName\":\"<last>\",\"PrimaryPhoneAreaCode\":\"<area>\",\"PrimaryPhoneNumber\":\"<number>\",\"PartySize\":2,\"WaitMinutes\":10}' | texas-roadhouse-pp-cli texasroadhouse submit 901 --stdin --dry-run",
 		Annotations: map[string]string{"pp:endpoint": "texasroadhouse.submit", "pp:method": "POST", "pp:path": "/api/texasroadhouse/waitlist/{waitlist_id}/submit"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Bare invocation of a command with required input prints help
@@ -65,28 +64,8 @@ func newTexasroadhouseSubmitCmd(flags *rootFlags) *cobra.Command {
 				}
 				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <waitlist_id>"))
 			}
-			if !stdinBody {
-				if !cmd.Flags().Changed("email-address") && !flags.dryRun {
-					return fmt.Errorf("required flag \"%s\" not set", "email-address")
-				}
-				if !cmd.Flags().Changed("first-name") && !flags.dryRun {
-					return fmt.Errorf("required flag \"%s\" not set", "first-name")
-				}
-				if !cmd.Flags().Changed("last-name") && !flags.dryRun {
-					return fmt.Errorf("required flag \"%s\" not set", "last-name")
-				}
-				if !cmd.Flags().Changed("primary-phone-area-code") && !flags.dryRun {
-					return fmt.Errorf("required flag \"%s\" not set", "primary-phone-area-code")
-				}
-				if !cmd.Flags().Changed("primary-phone-number") && !flags.dryRun {
-					return fmt.Errorf("required flag \"%s\" not set", "primary-phone-number")
-				}
-				if !cmd.Flags().Changed("party-size") && !flags.dryRun {
-					return fmt.Errorf("required flag \"%s\" not set", "party-size")
-				}
-				if !cmd.Flags().Changed("wait-minutes") && !flags.dryRun {
-					return fmt.Errorf("required flag \"%s\" not set", "wait-minutes")
-				}
+			if err := rejectWaitlistPIIFlags(cmd); err != nil {
+				return err
 			}
 			path := "/api/texasroadhouse/waitlist/{waitlist_id}/submit"
 			if len(args) < 1 || args[0] == "" {
@@ -101,53 +80,19 @@ func newTexasroadhouseSubmitCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			var body any
-			if stdinBody {
-				stdinData, err := io.ReadAll(os.Stdin)
-				if err != nil {
-					return fmt.Errorf("reading stdin: %w", err)
-				}
-				var jsonBody map[string]any
-				if err := json.Unmarshal(stdinData, &jsonBody); err != nil {
-					return fmt.Errorf("parsing stdin JSON: %w", err)
-				}
-				body = jsonBody
-			} else {
-				bodyMap := map[string]any{}
-				body = bodyMap
-				if cmd.Flags().Changed("email-address") || bodyEmailAddress != "" {
-					bodyMap["EmailAddress"] = bodyEmailAddress
-				}
-				if cmd.Flags().Changed("first-name") || bodyFirstName != "" {
-					bodyMap["FirstName"] = bodyFirstName
-				}
-				if cmd.Flags().Changed("last-name") || bodyLastName != "" {
-					bodyMap["LastName"] = bodyLastName
-				}
-				if cmd.Flags().Changed("is-smoking") {
-					bodyMap["IsSmoking"] = bodyIsSmoking
-				}
-				if cmd.Flags().Changed("primary-phone-area-code") || bodyPrimaryPhoneAreaCode != "" {
-					bodyMap["PrimaryPhoneAreaCode"] = bodyPrimaryPhoneAreaCode
-				}
-				if cmd.Flags().Changed("primary-phone-extension") || bodyPrimaryPhoneExtension != "" {
-					bodyMap["PrimaryPhoneExtension"] = bodyPrimaryPhoneExtension
-				}
-				if cmd.Flags().Changed("primary-phone-number") || bodyPrimaryPhoneNumber != "" {
-					bodyMap["PrimaryPhoneNumber"] = bodyPrimaryPhoneNumber
-				}
-				if cmd.Flags().Changed("primary-phone-type") || bodyPrimaryPhoneType != 0 {
-					bodyMap["PrimaryPhoneType"] = bodyPrimaryPhoneType
-				}
-				if cmd.Flags().Changed("party-size") || bodyPartySize != 0.0 {
-					bodyMap["PartySize"] = bodyPartySize
-				}
-				if cmd.Flags().Changed("wait-minutes") || bodyWaitMinutes != 0 {
-					bodyMap["WaitMinutes"] = bodyWaitMinutes
-				}
-				if cmd.Flags().Changed("platform") || bodyPlatform != "" {
-					bodyMap["Platform"] = bodyPlatform
-				}
+			guest, err := collectWaitlistGuestPII(cmd, flags, stdinBody)
+			if err != nil {
+				return err
+			}
+			bodyMap := map[string]any{}
+			mergeWaitlistJSON(bodyMap, guest)
+			applyWaitlistNonPIIFlags(cmd, bodyMap, bodyIsSmoking, bodyPartySize, bodyWaitMinutes, bodyPlatform, bodyPrimaryPhoneType)
+			if err := requireWaitlistSubmitFields(bodyMap, flags.dryRun); err != nil {
+				return err
+			}
+			var body any = bodyMap
+			if flags.dryRun {
+				body = redactWaitlistPII(bodyMap)
 			}
 			data, statusCode, err := c.PostWithParams(cmd.Context(), path, params, body)
 			if err != nil {
@@ -305,18 +250,24 @@ func newTexasroadhouseSubmitCmd(flags *rootFlags) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&bodyEmailAddress, "email-address", "", "Guest email")
-	cmd.Flags().StringVar(&bodyFirstName, "first-name", "", "Guest first name")
-	cmd.Flags().StringVar(&bodyLastName, "last-name", "", "Guest last name")
+	cmd.Flags().StringVar(&bodyEmailAddress, "email-address", "", "Do not use: guest email belongs on stdin JSON")
+	cmd.Flags().StringVar(&bodyFirstName, "first-name", "", "Do not use: guest first name belongs on stdin JSON")
+	cmd.Flags().StringVar(&bodyLastName, "last-name", "", "Do not use: guest last name belongs on stdin JSON")
 	cmd.Flags().BoolVar(&bodyIsSmoking, "is-smoking", false, "Always false in the web app")
-	cmd.Flags().StringVar(&bodyPrimaryPhoneAreaCode, "primary-phone-area-code", "", "3-digit area code")
-	cmd.Flags().StringVar(&bodyPrimaryPhoneExtension, "primary-phone-extension", "", "Usually empty")
-	cmd.Flags().StringVar(&bodyPrimaryPhoneNumber, "primary-phone-number", "", "Local number as xxx-xxxx")
+	cmd.Flags().StringVar(&bodyPrimaryPhoneAreaCode, "primary-phone-area-code", "", "Do not use: guest phone belongs on stdin JSON")
+	cmd.Flags().StringVar(&bodyPrimaryPhoneExtension, "primary-phone-extension", "", "Do not use: guest phone belongs on stdin JSON")
+	cmd.Flags().StringVar(&bodyPrimaryPhoneNumber, "primary-phone-number", "", "Do not use: guest phone belongs on stdin JSON")
 	cmd.Flags().IntVar(&bodyPrimaryPhoneType, "primary-phone-type", 0, "Web app sends 1")
 	cmd.Flags().Float64Var(&bodyPartySize, "party-size", 0.0, "Party size, max 6")
 	cmd.Flags().IntVar(&bodyWaitMinutes, "wait-minutes", 0, "From quote MinQuote for this party size")
 	cmd.Flags().StringVar(&bodyPlatform, "platform", "", "Web app sends web")
-	cmd.Flags().BoolVar(&stdinBody, "stdin", false, "Read request body as JSON from stdin")
+	cmd.Flags().BoolVar(&stdinBody, "stdin", false, "Read guest PII and submit body as JSON from stdin (default for agents)")
+	_ = cmd.Flags().MarkHidden("email-address")
+	_ = cmd.Flags().MarkHidden("first-name")
+	_ = cmd.Flags().MarkHidden("last-name")
+	_ = cmd.Flags().MarkHidden("primary-phone-area-code")
+	_ = cmd.Flags().MarkHidden("primary-phone-extension")
+	_ = cmd.Flags().MarkHidden("primary-phone-number")
 
 	return cmd
 }

--- a/library/food-and-dining/texas-roadhouse/internal/learn/journal.go
+++ b/library/food-and-dining/texas-roadhouse/internal/learn/journal.go
@@ -64,7 +64,7 @@ const (
 // credentials. Over-matching is fine (a redacted class loses only the
 // value class, and values are never written anyway); under-matching
 // would leak a secret's shape.
-var journalRedactedFlagPattern = regexp.MustCompile(`(?i)token|key|secret|password|cookie|auth`)
+var journalRedactedFlagPattern = regexp.MustCompile(`(?i)token|key|secret|password|cookie|auth|email|phone|first-name|last-name`)
 
 // JournalEntry is the on-disk record for one CLI invocation. Fields
 // keep omitempty so older readers parsing a newer-shape entry still

--- a/library/food-and-dining/texas-roadhouse/internal/mcp/tools.go
+++ b/library/food-and-dining/texas-roadhouse/internal/mcp/tools.go
@@ -82,7 +82,7 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("texasroadhouse_checkin",
-			mcplib.WithDescription("Check in once the party is at the host stand (destructive). Live check-in requires yes=true; dry-run=true previews without POSTing. Required: waitlist_id. Optional: yes, dry-run. Returns the new WaitlistCheckinResult."),
+			mcplib.WithDescription("Mark the party HERE after the guest texts HERE once everyone has arrived (text REMOVE to leave). Not a host-stand visit (destructive). Live check-in requires yes=true; dry-run=true previews without POSTing. Required: waitlist_id. Optional: yes, dry-run. Returns the new WaitlistCheckinResult."),
 			mcplib.WithString("waitlist_id", mcplib.Required(), mcplib.Description("Store extref (not internal store id). Springfield MO is 218.")),
 			mcplib.WithBoolean("yes", mcplib.Description("Required for a live check-in. Same meaning as CLI --yes.")),
 			mcplib.WithBoolean("dry-run", mcplib.Description("Preview the request body without POSTing. Same meaning as CLI --dry-run.")),
@@ -135,7 +135,7 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("texasroadhouse_submit",
-			mcplib.WithDescription("Join a store waitlist (destructive). Live join requires yes=true; dry-run=true previews without POSTing. Required: waitlist_id, EmailAddress, FirstName, LastName, PrimaryPhoneAreaCode, PrimaryPhoneNumber, PartySize, WaitMinutes. Optional: IsSmoking, PrimaryPhoneExtension, PrimaryPhoneType, Platform, yes, dry-run. Returns the new WaitlistSubmitResult."),
+			mcplib.WithDescription("Join a store waitlist (destructive). Unofficial sniffed endpoint; get guest consent before sending name/email/phone. Live join requires yes=true; dry-run=true previews a redacted body without POSTing. Required: waitlist_id, EmailAddress, FirstName, LastName, PrimaryPhoneAreaCode, PrimaryPhoneNumber, PartySize, WaitMinutes. Optional: IsSmoking, PrimaryPhoneExtension, PrimaryPhoneType, Platform, yes, dry-run. Returns the new WaitlistSubmitResult."),
 			mcplib.WithString("waitlist_id", mcplib.Required(), mcplib.Description("Store extref (not internal store id). Springfield MO is 218.")),
 			mcplib.WithString("EmailAddress", mcplib.Required(), mcplib.Description("Guest email")),
 			mcplib.WithString("FirstName", mcplib.Required(), mcplib.Description("Guest first name")),
@@ -470,6 +470,9 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 					"\n      See API docs: https://www.texasroadhouse.com" +
 					"\n      Run 'texas-roadhouse-pp-cli doctor' to check auth status."), nil
 			case strings.Contains(msg, "HTTP 403"):
+				if cli.LooksLikeCloudflareChallenge(msg) {
+					return mcpToolError(cli.CloudflareChallengeToolMessage(msg)), nil
+				}
 				return mcpToolError("permission denied: " + msg +
 					"\nhint: this API is configured without credentials; the service may be blocking the request by rate limit, geography, bot protection, or endpoint policy." +
 					"\n      See API docs: https://www.texasroadhouse.com" +
@@ -478,7 +481,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				if method == "DELETE" {
 					return mcpToolTextWithPlatform("already deleted (no-op)", platformSession), nil
 				}
-				return mcpToolError("not found: " + msg), nil
+				return mcpToolError("not found: " + msg + "\nhint: this CLI has no list command; use stores --lat/--long or texasroadhouse get-quote <extref>."), nil
 			case strings.Contains(msg, "HTTP 429"):
 				return mcpToolError("rate limited: " + msg), nil
 			default:

--- a/library/food-and-dining/texas-roadhouse/join-waitlist.json
+++ b/library/food-and-dining/texas-roadhouse/join-waitlist.json
@@ -30,7 +30,7 @@
     },
     {
       "cmd": "texasroadhouse submit {store.extref} --dry-run --stdin",
-      "purpose": "Show the join body only after they picked a store and party size. Live submit is a later step with an explicit yes."
+      "purpose": "Show the redacted join body only after they picked a store and party size. Guest name/email/phone stay on stdin JSON. Live submit is a later step with an explicit yes."
     }
   ]
 }

--- a/library/food-and-dining/texas-roadhouse/spec.yaml
+++ b/library/food-and-dining/texas-roadhouse/spec.yaml
@@ -302,7 +302,7 @@ resources:
             checkin:
                 method: POST
                 path: /api/texasroadhouse/waitlist/{waitlist_id}/checkin
-                description: Check in once the party is at the host stand. Do not fire without a yes.
+                description: Mark the party HERE after the guest texts HERE once everyone has arrived (text REMOVE to leave). Not a host-stand visit. Do not fire without a yes.
                 params:
                     - name: waitlist_id
                       type: string

--- a/library/food-and-dining/texas-roadhouse/tools-manifest.json
+++ b/library/food-and-dining/texas-roadhouse/tools-manifest.json
@@ -127,7 +127,7 @@
     },
     {
       "name": "texasroadhouse_checkin",
-      "description": "Check in once the party is at the host stand (destructive). Live check-in requires yes=true; dry-run=true previews without POSTing. Required: waitlist_id. Optional: yes, dry-run. Returns the new WaitlistCheckinResult.",
+      "description": "Mark the party HERE after the guest texts HERE once everyone has arrived (text REMOVE to leave). Not a host-stand visit (destructive). Live check-in requires yes=true; dry-run=true previews without POSTing. Required: waitlist_id. Optional: yes, dry-run. Returns the new WaitlistCheckinResult.",
       "method": "POST",
       "path": "/api/texasroadhouse/waitlist/{waitlist_id}/checkin",
       "no_auth": true,
@@ -232,7 +232,7 @@
     },
     {
       "name": "texasroadhouse_submit",
-      "description": "Join a store waitlist (destructive). Live join requires yes=true; dry-run=true previews without POSTing. Required: waitlist_id, EmailAddress, FirstName, LastName, PrimaryPhoneAreaCode, PrimaryPhoneNumber, PartySize, WaitMinutes. Optional: IsSmoking, PrimaryPhoneExtension, PrimaryPhoneType, Platform, yes, dry-run. Returns the new WaitlistSubmitResult.",
+      "description": "Join a store waitlist (destructive). Unofficial sniffed endpoint; get guest consent before sending name/email/phone. Live join requires yes=true; dry-run=true previews a redacted body without POSTing. Required: waitlist_id, EmailAddress, FirstName, LastName, PrimaryPhoneAreaCode, PrimaryPhoneNumber, PartySize, WaitMinutes. Optional: IsSmoking, PrimaryPhoneExtension, PrimaryPhoneType, Platform, yes, dry-run. Returns the new WaitlistSubmitResult.",
       "method": "POST",
       "path": "/api/texasroadhouse/waitlist/{waitlist_id}/submit",
       "no_auth": true,


### PR DESCRIPTION
## texas-roadhouse

Follow-up to #1870. Six documentation/privacy defects in the published Texas Roadhouse waitlist CLI.

**API:** texas-roadhouse | **Category:** food-and-dining | **Press version:** 4.31.2
**Spec:** sniffed / internal (`spec.yaml`)
**Creator:** Thomas McCormick (@DashLabsDev)

### What Changed

1. First-command examples use `stores` / `texasroadhouse get-quote` instead of fake `mapbox mock-value`.
2. Troubleshooting and 404 hints no longer tell users to run a nonexistent `list` command.
3. Check-in copy is guest texts HERE once everyone has arrived (REMOVE to leave), not a host-stand visit. Live check-in still requires `--yes`.
4. Guest first/last name, email, and phone no longer default to argv flags. Default is stdin JSON or an interactive prompt. `--dry-run` and logs redact PII. Live `submit` / `checkin` / `cancel` still require `--yes`.
5. Unofficial / not affiliated, sniffed endpoints, PII/consent, local retention, endpoint instability, and ToS disclosures appear before install and before submit.
6. Last-verified note (live-tested late Aug 2026; naked HTTP gets Cloudflare 403; CLI uses Chrome-compatible transport) plus a specific Cloudflare-challenge error.

Matt's platform items (installer pin, Flight GOAT links, music bar, CSP) are out of scope.

### Safety

- No `registry.json` or `cli-skills/` edits.
- No CHANGELOG / release-ledger / runtime version bump.
- No secrets, real phones, emails, or streets.
- No live waitlist join/cancel.

### Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/food-and-dining/texas-roadhouse/`
- [x] `go build ./...` / `go vet ./...` / `go test ./...` from the CLI root
- [x] `git diff --check`