### PR TITLE
feat(anylist): add items recent remove for the sharded recent-items store

### DIFF
--- a/library/food-and-dining/anylist/.printing-press-patches/items-recent-remove.json
+++ b/library/food-and-dining/anylist/.printing-press-patches/items-recent-remove.json
@@ -1,0 +1,17 @@
+{
+ "schema_version": 2,
+ "id": "items-recent-remove",
+ "applied_at": "2026-09-01",
+ "base_run_id": "20260514-120439",
+ "base_printing_press_version": "4.30.2",
+ "summary": "Add `items recent remove` to delete one entry from the Recent Items store (the sharded autocomplete backing store), with all-chunk resolution, ambiguity rejection, and all-chunk read-back verification.",
+ "reason": "The recent-items store is a PBStarterList of RecentItemsType sharded across many chunks, but the CLI only wired the starters and favorites batches into the starter-list mutation path, so junk entries (e.g. misspelled names that feed autocomplete) could never be removed. A live probe confirmed POST /data/starter-lists/update with a PBStarterListOperation remove handler works against recent chunks; this patch makes that path a first-class, verified command.",
+ "files": [
+  "internal/cli/items_recent_remove.go",
+  "internal/cli/items_recent_remove_test.go",
+  "internal/cli/items_recent.go",
+  "SKILL.md",
+  "README.md"
+ ],
+ "validated_outcome": "Offline unit tests cover all-chunk scan, ambiguity rejection, exact-ID match, chunk disambiguation, and empty-selector rejection. Live dogfood of the preview path against a real account resolved an ambiguous name across two chunks and rejected it with the disambiguation hint, and reported a clean miss for an absent name. A prior throwaway probe already proved the write+read-back round trip against a real recent chunk."
+}

--- a/library/food-and-dining/anylist/.printing-press-patches/items-recent-remove.json
+++ b/library/food-and-dining/anylist/.printing-press-patches/items-recent-remove.json
@@ -13,5 +13,5 @@
   "SKILL.md",
   "README.md"
  ],
- "validated_outcome": "Offline unit tests cover all-chunk scan, ambiguity rejection, exact-ID match, chunk disambiguation, and empty-selector rejection. Live dogfood of the preview path against a real account resolved an ambiguous name across two chunks and rejected it with the disambiguation hint, and reported a clean miss for an absent name. A prior throwaway probe already proved the write+read-back round trip against a real recent chunk."
+ "validated_outcome": "Offline unit tests cover all-chunk scan, ambiguity rejection, exact-ID match, chunk disambiguation, and empty-selector rejection, plus fail-closed verification: a read-back where the ID survives in multiple chunks (Greptile P1 on #1892 — the original verification treated the resolver's ambiguity error as absence) and a read-back with zero recent chunks both fail verification instead of reporting success. Live dogfood of the preview path against a real account resolved an ambiguous name across two chunks and rejected it with the disambiguation hint, and reported a clean miss for an absent name. A prior throwaway probe already proved the write+read-back round trip against a real recent chunk."
 }

--- a/library/food-and-dining/anylist/README.md
+++ b/library/food-and-dining/anylist/README.md
@@ -348,6 +348,7 @@ Manage items within a shopping list
 - **`anylist-pp-cli items list`** - List items in a shopping list; JSON output includes cached package size, photo IDs, prices, store IDs, category match ID, and category assignments when available
 - **`anylist-pp-cli items lookup`** - Look up product details by UPC/EAN barcode
 - **`anylist-pp-cli items recent`** - Show recently added items across all lists
+- **`anylist-pp-cli items recent remove`** - Remove an entry from the Recent Items autocomplete store (sharded across many starter-list chunks). Preview is the default and `--apply` is required; the selector must be an exact item ID or an exact name (case-insensitive), and a name present in several chunks is rejected until disambiguated with the ID or `--chunk`. Every removal is verified by a fresh read-back of all chunks before the local cache is updated.
 - **`anylist-pp-cli items remove`** - Remove an item from a shopping list
 - **`anylist-pp-cli items search`** - Search for items by name across all shopping lists
 - **`anylist-pp-cli items uncheck`** - Mark one or more items as unchecked

--- a/library/food-and-dining/anylist/SKILL.md
+++ b/library/food-and-dining/anylist/SKILL.md
@@ -233,6 +233,7 @@ Create/delete, rename, parent movement, and child ordering use handlers verified
 - `anylist-pp-cli items list` — List items in a shopping list; JSON output includes cached package size, photo IDs, prices, store IDs, category match ID, and category assignments when available
 - `anylist-pp-cli items lookup` — Look up product details by UPC/EAN barcode
 - `anylist-pp-cli items recent` — Show recently added items across all lists
+- `anylist-pp-cli items recent remove` — Preview or remove an entry from the Recent Items store (the sharded autocomplete backing store). The selector must be an exact item ID or an exact name (case-insensitive); a name present in several chunks is rejected until disambiguated with the exact item ID or `--chunk`. Preview resolves against a fresh live read; `--apply` is required to write, and the removal is verified by reading back every chunk before the local cache is updated.
 - `anylist-pp-cli items remove` — Remove an item from a shopping list
 - `anylist-pp-cli items search` — Search for items by name across all shopping lists
 - `anylist-pp-cli items uncheck` — Mark one or more items as unchecked

--- a/library/food-and-dining/anylist/internal/cli/items_recent.go
+++ b/library/food-and-dining/anylist/internal/cli/items_recent.go
@@ -57,6 +57,7 @@ func newItemsRecentCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().IntVar(&bodyLimit, "limit", 20, "Maximum number of items to return")
 	cmd.Flags().BoolVar(&stdinBody, "stdin", false, "Read request body as JSON from stdin")
+	cmd.AddCommand(newItemsRecentRemoveCmd(flags))
 
 	return cmd
 }

--- a/library/food-and-dining/anylist/internal/cli/items_recent_remove.go
+++ b/library/food-and-dining/anylist/internal/cli/items_recent_remove.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/anylist/internal/anylist"
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/anylist/internal/anylist/pb"
+	"github.com/spf13/cobra"
+)
+
+// recentChunk pairs a recent-items starter-list chunk with the entry inside
+// it that matched a selector.
+type recentChunk struct {
+	list *pb.StarterList
+	item *pb.ListItem
+}
+
+// recentChunks returns every chunk of the Recent Items store. The store is
+// sharded across many starter lists, so every reader and writer must scan
+// them all; a scan of a single chunk can never be exhaustive.
+func recentChunks(data *pb.PBUserDataResponse) []*pb.StarterList {
+	if data == nil || data.GetStarterListsResponse() == nil {
+		return nil
+	}
+	batch := data.GetStarterListsResponse().GetRecentItemListsResponse()
+	if batch == nil {
+		return nil
+	}
+	lists := make([]*pb.StarterList, 0, len(batch.GetListResponses()))
+	for _, response := range batch.GetListResponses() {
+		if response != nil && response.GetStarterList() != nil {
+			lists = append(lists, response.GetStarterList())
+		}
+	}
+	return lists
+}
+
+// resolveRecentEntry scans every recent-items chunk for the selector. The
+// selector is an exact item ID or an exact name (case-insensitive). An
+// optional chunkSelector narrows the scan to one chunk by ID or name.
+// Multiple matches are rejected with the full candidate set returned so the
+// caller can report how to disambiguate; verification after a removal must
+// check absence across all chunks, never just the written one.
+func resolveRecentEntry(data *pb.PBUserDataResponse, itemSelector, chunkSelector string) (*recentChunk, []*recentChunk, error) {
+	itemSelector = strings.TrimSpace(itemSelector)
+	chunkSelector = strings.TrimSpace(chunkSelector)
+	if itemSelector == "" {
+		return nil, nil, fmt.Errorf("--item is required")
+	}
+	var matches []*recentChunk
+	for _, list := range recentChunks(data) {
+		if list == nil || list.GetIdentifier() == "" {
+			continue
+		}
+		if chunkSelector != "" &&
+			!strings.EqualFold(strings.TrimSpace(list.GetIdentifier()), chunkSelector) &&
+			!strings.EqualFold(strings.TrimSpace(list.GetName()), chunkSelector) {
+			continue
+		}
+		for _, item := range list.GetItems() {
+			if item == nil {
+				continue
+			}
+			if item.GetIdentifier() == itemSelector || strings.EqualFold(strings.TrimSpace(item.GetName()), itemSelector) {
+				matches = append(matches, &recentChunk{list: list, item: item})
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return nil, nil, fmt.Errorf("no recent-items entry matches %q", itemSelector)
+	}
+	if len(matches) > 1 {
+		return nil, matches, fmt.Errorf("recent-items selector %q matches %d entries; pass the exact item ID or --chunk to disambiguate", itemSelector, len(matches))
+	}
+	return matches[0], matches, nil
+}
+
+func newItemsRecentRemoveCmd(flags *rootFlags) *cobra.Command {
+	var itemSelector, chunkSelector string
+	var apply bool
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove an entry from the Recent Items store (preview unless --apply)",
+		Long: `Removes one entry from the Recent Items store — the autocomplete
+backing store sharded across many starter-list chunks. The selector is an
+exact item ID or an exact item name (case-insensitive); a name present in
+several chunks is rejected until disambiguated with the exact item ID or
+--chunk. The removal is verified by a fresh read-back of every chunk before
+the local cache is updated.`,
+		Example: `  anylist-pp-cli items recent remove --item "bell peppers"
+  anylist-pp-cli items recent remove --item <item-id> --chunk <chunk-list-id> --apply`,
+		Annotations: map[string]string{
+			"pp:endpoint": "starter-lists.remove",
+			"pp:method":   "POST",
+			"pp:path":     "/data/starter-lists/update",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			itemSelector = strings.TrimSpace(itemSelector)
+			chunkSelector = strings.TrimSpace(chunkSelector)
+			if itemSelector == "" {
+				return fmt.Errorf("required flag \"item\" not set")
+			}
+			if flags.dryRun {
+				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+					"dry_run": true, "status": "preview", "action": "remove", "kind": "recent",
+					"item": itemSelector, "chunk": chunkSelector, "apply": apply,
+				}, flags)
+			}
+			if !apply {
+				cfg, st, err := openAuthedLocalStore(flags)
+				if err != nil {
+					return err
+				}
+				defer st.Close()
+				client := anylist.New(cfg)
+				liveData, err := client.GetUserData(cmd.Context())
+				if err != nil {
+					return fmt.Errorf("reading live recent items: %w", err)
+				}
+				chunk, _, err := resolveRecentEntry(liveData, itemSelector, chunkSelector)
+				if err != nil {
+					return err
+				}
+				result := map[string]any{
+					"status":   "preview",
+					"action":   "remove",
+					"kind":     "recent",
+					"item":     chunk.item.GetName(),
+					"item_id":  chunk.item.GetIdentifier(),
+					"chunk":    chunk.list.GetName(),
+					"chunk_id": chunk.list.GetIdentifier(),
+					"apply":    false,
+				}
+				if flags.asJSON {
+					return printJSONFiltered(cmd.OutOrStdout(), result, flags)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Preview: would remove %q (id %s) from recent chunk %s (id %s); pass --apply to write\n",
+					chunk.item.GetName(), chunk.item.GetIdentifier(), chunk.list.GetName(), chunk.list.GetIdentifier())
+				return nil
+			}
+			if !starterListWritesEnabled() {
+				return fmt.Errorf("recent-items mutation is disabled until AnyList's starter-list protobuf round-trip is verified")
+			}
+			cfg, st, err := openAuthedLocalStore(flags)
+			if err != nil {
+				return err
+			}
+			defer st.Close()
+			client := anylist.New(cfg)
+			liveData, err := client.GetUserData(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("reading live recent items: %w", err)
+			}
+			chunk, _, err := resolveRecentEntry(liveData, itemSelector, chunkSelector)
+			if err != nil {
+				return err
+			}
+			chunkID, itemName, itemID := chunk.list.GetIdentifier(), chunk.item.GetName(), chunk.item.GetIdentifier()
+			if err := client.RemoveStarterListItem(cmd.Context(), chunkID, chunk.item); err != nil {
+				return fmt.Errorf("removing recent entry %q: %w", itemName, err)
+			}
+			verifiedData, err := client.GetUserData(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("verifying removal of recent entry %q: %w", itemName, err)
+			}
+			// Absence must hold across every chunk, not just the written one.
+			if found, _, verr := resolveRecentEntry(verifiedData, itemID, ""); verr == nil {
+				return fmt.Errorf("recent remove verification failed: entry %q (id %s) is still present in chunk %s", itemName, itemID, found.list.GetIdentifier())
+			}
+			if err := st.SyncFromUserData(verifiedData); err != nil {
+				return fmt.Errorf("updating local cache after recent remove: %w", err)
+			}
+			if flags.quiet {
+				return nil
+			}
+			result := map[string]any{
+				"removed": true, "kind": "recent", "item_id": itemID, "name": itemName,
+				"chunk_id": chunkID, "chunk": chunk.list.GetName(), "verified": true,
+			}
+			if flags.asJSON {
+				return printJSONFiltered(cmd.OutOrStdout(), result, flags)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Removed %q from recent chunk %s (id %s)\n", itemName, chunk.list.GetName(), chunkID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&itemSelector, "item", "", "Item name or stable item ID")
+	cmd.Flags().StringVar(&chunkSelector, "chunk", "", "Optional chunk list ID or name to narrow the search")
+	cmd.Flags().BoolVar(&apply, "apply", false, "Apply the removal; preview is the default")
+	return cmd
+}

--- a/library/food-and-dining/anylist/internal/cli/items_recent_remove.go
+++ b/library/food-and-dining/anylist/internal/cli/items_recent_remove.go
@@ -76,6 +76,35 @@ func resolveRecentEntry(data *pb.PBUserDataResponse, itemSelector, chunkSelector
 	return matches[0], matches, nil
 }
 
+// verifyRecentAbsence positively establishes that itemID is absent from every
+// chunk of the read-back. It deliberately does not reuse resolveRecentEntry:
+// that resolver's error path conflates "no match" with "ambiguous match", so
+// an entry still present in several chunks would look like verified absence.
+// A read-back without any recent chunks is likewise inconclusive and fails
+// closed.
+func verifyRecentAbsence(data *pb.PBUserDataResponse, itemID, itemName string) error {
+	chunks := recentChunks(data)
+	if len(chunks) == 0 {
+		return fmt.Errorf("recent remove verification failed: read-back contained no recent-items chunks")
+	}
+	var present []string
+	for _, list := range chunks {
+		if list == nil || list.GetIdentifier() == "" {
+			continue
+		}
+		for _, item := range list.GetItems() {
+			if item != nil && item.GetIdentifier() == itemID {
+				present = append(present, list.GetIdentifier())
+				break
+			}
+		}
+	}
+	if len(present) > 0 {
+		return fmt.Errorf("recent remove verification failed: entry %q (id %s) is still present in chunk(s) %s", itemName, itemID, strings.Join(present, ", "))
+	}
+	return nil
+}
+
 func newItemsRecentRemoveCmd(flags *rootFlags) *cobra.Command {
 	var itemSelector, chunkSelector string
 	var apply bool
@@ -164,9 +193,8 @@ the local cache is updated.`,
 			if err != nil {
 				return fmt.Errorf("verifying removal of recent entry %q: %w", itemName, err)
 			}
-			// Absence must hold across every chunk, not just the written one.
-			if found, _, verr := resolveRecentEntry(verifiedData, itemID, ""); verr == nil {
-				return fmt.Errorf("recent remove verification failed: entry %q (id %s) is still present in chunk %s", itemName, itemID, found.list.GetIdentifier())
+			if err := verifyRecentAbsence(verifiedData, itemID, itemName); err != nil {
+				return err
 			}
 			if err := st.SyncFromUserData(verifiedData); err != nil {
 				return fmt.Errorf("updating local cache after recent remove: %w", err)

--- a/library/food-and-dining/anylist/internal/cli/items_recent_remove_test.go
+++ b/library/food-and-dining/anylist/internal/cli/items_recent_remove_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/anylist/internal/anylist/pb"
+)
+
+func recentStoreFixture(chunks ...*pb.StarterList) *pb.PBUserDataResponse {
+	batch := &pb.StarterListBatchResponse{}
+	for _, list := range chunks {
+		batch.ListResponses = append(batch.ListResponses, &pb.StarterListResponse{StarterList: list})
+	}
+	return &pb.PBUserDataResponse{
+		StarterListsResponse: &pb.StarterListsResponseV2{RecentItemListsResponse: batch},
+	}
+}
+
+func TestResolveRecentEntry_AmbiguousNameAcrossChunks(t *testing.T) {
+	data := recentStoreFixture(
+		&pb.StarterList{Identifier: "chunk-a", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "id-a", Name: "bell peppers"}}},
+		&pb.StarterList{Identifier: "chunk-b", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "id-b", Name: "Bell Peppers"}}},
+	)
+	chunk, matches, err := resolveRecentEntry(data, "bell peppers", "")
+	if err == nil {
+		t.Fatalf("expected ambiguity error, got chunk %v", chunk)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(matches))
+	}
+	if !strings.Contains(err.Error(), "disambiguate") {
+		t.Fatalf("error must point at the disambiguation path: %v", err)
+	}
+}
+
+func TestResolveRecentEntry_FindsEntryInLaterChunk(t *testing.T) {
+	data := recentStoreFixture(
+		&pb.StarterList{Identifier: "chunk-1", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "id-1", Name: "milk"}}},
+		&pb.StarterList{Identifier: "chunk-2", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "id-2", Name: "eggs"}}},
+		&pb.StarterList{Identifier: "chunk-3", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "id-3", Name: "tortillas"}}},
+	)
+	chunk, _, err := resolveRecentEntry(data, "tortillas", "")
+	if err != nil {
+		t.Fatalf("resolve failed: %v", err)
+	}
+	if chunk.list.GetIdentifier() != "chunk-3" || chunk.item.GetIdentifier() != "id-3" {
+		t.Fatalf("resolved wrong entry: chunk=%s item=%s", chunk.list.GetIdentifier(), chunk.item.GetIdentifier())
+	}
+}
+
+func TestResolveRecentEntry_ExactIDMatch(t *testing.T) {
+	data := recentStoreFixture(
+		&pb.StarterList{Identifier: "chunk-a", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "id-x", Name: "milk"}, {Identifier: "target", Name: "Milk"}}},
+	)
+	chunk, _, err := resolveRecentEntry(data, "target", "")
+	if err != nil {
+		t.Fatalf("exact ID must resolve even when a differently-cased name collides: %v", err)
+	}
+	if chunk.item.GetName() != "Milk" {
+		t.Fatalf("resolved wrong item: %q", chunk.item.GetName())
+	}
+}
+
+func TestResolveRecentEntry_ChunkSelectorDisambiguates(t *testing.T) {
+	data := recentStoreFixture(
+		&pb.StarterList{Identifier: "chunk-a", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "id-a", Name: "milk"}}},
+		&pb.StarterList{Identifier: "chunk-b", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "id-b", Name: "milk"}}},
+	)
+	chunk, _, err := resolveRecentEntry(data, "milk", "chunk-b")
+	if err != nil {
+		t.Fatalf("chunk selector must disambiguate: %v", err)
+	}
+	if chunk.list.GetIdentifier() != "chunk-b" {
+		t.Fatalf("resolved chunk %s, want chunk-b", chunk.list.GetIdentifier())
+	}
+	if _, _, err := resolveRecentEntry(data, "milk", "chunk-c"); err == nil {
+		t.Fatal("unknown chunk selector with a matching name elsewhere must report no match")
+	}
+}
+
+func TestResolveRecentEntry_EmptySelector(t *testing.T) {
+	data := recentStoreFixture(
+		&pb.StarterList{Identifier: "chunk-a", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "id-a", Name: "milk"}}},
+	)
+	if _, _, err := resolveRecentEntry(data, "   ", ""); err == nil {
+		t.Fatal("blank selector must be rejected")
+	}
+	if _, _, err := resolveRecentEntry(data, "missing", ""); err == nil {
+		t.Fatal("unknown selector must be rejected")
+	}
+}

--- a/library/food-and-dining/anylist/internal/cli/items_recent_remove_test.go
+++ b/library/food-and-dining/anylist/internal/cli/items_recent_remove_test.go
@@ -79,6 +79,41 @@ func TestResolveRecentEntry_ChunkSelectorDisambiguates(t *testing.T) {
 	}
 }
 
+func TestVerifyRecentAbsence(t *testing.T) {
+	// A removal that silently failed leaves the ID in several chunks. The
+	// original verification treated resolveRecentEntry's ambiguity error as
+	// absence and would have reported success; absence must be positive.
+	multi := recentStoreFixture(
+		&pb.StarterList{Identifier: "chunk-a", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "victim", Name: "milk"}}},
+		&pb.StarterList{Identifier: "chunk-b", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "victim", Name: "milk"}}},
+	)
+	if err := verifyRecentAbsence(multi, "victim", "milk"); err == nil {
+		t.Fatal("ID present in two chunks must fail verification")
+	} else if !strings.Contains(err.Error(), "chunk-a") || !strings.Contains(err.Error(), "chunk-b") {
+		t.Fatalf("error must name the surviving chunks: %v", err)
+	}
+
+	single := recentStoreFixture(
+		&pb.StarterList{Identifier: "chunk-a", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "victim", Name: "milk"}}},
+	)
+	if err := verifyRecentAbsence(single, "victim", "milk"); err == nil {
+		t.Fatal("ID present in one chunk must fail verification")
+	}
+
+	clean := recentStoreFixture(
+		&pb.StarterList{Identifier: "chunk-a", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "other", Name: "milk"}}},
+		&pb.StarterList{Identifier: "chunk-b", Name: "Recent Items"},
+	)
+	if err := verifyRecentAbsence(clean, "victim", "milk"); err != nil {
+		t.Fatalf("genuinely absent ID must pass: %v", err)
+	}
+
+	// A read-back without any recent chunks is inconclusive, not verified.
+	if err := verifyRecentAbsence(&pb.PBUserDataResponse{}, "victim", "milk"); err == nil {
+		t.Fatal("read-back with zero chunks must fail verification")
+	}
+}
+
 func TestResolveRecentEntry_EmptySelector(t *testing.T) {
 	data := recentStoreFixture(
 		&pb.StarterList{Identifier: "chunk-a", Name: "Recent Items", Items: []*pb.ListItem{{Identifier: "id-a", Name: "milk"}}},


### PR DESCRIPTION
## What
Adds `anylist-pp-cli items recent remove` — delete one entry from the Recent Items store (the autocomplete backing store).

## Why
The Recent Items store is a `RecentItemsType` starter-list batch sharded across many chunks (dozens per account), but only the *starters* and *favorites* batches were wired into the starter-list mutation path (`POST /data/starter-lists/update`). Junk entries — e.g. a misspelled item name that keeps re-offering itself in autocomplete — had no CLI removal path.

## How
- `internal/cli/items_recent_remove.go` (new):
  - `recentChunks()` — returns every chunk of the recent batch (a single-chunk scan is never exhaustive).
  - `resolveRecentEntry()` — all-chunk scan for an exact item ID or exact case-insensitive name; optional `--chunk` narrows the search; multiple matches are rejected with the full candidate set.
  - `items recent remove` — preview by default (resolves against a fresh live read), `--apply` required to write, fresh read-back verifies absence across **every** chunk, then local cache sync. Same preview/apply/verify convention as the existing `starters`/`favorites` mutations.
- 5 offline unit tests: ambiguity across chunks, entry found in a later chunk, exact-ID match, `--chunk` disambiguation, empty/unknown selector rejection.

## Live evidence
- Write path was live-probed before this change: a remove operation against a real recent chunk succeeded and verified on read-back (throwaway script, not in this PR).
- Preview path dogfooded against a real account: a name present in two chunks was rejected with the disambiguation hint; an absent name produced a clean miss.

## Notes
- `publish validate`'s `phase5` fingerprint check fails on pristine `upstream/main` too (the marker predates the #1852 source split) — pre-existing drift, not introduced here.
- MCP surface unchanged; exposing this as an MCP tool is a follow-up (favorites/starter removes are in the MCP registry).

## Files
- `internal/cli/items_recent_remove.go` (new)
- `internal/cli/items_recent_remove_test.go` (new)
- `internal/cli/items_recent.go` (1-line registration)
- `SKILL.md`, `README.md` (cookbook entries)
- `.printing-press-patches/items-recent-remove.json` (evidence record)
