### PR TITLE
feat(flight-goat): round-trip return-leg selection and cheapest-dates fix

### DIFF
--- a/library/travel/flight-goat/.printing-press-patches/round-trip-dates-native.json
+++ b/library/travel/flight-goat/.printing-press-patches/round-trip-dates-native.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "round-trip-dates-native",
+  "applied_at": "2026-08-31",
+  "base_run_id": "20260712-220852",
+  "base_printing_press_version": "4.28.0",
+  "upstream_issue": "",
+  "files": [
+    "internal/gflights/dates_native.go",
+    "internal/gflights/dates_native_test.go",
+    "internal/gflights/html_fallback.go",
+    "internal/gflights/html_fallback_test.go"
+  ],
+  "summary": "GetCalendarGraph round-trip requests need a second segment (origin/dest swapped, travel_date = anchor + --duration nights), trip_type=1, and an outer [min,max]-nights duration filter appended after the [from,to] date range — the one-way payload's 3-element outer filters array grows to 5 elements for round trip. The response is a single combined round-trip total keyed off the outbound date, not a 2D grid; ReturnDate is computed client-side as departure + Duration, not read from the response. The RPC-blocked HTML fallback (datesViaHTML) mirrors this: it now sets SearchOptions.ReturnDate per day and, on a round-trip page, must pick the cheapest candidate only from the 'outbound' Direction bucket — the 'return' bucket holds incremental fares priced against a pre-selected outbound, not standalone round-trip totals, and would otherwise surface an artificially low partial fare as the day's price.",
+  "reason": "buildDatesPayload previously rejected opts.RoundTrip outright ('round-trip date searches not yet implemented in native backend'), even though DatesOptions.RoundTrip/Duration and DatePrice.ReturnDate were already wired end-to-end from the CLI flags. Shape verified against a live captured GetCalendarGraph f.req payload for a real round-trip search and against a live LHR-BCN round-trip response. datesViaHTML previously ignored RoundTrip/Duration entirely (silent one-way fallback on a round-trip query); fixed in the same patch since both paths share DatesOptions and the bug is easy to reintroduce independently on a future edit to either.",
+  "validated_outcome": "go build ./...; go vet ./...; go test ./...; live: `flight-goat-pp-cli dates LHR BCN --round --duration 2 --from 2027-03-01 --to 2027-03-10 --sort --agent` returns 10 rows with sane round-trip totals ($109-$127) and correct return_date = departure_date + 2 days; one-way dates queries unaffected (regression-checked live and via TestBuildDatesPayloadOneWayUnaffected). HTML fallback path covered by TestDatesViaHTMLRoundTripSetsReturnDate (round-trip tfs param built, ReturnDate echoed) and TestCheapestFallbackCandidateRoundTripIgnoresReturnBucket (guards against picking a partial return-bucket fare over the real outbound-bucket total)."
+}

--- a/library/travel/flight-goat/.printing-press-patches/round-trip-select-outbound-two-step.json
+++ b/library/travel/flight-goat/.printing-press-patches/round-trip-select-outbound-two-step.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 2,
+  "id": "round-trip-select-outbound-two-step",
+  "applied_at": "2026-08-31",
+  "base_run_id": "20260712-220852",
+  "base_printing_press_version": "4.28.0",
+  "upstream_issue": "",
+  "files": [
+    "internal/gflights/gflights.go",
+    "internal/gflights/flights_native.go",
+    "internal/gflights/flights_native_test.go",
+    "internal/gflights/html_fallback.go",
+    "internal/cli/primary.go",
+    "SKILL.md",
+    "README.md"
+  ],
+  "summary": "A round-trip `flights` search must support Google's real two-step selection flow: pick a specific outbound itinerary and re-query so the response's Flights are genuine return-leg options priced and paired against that outbound, in addition to the existing default single-request behavior (outbound-only rows, each carrying Google's own auto-picked cheapest-return total).",
+  "reason": "The native RPC's GetShoppingResults response is a single flat itinerary list regardless of trip type — a plain round-trip request (two segments, no selection) returns outbound options only; there is no separate return-leg bucket until a specific outbound is selected via the request's segment[8] `selected_flight` field and an opaque per-itinerary continuation token (row priceBlock[1], previously parsed for price only and discarded). Verified against a live captured browser request for the real UI's step-2 POST. This RPC-envelope bucket behavior is distinct from — and must not be confused with — the pre-existing HTML-fallback path's outbound/return bucket split at inner[2]/inner[3] (see return-leg-independent-time-window.json), which is a different response shape and stays unchanged.",
+  "validated_outcome": "go build ./... ; go vet ./... ; go test ./... all pass. python3 .github/scripts/verify-skill/verify_skill.py --dir library/travel/flight-goat/ passes. Live smoke test against LHR->BCN 2027-03-01/2027-03-18: step 1 unchanged (10 outbound-only rows, bundled price); step 2 (--select-outbound 1) returned 10 independently-priced BCN->LHR return options (GBP 91-220, not the flat bundled price) tagged direction=\"return\", with selected_outbound echoing the chosen outbound. Out-of-range index, missing --return, and --trip conflicts all reject with the expected usage/runtime errors."
+}

--- a/library/travel/flight-goat/README.md
+++ b/library/travel/flight-goat/README.md
@@ -266,7 +266,7 @@ Existing installs keep working because the platform-default rung matches the leg
 
 The headline commands query consumer fare sources directly — no `FLIGHT_GOAT_API_KEY` needed. FlightAware AeroAPI (the resources below) is secondary and optional.
 
-- **`flight-goat-pp-cli flights <origin> <destination> <date>`** - Google Flights fare search with real prices, durations, airlines, and leg details. Round trip with `--return`, multi-city with repeated `--segment`, batch probes with repeated `--trip`. Departure time window with `--time` (outbound) and `--return-time` (return leg, independent of `--time`; falls back to it when unset).
+- **`flight-goat-pp-cli flights <origin> <destination> <date>`** - Google Flights fare search with real prices, durations, airlines, and leg details. Round trip with `--return`, multi-city with repeated `--segment`, batch probes with repeated `--trip`. Departure time window with `--time` (outbound) and `--return-time` (return leg, independent of `--time`; falls back to it when unset). `--select-outbound N` fetches real return-leg options priced against a specific outbound instead of Google's default bundled total — see below.
 - **`flight-goat-pp-cli dates <origin> <destination>`** - Cheapest-date scan for a route across a travel window.
 - **`flight-goat-pp-cli explore <airport>`** / **`flight-goat-pp-cli longhaul <airport>`** - Kayak nonstop and long-haul route discovery.
 - **`flight-goat-pp-cli soar <origin> <destination> <date>`** - FlySoar (Duffel NDC/GDS) second price opinion with a booking handoff.
@@ -275,6 +275,12 @@ The headline commands query consumer fare sources directly — no `FLIGHT_GOAT_A
 - **`flight-goat-pp-cli assess`** - Delayed-flight/rebooking decision support.
 
 Booking deeplinks in each result's `booking_urls` quote the same `--currency` the search ran in. `award` is the exception: it quotes mileage/points rather than cash and does not produce booking deeplinks.
+
+#### Round trip: getting real return-leg options with `--select-outbound`
+
+`--return` alone returns **outbound itineraries only**. Each row's price already bundles Google's own auto-picked "cheapest return" total, but no actual return flight (time, airline, duration) is shown. To see and choose real return-leg options — the same two-step flow Google's own site uses — run the search twice: first `flight-goat-pp-cli flights LHR BCN 2027-03-01 --return 2027-03-18` for the outbound list, then `flight-goat-pp-cli flights LHR BCN 2027-03-01 --return 2027-03-18 --select-outbound 1` to fetch return options priced against the 1st outbound in that list.
+
+`--select-outbound N` is a 1-based index into the outbound list step 1 returned. It requires `--return` and cannot combine with `--trip` or `--segment`. JSON output (`--json`/`--agent`) adds `direction` (`outbound`/`return`) on each flight and `selected_outbound` on the envelope, so a script or agent can tell which itinerary a set of return options is paired against.
 
 #### Bulk fare probes with built-in pacing
 

--- a/library/travel/flight-goat/README.md
+++ b/library/travel/flight-goat/README.md
@@ -267,7 +267,7 @@ Existing installs keep working because the platform-default rung matches the leg
 The headline commands query consumer fare sources directly — no `FLIGHT_GOAT_API_KEY` needed. FlightAware AeroAPI (the resources below) is secondary and optional.
 
 - **`flight-goat-pp-cli flights <origin> <destination> <date>`** - Google Flights fare search with real prices, durations, airlines, and leg details. Round trip with `--return`, multi-city with repeated `--segment`, batch probes with repeated `--trip`. Departure time window with `--time` (outbound) and `--return-time` (return leg, independent of `--time`; falls back to it when unset). `--select-outbound N` fetches real return-leg options priced against a specific outbound instead of Google's default bundled total — see below.
-- **`flight-goat-pp-cli dates <origin> <destination>`** - Cheapest-date scan for a route across a travel window.
+- **`flight-goat-pp-cli dates <origin> <destination>`** - Cheapest-date scan for a route across a travel window. One-way by default; `--round --duration N` scans round-trip totals instead — see below.
 - **`flight-goat-pp-cli explore <airport>`** / **`flight-goat-pp-cli longhaul <airport>`** - Kayak nonstop and long-haul route discovery.
 - **`flight-goat-pp-cli soar <origin> <destination> <date>`** - FlySoar (Duffel NDC/GDS) second price opinion with a booking handoff.
 - **`flight-goat-pp-cli award <origin> <destination> [--from YYYY-MM-DD --to YYYY-MM-DD]`** - Seats.aero award (mileage) availability across cabin classes (economy/premium/business/first). Requires `SEATS_AERO_API_KEY` (Seats.aero Partner API key; cached search is Pro-eligible). Read-only — miles + taxes, no booking deeplinks.
@@ -281,6 +281,10 @@ Booking deeplinks in each result's `booking_urls` quote the same `--currency` th
 `--return` alone returns **outbound itineraries only**. Each row's price already bundles Google's own auto-picked "cheapest return" total, but no actual return flight (time, airline, duration) is shown. To see and choose real return-leg options — the same two-step flow Google's own site uses — run the search twice: first `flight-goat-pp-cli flights LHR BCN 2027-03-01 --return 2027-03-18` for the outbound list, then `flight-goat-pp-cli flights LHR BCN 2027-03-01 --return 2027-03-18 --select-outbound 1` to fetch return options priced against the 1st outbound in that list.
 
 `--select-outbound N` is a 1-based index into the outbound list step 1 returned. It requires `--return` and cannot combine with `--trip` or `--segment`. JSON output (`--json`/`--agent`) adds `direction` (`outbound`/`return`) on each flight and `selected_outbound` on the envelope, so a script or agent can tell which itinerary a set of return options is paired against.
+
+#### Round trip cheapest dates: `dates --round --duration`
+
+`dates` scans one-way prices by default. `--round --duration N` scans round-trip totals instead: `flight-goat-pp-cli dates SEA HNL --round --duration 7 --sort --agent` returns, for each candidate departure day, the cheapest combined round-trip price for departing that day and returning `N` nights later — not a separate outbound/return price pair. `--duration` is required with `--round` (nights, must be greater than zero). Each result row's `price` is already the round-trip total, and `return_date` (`departure_date` + `--duration`) is included alongside it.
 
 #### Bulk fare probes with built-in pacing
 

--- a/library/travel/flight-goat/SKILL.md
+++ b/library/travel/flight-goat/SKILL.md
@@ -68,6 +68,14 @@ flight-goat-pp-cli flights \
 
 Round trips can constrain each leg's departure window independently: `--time` sets the outbound window, `--return-time` sets the return leg's window (falls back to `--time` when unset). Both take the same `H-H` 24h form, e.g. `flight-goat-pp-cli flights SEA HNL 2026-08-01 --return 2026-08-10 --time 6-12 --return-time 17-23` for a morning outbound and evening return.
 
+### Round trip: `--return` alone does not return return-leg options
+
+`--return` alone shows **outbound itineraries only**. Each one's `price` already bundles Google's own auto-picked "cheapest return" total, but no return-leg flight (times, airline, duration) is ever shown — do not read the outbound list as containing both directions, and do not assume the price is for the outbound leg alone.
+
+To see and choose real return-leg options, run the true two-step flow Google's own UI uses. Step 1, `flight-goat-pp-cli flights LHR BCN 2027-03-01 --return 2027-03-18 --agent`, returns outbound options with `flights[0].direction == "outbound"` — note the 1-based position of the one you want. Step 2, `flight-goat-pp-cli flights LHR BCN 2027-03-01 --return 2027-03-18 --select-outbound 1 --agent`, returns real return options priced against that specific outbound: `flights[]` now has `direction == "return"` with independent prices, and the envelope's `selected_outbound` echoes which outbound they're paired with.
+
+`--select-outbound N` is 1-based, counted in the order step 1 returned them. It requires `--return` (round trip only) and does not combine with `--trip` or `--segment` (>=2). Each `Flight` also carries `selection_token` on round-trip outbound rows — the same value the CLI itself uses internally to build the step-2 request — for callers building their own selection flow instead of a fixed index.
+
 Rate-limit semantics:
 
 - Transient 429s are retried automatically (2s/5s/12s backoff) before a command fails.

--- a/library/travel/flight-goat/SKILL.md
+++ b/library/travel/flight-goat/SKILL.md
@@ -82,6 +82,10 @@ Rate-limit semantics:
 - On a persistent 429 a batch stops early — continuing would deepen the IP block — the partial envelope is still emitted, and the exit code is 7 (rate limited).
 - While Google is blocked, `soar` and `explore`/`longhaul` use different backends and keep working; `doctor` documents the same contract under `google_flights`.
 
+### Round trip cheapest dates: `dates --round --duration`
+
+`dates` scans one-way prices by default. Add `--round --duration N` to scan round-trip totals instead — each row is the cheapest combined round-trip price for departing that day and returning `N` nights later, not a separate outbound/return price pair: `flight-goat-pp-cli dates SEA HNL --round --duration 7 --sort --agent`. `--duration` is required with `--round` and must be greater than zero. Each result row carries `return_date` (`departure_date` + `--duration`) alongside `price`, which is already the round-trip total.
+
 # Introduction
 AeroAPI is a simple, query-based API that gives software developers access
 to a variety of FlightAware's flight data. Users can obtain current or

--- a/library/travel/flight-goat/internal/cli/primary.go
+++ b/library/travel/flight-goat/internal/cli/primary.go
@@ -83,6 +83,9 @@ func newGfFlightsCmd(flags *rootFlags) *cobra.Command {
 	// See flights_batch.go for the dogfood origin.
 	var tripStrs []string
 	var pace time.Duration
+	// PATCH(library): true two-step round-trip flow. See
+	// gflights.SearchOptions.SelectOutbound.
+	var selectOutbound int
 
 	// buildSearchBase constructs the SearchOptions shared by every mode
 	// (single search, batch trips). One construction site so a future flag
@@ -144,8 +147,33 @@ durations, airlines, and leg details. No API key. No auth. Just results.`,
 
   # Batch of independent searches with built-in pacing (Google rate-limits
   # bulk probes per IP — never fan these out in a shell loop)
-  flight-goat-pp-cli flights --trip "SEA>DEN@2026-09-14" --trip "PDX>DEN@2026-09-15@2026-09-17" --pace 3s --currency EUR`,
+  flight-goat-pp-cli flights --trip "SEA>DEN@2026-09-14" --trip "PDX>DEN@2026-09-15@2026-09-17" --pace 3s --currency EUR
+
+  # True two-step round trip: --return alone shows outbound options, each
+  # priced with Google's own auto-picked "cheapest return" total but no
+  # return-leg detail. Run once to see the outbound list (--json for
+  # indices), then re-run with --select-outbound N to fetch the actual
+  # return options priced against that specific outbound.
+  flight-goat-pp-cli flights LHR BCN 2027-03-01 --return 2027-03-18 --json
+  flight-goat-pp-cli flights LHR BCN 2027-03-01 --return 2027-03-18 --select-outbound 1 --json`,
 		Args: func(cmd *cobra.Command, args []string) error {
+			// PATCH(library): --select-outbound only makes sense against a
+			// plain round-trip single search — reject the other modes before
+			// they run any network call.
+			if selectOutbound != 0 {
+				if selectOutbound < 1 {
+					return usageErr(fmt.Errorf("--select-outbound must be >= 1 (1-based index into the outbound itineraries a prior round-trip search returned)"))
+				}
+				if len(tripStrs) > 0 {
+					return usageErr(fmt.Errorf("--select-outbound does not apply to --trip batches; run the two-step flow per trip manually"))
+				}
+				if len(segmentStrs) >= 2 {
+					return usageErr(fmt.Errorf("--select-outbound does not apply to multi-city (--segment) searches"))
+				}
+				if returnDate == "" {
+					return usageErr(fmt.Errorf("--select-outbound requires --return (round trip only) — it fetches return-leg options for a specific outbound"))
+				}
+			}
 			// PATCH(amend-2026-07-31): batch mode (--trip) replaces the
 			// positional query entirely; mixing modes would be ambiguous.
 			// These conflict checks run BEFORE the multi-city early return —
@@ -264,6 +292,7 @@ durations, airlines, and leg details. No API key. No auth. Just results.`,
 			opts.DepartureDate = departureDate
 			opts.ReturnDate = returnDate
 			opts.Segments = segments
+			opts.SelectOutbound = selectOutbound
 			// PATCH(greptile review): mirror the batch path's --return-time
 			// preflight for the single-search form — otherwise a malformed
 			// value reports success on --dry-run and a generic error (not a
@@ -282,6 +311,9 @@ durations, airlines, and leg details. No API key. No auth. Just results.`,
 				}
 				if opts.ReturnTimeWindow != "" {
 					fmt.Fprintf(cmd.OutOrStdout(), " return-time=%s", opts.ReturnTimeWindow)
+				}
+				if opts.SelectOutbound > 0 {
+					fmt.Fprintf(cmd.OutOrStdout(), " select-outbound=%d", opts.SelectOutbound)
 				}
 				if opts.MaxStops != "" {
 					fmt.Fprintf(cmd.OutOrStdout(), " stops=%s", strings.ToUpper(opts.MaxStops))
@@ -310,8 +342,24 @@ durations, airlines, and leg details. No API key. No auth. Just results.`,
 				return nil
 			}
 
-			fmt.Fprintf(cmd.ErrOrStderr(), "%d flights found for %s -> %s on %s (source: %s)\n",
-				result.Count, opts.Origin, opts.Destination, opts.DepartureDate, result.Source)
+			// PATCH(library): --select-outbound's response is return-leg-only
+			// (result.Flights holds Direction=="return" rows against the
+			// destination->origin route on ReturnDate) — label it as such
+			// instead of the default header, which would otherwise claim
+			// these are outbound results for the wrong route/date.
+			if result.SelectedOutbound != nil {
+				ob := result.SelectedOutbound
+				obDepart, carrier := "", ""
+				if len(ob.Legs) > 0 {
+					obDepart = trimTime(ob.Legs[0].DepartureTime)
+					carrier = ob.Legs[0].Airline.Code + ob.Legs[0].FlightNumber
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(), "%d return options for %s -> %s on %s, paired with outbound %s (%s, departs %s) (source: %s)\n",
+					result.Count, opts.Destination, opts.Origin, opts.ReturnDate, carrier, formatPrice(ob.Currency, ob.Price), obDepart, result.Source)
+			} else {
+				fmt.Fprintf(cmd.ErrOrStderr(), "%d flights found for %s -> %s on %s (source: %s)\n",
+					result.Count, opts.Origin, opts.Destination, opts.DepartureDate, result.Source)
+			}
 
 			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 			fmt.Fprintln(tw, "PRICE\tDURATION\tSTOPS\tAIRLINES\tDEPART\tARRIVE")
@@ -367,6 +415,7 @@ durations, airlines, and leg details. No API key. No auth. Just results.`,
 	cmd.Flags().BoolVar(&nonstop, "nonstop", false, "Multi-city only: restrict to nonstop flights on every leg. Equivalent to /nonstop on Kayak.")
 	cmd.Flags().StringSliceVar(&tripStrs, "trip", nil, "Batch: repeatable independent search in 'ORIG>DEST@YYYY-MM-DD' or 'ORIG>DEST@DEPART@RETURN' form. Trips run sequentially with --pace between them; positional args must be omitted.")
 	cmd.Flags().DurationVar(&pace, "pace", 2*time.Second, "Batch only: delay between consecutive --trip searches (Google rate-limits bulk probes per IP)")
+	cmd.Flags().IntVar(&selectOutbound, "select-outbound", 0, "Round trip only: 1-based index (in outbound order from a prior plain --return search) of the outbound itinerary to select, then fetch real return-leg options priced against it. Without this flag, --return alone shows outbound-only results, each carrying Google's own auto-picked cheapest-return total with no return-leg detail.")
 	return cmd
 }
 

--- a/library/travel/flight-goat/internal/gflights/capture_test.go
+++ b/library/travel/flight-goat/internal/gflights/capture_test.go
@@ -51,7 +51,7 @@ func captureFixture(t *testing.T, opts SearchOptions, outName string) {
 	depDate, _ := time.Parse("2006-01-02", opts.DepartureDate)
 	retDate, _ := time.Parse("2006-01-02", opts.ReturnDate)
 
-	payload, err := buildOffersPayload(opts, depDate, retDate, tripTypeRoundTrip, "")
+	payload, err := buildOffersPayload(opts, depDate, retDate, tripTypeRoundTrip, "", nil, "")
 	if err != nil {
 		t.Fatalf("buildOffersPayload: %v", err)
 	}

--- a/library/travel/flight-goat/internal/gflights/dates_native.go
+++ b/library/travel/flight-goat/internal/gflights/dates_native.go
@@ -146,7 +146,7 @@ func datesChunk(ctx context.Context, opts DatesOptions, from, to time.Time) ([]D
 		if err != nil {
 			return err
 		}
-		rows, err = parseDatesResponse(respBody, currencyCode)
+		rows, err = parseDatesResponse(respBody, currencyCode, opts)
 		return err
 	})
 	return rows, err
@@ -154,13 +154,11 @@ func datesChunk(ctx context.Context, opts DatesOptions, from, to time.Time) ([]D
 
 // buildDatesPayload constructs the URL-encoded `f.req` value for a single
 // chunk. The shape mirrors fli's DateSearchFilters.format() — see
-// fli/models/google_flights/dates.py for the canonical field map.
+// fli/models/google_flights/dates.py for the canonical field map, cross-checked
+// against a captured live round-trip GetCalendarGraph request (2026-08-31).
 func buildDatesPayload(opts DatesOptions, from, to time.Time) (string, error) {
-	if opts.RoundTrip {
-		// Round-trip needs a second segment with origin/dest swapped (per fli's
-		// flight_segments len-2 case). Reject up front rather than build a
-		// one-way payload that wouldn't match the user's intent.
-		return "", errors.New("round-trip date searches not yet implemented in native backend")
+	if opts.RoundTrip && opts.Duration <= 0 {
+		return "", errors.New("--round requires --duration (nights) greater than zero")
 	}
 
 	seat, err := mapSeatType(opts.CabinClass)
@@ -186,9 +184,73 @@ func buildDatesPayload(opts DatesOptions, from, to time.Time) (string, error) {
 		airlinesField = airlines
 	}
 
-	segment := []any{
-		[]any{[]any{[]any{strings.ToUpper(opts.Origin), 0}}},      // [0] departure airport, nested 3 deep
-		[]any{[]any{[]any{strings.ToUpper(opts.Destination), 0}}}, // [1] arrival airport
+	tripType := tripTypeOneWay
+	segments := []any{buildDatesSegment(opts, opts.Origin, opts.Destination, stops, airlinesField, travelDate)}
+	// PATCH(library): round-trip needs a second segment with origin/dest
+	// swapped and its own travel_date = anchor + Duration nights, matching a
+	// captured live GetCalendarGraph request (2026-08-31). Google prices the
+	// pair as one round-trip total keyed off the outbound date, not a 2D grid.
+	if opts.RoundTrip {
+		tripType = tripTypeRoundTrip
+		returnDate := from.AddDate(0, 0, opts.Duration).Format("2006-01-02")
+		segments = append(segments, buildDatesSegment(opts, opts.Destination, opts.Origin, stops, airlinesField, returnDate))
+	}
+
+	// duration is the outer [2,2]-shaped min/max trip-length-in-nights filter
+	// seen in the captured round-trip payload; nil for one-way (matches the
+	// working one-way payload shape, which never set this field).
+	var duration any
+	if opts.RoundTrip {
+		duration = []any{opts.Duration, opts.Duration}
+	}
+
+	filters := []any{
+		nil, // [0] placeholder (dates uses nil; flights uses [])
+		[]any{
+			nil,                                   // [0]
+			nil,                                   // [1]
+			tripType,                              // [2] trip type
+			nil,                                   // [3]
+			[]any{},                               // [4]
+			seat,                                  // [5] seat type
+			[]any{passengerAdults(opts), 0, 0, 0}, // [6] passengers: [adults, children, lap, seat]
+			nil,                                   // [7] price limit
+			nil,                                   // [8]
+			nil,                                   // [9]
+			nil,                                   // [10] bags
+			nil,                                   // [11]
+			nil,                                   // [12]
+			segments,                              // [13] segments
+			nil,                                   // [14]
+			nil,                                   // [15]
+			nil,                                   // [16]
+			1,                                     // [17]
+		},
+		[]any{from.Format("2006-01-02"), to.Format("2006-01-02")},
+		nil,      // [3] unknown — present as null in captured round-trip payload
+		duration, // [4] [min,max] trip-length-in-nights filter, round-trip only
+	}
+
+	innerJSON, err := json.Marshal(filters)
+	if err != nil {
+		return "", fmt.Errorf("marshaling filters: %w", err)
+	}
+	wrapped := []any{nil, string(innerJSON)}
+	wrappedJSON, err := json.Marshal(wrapped)
+	if err != nil {
+		return "", fmt.Errorf("marshaling wrapper: %w", err)
+	}
+	return url.QueryEscape(string(wrappedJSON)), nil
+}
+
+// buildDatesSegment builds one 15-field segment slot for the calendar RPC —
+// same shape flights_native.go's buildOneSegment uses for the offers RPC,
+// minus the fields (time window, selected flight, layover) dates search
+// doesn't expose.
+func buildDatesSegment(opts DatesOptions, origin, dest string, stops int, airlinesField any, travelDate string) []any {
+	return []any{
+		[]any{[]any{[]any{strings.ToUpper(origin), 0}}}, // [0] departure airport, nested 3 deep
+		[]any{[]any{[]any{strings.ToUpper(dest), 0}}},   // [1] arrival airport
 		nil,           // [2] time restrictions
 		stops,         // [3] stops
 		airlinesField, // [4] airlines
@@ -203,42 +265,6 @@ func buildDatesPayload(opts DatesOptions, from, to time.Time) (string, error) {
 		nil,           // [13] emissions filter
 		3,             // [14] unknown — fli always sends 3
 	}
-
-	filters := []any{
-		nil, // [0] placeholder (dates uses nil; flights uses [])
-		[]any{
-			nil,                                   // [0]
-			nil,                                   // [1]
-			tripTypeOneWay,                        // [2] trip type (round-trip rejected above)
-			nil,                                   // [3]
-			[]any{},                               // [4]
-			seat,                                  // [5] seat type
-			[]any{passengerAdults(opts), 0, 0, 0}, // [6] passengers: [adults, children, lap, seat]
-			nil,                                   // [7] price limit
-			nil,                                   // [8]
-			nil,                                   // [9]
-			nil,                                   // [10] bags
-			nil,                                   // [11]
-			nil,                                   // [12]
-			[]any{segment},                        // [13] segments
-			nil,                                   // [14]
-			nil,                                   // [15]
-			nil,                                   // [16]
-			1,                                     // [17]
-		},
-		[]any{from.Format("2006-01-02"), to.Format("2006-01-02")},
-	}
-
-	innerJSON, err := json.Marshal(filters)
-	if err != nil {
-		return "", fmt.Errorf("marshaling filters: %w", err)
-	}
-	wrapped := []any{nil, string(innerJSON)}
-	wrappedJSON, err := json.Marshal(wrapped)
-	if err != nil {
-		return "", fmt.Errorf("marshaling wrapper: %w", err)
-	}
-	return url.QueryEscape(string(wrappedJSON)), nil
 }
 
 func passengerAdults(_ DatesOptions) int {
@@ -281,8 +307,10 @@ func mapMaxStops(s string) (int, error) {
 
 // parseDatesResponse unwraps Google's )]}' prefix, drills into the wrb.fr
 // envelope, and returns one DatePrice per date that came back with a price.
-// Items with null price are silently skipped (mirrors fli).
-func parseDatesResponse(body []byte, defaultCurrency string) ([]DatePrice, error) {
+// Items with null price are silently skipped (mirrors fli). opts is used only
+// to compute ReturnDate for round-trip queries (the response itself carries a
+// combined round-trip total keyed off the outbound date, not the return date).
+func parseDatesResponse(body []byte, defaultCurrency string, opts DatesOptions) ([]DatePrice, error) {
 	stripped := strings.TrimPrefix(string(body), googleResponsePrefix)
 	stripped = strings.TrimSpace(stripped)
 
@@ -334,11 +362,17 @@ func parseDatesResponse(body []byte, defaultCurrency string) ([]DatePrice, error
 		if currency == "" {
 			currency = defaultCurrency
 		}
-		out = append(out, DatePrice{
+		row := DatePrice{
 			DepartureDate: dateStr,
 			Price:         price,
 			Currency:      currency,
-		})
+		}
+		if opts.RoundTrip && opts.Duration > 0 {
+			if dep, err := time.Parse("2006-01-02", dateStr); err == nil {
+				row.ReturnDate = dep.AddDate(0, 0, opts.Duration).Format("2006-01-02")
+			}
+		}
+		out = append(out, row)
 	}
 	return out, nil
 }

--- a/library/travel/flight-goat/internal/gflights/dates_native_test.go
+++ b/library/travel/flight-goat/internal/gflights/dates_native_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Matt Van Horn and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package gflights
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestBuildDatesPayloadRoundTripRequiresDuration(t *testing.T) {
+	opts := DatesOptions{Origin: "LHR", Destination: "BCN", RoundTrip: true}
+	from, _ := time.Parse("2006-01-02", "2027-03-01")
+	to, _ := time.Parse("2006-01-02", "2027-03-27")
+	if _, err := buildDatesPayload(opts, from, to); err == nil {
+		t.Fatal("expected error for --round without --duration")
+	}
+}
+
+// TestBuildDatesPayloadRoundTripShape locks in the payload shape against a
+// live captured GetCalendarGraph round-trip request (2026-08-31): two
+// segments (second origin/dest swapped, travel_date = anchor + duration),
+// trip_type=1, and a trailing [min,max]-nights duration filter.
+func TestBuildDatesPayloadRoundTripShape(t *testing.T) {
+	opts := DatesOptions{Origin: "LHR", Destination: "BCN", RoundTrip: true, Duration: 2}
+	from, _ := time.Parse("2006-01-02", "2027-03-01")
+	to, _ := time.Parse("2006-01-02", "2027-03-27")
+
+	payload, err := buildDatesPayload(opts, from, to)
+	if err != nil {
+		t.Fatalf("buildDatesPayload: %v", err)
+	}
+	decoded, err := url.QueryUnescape(payload)
+	if err != nil {
+		t.Fatalf("QueryUnescape: %v", err)
+	}
+
+	var wrapped []any
+	if err := json.Unmarshal([]byte(decoded), &wrapped); err != nil {
+		t.Fatalf("unmarshal wrapper: %v", err)
+	}
+	if len(wrapped) != 2 {
+		t.Fatalf("wrapper: want 2 elements, got %d", len(wrapped))
+	}
+	var filters []any
+	if err := json.Unmarshal([]byte(wrapped[1].(string)), &filters); err != nil {
+		t.Fatalf("unmarshal filters: %v", err)
+	}
+	if len(filters) != 5 {
+		t.Fatalf("filters: want 5 elements (outer shape), got %d: %v", len(filters), filters)
+	}
+	if filters[3] != nil {
+		t.Errorf("filters[3]: want nil, got %v", filters[3])
+	}
+	duration, ok := filters[4].([]any)
+	if !ok || len(duration) != 2 || duration[0] != float64(2) || duration[1] != float64(2) {
+		t.Errorf("filters[4] duration: want [2,2], got %v", filters[4])
+	}
+
+	inner, ok := filters[1].([]any)
+	if !ok || len(inner) != 18 {
+		t.Fatalf("filters[1]: want 18-element inner filter array, got %v", filters[1])
+	}
+	if tripType := inner[2]; tripType != float64(tripTypeRoundTrip) {
+		t.Errorf("trip type: want %d, got %v", tripTypeRoundTrip, tripType)
+	}
+	segments, ok := inner[13].([]any)
+	if !ok || len(segments) != 2 {
+		t.Fatalf("segments: want 2 segments for round trip, got %v", inner[13])
+	}
+	outbound := segments[0].([]any)
+	inbound := segments[1].([]any)
+	if outbound[6] != "2027-03-01" {
+		t.Errorf("outbound travel_date: want 2027-03-01, got %v", outbound[6])
+	}
+	if inbound[6] != "2027-03-03" {
+		t.Errorf("inbound travel_date: want anchor+duration 2027-03-03, got %v", inbound[6])
+	}
+}
+
+func TestBuildDatesPayloadOneWayUnaffected(t *testing.T) {
+	opts := DatesOptions{Origin: "LHR", Destination: "BCN"}
+	from, _ := time.Parse("2006-01-02", "2027-03-01")
+	to, _ := time.Parse("2006-01-02", "2027-03-27")
+
+	payload, err := buildDatesPayload(opts, from, to)
+	if err != nil {
+		t.Fatalf("buildDatesPayload: %v", err)
+	}
+	decoded, _ := url.QueryUnescape(payload)
+	var wrapped []any
+	if err := json.Unmarshal([]byte(decoded), &wrapped); err != nil {
+		t.Fatalf("unmarshal wrapper: %v", err)
+	}
+	var filters []any
+	if err := json.Unmarshal([]byte(wrapped[1].(string)), &filters); err != nil {
+		t.Fatalf("unmarshal filters: %v", err)
+	}
+	if filters[4] != nil {
+		t.Errorf("one-way filters[4]: want nil, got %v", filters[4])
+	}
+	inner := filters[1].([]any)
+	if tripType := inner[2]; tripType != float64(tripTypeOneWay) {
+		t.Errorf("trip type: want %d, got %v", tripTypeOneWay, tripType)
+	}
+	segments := inner[13].([]any)
+	if len(segments) != 1 {
+		t.Errorf("segments: want 1 for one-way, got %d", len(segments))
+	}
+}

--- a/library/travel/flight-goat/internal/gflights/flights_native.go
+++ b/library/travel/flight-goat/internal/gflights/flights_native.go
@@ -184,7 +184,7 @@ func searchNativeDirect(ctx context.Context, opts SearchOptions) (*SearchResult,
 		}, nil
 	}
 
-	payload, err := buildOffersPayload(opts, depDate, retDate, tripType, "")
+	payload, err := buildOffersPayload(opts, depDate, retDate, tripType, "", nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("building payload: %w", err)
 	}
@@ -233,6 +233,34 @@ func searchNativeDirect(ctx context.Context, opts SearchOptions) (*SearchResult,
 		flights[i].BookingURLs = buildBookingURLs(opts, flights[i])
 	}
 
+	// PATCH(library): unlike the HTML-embedded payload (which splits
+	// outbound/return across two buckets — see flightsFromEmbeddedPayload),
+	// the native RPC's GetShoppingResults response carries a single flat
+	// list here regardless of trip type: a plain round-trip request (no
+	// SelectOutbound) gets back outbound itineraries only, each already
+	// priced with Google's own auto-picked "cheapest return" baked in — no
+	// separate return-leg data exists pre-selection. So direction is tagged
+	// from the REQUEST shape, not any response bucket position. One-way
+	// results are left untagged (no direction concept applies).
+	if tripType == tripTypeRoundTrip {
+		for i := range flights {
+			flights[i].Direction = "outbound"
+		}
+	} else {
+		for i := range flights {
+			flights[i].SelectionToken = ""
+		}
+	}
+
+	var selectedOutbound *Flight
+	if opts.SelectOutbound > 0 {
+		selectedOutbound, flights, err = fetchSelectedReturn(ctx, opts, tripType, depDate, retDate, currencyCode, flights)
+		if err != nil {
+			return nil, err
+		}
+		note = strings.TrimSpace(note + " return options priced against the selected outbound (see selected_outbound).")
+	}
+
 	tripTypeName := "ONE_WAY"
 	if tripType == tripTypeRoundTrip {
 		tripTypeName = "ROUND_TRIP"
@@ -253,17 +281,81 @@ func searchNativeDirect(ctx context.Context, opts SearchOptions) (*SearchResult,
 			CabinClass:    strings.ToUpper(opts.CabinClass),
 			Currency:      currencyCode,
 		},
-		Count:   len(flights),
-		Flights: flights,
-		Note:    note,
+		Count:            len(flights),
+		Flights:          flights,
+		Note:             note,
+		SelectedOutbound: selectedOutbound,
 	}, nil
+}
+
+// fetchSelectedReturn implements the second request of the
+// SearchOptions.SelectOutbound two-step flow. firstFlights is the first
+// (plain) response's Flights — all outbound itineraries, per searchNativeDirect.
+// It picks the requested 1-based outbound, re-queries Google with that
+// specific itinerary selected (via its SelectionToken — see
+// buildOffersPayload), and returns the chosen outbound alongside the second
+// response's flights, which (per the same single-bucket RPC shape) are
+// entirely return-leg options once selection makes the request unambiguous.
+//
+// PATCH(library): no HTML fallback exists for this step. The selected_flight
+// segment field and continuation token only make sense against the RPC that
+// produced them; a BotGuard block here surfaces as an error rather than
+// silently falling back to a differently-shaped page fetch.
+func fetchSelectedReturn(ctx context.Context, opts SearchOptions, tripType int, depDate, retDate time.Time, currencyCode string, firstFlights []Flight) (*Flight, []Flight, error) {
+	if opts.SelectOutbound > len(firstFlights) {
+		return nil, nil, fmt.Errorf("--select-outbound %d out of range: this search returned %d outbound itineraries", opts.SelectOutbound, len(firstFlights))
+	}
+	chosen := firstFlights[opts.SelectOutbound-1]
+	if chosen.SelectionToken == "" {
+		return nil, nil, fmt.Errorf("selected outbound itinerary carries no Google selection token; retry the search or pick a different --select-outbound index")
+	}
+
+	payload, err := buildOffersPayload(opts, depDate, retDate, tripType, "", &chosen, chosen.SelectionToken)
+	if err != nil {
+		return nil, nil, fmt.Errorf("building return-leg payload: %w", err)
+	}
+	body := "f.req=" + payload
+
+	var flights []Flight
+	err = retryBlockedRPC(ctx, func() error {
+		respBody, err := postFlightsFrontendRPC(ctx, offersEndpoint, "shopping", body, currencyCode)
+		if err != nil {
+			return err
+		}
+		flights, err = parseOffersResponse(respBody, currencyCode)
+		return err
+	})
+	switch {
+	case errors.Is(err, errShoppingBlocked):
+		return nil, nil, fmt.Errorf("google flights blocked the return-leg selection request; --select-outbound is RPC-only, no HTML fallback exists for it: %w", err)
+	case err != nil:
+		return nil, nil, fmt.Errorf("fetching return-leg options for the selected outbound: %w", err)
+	}
+	applyPerPassengerPrice(flights, opts.Passengers)
+	for i := range flights {
+		flights[i].BookingURLs = buildBookingURLs(opts, flights[i])
+		// PATCH(library): once an outbound is selected the request is
+		// unambiguous — everything this response carries is a return-leg
+		// option priced against it (see the func doc above).
+		flights[i].Direction = "return"
+	}
+	// PATCH(library): single-use token; clear it before handing the chosen
+	// outbound back so output doesn't imply it can be replayed again.
+	chosen.SelectionToken = ""
+	return &chosen, flights, nil
 }
 
 // buildOffersPayload constructs the URL-encoded `f.req` value mirroring
 // fli's FlightSearchFilters.format(). Field positions documented inline.
 // sessionTok is non-empty only for multi-city queries; it goes at
 // inner[0][3] of the JSON, mirroring what Google's own UI POSTs.
-func buildOffersPayload(opts SearchOptions, depDate, retDate time.Time, tripType int, sessionTok string) (string, error) {
+// selectedOutbound and continuationToken are set together, only by the
+// second request of the SearchOptions.SelectOutbound two-step flow:
+// selectedOutbound pins the outbound segment (buildOfferSegments), and
+// continuationToken — the chosen outbound row's SelectionToken — goes in the
+// outer envelope so Google associates the request with that itinerary. Both
+// nil/"" (the common case) preserves the prior single-request shape.
+func buildOffersPayload(opts SearchOptions, depDate, retDate time.Time, tripType int, sessionTok string, selectedOutbound *Flight, continuationToken string) (string, error) {
 	seat, err := mapSeatType(opts.CabinClass)
 	if err != nil {
 		return "", err
@@ -277,7 +369,7 @@ func buildOffersPayload(opts SearchOptions, depDate, retDate time.Time, tripType
 		return "", err
 	}
 
-	segments, err := buildOfferSegments(opts, depDate, retDate, tripType, stops)
+	segments, err := buildOfferSegments(opts, depDate, retDate, tripType, stops, selectedOutbound)
 	if err != nil {
 		return "", err
 	}
@@ -338,12 +430,19 @@ func buildOffersPayload(opts SearchOptions, depDate, retDate time.Time, tripType
 	// multi-city UI does not surface those controls). For one-way / round-trip
 	// the existing shape `[[], main, sortBy, showAll, 0, 1]` is preserved.
 	var outer []any
-	if tripType == tripTypeMultiCity {
+	switch {
+	case tripType == tripTypeMultiCity:
 		outer = []any{
 			[]any{nil, nil, nil, sessionTok},
 			main, 0, 0, 0, 1,
 		}
-	} else {
+	case continuationToken != "":
+		// PATCH(library): verified against a live captured browser request
+		// for the SelectOutbound follow-up — outer[0] becomes [nil, token]
+		// instead of the empty []any{} below; sortBy/showAll/trailing flags
+		// are unchanged from the plain shape.
+		outer = []any{[]any{nil, continuationToken}, main, sortBy, showAll, 0, 1}
+	default:
 		outer = []any{[]any{}, main, sortBy, showAll, 0, 1}
 	}
 
@@ -359,7 +458,7 @@ func buildOffersPayload(opts SearchOptions, depDate, retDate time.Time, tripType
 	return url.QueryEscape(string(wrappedJSON)), nil
 }
 
-func buildOfferSegments(opts SearchOptions, depDate, retDate time.Time, tripType int, stops int) ([]any, error) {
+func buildOfferSegments(opts SearchOptions, depDate, retDate time.Time, tripType int, stops int, selectedOutbound *Flight) ([]any, error) {
 	// PATCH(library): multi-city emits N segments from opts.Segments rather
 	// than the single (origin, dest, date) tuple. Each segment slot mirrors
 	// buildOneSegment's 15-field shape.
@@ -370,7 +469,7 @@ func buildOfferSegments(opts SearchOptions, depDate, retDate time.Time, tripType
 			if err != nil {
 				return nil, fmt.Errorf("segment %d date %q: %w", i+1, s.DepartureDate, err)
 			}
-			seg, err := buildOneSegment(opts, d, s.Origin, s.Destination, stops, opts.TimeWindow)
+			seg, err := buildOneSegment(opts, d, s.Origin, s.Destination, stops, opts.TimeWindow, nil)
 			if err != nil {
 				return nil, fmt.Errorf("segment %d: %w", i+1, err)
 			}
@@ -379,7 +478,12 @@ func buildOfferSegments(opts SearchOptions, depDate, retDate time.Time, tripType
 		return segs, nil
 	}
 	var segments []any
-	outbound, err := buildOneSegment(opts, depDate, opts.Origin, opts.Destination, stops, opts.TimeWindow)
+	// PATCH(library): selectedOutbound is set only by the two-step
+	// SearchOptions.SelectOutbound flow's follow-up request — it pins the
+	// outbound segment to the specific itinerary the caller chose, so
+	// Google prices/pairs the return leg against it instead of picking its
+	// own cheapest return. nil (the common case) preserves prior behavior.
+	outbound, err := buildOneSegment(opts, depDate, opts.Origin, opts.Destination, stops, opts.TimeWindow, selectedFlightField(selectedOutbound))
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +497,7 @@ func buildOfferSegments(opts SearchOptions, depDate, retDate time.Time, tripType
 		if returnWindow == "" {
 			returnWindow = opts.TimeWindow
 		}
-		inbound, err := buildOneSegment(opts, retDate, opts.Destination, opts.Origin, stops, returnWindow)
+		inbound, err := buildOneSegment(opts, retDate, opts.Destination, opts.Origin, stops, returnWindow, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -402,7 +506,36 @@ func buildOfferSegments(opts SearchOptions, depDate, retDate time.Time, tripType
 	return segments, nil
 }
 
-func buildOneSegment(opts SearchOptions, date time.Time, origin, dest string, stops int, timeWindow string) ([]any, error) {
+// selectedFlightField builds Google's "selected_flight" segment field
+// (buildOneSegment's index [8]) from a previously-returned outbound
+// itinerary: one [origin, date, dest, nil, airlineCode, flightNumber] entry
+// per flown leg, in the order flown. Verified against a live captured
+// browser request for a nonstop outbound; connections are inferred by
+// extending the same one-entry-per-leg shape. Returns nil (the prior,
+// unselected behavior) when f is nil or has no legs.
+func selectedFlightField(f *Flight) any {
+	if f == nil || len(f.Legs) == 0 {
+		return nil
+	}
+	rows := make([]any, 0, len(f.Legs))
+	for _, leg := range f.Legs {
+		date := leg.DepartureTime
+		if len(date) >= 10 {
+			date = date[:10]
+		}
+		rows = append(rows, []any{
+			strings.ToUpper(leg.DepartureAirport.Code),
+			date,
+			strings.ToUpper(leg.ArrivalAirport.Code),
+			nil,
+			strings.ToUpper(leg.Airline.Code),
+			leg.FlightNumber,
+		})
+	}
+	return rows
+}
+
+func buildOneSegment(opts SearchOptions, date time.Time, origin, dest string, stops int, timeWindow string, selectedFlight any) ([]any, error) {
 	var timeField any
 	if timeWindow != "" {
 		earliest, latest, err := parseTimeWindow(timeWindow)
@@ -452,7 +585,7 @@ func buildOneSegment(opts SearchOptions, date time.Time, origin, dest string, st
 		nil,                       // [5]
 		date.Format("2006-01-02"), // [6] travel date
 		nil,                       // [7] max duration
-		nil,                       // [8] selected_flight
+		selectedFlight,            // [8] selected_flight — see selectedFlightField
 		layoverAirports,           // [9] layover airports
 		nil,                       // [10]
 		nil,                       // [11]
@@ -562,13 +695,14 @@ func parseOfferRow(row any, currency string) (Flight, bool) {
 			legs = append(legs, leg)
 		}
 	}
-	price := parseOfferPrice(r)
+	price, token := parseOfferPrice(r)
 	return Flight{
 		DurationMinutes: duration,
 		Stops:           max0(len(legs) - 1),
 		Price:           price,
 		Currency:        currency,
 		Legs:            legs,
+		SelectionToken:  token,
 	}, true
 }
 
@@ -725,27 +859,39 @@ func applyPerPassengerPrice(flights []Flight, passengers int) {
 	}
 }
 
-// parseOfferPrice returns the numeric price from the flight row.
+// parseOfferPrice returns the numeric price and Google's opaque per-itinerary
+// selection token from the flight row.
 //
 // PATCH(greptile P1): the row's priceBlock[1] is Google's opaque price token
 // (e.g. "CJRIDJNH..."), not an ISO currency code. Earlier versions returned
 // it as a currency string, which then overwrote the user-requested ISO code
-// downstream. Now this returns only the price; callers preserve the ISO
+// downstream. This returns the price separately; callers preserve the ISO
 // code resolved from `--currency` / normalizeCurrency.
-func parseOfferPrice(row []any) float64 {
+//
+// PATCH(library): that same priceBlock[1] token is also exactly what a
+// captured browser session sends back as the outer envelope's continuation
+// token (outer[0][1]) when selecting a specific outbound itinerary — see
+// SearchOptions.SelectOutbound. Now returned alongside price instead of
+// discarded.
+func parseOfferPrice(row []any) (price float64, selectionToken string) {
 	if len(row) < 2 {
-		return 0
+		return 0, ""
 	}
 	priceBlock, ok := row[1].([]any)
 	if !ok {
-		return 0
+		return 0, ""
 	}
 	if len(priceBlock) > 0 {
 		if outer, ok := priceBlock[0].([]any); ok && len(outer) > 0 {
-			return numericFloat(outer[len(outer)-1])
+			price = numericFloat(outer[len(outer)-1])
 		}
 	}
-	return 0
+	if len(priceBlock) > 1 {
+		if t, ok := priceBlock[1].(string); ok {
+			selectionToken = t
+		}
+	}
+	return price, selectionToken
 }
 
 // --- small helpers ---

--- a/library/travel/flight-goat/internal/gflights/flights_native.go
+++ b/library/travel/flight-goat/internal/gflights/flights_native.go
@@ -142,6 +142,28 @@ func searchNativeDirect(ctx context.Context, opts SearchOptions) (*SearchResult,
 		}
 	}
 
+	// PATCH(library): SelectOutbound's contract (round trip only, positive
+	// index) was previously enforced only by the CLI's cobra Args validator
+	// (primary.go) — a direct library caller could pass a negative index
+	// (silently ignored, since only opts.SelectOutbound > 0 gates the
+	// two-step flow) or combine it with multi-city (silently ignored, since
+	// the multi-city branch below returns before SelectOutbound is ever
+	// read) or one-way (previously reached fetchSelectedReturn and failed
+	// with a confusing "out of range" error instead of a clear one).
+	// Greptile review finding: validate here so gflights.Search enforces its
+	// own contract regardless of caller.
+	if opts.SelectOutbound < 0 {
+		return nil, fmt.Errorf("SelectOutbound must be >= 0 (got %d)", opts.SelectOutbound)
+	}
+	if opts.SelectOutbound > 0 {
+		if tripType == tripTypeMultiCity {
+			return nil, fmt.Errorf("SelectOutbound does not apply to multi-city (Segments) searches")
+		}
+		if tripType != tripTypeRoundTrip {
+			return nil, fmt.Errorf("SelectOutbound requires a round trip (ReturnDate set); got a one-way search")
+		}
+	}
+
 	// PATCH(library): Google's multi-city POST endpoint requires an
 	// authenticated Google session (SAPISID cookie + XSRF hash); anonymous
 	// POSTs return ErrorResponse regardless of token tweaks. flight-goat
@@ -191,6 +213,7 @@ func searchNativeDirect(ctx context.Context, opts SearchOptions) (*SearchResult,
 	body := "f.req=" + payload
 
 	note := ""
+	viaHTMLFallback := false
 	var flights []Flight
 	err = retryBlockedRPC(ctx, func() error {
 		respBody, err := postFlightsFrontendRPC(ctx, offersEndpoint, "shopping", body, currencyCode)
@@ -217,6 +240,7 @@ func searchNativeDirect(ctx context.Context, opts SearchOptions) (*SearchResult,
 		if err != nil {
 			return nil, fmt.Errorf("google flights RPC is blocked and the HTML fallback failed: %w", err)
 		}
+		viaHTMLFallback = true
 	case err != nil:
 		return nil, fmt.Errorf("parsing response: %w", err)
 	default:
@@ -234,19 +258,26 @@ func searchNativeDirect(ctx context.Context, opts SearchOptions) (*SearchResult,
 	}
 
 	// PATCH(library): unlike the HTML-embedded payload (which splits
-	// outbound/return across two buckets — see flightsFromEmbeddedPayload),
-	// the native RPC's GetShoppingResults response carries a single flat
-	// list here regardless of trip type: a plain round-trip request (no
-	// SelectOutbound) gets back outbound itineraries only, each already
-	// priced with Google's own auto-picked "cheapest return" baked in — no
-	// separate return-leg data exists pre-selection. So direction is tagged
-	// from the REQUEST shape, not any response bucket position. One-way
-	// results are left untagged (no direction concept applies).
-	if tripType == tripTypeRoundTrip {
+	// outbound/return across two buckets and is already tagged by
+	// searchViaHTML — see flightsFromEmbeddedPayload), the native RPC's
+	// GetShoppingResults response carries a single flat list here regardless
+	// of trip type: a plain round-trip request (no SelectOutbound) gets back
+	// outbound itineraries only, each already priced with Google's own
+	// auto-picked "cheapest return" baked in — no separate return-leg data
+	// exists pre-selection. So direction is tagged from the REQUEST shape,
+	// not any response bucket position — but only on the native RPC path.
+	// Greptile review finding: this block used to run unconditionally and
+	// stomped the HTML fallback's correct per-row outbound/return tagging,
+	// which let fetchSelectedReturn treat every row (including true return
+	// rows) as a selectable outbound.
+	switch {
+	case viaHTMLFallback:
+		// searchViaHTML already tagged Direction correctly; leave it alone.
+	case tripType == tripTypeRoundTrip:
 		for i := range flights {
 			flights[i].Direction = "outbound"
 		}
-	} else {
+	default:
 		for i := range flights {
 			flights[i].SelectionToken = ""
 		}
@@ -302,10 +333,24 @@ func searchNativeDirect(ctx context.Context, opts SearchOptions) (*SearchResult,
 // produced them; a BotGuard block here surfaces as an error rather than
 // silently falling back to a differently-shaped page fetch.
 func fetchSelectedReturn(ctx context.Context, opts SearchOptions, tripType int, depDate, retDate time.Time, currencyCode string, firstFlights []Flight) (*Flight, []Flight, error) {
-	if opts.SelectOutbound > len(firstFlights) {
-		return nil, nil, fmt.Errorf("--select-outbound %d out of range: this search returned %d outbound itineraries", opts.SelectOutbound, len(firstFlights))
+	// PATCH(library): firstFlights is "all outbound" only on the native RPC
+	// path (searchNativeDirect tags every row "outbound" uniformly there —
+	// see the comment above that loop). The HTML fallback path
+	// (searchViaHTML) can hand back a list that already concatenates
+	// outbound and return buckets. Filtering here — rather than indexing
+	// firstFlights directly — keeps an out-of-range or return-bucket index
+	// from ever picking a return itinerary and sending its reversed route
+	// as the "outbound" selection. Greptile review finding.
+	var outboundOnly []Flight
+	for _, f := range firstFlights {
+		if f.Direction == "outbound" {
+			outboundOnly = append(outboundOnly, f)
+		}
 	}
-	chosen := firstFlights[opts.SelectOutbound-1]
+	if opts.SelectOutbound > len(outboundOnly) {
+		return nil, nil, fmt.Errorf("--select-outbound %d out of range: this search returned %d outbound itineraries", opts.SelectOutbound, len(outboundOnly))
+	}
+	chosen := outboundOnly[opts.SelectOutbound-1]
 	if chosen.SelectionToken == "" {
 		return nil, nil, fmt.Errorf("selected outbound itinerary carries no Google selection token; retry the search or pick a different --select-outbound index")
 	}

--- a/library/travel/flight-goat/internal/gflights/flights_native_test.go
+++ b/library/travel/flight-goat/internal/gflights/flights_native_test.go
@@ -284,7 +284,7 @@ func TestBuildOfferSegments_ReturnTimeWindowAppliesToInboundOnly(t *testing.T) {
 	depDate, _ := time.Parse("2006-01-02", opts.DepartureDate)
 	retDate, _ := time.Parse("2006-01-02", opts.ReturnDate)
 
-	segments, err := buildOfferSegments(opts, depDate, retDate, tripTypeRoundTrip, maxStopsAny)
+	segments, err := buildOfferSegments(opts, depDate, retDate, tripTypeRoundTrip, maxStopsAny, nil)
 	if err != nil {
 		t.Fatalf("buildOfferSegments: %v", err)
 	}
@@ -317,7 +317,7 @@ func TestBuildOfferSegments_ReturnTimeWindowFallsBackToTimeWindow(t *testing.T) 
 	depDate, _ := time.Parse("2006-01-02", opts.DepartureDate)
 	retDate, _ := time.Parse("2006-01-02", opts.ReturnDate)
 
-	segments, err := buildOfferSegments(opts, depDate, retDate, tripTypeRoundTrip, maxStopsAny)
+	segments, err := buildOfferSegments(opts, depDate, retDate, tripTypeRoundTrip, maxStopsAny, nil)
 	if err != nil {
 		t.Fatalf("buildOfferSegments: %v", err)
 	}

--- a/library/travel/flight-goat/internal/gflights/gflights.go
+++ b/library/travel/flight-goat/internal/gflights/gflights.go
@@ -58,6 +58,20 @@ type Flight struct {
 	// always populated; Airline is populated only when all legs are operated
 	// by a single carrier in the airlineTemplates table. See booking_urls.go.
 	BookingURLs BookingURLs `json:"booking_urls"`
+	// PATCH(library): round trip only. Distinguishes an outbound-leg
+	// itinerary from a return-leg itinerary in the flat Flights list — each
+	// row is a self-contained one-way offer, not a paired round-trip total,
+	// so callers (agents especially) need this to avoid mixing directions.
+	// Empty for one-way and multi-city results.
+	Direction string `json:"direction,omitempty"`
+	// PATCH(library): Google's opaque per-itinerary continuation token
+	// (row priceBlock[1] in the raw response), present only on round-trip
+	// outbound rows. Feed it back via SearchOptions.SelectOutbound (by
+	// index) to run the true two-step round-trip flow: Google then returns
+	// return-leg options actually priced and paired against this specific
+	// outbound, instead of the auto-picked "cheapest return" total baked
+	// into every outbound row's Price today.
+	SelectionToken string `json:"selection_token,omitempty"`
 }
 
 // SearchResult is the normalized envelope returned by Search.
@@ -78,6 +92,11 @@ type SearchResult struct {
 	// from a retired IATA code. The Query echo above keeps the user's
 	// original input; AirportRemapped is the only signal of substitution.
 	AirportRemapped *AirportRemapNote `json:"airport_remapped,omitempty"`
+	// PATCH(library): populated only when SearchOptions.SelectOutbound was
+	// used. The specific outbound itinerary Flights (now return-leg options
+	// only) are priced and paired against — see the two-step flow doc on
+	// SearchOptions.SelectOutbound.
+	SelectedOutbound *Flight `json:"selected_outbound,omitempty"`
 }
 
 // SearchQuery echoes the user's query back in the response envelope.
@@ -158,6 +177,19 @@ type SearchOptions struct {
 	// authenticated session); see multicity.go and the CLI's --provider flag
 	// for the cross-provider dispatch.
 	Segments []Segment
+	// PATCH(library): SelectOutbound requests Google Flights' real two-step
+	// round-trip flow instead of the default single request. 1-based index
+	// into the outbound itineraries a prior plain round-trip search
+	// returned (Flights entries with Direction == "outbound", in that
+	// order). flight-goat re-queries Google with that specific outbound
+	// selected (via its SelectionToken); Google responds with return-leg
+	// options genuinely priced and paired against it, returned as Flights
+	// (Direction == "return") with SearchResult.SelectedOutbound set to the
+	// chosen outbound for reference. Round trip only (ReturnDate set); zero
+	// (default) keeps today's single-request behavior — every outbound row
+	// carries Google's own auto-picked "cheapest return" total baked into
+	// Price, with no return-leg detail.
+	SelectOutbound int
 }
 
 // Search runs a flight search against Google Flights' GetShoppingResults.

--- a/library/travel/flight-goat/internal/gflights/html_fallback.go
+++ b/library/travel/flight-goat/internal/gflights/html_fallback.go
@@ -411,6 +411,21 @@ func searchViaHTML(ctx context.Context, opts SearchOptions, currencyCode string)
 	}
 	outbound := filterFlightsClientSide(append([]Flight(nil), flights[:outboundCount]...), outboundOpts)
 	inbound := filterFlightsClientSide(append([]Flight(nil), flights[outboundCount:]...), returnOpts)
+	// PATCH(library): tag direction from the already-established
+	// outboundCount boundary (see TestFlightsFromEmbeddedPayload_OutboundReturnSplit)
+	// rather than guessing from airport codes — round trip only; a one-way
+	// search has nothing in the return bucket so outbound/inbound collapse
+	// to the same untagged list. See gflights.go's SelectOutbound doc; the
+	// native RPC path (flights_native.go) has no equivalent bucket split and
+	// tags Direction itself from request shape instead.
+	if opts.ReturnDate != "" {
+		for i := range outbound {
+			outbound[i].Direction = "outbound"
+		}
+		for i := range inbound {
+			inbound[i].Direction = "return"
+		}
+	}
 	flights = append(outbound, inbound...)
 	note := htmlFallbackNote
 	if !sortFlightsClientSide(flights, opts.SortBy) {

--- a/library/travel/flight-goat/internal/gflights/html_fallback.go
+++ b/library/travel/flight-goat/internal/gflights/html_fallback.go
@@ -524,6 +524,37 @@ func filterFlightsClientSide(flights []Flight, opts SearchOptions) []Flight {
 	return out
 }
 
+// cheapestFallbackCandidate picks the cheapest priced flight to report for
+// one fallback day. On a round-trip page the "return" bucket holds
+// incremental fares priced against whatever outbound the page pre-selected,
+// not standalone round-trip totals — picking the global cheapest across both
+// buckets can surface a partial fare. The "outbound" bucket's Price is
+// already the full round-trip total for that itinerary (same convention
+// flights_native.go's first-fetch round-trip response uses), so round-trip
+// callers restrict to it; one-way callers (roundTrip=false) consider every
+// flight since there is only one bucket.
+func cheapestFallbackCandidate(flights []Flight, roundTrip bool) *Flight {
+	candidates := flights
+	if roundTrip {
+		candidates = nil
+		for i := range flights {
+			if flights[i].Direction == "outbound" {
+				candidates = append(candidates, flights[i])
+			}
+		}
+	}
+	var cheapest *Flight
+	for i := range candidates {
+		if candidates[i].Price <= 0 {
+			continue
+		}
+		if cheapest == nil || candidates[i].Price < cheapest.Price {
+			cheapest = &candidates[i]
+		}
+	}
+	return cheapest
+}
+
 // datesViaHTML serves the cheapest-dates query when the calendar RPC is
 // blocked: one server-rendered page per day, cheapest itinerary kept.
 // Bounded concurrency keeps the fan-out polite; individual day failures are
@@ -554,10 +585,15 @@ func datesViaHTML(ctx context.Context, opts DatesOptions, from, to time.Time, cu
 				results[i] = dayResult{idx: i, err: ctx.Err()}
 				return
 			}
+			var returnDate string
+			if opts.RoundTrip {
+				returnDate = day.AddDate(0, 0, opts.Duration).Format("2006-01-02")
+			}
 			searchOpts := SearchOptions{
 				Origin:        opts.Origin,
 				Destination:   opts.Destination,
 				DepartureDate: day.Format("2006-01-02"),
+				ReturnDate:    returnDate,
 				Airlines:      opts.Airlines,
 				CabinClass:    opts.CabinClass,
 				MaxStops:      opts.MaxStops,
@@ -567,21 +603,14 @@ func datesViaHTML(ctx context.Context, opts DatesOptions, from, to time.Time, cu
 				results[i] = dayResult{idx: i, err: err}
 				return
 			}
-			var cheapest *Flight
-			for j := range flights {
-				if flights[j].Price <= 0 {
-					continue
-				}
-				if cheapest == nil || flights[j].Price < cheapest.Price {
-					cheapest = &flights[j]
-				}
-			}
+			cheapest := cheapestFallbackCandidate(flights, opts.RoundTrip)
 			if cheapest == nil {
 				results[i] = dayResult{idx: i}
 				return
 			}
 			results[i] = dayResult{idx: i, price: &DatePrice{
 				DepartureDate: day.Format("2006-01-02"),
+				ReturnDate:    returnDate,
 				Price:         cheapest.Price,
 				Currency:      currencyCode,
 			}}

--- a/library/travel/flight-goat/internal/gflights/html_fallback_test.go
+++ b/library/travel/flight-goat/internal/gflights/html_fallback_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -48,7 +49,7 @@ func TestParseOffersResponseDetectsBlockedEnvelope(t *testing.T) {
 // "response wrb.fr payload is not a string" error).
 func TestParseDatesResponseDetectsBlockedEnvelope(t *testing.T) {
 	body := loadFixture(t, "error_response_blocked.json")
-	_, err := parseDatesResponse(body, "USD")
+	_, err := parseDatesResponse(body, "USD", DatesOptions{})
 	if !errors.Is(err, errShoppingBlocked) {
 		t.Fatalf("parseDatesResponse error = %v, want errShoppingBlocked", err)
 	}
@@ -56,7 +57,7 @@ func TestParseDatesResponseDetectsBlockedEnvelope(t *testing.T) {
 
 func TestParseDatesResponseEmptyStringIsNotBlockedEnvelope(t *testing.T) {
 	body := []byte(googleResponsePrefix + ` [["wrb.fr","opaque",""]]`)
-	_, err := parseDatesResponse(body, "USD")
+	_, err := parseDatesResponse(body, "USD", DatesOptions{})
 	if err == nil {
 		t.Fatal("expected parseDatesResponse to reject an empty inner payload")
 	}
@@ -96,7 +97,7 @@ func TestParseOffersResponseDetectsCompactBlockedEnvelope(t *testing.T) {
 func TestParseDatesResponseDetectsCompactBlockedEnvelope(t *testing.T) {
 	body := []byte(googleResponsePrefix + `
 [["wrb.fr",null,null,null,null,[13]],["di",39],["af.httprm",38,"redacted",6]]`)
-	_, err := parseDatesResponse(body, "USD")
+	_, err := parseDatesResponse(body, "USD", DatesOptions{})
 	if !errors.Is(err, errShoppingBlocked) {
 		t.Fatalf("parseDatesResponse error = %v, want errShoppingBlocked", err)
 	}
@@ -452,5 +453,81 @@ func TestFilterFlightsClientSide_ReturnTimeWindowAppliesOnlyToReturnBucket(t *te
 	}
 	if len(filteredInbound) != 1 || filteredInbound[0].Legs[0].DepartureTime != "2026-07-20T18:00:00" {
 		t.Fatalf("inbound filter = %+v, want only the 18:00 departure", filteredInbound)
+	}
+}
+
+// TestCheapestFallbackCandidateRoundTripIgnoresReturnBucket guards against
+// picking a cheap "return" bucket entry (an incremental fare priced against
+// whatever outbound the page pre-selected, not a standalone round-trip
+// total) over a pricier but real round-trip total from the outbound bucket.
+func TestCheapestFallbackCandidateRoundTripIgnoresReturnBucket(t *testing.T) {
+	flights := []Flight{
+		{Price: 400, Direction: "outbound"},
+		{Price: 350, Direction: "outbound"},
+		{Price: 40, Direction: "return"}, // incremental fare, not a real total
+	}
+	got := cheapestFallbackCandidate(flights, true)
+	if got == nil || got.Price != 350 {
+		t.Fatalf("cheapestFallbackCandidate(roundTrip) = %+v, want outbound Price=350", got)
+	}
+}
+
+// One-way fallback pages have no Direction tagging (untagged/"") — every
+// flight is eligible.
+func TestCheapestFallbackCandidateOneWayConsidersAllFlights(t *testing.T) {
+	flights := []Flight{{Price: 120}, {Price: 90}, {Price: 200}}
+	got := cheapestFallbackCandidate(flights, false)
+	if got == nil || got.Price != 90 {
+		t.Fatalf("cheapestFallbackCandidate(oneWay) = %+v, want Price=90", got)
+	}
+}
+
+func TestCheapestFallbackCandidateSkipsNonPositivePrices(t *testing.T) {
+	flights := []Flight{{Price: 0}, {Price: -5}}
+	if got := cheapestFallbackCandidate(flights, false); got != nil {
+		t.Fatalf("cheapestFallbackCandidate = %+v, want nil (no positive-priced flights)", got)
+	}
+}
+
+// TestDatesViaHTMLRoundTripSetsReturnDate exercises the full per-day
+// fallback path: ReturnDate must be passed into the round-trip search page
+// request (day + Duration) and echoed back on the resulting DatePrice.
+func TestDatesViaHTMLRoundTripSetsReturnDate(t *testing.T) {
+	origFetch := fetchSearchPage
+	defer func() { fetchSearchPage = origFetch }()
+
+	var gotReturnDates []string
+	var mu sync.Mutex
+	html := wrapDs1HTML(loadFixture(t, "aus_lax_embedded_ds1.json"))
+	fetchSearchPage = func(_ context.Context, pageURL string) (string, error) {
+		u, err := url.Parse(pageURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mu.Lock()
+		gotReturnDates = append(gotReturnDates, u.Query().Get("tfs"))
+		mu.Unlock()
+		return html, nil
+	}
+
+	from, _ := time.Parse("2006-01-02", "2026-07-13")
+	to, _ := time.Parse("2006-01-02", "2026-07-13")
+	rows, _, err := datesViaHTML(context.Background(), DatesOptions{
+		Origin:      "AUS",
+		Destination: "LAX",
+		RoundTrip:   true,
+		Duration:    3,
+	}, from, to, "USD")
+	if err != nil {
+		t.Fatalf("datesViaHTML returned error: %v", err)
+	}
+	if len(gotReturnDates) != 1 || gotReturnDates[0] == "" {
+		t.Fatalf("expected one request with a non-empty tfs (round-trip) param, got %v", gotReturnDates)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].ReturnDate != "2026-07-16" {
+		t.Fatalf("ReturnDate = %q, want 2026-07-16 (departure + 3 days)", rows[0].ReturnDate)
 	}
 }

--- a/library/travel/flight-goat/internal/gflights/multicity_test.go
+++ b/library/travel/flight-goat/internal/gflights/multicity_test.go
@@ -112,7 +112,7 @@ func TestBuildOffersPayload_OneWayUnchanged(t *testing.T) {
 		Passengers:    1,
 	}
 	d, _ := time.Parse("2006-01-02", opts.DepartureDate)
-	payload, err := buildOffersPayload(opts, d, time.Time{}, tripTypeOneWay, "")
+	payload, err := buildOffersPayload(opts, d, time.Time{}, tripTypeOneWay, "", nil, "")
 	if err != nil {
 		t.Fatalf("buildOffersPayload one-way: %v", err)
 	}


### PR DESCRIPTION
## Summary

Two related round-trip fixes for `flight-goat-pp-cli`, bundled because both touch the same round-trip request/response plumbing (`Flight.Direction`, the native/HTML-fallback split) in `internal/gflights/`:

1. **`--select-outbound N`** (new): `flights --return` alone only ever returns outbound itineraries — each row's price already bundles Google's own auto-picked "cheapest return" total, but no actual return-leg flight (time, airline, duration) is ever shown or selectable. This adds a true two-step flow that re-queries Google with a specific outbound selected, returning genuine return-leg options priced and paired against that outbound.
2. **`dates --round --duration N`** (fix): previously failed outright with `building payload: round-trip date searches not yet implemented in native backend`, even though the flags were already wired end-to-end from the CLI and documented in `dates --help`'s own example. Now builds a real round-trip calendar-RPC payload and fixes the RPC-blocked HTML fallback, which silently returned one-way prices for round-trip queries.

## 1. `--select-outbound N`: real return-leg options

- Step 1 (unchanged): `flights ORIG DEST DATE --return RETURN` → outbound-only results
- Step 2 (new): add `--select-outbound N` (1-based index from step 1's order) → real return-leg options, `direction: "return"` tagged, `selected_outbound` in the envelope echoing which outbound they're paired against

Without this, an agent or user reading `--return` output has no way to actually compare return flights — only a single bundled price with the outbound leg's own detail. The two-step flow is required because Google's `GetShoppingResults` RPC genuinely has no return-leg data pre-selection; it can't be worked around client-side.

**What changed:**

- `internal/gflights/gflights.go` — `Flight.Direction`/`SelectionToken`, `SearchOptions.SelectOutbound`, `SearchResult.SelectedOutbound` (additive JSON fields, `omitempty`)
- `internal/gflights/flights_native.go` — `fetchSelectedReturn` implements the second request: builds the `selected_flight` segment field from the chosen outbound's own leg data, threads the continuation token into the request envelope
- `internal/gflights/html_fallback.go` — direction tagging for the (separate, pre-existing) HTML-fallback bucket split
- `internal/cli/primary.go` — `--select-outbound N` flag, usage-error guards (`--return` required, incompatible with `--trip`/`--segment`), dry-run + example text, distinct output header for the return-options view
- `.printing-press-patches/round-trip-select-outbound-two-step.json` — reprint-guard entry

Default behavior (no flag) is byte-for-byte unchanged — verified live before/after.

## 2. `dates --round --duration N`: round-trip cheapest dates

`buildDatesPayload` previously rejected round trip outright before ever building a payload, even though `DatesOptions.RoundTrip`/`Duration` and `DatePrice.ReturnDate` were already wired end-to-end from the CLI flags.

**What changed:**

- `internal/gflights/dates_native.go` — `buildDatesPayload` now builds a real round-trip payload: a second segment (origin/dest swapped, `travel_date` = anchor + `--duration`), `trip_type=1`, and an outer `[min,max]`-nights duration filter. Shape verified field-for-field against a live captured `GetCalendarGraph` round-trip request. `parseDatesResponse` computes `DatePrice.ReturnDate` client-side (departure + duration) — the response is a single combined round-trip total keyed off the outbound date, not a 2D grid.
- `internal/gflights/html_fallback.go` — the RPC-blocked HTML fallback (`datesViaHTML`) previously ignored `RoundTrip`/`Duration` entirely and silently returned one-way prices for a round-trip query. It now requests the round-trip search page per day and picks the cheapest candidate only from the `outbound` `Direction` bucket via a new `cheapestFallbackCandidate` helper — the `return` bucket holds incremental fares priced against a pre-selected outbound, not standalone round-trip totals, and would otherwise surface an artificially low partial fare as the day's price. This depends on the `Flight.Direction` field added in part 1.
- `.printing-press-patches/round-trip-dates-native.json` — reprint-guard entry.

Default one-way `dates` behavior is unchanged (regression-tested).

## Documentation

- `SKILL.md` / `README.md` — documented the `--select-outbound` two-step gotcha and the `dates --round --duration` round-trip-total semantics.

## Testing

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, all packages)
- [x] `gofmt -l` clean on all touched files
- [x] `govulncheck ./...` — 0 reachable vulnerabilities
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/travel/flight-goat/` — all checks pass
- [x] Live: `--select-outbound` smoke test against LHR→BCN 2027-03-01/2027-03-18 — step 1 unchanged (10 outbound-only rows, bundled £91 price); `--select-outbound 1` returned 10 independently-priced return options (£102–£220), correctly tagged and paired
- [x] Live: `--select-outbound` error paths — out-of-range index, missing `--return`, `--trip` conflict all reject with expected messages/exit codes
- [x] Live: `dates LHR BCN --round --duration 2 --from 2027-03-01 --to 2027-03-10 --sort --agent` → 10 rows, sane round-trip totals ($109–$127), correct `return_date` = `departure_date` + 2 days
- [x] Live: one-way `dates` query unaffected
- [x] New tests: `TestBuildDatesPayloadRoundTripShape` / `TestBuildDatesPayloadOneWayUnaffected` / `TestBuildDatesPayloadRoundTripRequiresDuration` lock the payload shape; `TestDatesViaHTMLRoundTripSetsReturnDate` and `TestCheapestFallbackCandidateRoundTripIgnoresReturnBucket` cover the HTML fallback path

https://claude.ai/code/session_014FgSJoybgLY5mRUXTRoGzj