### PR TITLE
fix(kuma): document kumactl HTTP MCP and bound Socket.IO reads

### DIFF
--- a/library/monitoring/kuma/README.md
+++ b/library/monitoring/kuma/README.md
@@ -2,6 +2,8 @@
 
 `kuma-pp-cli` is a small operator CLI for Uptime Kuma v2. It uses Kuma's Socket.IO protocol rather than pretending the dashboard is a REST API.
 
+This catalog package is intentionally separate from the native `kumactl` HTTP MCP service. The package currently contains the generated Go CLI and its Socket.IO client; it does not install or embed a Python `kumactl` dependency, and it does not provide an MCP transport.
+
 ## Configuration
 
 Set `UPTIME_KUMA_URL`, `UPTIME_KUMA_USERNAME`, and `UPTIME_KUMA_PASSWORD` (or pass `--url`, `--username`, and `--password`). Never commit credentials.
@@ -23,6 +25,16 @@ kuma-pp-cli --version
 `UPTIME_KUMA_URL` must be the server origin (for example `https://kuma.example.com`). A dashboard page URL is reduced to its origin automatically.
 
 `agent-context` emits machine-readable JSON describing every command, flag, and auth variable, so agents can introspect the CLI without parsing `--help`.
+
+## Native HTTP MCP service
+
+For MCP clients, deploy the separately published native `kumactl` service rather than this generated Go CLI:
+
+```bash
+kumactl-mcp --transport streamable-http --host 127.0.0.1 --port 40108 --path /mcp
+```
+
+The native service uses the same `UPTIME_KUMA_URL`, `UPTIME_KUMA_USERNAME`, and `UPTIME_KUMA_PASSWORD` environment variables. This package preserves those variables for `kuma-pp-cli`; it does not rename the CLI to `kumactl` or add a dependency on the native service.
 
 All mutations are operator-gated and dry-run by default. The client sends complete monitor objects for `editMonitor`, because Kuma v2 treats edits as full replacement.
 

--- a/library/monitoring/kuma/SKILL.md
+++ b/library/monitoring/kuma/SKILL.md
@@ -24,6 +24,15 @@ go install github.com/mvanhorn/printing-press-library/library/monitoring/kuma/cm
 
 If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
+## Native HTTP MCP service
+
+This skill's `kuma-pp-cli` is the generated Go Socket.IO operator CLI, not the native `kumactl` MCP server. For MCP clients, install and deploy the separately published native service, then expose its Streamable HTTP endpoint with:
+
+```bash
+kumactl-mcp --transport streamable-http --host 127.0.0.1 --port 40108 --path /mcp
+```
+
+The native service and this CLI use the preserved `UPTIME_KUMA_URL`, `UPTIME_KUMA_USERNAME`, and `UPTIME_KUMA_PASSWORD` environment variables. Do not substitute `kumactl-mcp` for the commands below; this package has no `kumactl` dependency or embedded MCP transport.
 
 Use `kuma-pp-cli` for authenticated Kuma v2 inspection. Credentials come from `UPTIME_KUMA_URL`, `UPTIME_KUMA_USERNAME`, and `UPTIME_KUMA_PASSWORD`. `UPTIME_KUMA_URL` must be the server origin (for example `https://kuma.example.com`), not a dashboard page URL.
 

--- a/library/monitoring/kuma/internal/client/client.go
+++ b/library/monitoring/kuma/internal/client/client.go
@@ -198,6 +198,19 @@ func socketIOParse(base string) (*url.URL, error) {
 	return u, nil
 }
 
+const maxResponseBodyBytes = 10 << 20
+
+func readResponseBody(body io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(body, maxResponseBodyBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("response body exceeds %d-byte limit", maxResponseBodyBytes)
+	}
+	return data, nil
+}
+
 func (c *Client) do(ctx context.Context, u *url.URL, method string, body io.Reader) ([]byte, error) {
 	hc := c.cfg.HTTPClient
 	if hc == nil {
@@ -214,7 +227,7 @@ func (c *Client) do(ctx context.Context, u *url.URL, method string, body io.Read
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	data, err := readResponseBody(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/library/monitoring/kuma/internal/client/client_test.go
+++ b/library/monitoring/kuma/internal/client/client_test.go
@@ -286,6 +286,22 @@ func TestHTTPClientTimeoutBoundsHandshake(t *testing.T) {
 		t.Fatalf("timeout took too long: %v", time.Since(started))
 	}
 }
+
+func TestDoRejectsOversizedResponseBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, strings.Repeat("x", 10<<20+1))
+	}))
+	defer srv.Close()
+	c := New(Config{BaseURL: srv.URL})
+	u, err := socketIOParse(srv.URL)
+	if err != nil {
+		t.Fatalf("socketIOParse: %v", err)
+	}
+	if _, err := c.do(context.Background(), u, http.MethodGet, nil); err == nil {
+		t.Fatal("expected oversized response body to be rejected")
+	}
+}
+
 func TestHeartbeatCollectionKeepsMultipleObjectPushes(t *testing.T) {
 	f := newFakeKuma(t)
 	c := loginClient(t, context.Background(), f)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Extracts the unique leftover from community PR #1883 onto current `main`. Credit to @keithah for both leftover commits.

#1837 already merged the full kuma CLI on 2026-08-28 (phase5 8/8). #1883 is titled `docs(kuma)` but is a conflicted +3433 reprint of the whole package against a pre-merge base. This PR does **not** reprint the CLI. It applies only the two late unique commits onto `library/monitoring/kuma/`.

## Unique commits extracted from #1883

1. `2b1f5af` — `docs(kuma): document native kumactl HTTP MCP integration`
   - README/SKILL now state that this catalog package is the generated Go Socket.IO CLI (`kuma-pp-cli`), not the native `kumactl` HTTP MCP service.
   - MCP clients are pointed at `kumactl-mcp --transport streamable-http --host 127.0.0.1 --port 40108 --path /mcp`.
   - `UPTIME_KUMA_URL`, `UPTIME_KUMA_USERNAME`, and `UPTIME_KUMA_PASSWORD` stay shared; this package does not rename the CLI or add a `kumactl` dependency.

2. `7ed8328` — `fix(kuma): bound Socket.IO response reads`
   - Socket.IO HTTP reads in `internal/client` reject bodies over 10 MiB.
   - Adds `TestDoRejectsOversizedResponseBody` coverage.

## Files

- `library/monitoring/kuma/README.md`
- `library/monitoring/kuma/SKILL.md`
- `library/monitoring/kuma/internal/client/client.go`
- `library/monitoring/kuma/internal/client/client_test.go`

No registry.json / cli-skills regen. Close #1883 after this lands.

## Validation

- [x] `go test ./...` in `library/monitoring/kuma` — pass (`internal/cli`, `internal/client`)
- [x] `go vet ./...` in `library/monitoring/kuma`
- [x] `go build ./...` in `library/monitoring/kuma`
- [x] `gofmt -l .` — clean
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/monitoring/kuma/` — all checks passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aec36951-4de0-4785-9428-45703e6ea519?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aec36951-4de0-4785-9428-45703e6ea519&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

