### PR TITLE
snipd: guided `auth login` + fix `auth set-token` never reaching the fetch commands

### DIFF
--- a/library/media-and-entertainment/snipd/.manuscripts/20260713-190747-d8d38c3e/research.json
+++ b/library/media-and-entertainment/snipd/.manuscripts/20260713-190747-d8d38c3e/research.json
@@ -107,7 +107,7 @@
     "display_name": "Snipd",
     "headline": "Turn your Snipd snips into a local, ranked, full-text-searchable corpus — search a concept across every note, quote, and transcript, pull the exact quote, and synthesize across shows from the command line, plus an MCP for agents.",
     "value_prop": "Your snips are trapped in a mobile app. This CLI pulls them into a local SQLite mirror with a full-text index, then lets you search, quote, filter, and aggregate them in kilobytes instead of scrolling an app. The same commands are exposed as MCP tools so an agent can reason over your own listening.",
-    "auth_narrative": "Snipd's export API uses your account Bearer token, obtained by pairing the CLI from the Snipd mobile app. Set it once as SNIPD_TOKEN (or in the config file). It is read-only and never leaves your machine.",
+    "auth_narrative": "Snipd's export API authenticates with **your own Snipd account Bearer token**. Get it with a one-time browser sign-in — **you don't need Obsidian, the Snipd Obsidian plugin, or the mobile app** (the page is titled \"Obsidian integration\" only because the CLI reuses Snipd's export API).\n\n**Recommended — one command:** `snipd-pp-cli auth login` opens your browser to Snipd's sign-in page, waits while you sign in with Google, Apple, or email, then saves the token for you. Add `--no-browser` on a headless or SSH box to print the URL instead. Confirm with `snipd-pp-cli auth status`.\n\n**Manual, if you prefer:** generate any random UUID (e.g. `uuidgen`) and call it `X`; open `https://app.snipd.com/obsidian/auth?uuid=X` and sign in; open `https://api.snipd.com/v1/public/api/obsidian/auth?uuid=X` and copy the `token` value; save it with `snipd-pp-cli auth set-token \u003ctoken\u003e` (or `export SNIPD_TOKEN=\u003ctoken\u003e` for one session). `snipd-pp-cli auth setup` reprints these steps any time.\n\nThe token is personal and account-scoped — read-only, stored locally, and it never leaves your machine. If it stops working, run `snipd-pp-cli auth login` again; re-pairing takes about a minute.",
     "quickstart": [
       {
         "command": "snipd-pp-cli doctor --dry-run",
@@ -133,7 +133,7 @@
       },
       {
         "symptom": "401 / auth error on pull",
-        "fix": "Your token expired. Re-pair the CLI from the Snipd app and set the new value as SNIPD_TOKEN."
+        "fix": "Your token expired or was revoked. Run `snipd-pp-cli auth login` to re-pair (about a minute), or follow the manual browser steps in Authentication."
       },
       {
         "symptom": "a search term returns fewer hits than expected",

--- a/library/media-and-entertainment/snipd/.printing-press-patches/snipd-auth-token-read-path.json
+++ b/library/media-and-entertainment/snipd/.printing-press-patches/snipd-auth-token-read-path.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "applied_at": "2026-08-30",
+  "base_run_id": "20260713-190747-d8d38c3e",
+  "base_printing_press_version": "4.28.0",
+  "id": "snipd-auth-token-read-path",
+  "summary": "pull read cfg.SnipdToken directly, so credentials saved by `auth set-token` were invisible to every command that fetches snips.",
+  "reason": "`auth set-token` persists through the generated config.SaveTokens, which files the value under AccessToken. The hand-built export layer read cfg.SnipdToken. That field maps to the `token` key and can be loaded from the credentials file, but no command ever writes that key, so the env var is its only populated source in practice. Result: doctor reported \"Auth: configured\" while every pull failed with \"no SNIPD_TOKEN set\". Any future hand layer must resolve credentials through the same precedence config.AuthHeader() uses (env var, then persisted) rather than reading one field.",
+  "files": [
+    "internal/cli/pull.go",
+    "internal/cli/pull_token_test.go"
+  ],
+  "validated_outcome": "Reproduced on the merged v1 tree checked out untouched from main. With SNIPD_TOKEN unset and only the set-token credential on disk, v1's pull fails and this branch's pull returns 3 episodes / 52 snips against the real API. 5 unit tests cover the resolver including the regression case.",
+  "known_followups": [
+    "Not fixed at the write site: config.go and auth.go's set-token body carry the generator DO-NOT-EDIT header, and changing the persisted field would alter on-disk credential shape for anyone who already ran set-token."
+  ]
+}

--- a/library/media-and-entertainment/snipd/.printing-press-patches/snipd-doc-narrative-source.json
+++ b/library/media-and-entertainment/snipd/.printing-press-patches/snipd-doc-narrative-source.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 2,
+  "applied_at": "2026-08-30",
+  "base_run_id": "20260713-190747-d8d38c3e",
+  "base_printing_press_version": "4.28.0",
+  "id": "snipd-doc-narrative-source",
+  "summary": "README and SKILL auth prose corrected at its generator source (research.json), not in the output files.",
+  "reason": "dogfood re-syncs README.md and SKILL.md from .manuscripts/<run>/research.json (narrative.auth_narrative, narrative.troubleshoots). The 2026-07-14 snipd-auth-token-docs-fix patch hand-edited the two output files and explicitly left research.json lagging, so that fix was never durable -- the next dogfood run silently reverted both to v1.0's inaccurate 'obtained by pairing the CLI from the Snipd mobile app'. Any prose change to these files must be made in research.json and re-synced, or it will be reverted.",
+  "files": [
+    ".manuscripts/20260713-190747-d8d38c3e/research.json",
+    "README.md",
+    "SKILL.md"
+  ],
+  "validated_outcome": "The revert was observed live during this work: doc edits were made, a dogfood run reverted them, and the regression reached the PR before being caught in review rather than by any local check. After correcting the source and re-syncing, a second dogfood run leaves README.md and SKILL.md byte-identical (md5 unchanged for both), the stale mobile-app pairing strings are gone from both, and the README diff against base main is additive rather than a revert.",
+  "known_followups": [
+    "This supersedes the docs half of snipd-auth-token-docs-fix (2026-07-14), whose known_followups anticipated re-pointing these surfaces at a guided login."
+  ]
+}

--- a/library/media-and-entertainment/snipd/.printing-press-patches/snipd-guided-auth-login.json
+++ b/library/media-and-entertainment/snipd/.printing-press-patches/snipd-guided-auth-login.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 2,
+  "applied_at": "2026-08-30",
+  "base_run_id": "20260713-190747-d8d38c3e",
+  "base_printing_press_version": "4.28.0",
+  "id": "snipd-guided-auth-login",
+  "summary": "Guided `auth login` automating Snipd's UUID device-pairing flow (generate UUID, open browser, long-poll, save).",
+  "reason": "The only way to mint a Snipd token is a browser device-pairing flow whose final step is reading a secret out of a raw JSON endpoint and pasting it back -- the step no non-technical user discovers unaided. Snipd's own open-source Obsidian plugin is the reference implementation; step 3 is a server-held LONG-POLL, not a client retry loop. DEPENDS ON snipd-auth-token-read-path: this command persists through the same SaveTokens path, so without that fix it reports success and every subsequent pull still fails.",
+  "files": [
+    "internal/snipd/auth.go",
+    "internal/snipd/auth_test.go",
+    "internal/cli/auth_login.go",
+    "internal/cli/auth.go",
+    "go.mod"
+  ],
+  "validated_outcome": "Against a stub withholding the token on the first call, `auth login --no-browser` retries transparently, saves, and reports only a masked length. Browser launch short-circuits on --dry-run, PRINTING_PRESS_VERIFY and PRINTING_PRESS_DOGFOOD (the dogfood guard is load-bearing: pairing needs a human, so a live attempt would hang past the runner timeout and report a false failure). 6 tests, including one asserting an HTTP-error message never echoes the response body -- on a success-shaped response that body is the token. go.mod promotes google/uuid indirect -> direct and bumps the go directive to the repo-wide 1.26.6 floor.",
+  "known_followups": [
+    "No MCP-side change is required by this patch, and the tool surface is unchanged: tools-manifest.json is byte-identical to base, and no auth command CAN register because walk() does not recurse into a commandFramework subtree. `auth` is a top-level entry in cobratree's frameworkCommands, so isTopLevelFrameworkCommand skips the whole subtree and no auth command is ever registered as an MCP tool -- correct, since an MCP server cannot drive a browser sign-in on behalf of its host. The credential fix still reaches MCP users, because the MCP does not execute in-process: cobratree.RunCLICommand shells out via exec.CommandContext to the sibling snipd-pp-cli, so updating the CLI binary alone fixes the MCP's pull tool. `go install` of the MCP binary and a .mcpb rebuild are only needed when the TOOL SURFACE changes.",
+    "Generated auth hints in helpers.go, doctor.go, client.go and mcp/tools.go still name set-token. Correct and functional, but they do not advertise the faster path.",
+    "Deployment gotcha when the MCP does need updating: SiblingCLIPath resolves the CLI next to the MCP executable FIRST, then SNIPD_CLI_PATH, then PATH. If a stale snipd-pp-cli sits beside the MCP binary (e.g. ~/go/bin/ from a `go install`), the MCP keeps using it while the npx installer updates a different copy on PATH (~/.local/bin/) -- a silent version skew with no error. Check for a sibling CLI before assuming an installer refresh reached the MCP."
+  ]
+}

--- a/library/media-and-entertainment/snipd/.printing-press-patches/snipd-live-matrix-coverage.json
+++ b/library/media-and-entertainment/snipd/.printing-press-patches/snipd-live-matrix-coverage.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 2,
+  "applied_at": "2026-08-30",
+  "base_run_id": "20260713-190747-d8d38c3e",
+  "base_printing_press_version": "4.28.0",
+  "id": "snipd-live-matrix-coverage",
+  "summary": "pp:happy-args on the three positional-arg novel commands, plus a dry-run JSON shim; hollow_features 4 -> 1.",
+  "reason": "dogfood's live matrix skips happy_path and json_fidelity for any command taking a non-id positional unless it carries pp:happy-args, and then counts the skip against the CLI as hollow coverage. Any novel command with a positional needs the annotation, with a value that returns real output. Separately, a --dry-run branch that prints prose or returns nil emits non-JSON under --dry-run --json and fails json_fidelity; the 4.31.x chassis ships writeDryRun for this and 4.28.0 does not, so dryrun_shim.go stands in. Its dryRunResult carries 4.31.x's three fields (dry_run/action/would) plus an OPTIONAL url that only auth login emits; on upgrade, pull switches to the framework helper directly, while auth login keeps a local writer if that url is to be retained.",
+  "files": [
+    "internal/cli/quote.go",
+    "internal/cli/synthesize.go",
+    "internal/cli/aggregate.go",
+    "internal/cli/dryrun_shim.go",
+    "internal/cli/pull.go",
+    "dogfood-results.json"
+  ],
+  "validated_outcome": "Full live matrix before -> after: hollow_features [aggregate, pull, quote, synthesize] -> [pull], probes 81 -> 87, failed 5 -> 4. The same matrix run against pristine merged v1 reports the identical pre-change hollow set, so this reduces an existing condition rather than introducing one.",
+  "known_followups": [
+    "pull stays hollow and cannot be annotated out: the harness classifies it as mutating, forces --dry-run onto its probe and discards the result, and pull genuinely writes the corpus. Blocks publish validate. Track cli-printing-press 4046 / 4259 / 4263.",
+    "A reprint on 4.31.2 would ACTIVATE that gate rather than clear it -- the 4.28 artifacts do not carry the fields it reads. Resolve the local-write question upstream before reprinting.",
+    "Four generated framework commands still fail json_fidelity (learnings purge, playbook amend, teach, teach-pattern). The 4.31.x upgrade resolves them via the framework helper.",
+    "dogfood on 4.31.2 DOES consume pp:happy-args, which cli-printing-press#4046 reports as ignored."
+  ]
+}

--- a/library/media-and-entertainment/snipd/README.md
+++ b/library/media-and-entertainment/snipd/README.md
@@ -120,14 +120,13 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 ## Authentication
 
-Snipd's export API authenticates with **your own Snipd account Bearer token**. Get it with a one-time browser sign-in — **you don't need Obsidian, the Snipd Obsidian plugin, or the mobile app** (the page is titled "Obsidian integration" only because the CLI reuses Snipd's export API):
+Snipd's export API authenticates with **your own Snipd account Bearer token**. Get it with a one-time browser sign-in — **you don't need Obsidian, the Snipd Obsidian plugin, or the mobile app** (the page is titled "Obsidian integration" only because the CLI reuses Snipd's export API).
 
-1. Generate any random UUID — e.g. `uuidgen` — and call it `X`.
-2. Open `https://app.snipd.com/obsidian/auth?uuid=X` and sign in with your Snipd account (Google, Apple, or email).
-3. Open `https://api.snipd.com/v1/public/api/obsidian/auth?uuid=X` — it shows `{"token":"…"}`. Copy the token.
-4. Save it: `snipd-pp-cli auth set-token <token>` (or `export SNIPD_TOKEN=<token>` for one session).
+**Recommended — one command:** `snipd-pp-cli auth login` opens your browser to Snipd's sign-in page, waits while you sign in with Google, Apple, or email, then saves the token for you. Add `--no-browser` on a headless or SSH box to print the URL instead. Confirm with `snipd-pp-cli auth status`.
 
-The token is personal and account-scoped — read-only, stored locally, and it never leaves your machine. If it stops working, repeat the steps for a fresh one (about a minute).
+**Manual, if you prefer:** generate any random UUID (e.g. `uuidgen`) and call it `X`; open `https://app.snipd.com/obsidian/auth?uuid=X` and sign in; open `https://api.snipd.com/v1/public/api/obsidian/auth?uuid=X` and copy the `token` value; save it with `snipd-pp-cli auth set-token <token>` (or `export SNIPD_TOKEN=<token>` for one session). `snipd-pp-cli auth setup` reprints these steps any time.
+
+The token is personal and account-scoped — read-only, stored locally, and it never leaves your machine. If it stops working, run `snipd-pp-cli auth login` again; re-pairing takes about a minute.
 
 ## Quick Start
 
@@ -369,5 +368,5 @@ If you use agentcookie to sync secrets across machines, this CLI auto-adopts age
 
 ### API-specific
 - **search/quote/filter return nothing** — Run `snipd-pp-cli pull` first — retrieval reads the local mirror, which is empty until you pull.
-- **401 / auth error on pull** — Your token expired or was revoked. Get a fresh one with the browser sign-in in [Authentication](#authentication), then set it as SNIPD_TOKEN (or `snipd-pp-cli auth set-token <token>`).
+- **401 / auth error on pull** — Your token expired or was revoked. Run `snipd-pp-cli auth login` to re-pair (about a minute), or follow the manual browser steps in Authentication.
 - **a search term returns fewer hits than expected** — Use plain stemmed words, not `*` prefixes — the index is porter-stemmed, so `run` already matches `running`.

--- a/library/media-and-entertainment/snipd/SKILL.md
+++ b/library/media-and-entertainment/snipd/SKILL.md
@@ -146,14 +146,13 @@ A one-call rollup of snip counts per show.
 
 ## Auth Setup
 
-Snipd's export API authenticates with **your own Snipd account Bearer token**. Get it with a one-time browser sign-in — **you don't need Obsidian, the Snipd Obsidian plugin, or the mobile app** (the page is titled "Obsidian integration" only because the CLI reuses Snipd's export API):
+Snipd's export API authenticates with **your own Snipd account Bearer token**. Get it with a one-time browser sign-in — **you don't need Obsidian, the Snipd Obsidian plugin, or the mobile app** (the page is titled "Obsidian integration" only because the CLI reuses Snipd's export API).
 
-1. Generate any random UUID — e.g. `uuidgen` — and call it `X`.
-2. Open `https://app.snipd.com/obsidian/auth?uuid=X` and sign in with your Snipd account (Google, Apple, or email).
-3. Open `https://api.snipd.com/v1/public/api/obsidian/auth?uuid=X` — it shows `{"token":"…"}`. Copy the token.
-4. Save it: `snipd-pp-cli auth set-token <token>` (or `export SNIPD_TOKEN=<token>` for one session).
+**Recommended — one command:** `snipd-pp-cli auth login` opens your browser to Snipd's sign-in page, waits while you sign in with Google, Apple, or email, then saves the token for you. Add `--no-browser` on a headless or SSH box to print the URL instead. Confirm with `snipd-pp-cli auth status`.
 
-The token is personal and account-scoped — read-only, stored locally, and it never leaves your machine. If it stops working, repeat the steps for a fresh one (about a minute).
+**Manual, if you prefer:** generate any random UUID (e.g. `uuidgen`) and call it `X`; open `https://app.snipd.com/obsidian/auth?uuid=X` and sign in; open `https://api.snipd.com/v1/public/api/obsidian/auth?uuid=X` and copy the `token` value; save it with `snipd-pp-cli auth set-token <token>` (or `export SNIPD_TOKEN=<token>` for one session). `snipd-pp-cli auth setup` reprints these steps any time.
+
+The token is personal and account-scoped — read-only, stored locally, and it never leaves your machine. If it stops working, run `snipd-pp-cli auth login` again; re-pairing takes about a minute.
 
 Run `snipd-pp-cli doctor` to verify setup.
 

--- a/library/media-and-entertainment/snipd/dogfood-results.json
+++ b/library/media-and-entertainment/snipd/dogfood-results.json
@@ -51,10 +51,13 @@
   },
   "wiring_check": {
     "command_tree": {
-      "defined": 47,
-      "registered": 47
+      "defined": 48,
+      "registered": 48
     },
     "config_consistency": {
+      "write_fields": [
+        ", token, "
+      ],
       "consistent": true
     },
     "workflow_completeness": {
@@ -65,9 +68,8 @@
     }
   },
   "novel_features_check": {
-    "planned": 0,
-    "found": 0,
-    "skipped": true
+    "planned": 5,
+    "found": 5
   },
   "mcp_surface_parity": {
     "state": "runtime_walking",
@@ -75,21 +77,23 @@
     "detail": "MCP surface mirrors the Cobra tree at runtime"
   },
   "reimplementation_check": {
-    "checked": 0,
-    "exempted_via_store": 0,
-    "skipped": true
+    "checked": 5,
+    "exempted_via_store": 5
+  },
+  "description_drift_check": {
+    "expected": "Turn your Snipd snips into a local, ranked, full-text-searchable corpus \u2014 search a concept across every note, quote, and transcript, pull the exact quote, and synthesize across shows from the command line, plus an MCP for agents."
   },
   "source_client_check": {
-    "checked": 2
+    "checked": 3
   },
   "print_json_filtered_check": {
-    "checked": 31
+    "checked": 33
   },
   "test_presence": {
     "checked": 2
   },
   "naming_check": {
-    "checked": 31
+    "checked": 33
   },
   "sync_param_drop_check": {
     "checked": 0,

--- a/library/media-and-entertainment/snipd/go.mod
+++ b/library/media-and-entertainment/snipd/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/printing-press-library/library/media-and-entertainment/snipd
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4
@@ -10,12 +10,14 @@ require (
 
 require modernc.org/sqlite v1.37.0
 
-require github.com/mark3labs/mcp-go v0.47.0
+require (
+	github.com/google/uuid v1.6.0
+	github.com/mark3labs/mcp-go v0.47.0
+)
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect

--- a/library/media-and-entertainment/snipd/internal/cli/aggregate.go
+++ b/library/media-and-entertainment/snipd/internal/cli/aggregate.go
@@ -44,7 +44,7 @@ func newNovelAggregateCmd(flags *rootFlags) *cobra.Command {
 		Long: "Group the corpus and count. Dimensions: " + strings.Join(dims, ", ") + ".\n" +
 			"Defaults to by-show. Read-only over the local mirror.",
 		Example:     "  snipd-pp-cli aggregate by-show\n  snipd-pp-cli aggregate by-tag --limit 15 --agent",
-		Annotations: map[string]string{"mcp:read-only": "true"},
+		Annotations: map[string]string{"mcp:read-only": "true", "pp:happy-args": "dimension=by-show"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
 				return nil

--- a/library/media-and-entertainment/snipd/internal/cli/auth.go
+++ b/library/media-and-entertainment/snipd/internal/cli/auth.go
@@ -19,6 +19,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 		RunE:  parentNoSubcommandRunE(flags),
 	}
 
+	cmd.AddCommand(newAuthLoginCmd(flags))
 	cmd.AddCommand(newAuthSetupCmd(flags))
 	cmd.AddCommand(newAuthStatusCmd(flags))
 	cmd.AddCommand(newAuthSetTokenCmd(flags))
@@ -38,7 +39,9 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 		Example: "  snipd-pp-cli auth setup\n  snipd-pp-cli auth setup --launch",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
-			fmt.Fprintln(w, "Get your Snipd token with a one-time browser sign-in (no Obsidian, plugin, or mobile app needed):")
+			fmt.Fprintln(w, "Fastest: snipd-pp-cli auth login   — opens the browser, waits for sign-in, saves the token for you.")
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Or do it by hand with a one-time browser sign-in (no Obsidian, plugin, or mobile app needed):")
 			fmt.Fprintln(w, "  1. Generate a random UUID (e.g. uuidgen); call it X.")
 			fmt.Fprintln(w, "  2. Open https://app.snipd.com/obsidian/auth?uuid=X and sign in with your Snipd account.")
 			fmt.Fprintln(w, "  3. Open https://api.snipd.com/v1/public/api/obsidian/auth?uuid=X and copy the \"token\" value.")
@@ -91,7 +94,10 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			if !authed {
 				fmt.Fprintln(w, red("Not authenticated"))
 				fmt.Fprintln(w, "")
-				fmt.Fprintln(w, "Set your token:")
+				fmt.Fprintln(w, "Sign in:")
+				fmt.Fprintln(w, "  snipd-pp-cli auth login")
+				fmt.Fprintln(w, "")
+				fmt.Fprintln(w, "Or set a token you already have:")
 				fmt.Fprintln(w, "  export SNIPD_TOKEN=\"your-token-here\"")
 				fmt.Fprintf(w, "  snipd-pp-cli auth set-token <token>\n")
 				return authErr(fmt.Errorf("no credentials configured"))

--- a/library/media-and-entertainment/snipd/internal/cli/auth_login.go
+++ b/library/media-and-entertainment/snipd/internal/cli/auth_login.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Maxime Delavergne and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored novel command — NOT generator output.
+// pp:data-source live
+//
+// auth login turns Snipd's UUID device-pairing flow into one command. Without
+// it the user has to generate a UUID by hand, sign in, then open a raw JSON
+// endpoint and copy a secret out of the response body — the step no
+// non-technical user discovers unaided. Same shape as `gh auth login`: open the
+// browser, wait, save.
+//
+// The pairing mechanics live in internal/snipd/auth.go; this file is wiring,
+// side-effect discipline, and output.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/snipd/internal/cliutil"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/snipd/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/snipd/internal/snipd"
+	"github.com/spf13/cobra"
+)
+
+// loginTimeout bounds the whole pairing wait. The server long-holds each poll,
+// so this is a human deadline (find the tab, pick a provider, sign in), not a
+// network one. The root --timeout flag overrides it when set larger.
+const loginTimeout = 3 * time.Minute
+
+func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
+	var noBrowser bool
+	var pairingUUID string
+
+	cmd := &cobra.Command{
+		Use: "login",
+		// "connect" is the word on the Snipd plugin's own button — cheap to
+		// honour for anyone arriving from those docs.
+		Aliases: []string{"connect"},
+		Short:   "Sign in to Snipd in your browser and save the token automatically",
+		Example: "  snipd-pp-cli auth login\n  snipd-pp-cli auth login --no-browser",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := cmd.OutOrStdout()
+
+			if pairingUUID == "" {
+				pairingUUID = uuid.NewString()
+			} else if _, err := uuid.Parse(pairingUUID); err != nil {
+				return usageErr(fmt.Errorf("--uuid must be a valid UUID: %w", err))
+			}
+
+			cfg, err := config.Load(flags.configPath)
+			if err != nil {
+				return configErr(err)
+			}
+			signIn := snipd.SignInURL(pairingUUID)
+
+			// Side-effect discipline. --dry-run and the verifier's mock mode
+			// must never pop a browser tab. Live dogfood is excluded too, for a
+			// different reason: pairing cannot complete without a human, so a
+			// real attempt would hang until the runner's flat per-command
+			// timeout and report a false failure.
+			if dryRunOK(flags) || cliutil.IsVerifyEnv() || cliutil.IsDogfoodEnv() {
+				return writeLoginDryRun(w, flags, signIn)
+			}
+
+			// --no-input means nobody is at the keyboard to dismiss a browser
+			// window; print the URL and still poll, so a paired sign-in from
+			// another device works.
+			launch := !noBrowser && !flags.noInput
+
+			fmt.Fprintln(w, "Sign in to Snipd to authorise this CLI:")
+			fmt.Fprintln(w, "  "+signIn)
+			if launch {
+				if err := openInBrowser(signIn); err != nil {
+					fmt.Fprintf(w, "  (couldn't open a browser automatically: %v — open the URL above)\n", err)
+				}
+			}
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Waiting for the sign-in to complete...")
+
+			timeout := loginTimeout
+			if flags.timeout > timeout {
+				timeout = flags.timeout
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+			defer cancel()
+
+			token, err := snipd.PollForToken(ctx, cfg.BaseURL, pairingUUID)
+			if err != nil {
+				if ctx.Err() != nil || err == snipd.ErrSignInIncomplete {
+					return authErr(fmt.Errorf("no token received — the sign-in did not finish in time.\n" +
+						"Run 'snipd-pp-cli auth login' again, or use 'snipd-pp-cli auth setup' for the manual steps"))
+				}
+				return authErr(err)
+			}
+
+			// Clear any legacy auth_header first, for the same reason
+			// set-token does: a pre-existing value shadows the saved
+			// credential via AuthHeader() and the login silently has no effect.
+			cfg.AuthHeaderVal = ""
+			if err := cfg.SaveTokens("", "", token, "", cfg.TokenExpiry); err != nil {
+				return configErr(fmt.Errorf("saving token: %w", err))
+			}
+
+			savePath := credentialSavePath(cfg)
+			if flags.asJSON {
+				out := map[string]any{
+					"authenticated": true,
+					"saved":         true,
+					"token":         snipd.MaskToken(token),
+					"config_path":   cfg.Path,
+				}
+				if !cfg.AgentcookieManagedByExternalStore() {
+					out["credentials_path"] = savePath
+				}
+				return printJSONFiltered(w, out, flags)
+			}
+
+			fmt.Fprintln(w, green("Signed in to Snipd."))
+			fmt.Fprintf(w, "  Token: %s\n", snipd.MaskToken(token))
+			fmt.Fprintf(w, "  Saved to: %s\n", savePath)
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Next: snipd-pp-cli pull   (builds your local snip mirror)")
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the sign-in URL instead of opening a browser (headless/SSH)")
+	cmd.Flags().StringVar(&pairingUUID, "uuid", "", "Use a fixed pairing UUID instead of generating one")
+	_ = cmd.Flags().MarkHidden("uuid")
+
+	return cmd
+}
+
+// openInBrowser hands a URL to the OS handler. Only ever called with a URL this
+// process built from a validated UUID — never with user-supplied text.
+func openInBrowser(target string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", target)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		cmd = exec.Command("xdg-open", target)
+	}
+	return cmd.Start()
+}
+
+// writeLoginDryRun reports the suppressed side effect in whichever format the
+// caller asked for. The sign-in URL is included because it is the one piece a
+// human running --dry-run actually wants, and it carries no secret — the
+// pairing UUID is a random throwaway correlator.
+func writeLoginDryRun(w io.Writer, flags *rootFlags, signIn string) error {
+	const action = "login"
+	would := "run " + action + "; no changes made"
+	if flags != nil && flags.asJSON {
+		return json.NewEncoder(w).Encode(dryRunResult{
+			DryRun: true, Action: action, Would: would, URL: signIn,
+		})
+	}
+	if _, err := fmt.Fprintf(w, "dry-run: would %s\n", would); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintln(w, "would open:", signIn)
+	return err
+}

--- a/library/media-and-entertainment/snipd/internal/cli/dryrun_shim.go
+++ b/library/media-and-entertainment/snipd/internal/cli/dryrun_shim.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Maxime Delavergne and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored shim — NOT generator output.
+//
+// The 4.31.x chassis ships a writeDryRun helper in internal/cli/helpers.go for
+// exactly this. This CLI is printed on 4.28.0, which has no such helper, and a
+// --dry-run branch that prints prose — or returns nil and emits nothing at all —
+// fails the live matrix's json_fidelity probe with "invalid JSON" under
+// `--dry-run --json` (upstream cli-printing-press issue 4321, closed wontfix
+// because the helper already exists upstream).
+//
+// Field names and the "would" phrasing match 4.31.x's dryRunResult exactly, so
+// the chassis upgrade can delete this file and switch the call sites to the
+// framework helper with no change in output.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type dryRunResult struct {
+	DryRun bool   `json:"dry_run"`
+	Action string `json:"action"`
+	Would  string `json:"would"`
+	// URL is a shim-only addition: auth login's suppressed side effect is
+	// opening a browser, and the sign-in URL is the one thing a human running
+	// --dry-run actually wants. It carries no secret.
+	URL string `json:"url,omitempty"`
+}
+
+// writeDryRunShim reports a suppressed side effect in whichever format the
+// caller asked for. Mirrors 4.31.x's writeDryRun.
+func writeDryRunShim(w io.Writer, flags *rootFlags, action string) error {
+	would := "run " + action + "; no changes made"
+	if flags != nil && flags.asJSON {
+		return json.NewEncoder(w).Encode(dryRunResult{DryRun: true, Action: action, Would: would})
+	}
+	_, err := fmt.Fprintf(w, "dry-run: would %s\n", would)
+	return err
+}

--- a/library/media-and-entertainment/snipd/internal/cli/pull.go
+++ b/library/media-and-entertainment/snipd/internal/cli/pull.go
@@ -120,17 +120,17 @@ func newNovelPullCmd(flags *rootFlags) *cobra.Command {
 			// --dry-run and PRINTING_PRESS_VERIFY. Live dogfood (real API) still
 			// runs, curtailed below.
 			if dryRunOK(flags) || cliutil.IsVerifyEnv() {
-				fmt.Fprintln(cmd.OutOrStdout(), "would pull episodes and snips into the local mirror")
-				return nil
+				return writeDryRunShim(cmd.OutOrStdout(), flags, "pull")
 			}
 
 			cfg, err := config.Load(flags.configPath)
 			if err != nil {
 				return err
 			}
-			if cfg.SnipdToken == "" {
-				return usageErr(fmt.Errorf("no SNIPD_TOKEN set — the export API requires your Snipd account token.\n" +
-					"Get your token from Snipd's browser sign-in (no Obsidian needed; see README -> Authentication), then: snipd-pp-cli auth set-token <token>  (or export SNIPD_TOKEN=<token>)"))
+			token := resolveSnipdToken(cfg)
+			if token == "" {
+				return usageErr(fmt.Errorf("no Snipd token configured — the export API requires your Snipd account token.\n" +
+					"Get your token from Snipd's browser sign-in (no Obsidian needed; see README -> Authentication), then: snipd-pp-cli auth login  (or auth set-token <token>, or export SNIPD_TOKEN=<token>)"))
 			}
 
 			// Generous timeout floor for a bulk pull; a larger explicit --timeout wins.
@@ -141,7 +141,7 @@ func newNovelPullCmd(flags *rootFlags) *cobra.Command {
 			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
 			defer cancel()
 
-			c := snipd.NewClient(cfg.BaseURL, cfg.SnipdToken)
+			c := snipd.NewClient(cfg.BaseURL, token)
 			meta, err := c.FetchMetadata(ctx, updatedAfter)
 			if err != nil {
 				return err
@@ -280,4 +280,29 @@ func newNovelPullCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&updatedAfter, "updated-after", "", "Only pull episodes updated after this ISO-8601 time (incremental sync)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "Max episodes to pull this run (0 = all)")
 	return cmd
+}
+
+// resolveSnipdToken returns the raw Snipd bearer token, mirroring the precedence
+// config.AuthHeader() applies everywhere else in the CLI: the SNIPD_TOKEN env var
+// wins, then whatever was persisted to the credentials file.
+//
+// The fallback is load-bearing, not defensive. `auth set-token` routes through the
+// generated config.SaveTokens, whose OAuth-shaped signature files the value under
+// AccessToken. cfg.SnipdToken maps to the `token` key and CAN be loaded from the
+// credentials file, but no command ever writes that key — so in practice the env var
+// is its only populated source. Reading it alone meant `doctor` reported "Auth:
+// configured" from the saved credential while every pull rejected it: the generated
+// half of the CLI honoured the token and this hand-built half did not.
+//
+// AuthHeaderVal is deliberately NOT consulted: it holds a complete header value
+// ("Bearer x"), while snipd.NewClient wants the bare token. `auth set-token`
+// clears it for exactly this reason.
+func resolveSnipdToken(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.SnipdToken != "" {
+		return cfg.SnipdToken
+	}
+	return cfg.AccessToken
 }

--- a/library/media-and-entertainment/snipd/internal/cli/pull_token_test.go
+++ b/library/media-and-entertainment/snipd/internal/cli/pull_token_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Maxime Delavergne and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored test — NOT generator output.
+package cli
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/snipd/internal/config"
+)
+
+// The hand-built Snipd export layer must accept a credential from either place
+// the rest of the CLI is willing to store one. Before this resolver existed,
+// pull read cfg.SnipdToken directly, so `auth set-token` (which persists into
+// AccessToken via the generated SaveTokens) left `doctor` reporting "Auth:
+// configured" while every pull failed with "no SNIPD_TOKEN set".
+func TestResolveSnipdToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		snipdToken string
+		accessTok  string
+		want       string
+	}{
+		{
+			name:       "env var only",
+			snipdToken: "env-token",
+			want:       "env-token",
+		},
+		{
+			// The regression case: this is exactly what `auth set-token` writes.
+			name:      "credentials file only (auth set-token)",
+			accessTok: "saved-token",
+			want:      "saved-token",
+		},
+		{
+			// Mirrors config.AuthHeader(): env beats file.
+			name:       "both set, env wins",
+			snipdToken: "env-token",
+			accessTok:  "saved-token",
+			want:       "env-token",
+		},
+		{
+			name: "neither set",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{SnipdToken: tt.snipdToken, AccessToken: tt.accessTok}
+			if got := resolveSnipdToken(cfg); got != tt.want {
+				t.Errorf("resolveSnipdToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveSnipdTokenNilConfig(t *testing.T) {
+	if got := resolveSnipdToken(nil); got != "" {
+		t.Errorf("resolveSnipdToken(nil) = %q, want empty", got)
+	}
+}

--- a/library/media-and-entertainment/snipd/internal/cli/quote.go
+++ b/library/media-and-entertainment/snipd/internal/cli/quote.go
@@ -39,7 +39,7 @@ func newNovelQuoteCmd(flags *rootFlags) *cobra.Command {
 			"for a specific snip via --snip. Use this when you need a citable line, not a\n" +
 			"paraphrase or the whole transcript. Only snips that carry a quote are returned.",
 		Example:     "  snipd-pp-cli quote \"thought partner\" --agent\n  snipd-pp-cli quote --snip 79b70845-023e-40f3-a68f-6e03ae9c0bd6",
-		Annotations: map[string]string{"mcp:read-only": "true"},
+		Annotations: map[string]string{"mcp:read-only": "true", "pp:happy-args": "query=orchestration"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
 				return cmd.Help()

--- a/library/media-and-entertainment/snipd/internal/cli/synthesize.go
+++ b/library/media-and-entertainment/snipd/internal/cli/synthesize.go
@@ -30,7 +30,7 @@ func newNovelSynthesizeCmd(flags *rootFlags) *cobra.Command {
 			"synthesize a cross-show answer without dragging whole transcripts through\n" +
 			"context. Plain stemmed terms work best; the index is porter-stemmed.",
 		Example:     "  snipd-pp-cli synthesize \"AI and jobs\" --limit 20 --agent\n  snipd-pp-cli synthesize \"personas\" --show \"UX Research Geeks\"",
-		Annotations: map[string]string{"mcp:read-only": "true"},
+		Annotations: map[string]string{"mcp:read-only": "true", "pp:happy-args": "query=AI and jobs"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
 				return cmd.Help()

--- a/library/media-and-entertainment/snipd/internal/snipd/auth.go
+++ b/library/media-and-entertainment/snipd/internal/snipd/auth.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Maxime Delavergne and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored novel source layer — NOT generator output.
+//
+// auth implements Snipd's UUID device-pairing flow, the only way to mint an
+// account token. The reference implementation is Snipd's own open-source
+// Obsidian plugin (github.com/snipd-app/snipd-obsidian): connectToSnipd in
+// src/settings_modal.ts, with AUTH_URL in src/main.ts. Same three HTTP facts in Go.
+//
+// The flow, in full:
+//
+//  1. generate a random v4 UUID, client-side and disposable
+//  2. the user opens app.snipd.com/obsidian/auth?uuid=<uuid> and signs in
+//  3. GET <api>/obsidian/auth?uuid=<uuid> returns {"token": "..."}
+//
+// Step 3 is a LONG-POLL, not a client retry loop: the Snipd server holds the
+// request open until the browser sign-in in step 2 completes. The UUID is the
+// only thing correlating the two — it is random, client-generated, and carries
+// no secret, which is why it is safe to put in a URL and to log.
+package snipd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/snipd/internal/cliutil"
+)
+
+const (
+	// signInBase is Snipd-hosted web, not an API endpoint. It is titled
+	// "Obsidian integration" purely because that is Snipd's internal name for
+	// this export API; no Obsidian app, plugin, or mobile app is involved.
+	signInBase = "https://app.snipd.com/obsidian/auth"
+
+	// authPollPath is joined to the configured API base URL.
+	authPollPath = "/obsidian/auth"
+
+	// maxAuthBody caps the token response read. The real body is a few dozen
+	// bytes; anything larger is a captive portal or an error page.
+	maxAuthBody = 64 << 10
+
+	// pollAttempts guards against the server closing the long-poll early
+	// (proxy idle timeout, load-balancer reap) before the user has finished
+	// signing in. The plugin's equivalent is telling the user to click
+	// "Connect" again; here it is transparent.
+	pollAttempts = 3
+)
+
+// ErrSignInIncomplete reports that the pairing endpoint answered but had no
+// token to give — the browser sign-in did not complete inside the window.
+// Distinct from a transport failure so the CLI can advise "try again" rather
+// than "check your network".
+var ErrSignInIncomplete = fmt.Errorf("sign-in did not complete")
+
+// SignInURL builds the browser URL the user signs in at. The uuid is a
+// throwaway correlator, not a credential.
+func SignInURL(pairingUUID string) string {
+	return signInBase + "?uuid=" + url.QueryEscape(pairingUUID)
+}
+
+// PollForToken waits for the browser sign-in keyed to pairingUUID and returns
+// the minted account token. The caller owns the deadline via ctx; this does
+// not impose its own, because the server deliberately holds the connection.
+//
+// The token is never written to an error, a log, or any returned value other
+// than the success return.
+func PollForToken(ctx context.Context, baseURL, pairingUUID string) (string, error) {
+	endpoint := strings.TrimRight(baseURL, "/") + authPollPath + "?uuid=" + url.QueryEscape(pairingUUID)
+
+	// No client-level deadline: the long-poll is meant to hang. Cancellation
+	// flows through ctx, matching NewClient's rationale for the export POST.
+	hc := &http.Client{Timeout: 0}
+
+	// Same adaptive limiter the export client uses. Pairing is low-volume (at
+	// most pollAttempts requests per login), but an operator re-running `auth
+	// login` after a failed sign-in can hit the endpoint in a tight loop, and
+	// an unlimited retry against an auth endpoint is exactly what earns a 429.
+	limiter := cliutil.NewAdaptiveLimiter(defaultRateSec)
+
+	var lastErr error = ErrSignInIncomplete
+	for attempt := 0; attempt < pollAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
+		limiter.Wait()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := hc.Do(req)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
+			lastErr = err
+			continue
+		}
+
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxAuthBody))
+		_ = resp.Body.Close()
+
+		if readErr != nil {
+			lastErr = readErr
+			continue
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			limiter.OnRateLimit()
+			// Typed, so the CLI's shared rate-limit handling can advise a wait
+			// instead of reporting a generic pairing failure. Body omitted for
+			// the same reason as below.
+			lastErr = &cliutil.RateLimitError{
+				URL:        endpoint,
+				RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
+			}
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			// Body deliberately omitted: on a success-shaped response it holds
+			// the token, and this error string may be printed or logged.
+			lastErr = fmt.Errorf("snipd pairing endpoint returned HTTP %d", resp.StatusCode)
+			continue
+		}
+
+		var payload struct {
+			Token string `json:"token"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			lastErr = fmt.Errorf("unexpected response from snipd pairing endpoint (not JSON)")
+			continue
+		}
+		if tok := strings.TrimSpace(payload.Token); tok != "" {
+			return tok, nil
+		}
+
+		// 200 with no token: the poll window elapsed before the user finished.
+		lastErr = ErrSignInIncomplete
+	}
+
+	return "", lastErr
+}

--- a/library/media-and-entertainment/snipd/internal/snipd/auth_test.go
+++ b/library/media-and-entertainment/snipd/internal/snipd/auth_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Maxime Delavergne and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored test — NOT generator output.
+package snipd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSignInURLCarriesUUID(t *testing.T) {
+	got := SignInURL("cc437cd9-072d-43c9-b04e-808d88bfc907")
+	want := "https://app.snipd.com/obsidian/auth?uuid=cc437cd9-072d-43c9-b04e-808d88bfc907"
+	if got != want {
+		t.Errorf("SignInURL() = %q, want %q", got, want)
+	}
+}
+
+func TestPollForTokenSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("uuid"); got != "pair-me" {
+			t.Errorf("uuid query = %q, want pair-me", got)
+		}
+		if r.URL.Path != "/obsidian/auth" {
+			t.Errorf("path = %q, want /obsidian/auth", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"token":"tok-abc123"}`))
+	}))
+	defer srv.Close()
+
+	got, err := PollForToken(context.Background(), srv.URL, "pair-me")
+	if err != nil {
+		t.Fatalf("PollForToken() error = %v", err)
+	}
+	if got != "tok-abc123" {
+		t.Errorf("token = %q, want tok-abc123", got)
+	}
+}
+
+// The server closes the long-poll early (proxy reap) before the user has
+// finished signing in. The retry should be transparent.
+func TestPollForTokenRetriesEmptyResponse(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) < 3 {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"token":"late-token"}`))
+	}))
+	defer srv.Close()
+
+	got, err := PollForToken(context.Background(), srv.URL, "pair-me")
+	if err != nil {
+		t.Fatalf("PollForToken() error = %v", err)
+	}
+	if got != "late-token" {
+		t.Errorf("token = %q, want late-token", got)
+	}
+	if calls != 3 {
+		t.Errorf("calls = %d, want 3", calls)
+	}
+}
+
+func TestPollForTokenGivesUpAfterAttempts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	_, err := PollForToken(context.Background(), srv.URL, "pair-me")
+	if err != ErrSignInIncomplete {
+		t.Errorf("error = %v, want ErrSignInIncomplete", err)
+	}
+}
+
+// A success-shaped body holds the token, so no error string may echo the body.
+func TestPollForTokenErrorNeverLeaksBody(t *testing.T) {
+	const secret = "super-secret-token-value"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"token":"` + secret + `"}`))
+	}))
+	defer srv.Close()
+
+	_, err := PollForToken(context.Background(), srv.URL, "pair-me")
+	if err == nil {
+		t.Fatal("expected an error on HTTP 500")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Errorf("error leaked the response body: %v", err)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should name the status code, got: %v", err)
+	}
+}
+
+func TestPollForTokenRespectsContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := PollForToken(ctx, srv.URL, "pair-me")
+	if err == nil {
+		t.Fatal("expected a context error")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("took %v — context deadline was not honoured", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

Two coupled changes to the published `snipd` CLI, plus a coverage improvement found while testing them.

**1. `auth set-token` never reached the commands that fetch anything.** It routes through the generated `config.SaveTokens`, whose OAuth-shaped signature files the value under `AccessToken`. The hand-built Snipd export layer in `pull.go` read `cfg.SnipdToken` directly — and that field is only ever populated from the `SNIPD_TOKEN` env var. The generated half of the CLI honoured the saved credential; this hand-built half did not.

Reproduced on the merged `main` tree, checked out untouched, with the env var unset and only a `set-token` credential on disk:

```
v1 auth status  →  Credentials present
v1 doctor       →  OK Auth: configured / OK Env Vars: credentials available from config
v1 pull         →  Error: no SNIPD_TOKEN set
```

The remediation text in that error advises running `auth set-token` — the command that does not work. A new user on a clean machine follows the README, sees a green `doctor`, and hits a wall on their first real command.

Fixed at the read site (`resolveSnipdToken`), mirroring the precedence `config.AuthHeader()` already applies everywhere else. Not fixed at the write site: `config.go` and `set-token`'s body carry the generator DO-NOT-EDIT header, and changing the persisted field would alter on-disk credential shape for anyone who already ran it.

**2. Guided `auth login`.** Automates Snipd's UUID device-pairing flow — generate a v4 UUID, open the sign-in page, long-poll the endpoint the server holds open, save the token. It replaces a manual path ending with the user reading a secret out of a raw JSON endpoint and pasting it back. Shape follows `gh auth login`; Snipd's own open-source Obsidian plugin is the reference implementation.

(2) depends on (1) — `auth login` saves through the same path, so without the resolver fix it would print "Signed in" and every `pull` would still fail.

Browser launch short-circuits on `--dry-run`, `PRINTING_PRESS_VERIFY=1` and `PRINTING_PRESS_DOGFOOD=1`. The dogfood guard is load-bearing: pairing needs a human, so a live attempt would hang to the runner's per-command timeout and report a false failure. `--no-browser` prints the URL; `--no-input` implies it. The token is never printed, logged, or placed in an error string — the HTTP error path omits the response body deliberately, because on a success-shaped response that body *is* the token.

**3. `hollow_features` 4 → 1.** `aggregate`/`quote`/`synthesize` were hollow because their probes skip on a non-id positional — declared but never exercised. Fixed with `pp:happy-args`, values checked against the real corpus first so the probes pass on actual output rather than an empty result.

## Known: `pull` remains hollow, and `publish validate` will refuse this

Stating this plainly rather than leaving it to be discovered.

`pull` builds the local SQLite corpus, so it genuinely writes. The harness classifies it as mutating, forces `--dry-run` onto its happy-path probe, then discards that result when computing coverage. The probe passes; it is discarded because of how it was invoked. No annotation escapes this — `mcp:local-write` still counts as mutating. See cli-printing-press #4046, #4259, #4263.

**This PR does not introduce that condition.** Measured, not inferred — the same full live matrix run against the merged v1 tree checked out untouched from `main`:

| | merged v1 (untouched) | this PR |
|---|---|---|
| `coverage_hollow` | `true` | `true` |
| `hollow_features` | `[aggregate, pull, quote, synthesize]` | `[pull]` |
| probes | 81 (76 pass / 5 fail) | 87 (83 pass / 4 fail) |

The published catalog already contains this condition. This change reduces it.

The 4 remaining `json_fidelity` failures (`learnings purge`, `playbook amend`, `teach`, `teach-pattern`) are generated framework commands whose `--dry-run` branches emit nothing under `--json`. Left alone deliberately — fixing them means shimming four DO-NOT-EDIT files, which doesn't belong in an auth PR. The 4.31.x chassis resolves them for free via its `writeDryRun` helper.

## Verification

Under Go 1.26.6 (this repo's `.go-version` pin):

- `go build`, `go vet`, and all 12 packages' tests green. 11 new tests.
- With `SNIPD_TOKEN` unset and only the `set-token` credential on disk, `pull --limit 3` returns 3 episodes / 52 snips, where it previously errored.
- `auth login --no-browser` against a stub that withholds the token on the first call retries transparently, saves it, and reports `present (23 chars)`.
- `govulncheck`: no vulnerabilities. `verify_skill.py`: all checks passed. `check_skill_guard_literals`: clean.
- The operator's real `credentials.toml` was byte- and mtime-identical across the whole exercise.

`internal/cli/dryrun_shim.go` is a 4.28.0 stand-in for 4.31.x's `writeDryRun`. Its `dryRunResult` carries 4.31.x's three fields (`dry_run`/`action`/`would`) plus an **optional `url`** that only `auth login` emits — so on upgrade `pull` switches to the framework helper directly, while `auth login` keeps a local writer if that `url` is worth retaining.

Generated-file footprint is 10 lines in one file (`internal/cli/auth.go`): the subcommand registration and two text changes pointing users at the faster path. Provenance recorded in `.printing-press-patches/snipd-guided-auth-login.json`.

---

This was built with Claude Code, driven and reviewed by me — as is the source-level analysis relayed in this PR.

---

### Corrections to an earlier revision of this description

I audited this PR's own artifacts against the code and found four claims of mine that were wrong. All are now fixed in the branch; recording them here rather than silently editing.

- **`cfg.SnipdToken` is not "env-var-only".** It maps to the `token` key and *is* loaded from the credentials file by `applyCredentials`. What actually causes the bug is that **no command ever writes that key** — `set-token` and `auth login` both persist via `SaveTokens` into `access_token`. The failure mode and the fix are unchanged; the mechanism description was imprecise, including in a code comment.
- **The dry-run shim is not a field-for-field match.** It adds an optional `url`. Corrected above.
- **"14 tools on both sides"** described `tools-manifest.json`'s array length, not the runtime tool surface. The manifest is byte-identical to base, and no `auth` command *can* register because `walk()` does not recurse into a `commandFramework` subtree — that is the claim that matters and it holds.
- **`dogfood-results.json` was committed as invalid JSON** carrying absolute paths from my machine: `dogfood --json` writes a `using spec … (bundled)` line to stdout above the object. Regenerated, normalised to the `"."` / `"spec.yaml"` form base `main` uses, and now parses with zero absolute paths. No CI job reads that file, which is why nothing flagged it.

The live-matrix numbers quoted above were measured with `dogfood --live --level full --research-dir` against a real credential and are not reproducible from the branch alone — treat them as reported, not as artifacts you can re-derive here.