### PR TITLE
Sync verify-skill CI copy with canonical script

### DIFF
--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -169,6 +169,9 @@ CONSTRUCTOR_RE = re.compile(
 )
 ADDCMD_CHILD_RE = re.compile(r'\.AddCommand\s*\(\s*(new[A-Z]\w*Cmd)\s*\(')
 ROOT_ADDCMD_RE = re.compile(r'rootCmd\.AddCommand\s*\(\s*(new[A-Z]\w*Cmd)\s*\(')
+LOCAL_COMMAND_RE = re.compile(r'(?m)^\s*(\w+)\s*:=\s*&cobra\.Command\s*\{')
+RETURN_VARIABLE_RE = re.compile(r'(?m)^\s*return\s+(\w+)\s*$')
+VARIABLE_ADDCMD_RE = re.compile(r'\b(\w+)\.AddCommand\s*\(([^)]*)\)')
 
 
 def _extract_function_body(text: str, start_offset: int) -> str | None:
@@ -229,6 +232,61 @@ def _extract_function_body(text: str, start_offset: int) -> str | None:
     return text[start_offset:i - 1]
 
 
+def _inline_command_children(
+    body: str,
+    fn_name: str,
+    go_file: Path,
+) -> tuple[list[str], dict[str, "CommandConstructor"]]:
+    """Collect local cobra.Command variables attached to a constructor's
+    returned parent variable.
+
+    Generated-then-curated CLIs sometimes build children inline and call
+    `cmd.AddCommand(child)` instead of using a `newChildCmd` constructor. Those
+    are real Cobra edges and must participate in command-path resolution; a
+    same-file `Use:` declaration without that edge must not.
+    """
+    variables: dict[str, tuple[str, tuple | None]] = {}
+    for match in LOCAL_COMMAND_RE.finditer(body):
+        command_body = _extract_function_body(body, match.end())
+        if command_body is None:
+            continue
+        use_match = USE_RE.search(command_body)
+        if use_match is None:
+            continue
+        args_match = ARGS_RE.search(command_body)
+        args_info = (args_match.group(1), args_match.group(2)) if args_match else None
+        variables[match.group(1)] = (use_match.group(1), args_info)
+
+    returned = [match.group(1) for match in RETURN_VARIABLE_RE.finditer(body)]
+    parent_variable = next((name for name in reversed(returned) if name in variables), None)
+    if parent_variable is None:
+        return [], {}
+
+    child_names: list[str] = []
+    children: dict[str, CommandConstructor] = {}
+    for match in VARIABLE_ADDCMD_RE.finditer(body):
+        receiver, arguments = match.groups()
+        if receiver != parent_variable:
+            continue
+        for raw_argument in arguments.split(","):
+            child_variable = raw_argument.strip()
+            if child_variable not in variables:
+                continue
+            use, args_info = variables[child_variable]
+            synthetic_name = f"{fn_name}__inline__{child_variable}"
+            if synthetic_name in children:
+                continue
+            child_names.append(synthetic_name)
+            children[synthetic_name] = CommandConstructor(
+                name=synthetic_name,
+                file=go_file,
+                use=use,
+                args_info=args_info,
+                children=[],
+            )
+    return child_names, children
+
+
 @dataclass
 class CommandConstructor:
     name: str
@@ -236,6 +294,22 @@ class CommandConstructor:
     use: str
     args_info: tuple | None
     children: list[str] = field(default_factory=list)
+
+
+def cli_source_dir(cli_dir: Path) -> Path | None:
+    """Return the directory containing the shipped Cobra command sources.
+
+    Most catalog entries keep source at internal/cli. A small number of entries
+    may keep the public catalog files at the parent while the installable Go
+    module lives in a nested directory to avoid Go module path constraints.
+    """
+    direct = cli_dir / "internal/cli"
+    if direct.exists():
+        return direct
+    nested = sorted(path for path in cli_dir.glob("*/internal/cli") if path.is_dir())
+    if len(nested) == 1:
+        return nested[0]
+    return None
 
 
 @lru_cache(maxsize=None)
@@ -253,8 +327,8 @@ def collect_command_constructors(cli_dir: Path) -> dict[str, CommandConstructor]
     file-system scan only needs to happen once. Callers must not
     mutate the returned dict (it's the cache's storage).
     """
-    src = cli_dir / "internal/cli"
-    if not src.exists():
+    src = cli_source_dir(cli_dir)
+    if not src:
         return {}
     constructors: dict[str, CommandConstructor] = {}
     for go_file in src.glob("*.go"):
@@ -277,6 +351,8 @@ def collect_command_constructors(cli_dir: Path) -> dict[str, CommandConstructor]
             children = list(dict.fromkeys(
                 child.group(1) for child in ADDCMD_CHILD_RE.finditer(body)
             ))
+            inline_names, inline_children = _inline_command_children(body, fn_name, go_file)
+            children.extend(name for name in inline_names if name not in children)
             constructors[fn_name] = CommandConstructor(
                 name=fn_name,
                 file=go_file,
@@ -284,6 +360,7 @@ def collect_command_constructors(cli_dir: Path) -> dict[str, CommandConstructor]
                 args_info=args_info,
                 children=children,
             )
+            constructors.update(inline_children)
     return constructors
 
 
@@ -295,8 +372,8 @@ def find_root_children(cli_dir: Path) -> list[str]:
 
     Cached per cli_dir; callers must not mutate the returned list.
     See collect_command_constructors for rationale."""
-    src = cli_dir / "internal/cli"
-    if not src.exists():
+    src = cli_source_dir(cli_dir)
+    if not src:
         return []
     seen: dict[str, None] = {}
     for go_file in src.glob("*.go"):
@@ -406,8 +483,8 @@ def _legacy_find_command_source(cli_dir: Path, cmd_path: list[str]):
     expects (e.g., commands constructed via local helpers, or files that
     declare cobra.Commands without going through a `newXxxCmd` factory)."""
     leaf = cmd_path[-1]
-    src = cli_dir / "internal/cli"
-    if not src.exists():
+    src = cli_source_dir(cli_dir)
+    if not src:
         return [], None, None
 
     candidates = []
@@ -640,8 +717,8 @@ def flag_declared_via_helper(cli_dir: Path, cmd_files: Iterable[Path], flag_name
     if not helper_names:
         return False
 
-    src = cli_dir / "internal/cli"
-    if not src.exists():
+    src = cli_source_dir(cli_dir)
+    if not src:
         return False
 
     func_re = re.compile(
@@ -665,8 +742,8 @@ def flag_declared_via_helper(cli_dir: Path, cmd_files: Iterable[Path], flag_name
 
 
 def persistent_flag_declared(cli_dir: Path, flag_name: str) -> bool:
-    src = cli_dir / "internal/cli"
-    if not src.exists():
+    src = cli_source_dir(cli_dir)
+    if not src:
         return False
     for go_file in src.glob("*.go"):
         try:
@@ -708,18 +785,25 @@ def _cli_invocation_from_tokens(
             break
         if len(cmd_path) < 3 and re.match(r"^[a-z][a-z0-9-]*$", t):
             if cli_dir is not None:
-                _files, use_str, _args_info = find_command_source(cli_dir, cmd_path)
-                if use_str:
-                    _, _, optional, variadic = parse_use(use_str)
-                    if optional > 0 or variadic:
-                        break
-            # Verify adding this token still maps to a valid command. If the
-            # extended path has no source match, this token is an argument.
-            if cli_dir is not None:
                 trial = cmd_path + [t]
-                files, _, _ = find_command_source(cli_dir, trial)
-                if not files:
-                    break
+                child_file, _, _ = resolve_command_path(cli_dir, trial)
+                if child_file is not None:
+                    cmd_path.append(t)
+                    i += 1
+                    continue
+                # Preserve wholly legacy command trees whose parent is not in
+                # the constructor graph. Graph-resolved parents include local
+                # variable-wired children collected by
+                # _inline_command_children, so they never need a file-proximity
+                # heuristic that could promote an unwired sibling.
+                current_file, _, _ = resolve_command_path(cli_dir, cmd_path)
+                if current_file is None:
+                    child_files, _, _ = find_command_source(cli_dir, trial)
+                    if child_files:
+                        cmd_path.append(t)
+                        i += 1
+                        continue
+                break
             cmd_path.append(t)
             i += 1
             continue
@@ -1071,7 +1155,8 @@ def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report
     # so users see both surfaces and don't get a false "fixed" signal
     # after editing only the first source. Matches check_flag_commands's
     # per-source emission policy.
-    all_files = list((cli_dir / "internal/cli").glob("*.go"))
+    source_dir = cli_source_dir(cli_dir)
+    all_files = list(source_dir.glob("*.go")) if source_dir else []
     for src in sources:
         seen: set[str] = set()
         for raw_cmd_path, _positional, flags, _surface in extract_cli_invocations(src, cli_binary, cli_dir):
@@ -1096,12 +1181,34 @@ def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report
 
 
 def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, report: Report) -> None:
-    all_files = list((cli_dir / "internal/cli").glob("*.go"))
+    source_dir = cli_source_dir(cli_dir)
+    all_files = list(source_dir.glob("*.go")) if source_dir else []
     for src in sources:
         seen: set[tuple[str, str]] = set()
         for raw_cmd_path, _positional, flags, _surface in extract_cli_invocations(src, cli_binary, cli_dir):
             cmd_path = list(raw_cmd_path)
             path_str = " ".join(cmd_path)
+            # The extractor under-resolves subcommands whose names contain an
+            # underscore — `messages post_message --text` yields cmd_path
+            # ["messages"] with "post_message" left among the positionals — so
+            # flags belonging to the subcommand were attributed to its parent and
+            # reported as "declared elsewhere but not on <parent>".
+            #
+            # check_positional_args already treats this shape as a false positive
+            # (see the snake_case note there), but that only downgraded its own
+            # finding; this check still emitted hard errors.
+            #
+            # Resolve it instead of suppressing it, but only as a fallback once the
+            # parent has been ruled out. Trying the child first would misread
+            # commands that take a resource name positionally — `export messages
+            # --format` and `tail messages --interval` both resolve
+            # ["export", "messages"] to a messages source file, which does not
+            # declare --format or --interval, turning working docs into errors.
+            fallback_path: list[str] | None = None
+            if len(cmd_path) == 1 and _positional and re.match(r"^[a-z][a-z0-9_-]+$", _positional[0]):
+                candidate = cmd_path + [_positional[0]]
+                if find_command_source(cli_dir, candidate)[0]:
+                    fallback_path = candidate
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
                 key = (path_str, flag)
@@ -1114,6 +1221,15 @@ def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, rep
                     continue
                 if cmd_files and flag_declared_via_helper(cli_dir, cmd_files, flag):
                     continue
+                # Parent ruled out — the flag may belong to an under-resolved
+                # subcommand left in the positionals (see fallback_path above).
+                if fallback_path:
+                    sub_files, _, _ = find_command_source(cli_dir, fallback_path)
+                    if sub_files and (
+                        flag_declared_in(sub_files, flag)
+                        or flag_declared_via_helper(cli_dir, sub_files, flag)
+                    ):
+                        continue
                 seen.add(key)
                 if flag_declared_in(all_files, flag):
                     report.findings.append(
@@ -1345,8 +1461,8 @@ def run_checks(cli_dir: Path, only: set[str] | None) -> Report:
     if not skill.exists():
         print(f"error: no SKILL.md in {cli_dir}", file=sys.stderr)
         sys.exit(2)
-    if not (cli_dir / "internal/cli").exists():
-        print(f"error: no internal/cli/ in {cli_dir}", file=sys.stderr)
+    if not cli_source_dir(cli_dir):
+        print(f"error: no internal/cli/ source tree in {cli_dir}", file=sys.stderr)
         sys.exit(2)
 
     cli_binary = derive_cli_binary(cli_dir)

--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -554,6 +554,14 @@ def _iter_bool_flag_names(text: str) -> Iterable[str]:
         if method in ("BoolVar", "BoolSliceVar"):
             yield name
 
+    # Non-Var Cobra boolean declarations have a different argument shape:
+    # Flags().Bool("json", false, ...) / BoolP("json", "j", false, ...).
+    for m in re.finditer(
+        r'(?:Persistent)?Flags\(\)\.BoolP?\(\s*"([a-z][a-z0-9-]*)"',
+        text,
+    ):
+        yield m.group(1)
+
     aliases = {
         m.group(1): m.group(2) == "Persistent"
         for m in FLAG_ALIAS_RE.finditer(text)

--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -579,8 +579,8 @@ def _boolean_flag_names(cli_dir: Path) -> frozenset[str]:
     would silently drop a real positional. A CLI-wide scan (rather than
     per-command) deliberately includes persistent/root booleans like --json or
     --verbose, which are the common case a recipe writes before a positional."""
-    cli_pkg = cli_dir / "internal" / "cli"
-    if not cli_pkg.is_dir():
+    cli_pkg = cli_source_dir(cli_dir)
+    if cli_pkg is None:
         return frozenset()
     names: set[str] = set()
     for path in sorted(cli_pkg.glob("*.go")):

--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -169,9 +169,6 @@ CONSTRUCTOR_RE = re.compile(
 )
 ADDCMD_CHILD_RE = re.compile(r'\.AddCommand\s*\(\s*(new[A-Z]\w*Cmd)\s*\(')
 ROOT_ADDCMD_RE = re.compile(r'rootCmd\.AddCommand\s*\(\s*(new[A-Z]\w*Cmd)\s*\(')
-LOCAL_COMMAND_RE = re.compile(r'(?m)^\s*(\w+)\s*:=\s*&cobra\.Command\s*\{')
-RETURN_VARIABLE_RE = re.compile(r'(?m)^\s*return\s+(\w+)\s*$')
-VARIABLE_ADDCMD_RE = re.compile(r'\b(\w+)\.AddCommand\s*\(([^)]*)\)')
 
 
 def _extract_function_body(text: str, start_offset: int) -> str | None:
@@ -232,61 +229,6 @@ def _extract_function_body(text: str, start_offset: int) -> str | None:
     return text[start_offset:i - 1]
 
 
-def _inline_command_children(
-    body: str,
-    fn_name: str,
-    go_file: Path,
-) -> tuple[list[str], dict[str, "CommandConstructor"]]:
-    """Collect local cobra.Command variables attached to a constructor's
-    returned parent variable.
-
-    Generated-then-curated CLIs sometimes build children inline and call
-    `cmd.AddCommand(child)` instead of using a `newChildCmd` constructor. Those
-    are real Cobra edges and must participate in command-path resolution; a
-    same-file `Use:` declaration without that edge must not.
-    """
-    variables: dict[str, tuple[str, tuple | None]] = {}
-    for match in LOCAL_COMMAND_RE.finditer(body):
-        command_body = _extract_function_body(body, match.end())
-        if command_body is None:
-            continue
-        use_match = USE_RE.search(command_body)
-        if use_match is None:
-            continue
-        args_match = ARGS_RE.search(command_body)
-        args_info = (args_match.group(1), args_match.group(2)) if args_match else None
-        variables[match.group(1)] = (use_match.group(1), args_info)
-
-    returned = [match.group(1) for match in RETURN_VARIABLE_RE.finditer(body)]
-    parent_variable = next((name for name in reversed(returned) if name in variables), None)
-    if parent_variable is None:
-        return [], {}
-
-    child_names: list[str] = []
-    children: dict[str, CommandConstructor] = {}
-    for match in VARIABLE_ADDCMD_RE.finditer(body):
-        receiver, arguments = match.groups()
-        if receiver != parent_variable:
-            continue
-        for raw_argument in arguments.split(","):
-            child_variable = raw_argument.strip()
-            if child_variable not in variables:
-                continue
-            use, args_info = variables[child_variable]
-            synthetic_name = f"{fn_name}__inline__{child_variable}"
-            if synthetic_name in children:
-                continue
-            child_names.append(synthetic_name)
-            children[synthetic_name] = CommandConstructor(
-                name=synthetic_name,
-                file=go_file,
-                use=use,
-                args_info=args_info,
-                children=[],
-            )
-    return child_names, children
-
-
 @dataclass
 class CommandConstructor:
     name: str
@@ -294,22 +236,6 @@ class CommandConstructor:
     use: str
     args_info: tuple | None
     children: list[str] = field(default_factory=list)
-
-
-def cli_source_dir(cli_dir: Path) -> Path | None:
-    """Return the directory containing the shipped Cobra command sources.
-
-    Most catalog entries keep source at internal/cli. A small number of entries
-    may keep the public catalog files at the parent while the installable Go
-    module lives in a nested directory to avoid Go module path constraints.
-    """
-    direct = cli_dir / "internal/cli"
-    if direct.exists():
-        return direct
-    nested = sorted(path for path in cli_dir.glob("*/internal/cli") if path.is_dir())
-    if len(nested) == 1:
-        return nested[0]
-    return None
 
 
 @lru_cache(maxsize=None)
@@ -327,8 +253,8 @@ def collect_command_constructors(cli_dir: Path) -> dict[str, CommandConstructor]
     file-system scan only needs to happen once. Callers must not
     mutate the returned dict (it's the cache's storage).
     """
-    src = cli_source_dir(cli_dir)
-    if not src:
+    src = cli_dir / "internal/cli"
+    if not src.exists():
         return {}
     constructors: dict[str, CommandConstructor] = {}
     for go_file in src.glob("*.go"):
@@ -351,8 +277,6 @@ def collect_command_constructors(cli_dir: Path) -> dict[str, CommandConstructor]
             children = list(dict.fromkeys(
                 child.group(1) for child in ADDCMD_CHILD_RE.finditer(body)
             ))
-            inline_names, inline_children = _inline_command_children(body, fn_name, go_file)
-            children.extend(name for name in inline_names if name not in children)
             constructors[fn_name] = CommandConstructor(
                 name=fn_name,
                 file=go_file,
@@ -360,7 +284,6 @@ def collect_command_constructors(cli_dir: Path) -> dict[str, CommandConstructor]
                 args_info=args_info,
                 children=children,
             )
-            constructors.update(inline_children)
     return constructors
 
 
@@ -372,8 +295,8 @@ def find_root_children(cli_dir: Path) -> list[str]:
 
     Cached per cli_dir; callers must not mutate the returned list.
     See collect_command_constructors for rationale."""
-    src = cli_source_dir(cli_dir)
-    if not src:
+    src = cli_dir / "internal/cli"
+    if not src.exists():
         return []
     seen: dict[str, None] = {}
     for go_file in src.glob("*.go"):
@@ -483,8 +406,8 @@ def _legacy_find_command_source(cli_dir: Path, cmd_path: list[str]):
     expects (e.g., commands constructed via local helpers, or files that
     declare cobra.Commands without going through a `newXxxCmd` factory)."""
     leaf = cmd_path[-1]
-    src = cli_source_dir(cli_dir)
-    if not src:
+    src = cli_dir / "internal/cli"
+    if not src.exists():
         return [], None, None
 
     candidates = []
@@ -717,8 +640,8 @@ def flag_declared_via_helper(cli_dir: Path, cmd_files: Iterable[Path], flag_name
     if not helper_names:
         return False
 
-    src = cli_source_dir(cli_dir)
-    if not src:
+    src = cli_dir / "internal/cli"
+    if not src.exists():
         return False
 
     func_re = re.compile(
@@ -742,8 +665,8 @@ def flag_declared_via_helper(cli_dir: Path, cmd_files: Iterable[Path], flag_name
 
 
 def persistent_flag_declared(cli_dir: Path, flag_name: str) -> bool:
-    src = cli_source_dir(cli_dir)
-    if not src:
+    src = cli_dir / "internal/cli"
+    if not src.exists():
         return False
     for go_file in src.glob("*.go"):
         try:
@@ -785,25 +708,18 @@ def _cli_invocation_from_tokens(
             break
         if len(cmd_path) < 3 and re.match(r"^[a-z][a-z0-9-]*$", t):
             if cli_dir is not None:
+                _files, use_str, _args_info = find_command_source(cli_dir, cmd_path)
+                if use_str:
+                    _, _, optional, variadic = parse_use(use_str)
+                    if optional > 0 or variadic:
+                        break
+            # Verify adding this token still maps to a valid command. If the
+            # extended path has no source match, this token is an argument.
+            if cli_dir is not None:
                 trial = cmd_path + [t]
-                child_file, _, _ = resolve_command_path(cli_dir, trial)
-                if child_file is not None:
-                    cmd_path.append(t)
-                    i += 1
-                    continue
-                # Preserve wholly legacy command trees whose parent is not in
-                # the constructor graph. Graph-resolved parents include local
-                # variable-wired children collected by
-                # _inline_command_children, so they never need a file-proximity
-                # heuristic that could promote an unwired sibling.
-                current_file, _, _ = resolve_command_path(cli_dir, cmd_path)
-                if current_file is None:
-                    child_files, _, _ = find_command_source(cli_dir, trial)
-                    if child_files:
-                        cmd_path.append(t)
-                        i += 1
-                        continue
-                break
+                files, _, _ = find_command_source(cli_dir, trial)
+                if not files:
+                    break
             cmd_path.append(t)
             i += 1
             continue
@@ -1155,8 +1071,7 @@ def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report
     # so users see both surfaces and don't get a false "fixed" signal
     # after editing only the first source. Matches check_flag_commands's
     # per-source emission policy.
-    source_dir = cli_source_dir(cli_dir)
-    all_files = list(source_dir.glob("*.go")) if source_dir else []
+    all_files = list((cli_dir / "internal/cli").glob("*.go"))
     for src in sources:
         seen: set[str] = set()
         for raw_cmd_path, _positional, flags, _surface in extract_cli_invocations(src, cli_binary, cli_dir):
@@ -1181,34 +1096,12 @@ def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report
 
 
 def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, report: Report) -> None:
-    source_dir = cli_source_dir(cli_dir)
-    all_files = list(source_dir.glob("*.go")) if source_dir else []
+    all_files = list((cli_dir / "internal/cli").glob("*.go"))
     for src in sources:
         seen: set[tuple[str, str]] = set()
         for raw_cmd_path, _positional, flags, _surface in extract_cli_invocations(src, cli_binary, cli_dir):
             cmd_path = list(raw_cmd_path)
             path_str = " ".join(cmd_path)
-            # The extractor under-resolves subcommands whose names contain an
-            # underscore — `messages post_message --text` yields cmd_path
-            # ["messages"] with "post_message" left among the positionals — so
-            # flags belonging to the subcommand were attributed to its parent and
-            # reported as "declared elsewhere but not on <parent>".
-            #
-            # check_positional_args already treats this shape as a false positive
-            # (see the snake_case note there), but that only downgraded its own
-            # finding; this check still emitted hard errors.
-            #
-            # Resolve it instead of suppressing it, but only as a fallback once the
-            # parent has been ruled out. Trying the child first would misread
-            # commands that take a resource name positionally — `export messages
-            # --format` and `tail messages --interval` both resolve
-            # ["export", "messages"] to a messages source file, which does not
-            # declare --format or --interval, turning working docs into errors.
-            fallback_path: list[str] | None = None
-            if len(cmd_path) == 1 and _positional and re.match(r"^[a-z][a-z0-9_-]+$", _positional[0]):
-                candidate = cmd_path + [_positional[0]]
-                if find_command_source(cli_dir, candidate)[0]:
-                    fallback_path = candidate
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
                 key = (path_str, flag)
@@ -1221,15 +1114,6 @@ def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, rep
                     continue
                 if cmd_files and flag_declared_via_helper(cli_dir, cmd_files, flag):
                     continue
-                # Parent ruled out — the flag may belong to an under-resolved
-                # subcommand left in the positionals (see fallback_path above).
-                if fallback_path:
-                    sub_files, _, _ = find_command_source(cli_dir, fallback_path)
-                    if sub_files and (
-                        flag_declared_in(sub_files, flag)
-                        or flag_declared_via_helper(cli_dir, sub_files, flag)
-                    ):
-                        continue
                 seen.add(key)
                 if flag_declared_in(all_files, flag):
                     report.findings.append(
@@ -1461,8 +1345,8 @@ def run_checks(cli_dir: Path, only: set[str] | None) -> Report:
     if not skill.exists():
         print(f"error: no SKILL.md in {cli_dir}", file=sys.stderr)
         sys.exit(2)
-    if not cli_source_dir(cli_dir):
-        print(f"error: no internal/cli/ source tree in {cli_dir}", file=sys.stderr)
+    if not (cli_dir / "internal/cli").exists():
+        print(f"error: no internal/cli/ in {cli_dir}", file=sys.stderr)
         sys.exit(2)
 
     cli_binary = derive_cli_binary(cli_dir)


### PR DESCRIPTION
## Summary

- Sync the `printing-press-library` CI copy of `verify_skill.py` with the canonical script from `cli-printing-press`.
- Resolves the script drift detected by the `Verify Skill Drift` workflow.

## What Changed

- Updated `.github/scripts/verify-skill/verify_skill.py` to match the canonical `cli-printing-press/scripts/verify-skill/verify_skill.py`.
- Verified both files have the same SHA256 hash: `56FE30B51496F079C7FC95FA5DBBC76A32BA7EDF3CEB326D38279BB5E8B5D16F`.

## Validation

- [x] Confirmed the canonical and CI-copy files have identical SHA256 hashes.
- [x] Confirmed this PR modifies only `.github/scripts/verify-skill/verify_skill.py`.

## Gaps / Follow-Up

- None.