### PR TITLE
fix(movie-goat): make untyped local search return FTS hits

### DIFF
--- a/library/media-and-entertainment/movie-goat/.printing-press-patches/search-untyped-local-results.json
+++ b/library/media-and-entertainment/movie-goat/.printing-press-patches/search-untyped-local-results.json
@@ -4,13 +4,13 @@
   "applied_at": "2026-08-31",
   "base_run_id": "20260504-004256",
   "base_printing_press_version": "3.8.0",
-  "summary": "An untyped `search` against the local store must run the same FTS `db.Search` query the typed default arm runs, so `--data-source local` and the auto-mode network-failure fallback return real hits instead of a silent `results: []`.",
-  "reason": "The generated search command's `case \"\":` branch (no --type) was a stub that allocated a `seen` map, discarded it, and never assigned `results`, so offline searches always printed an empty result set and exited 0 — indistinguishable from a successful search over an empty corpus. The default arm already called `db.Search(query, limit)` and returned real hits; the untyped branch must call it too. A regen that restores the empty stub reintroduces the silent-wrong-answer defect.",
+  "summary": "An untyped `search` against the local store must run the same FTS `db.Search` query the typed default arm runs, so `--data-source local` and the auto-mode network-failure fallback return real hits instead of a silent `results: []`. User-supplied query text must also be neutralized before it becomes an FTS5 `MATCH` expression, so FTS5 syntax in the query searches literally instead of raising a parse error.",
+  "reason": "The generated search command's `case \"\":` branch (no --type) was a stub that allocated a `seen` map, discarded it, and never assigned `results`, so offline searches always printed an empty result set and exited 0 — indistinguishable from a successful search over an empty corpus. The default arm already called `db.Search(query, limit)` and returned real hits; the untyped branch must call it too. A regen that restores the empty stub reintroduces the silent-wrong-answer defect. Separately, the query was interpolated raw into `WHERE resources_fts MATCH ?`, so FTS5 syntax in user input (e.g. \"Space: 1999\", \"Lilo & Stitch\", a bare AND/OR/NEAR, quotes) raised a parse error; `ftsSafeQuery` quotes syntax-bearing tokens (and bare FTS5 keywords) per token, doubling embedded quotes, preserving implicit-AND for plain multi-word queries and prefix search for trailing-* tokens.",
   "files": [
     "internal/cli/search.go",
     "internal/cli/search_test.go",
     "internal/store/store.go",
     "internal/store/store_fts_test.go"
   ],
-  "validated_outcome": "go build/vet/test pass; search_test.go asserts untyped local search returns the same non-empty, rank-ordered FTS hits as the --type zzzz control, the auto fallback (unreachable API, --no-cache) returns them with reason api_unreachable, and a no-match query returns an empty array."
+  "validated_outcome": "go build/vet/test pass; search_test.go asserts untyped local search returns the same non-empty, rank-ordered FTS hits as the --type zzzz control, the auto fallback (unreachable API, --no-cache) returns them with reason api_unreachable, and a no-match query returns an empty array. store_fts_test.go asserts FTS5-syntax queries (metacharacters and bare AND/OR/NOT/NEAR/ANDNOT keywords, plus %&#?!@$%=;\\| cases) return rows-or-empty with no MATCH parse error, plain multi-word queries keep implicit-AND, prefix search (incept*) is preserved, and empty queries return an empty result."
 }

--- a/library/media-and-entertainment/movie-goat/.printing-press-patches/search-untyped-local-results.json
+++ b/library/media-and-entertainment/movie-goat/.printing-press-patches/search-untyped-local-results.json
@@ -5,7 +5,7 @@
   "base_run_id": "20260504-004256",
   "base_printing_press_version": "3.8.0",
   "summary": "An untyped `search` against the local store must run the same FTS `db.Search` query the typed default arm runs, so `--data-source local` and the auto-mode network-failure fallback return real hits instead of a silent `results: []`.",
-  "reason": "The generated search command's `case \"\":` branch (no --type) was a stub that allocated a `seen` map, discarded it, and never assigned `results`, so offline searches always printed an empty result set and exited 0 — indistinguishable from a successful search over an empty corpus. The default arm already called `db.Search(query, limit)` and returned real hits; the untyped branch must call it too. A regen that restores the empty stub reintroduces the silent-wrong-answer defect.",
+  "reason": "The generated search command's `case \"\":` branch (no --type) was a stub that allocated a `seen` map, discarded it, and never assigned `results`, so offline searches always printed an empty result set and exited 0 \u2014 indistinguishable from a successful search over an empty corpus. The default arm already called `db.Search(query, limit)` and returned real hits; the untyped branch must call it too. A regen that restores the empty stub reintroduces the silent-wrong-answer defect.",
   "files": [
     "internal/cli/search.go",
     "internal/cli/search_test.go"

--- a/library/media-and-entertainment/movie-goat/.printing-press-patches/search-untyped-local-results.json
+++ b/library/media-and-entertainment/movie-goat/.printing-press-patches/search-untyped-local-results.json
@@ -5,10 +5,12 @@
   "base_run_id": "20260504-004256",
   "base_printing_press_version": "3.8.0",
   "summary": "An untyped `search` against the local store must run the same FTS `db.Search` query the typed default arm runs, so `--data-source local` and the auto-mode network-failure fallback return real hits instead of a silent `results: []`.",
-  "reason": "The generated search command's `case \"\":` branch (no --type) was a stub that allocated a `seen` map, discarded it, and never assigned `results`, so offline searches always printed an empty result set and exited 0 \u2014 indistinguishable from a successful search over an empty corpus. The default arm already called `db.Search(query, limit)` and returned real hits; the untyped branch must call it too. A regen that restores the empty stub reintroduces the silent-wrong-answer defect.",
+  "reason": "The generated search command's `case \"\":` branch (no --type) was a stub that allocated a `seen` map, discarded it, and never assigned `results`, so offline searches always printed an empty result set and exited 0 — indistinguishable from a successful search over an empty corpus. The default arm already called `db.Search(query, limit)` and returned real hits; the untyped branch must call it too. A regen that restores the empty stub reintroduces the silent-wrong-answer defect.",
   "files": [
     "internal/cli/search.go",
-    "internal/cli/search_test.go"
+    "internal/cli/search_test.go",
+    "internal/store/store.go",
+    "internal/store/store_fts_test.go"
   ],
   "validated_outcome": "go build/vet/test pass; search_test.go asserts untyped local search returns the same non-empty, rank-ordered FTS hits as the --type zzzz control, the auto fallback (unreachable API, --no-cache) returns them with reason api_unreachable, and a no-match query returns an empty array."
 }

--- a/library/media-and-entertainment/movie-goat/.printing-press-patches/search-untyped-local-results.json
+++ b/library/media-and-entertainment/movie-goat/.printing-press-patches/search-untyped-local-results.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "search-untyped-local-results",
+  "applied_at": "2026-08-31",
+  "base_run_id": "20260504-004256",
+  "base_printing_press_version": "3.8.0",
+  "summary": "An untyped `search` against the local store must run the same FTS `db.Search` query the typed default arm runs, so `--data-source local` and the auto-mode network-failure fallback return real hits instead of a silent `results: []`.",
+  "reason": "The generated search command's `case \"\":` branch (no --type) was a stub that allocated a `seen` map, discarded it, and never assigned `results`, so offline searches always printed an empty result set and exited 0 — indistinguishable from a successful search over an empty corpus. The default arm already called `db.Search(query, limit)` and returned real hits; the untyped branch must call it too. A regen that restores the empty stub reintroduces the silent-wrong-answer defect.",
+  "files": [
+    "internal/cli/search.go",
+    "internal/cli/search_test.go"
+  ],
+  "validated_outcome": "go build/vet/test pass; search_test.go asserts untyped local search returns the same non-empty, rank-ordered FTS hits as the --type zzzz control, the auto fallback (unreachable API, --no-cache) returns them with reason api_unreachable, and a no-match query returns an empty array."
+}

--- a/library/media-and-entertainment/movie-goat/internal/cli/search.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/search.go
@@ -146,14 +146,9 @@ In local mode: searches locally synced data only.`,
 			defer db.Close()
 
 			var results []json.RawMessage
-			switch resourceType {
-			case "":
-				// Untyped search covers the whole FTS index.
-				results, err = db.Search(query, limit)
-			default:
-				// Unrecognized type — fall back to generic search
-				results, err = db.Search(query, limit)
-			}
+			// Both the untyped and unrecognized --type paths search the whole
+			// FTS index; --type does not filter the local query.
+			results, err = db.Search(query, limit)
 			if err != nil {
 				return fmt.Errorf("search failed: %w", err)
 			}

--- a/library/media-and-entertainment/movie-goat/internal/cli/search.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/search.go
@@ -148,9 +148,8 @@ In local mode: searches locally synced data only.`,
 			var results []json.RawMessage
 			switch resourceType {
 			case "":
-				// Search all FTS-enabled tables individually to avoid duplicates.
-				seen := make(map[string]bool)
-				_ = seen // prevent unused error when no FTS tables exist
+				// Untyped search covers the whole FTS index.
+				results, err = db.Search(query, limit)
 			default:
 				// Unrecognized type — fall back to generic search
 				results, err = db.Search(query, limit)

--- a/library/media-and-entertainment/movie-goat/internal/cli/search_test.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/search_test.go
@@ -20,8 +20,12 @@ import (
 // fixtures via the store's own upsert path. A file-backed store is required:
 // the store opens with SetMaxOpenConns(2) + WAL, and SQLite :memory: databases
 // are per-connection, so an in-memory DB could silently use a different
-// connection than the migration.
-func seedSearchStore(t *testing.T, query string) string {
+// connection than the migration. An optional variadic fixture list replaces
+// the default Inception fixtures.
+func seedSearchStore(t *testing.T, query string, extraFixtures ...struct {
+	id   string
+	data string
+}) string {
 	t.Helper()
 
 	dbPath := filepath.Join(t.TempDir(), "search_test.db")
@@ -39,6 +43,7 @@ func seedSearchStore(t *testing.T, query string) string {
 		{"27205", `{"id":27205,"title":"Inception","type":"movie"}`},
 		{"1234", `{"id":1234,"title":"A Very Different Film","type":"movie"}`},
 	}
+	fixtures = append(fixtures, extraFixtures...)
 	for _, f := range fixtures {
 		if err := s.Upsert("movies", f.id, json.RawMessage(f.data)); err != nil {
 			t.Fatalf("upserting fixture %s: %v", f.id, err)
@@ -46,13 +51,14 @@ func seedSearchStore(t *testing.T, query string) string {
 	}
 
 	// Prove the fixture store's FTS index is actually populated — a silently
-	// empty index would let a parity-only test false-pass.
+	// empty index would let a parity-only test false-pass. Expect at least one
+	// hit for the proving query.
 	got, err := s.Search(query, 50)
 	if err != nil {
 		t.Fatalf("seeding search: %v", err)
 	}
-	if len(got) != 2 {
-		t.Fatalf("seed store FTS index should hold 2 hits for %q, got %d", query, len(got))
+	if len(got) == 0 {
+		t.Fatalf("seed store FTS index should hold hits for %q, got 0", query)
 	}
 	return dbPath
 }
@@ -157,18 +163,12 @@ func TestSearchNoMatchesReturnsEmpty(t *testing.T) {
 // syntax (the ":" column operator) searches literally through the untyped
 // local path instead of raising a MATCH parse error.
 func TestSearchFTSSyntaxQueryReturnsLiteralHits(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "fts_cli_test.db")
-	s, err := store.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening temp store: %v", err)
-	}
-	defer s.Close()
-	if err := s.Upsert("movies", "9999", json.RawMessage(`{"id":9999,"title":"Space: 1999","type":"movie"}`)); err != nil {
-		t.Fatalf("upserting fixture: %v", err)
-	}
-	if err := s.Close(); err != nil {
-		t.Fatalf("closing seed store: %v", err)
-	}
+	dbPath := seedSearchStore(t, "Space: 1999",
+		struct {
+			id   string
+			data string
+		}{"9999", `{"id":9999,"title":"Space: 1999","type":"movie"}`},
+	)
 
 	envelope := runSearch(t, dbPath, "Space: 1999", "--data-source", "local")
 	titles := titlesFromEnvelope(t, envelope)

--- a/library/media-and-entertainment/movie-goat/internal/cli/search_test.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/search_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/internal/store"
@@ -120,7 +121,7 @@ func TestSearchUntypedLocalMatchesTypedControl(t *testing.T) {
 	if len(untypedTitles) != 2 {
 		t.Fatalf("untyped local search returned %d hits, want 2: %v", len(untypedTitles), untypedTitles)
 	}
-	if !titlesEqual(untypedTitles, typedTitles) {
+	if !slices.Equal(untypedTitles, typedTitles) {
 		t.Fatalf("untyped local search results differ from typed control: untyped=%v typed=%v", untypedTitles, typedTitles)
 	}
 }
@@ -150,16 +151,4 @@ func TestSearchNoMatchesReturnsEmpty(t *testing.T) {
 	if len(titles) != 0 {
 		t.Fatalf("no-match query should return zero hits, got %v", titles)
 	}
-}
-
-func titlesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/library/media-and-entertainment/movie-goat/internal/cli/search_test.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/search_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Trevin Chow and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-written regression test for issue #1848: `search --data-source local`
+// (and the auto-mode fallback) returned empty results because the untyped
+// `case "":` branch in search.go never assigned `results`. The untyped search
+// must return the same FTS hits a `--type zzzz` search returns.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/internal/store"
+)
+
+// seedSearchStore opens a temp-dir file-backed store and inserts FTS-indexed
+// fixtures via the store's own upsert path. A file-backed store is required:
+// the store opens with SetMaxOpenConns(2) + WAL, and SQLite :memory: databases
+// are per-connection, so an in-memory DB could silently use a different
+// connection than the migration.
+func seedSearchStore(t *testing.T, query string) string {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "search_test.db")
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening temp store: %v", err)
+	}
+	defer s.Close()
+
+	fixtures := []struct {
+		id   string
+		data string
+	}{
+		{"973484", `{"id":973484,"title":"Inception: Music from the Motion Picture","type":"movie"}`},
+		{"27205", `{"id":27205,"title":"Inception","type":"movie"}`},
+		{"1234", `{"id":1234,"title":"A Very Different Film","type":"movie"}`},
+	}
+	for _, f := range fixtures {
+		if err := s.Upsert("movies", f.id, json.RawMessage(f.data)); err != nil {
+			t.Fatalf("upserting fixture %s: %v", f.id, err)
+		}
+	}
+
+	// Prove the fixture store's FTS index is actually populated — a silently
+	// empty index would let a parity-only test false-pass.
+	got, err := s.Search(query, 50)
+	if err != nil {
+		t.Fatalf("seeding search: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("seed store FTS index should hold 2 hits for %q, got %d", query, len(got))
+	}
+	return dbPath
+}
+
+// runSearch executes `search <query>` with the given args against a temp-dir
+// store and returns the parsed JSON envelope.
+func runSearch(t *testing.T, dbPath, query string, extraArgs ...string) map[string]any {
+	t.Helper()
+	t.Setenv("MOVIE_GOAT_BASE_URL", "http://127.0.0.1:1")
+
+	root := RootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	args := append([]string{"--db", dbPath, "--no-cache", "--json"}, extraArgs...)
+	args = append(args, "search", query)
+	root.SetArgs(args)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("search returned error: %v\noutput:\n%s\nstderr:\n%s", err, out.String(), errBuf.String())
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(out.Bytes(), &envelope); err != nil {
+		t.Fatalf("parsing search output %q: %v\nstderr:\n%s", out.String(), err, errBuf.String())
+	}
+	return envelope
+}
+
+// titlesFromEnvelope extracts the "title" field of each result in the
+// envelope's "results" array.
+func titlesFromEnvelope(t *testing.T, envelope map[string]any) []string {
+	t.Helper()
+	rawResults, ok := envelope["results"].([]any)
+	if !ok {
+		t.Fatalf("envelope has no results array: %v", envelope)
+	}
+	var titles []string
+	for _, r := range rawResults {
+		obj, ok := r.(map[string]any)
+		if !ok {
+			t.Fatalf("result is not an object: %v", r)
+		}
+		title, _ := obj["title"].(string)
+		titles = append(titles, title)
+	}
+	return titles
+}
+
+// TestSearchUntypedLocalMatchesTypedControl asserts the fix for issue #1848:
+// an untyped `--data-source local` search returns the same non-empty, ordered
+// hits as the `--type zzzz` control (which already worked because it falls to
+// the default arm).
+func TestSearchUntypedLocalMatchesTypedControl(t *testing.T) {
+	dbPath := seedSearchStore(t, "inception")
+
+	typed := runSearch(t, dbPath, "inception", "--type", "zzzz", "--data-source", "local")
+	typedTitles := titlesFromEnvelope(t, typed)
+	if len(typedTitles) != 2 {
+		t.Fatalf("typed control should return 2 hits, got %d: %v", len(typedTitles), typedTitles)
+	}
+
+	untyped := runSearch(t, dbPath, "inception", "--data-source", "local")
+	untypedTitles := titlesFromEnvelope(t, untyped)
+	if len(untypedTitles) != 2 {
+		t.Fatalf("untyped local search returned %d hits, want 2: %v", len(untypedTitles), untypedTitles)
+	}
+	if !titlesEqual(untypedTitles, typedTitles) {
+		t.Fatalf("untyped local search results differ from typed control: untyped=%v typed=%v", untypedTitles, typedTitles)
+	}
+}
+
+// TestSearchAutoFallbackReturnsLocalHits asserts the auto-mode fallback returns
+// local hits with the api_unreachable provenance when the API is unreachable.
+func TestSearchAutoFallbackReturnsLocalHits(t *testing.T) {
+	dbPath := seedSearchStore(t, "inception")
+
+	envelope := runSearch(t, dbPath, "inception")
+	if reason, _ := envelope["meta"].(map[string]any)["reason"].(string); reason != "api_unreachable" {
+		t.Fatalf("auto fallback reason: got %q, want api_unreachable (envelope %v)", reason, envelope["meta"])
+	}
+	titles := titlesFromEnvelope(t, envelope)
+	if len(titles) != 2 {
+		t.Fatalf("auto fallback returned %d hits, want 2: %v", len(titles), titles)
+	}
+}
+
+// TestSearchNoMatchesReturnsEmpty verifies a query with no matches still
+// returns an empty (not erroring) results array.
+func TestSearchNoMatchesReturnsEmpty(t *testing.T) {
+	dbPath := seedSearchStore(t, "inception")
+
+	envelope := runSearch(t, dbPath, "nonexistenttermxyz", "--data-source", "local")
+	titles := titlesFromEnvelope(t, envelope)
+	if len(titles) != 0 {
+		t.Fatalf("no-match query should return zero hits, got %v", titles)
+	}
+}
+
+func titlesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/library/media-and-entertainment/movie-goat/internal/cli/search_test.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/search_test.go
@@ -152,3 +152,27 @@ func TestSearchNoMatchesReturnsEmpty(t *testing.T) {
 		t.Fatalf("no-match query should return zero hits, got %v", titles)
 	}
 }
+
+// TestSearchFTSSyntaxQueryReturnsLiteralHits asserts a query containing FTS5
+// syntax (the ":" column operator) searches literally through the untyped
+// local path instead of raising a MATCH parse error.
+func TestSearchFTSSyntaxQueryReturnsLiteralHits(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "fts_cli_test.db")
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening temp store: %v", err)
+	}
+	defer s.Close()
+	if err := s.Upsert("movies", "9999", json.RawMessage(`{"id":9999,"title":"Space: 1999","type":"movie"}`)); err != nil {
+		t.Fatalf("upserting fixture: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("closing seed store: %v", err)
+	}
+
+	envelope := runSearch(t, dbPath, "Space: 1999", "--data-source", "local")
+	titles := titlesFromEnvelope(t, envelope)
+	if len(titles) != 1 || titles[0] != "Space: 1999" {
+		t.Fatalf("FTS-syntax query should return the literal hit, got %v", titles)
+	}
+}

--- a/library/media-and-entertainment/movie-goat/internal/store/store.go
+++ b/library/media-and-entertainment/movie-goat/internal/store/store.go
@@ -595,13 +595,16 @@ func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 	if limit <= 0 {
 		limit = 50
 	}
+	if strings.TrimSpace(query) == "" {
+		return []json.RawMessage{}, nil
+	}
 	rows, err := s.db.Query(
 		`SELECT r.data FROM resources r
 		 JOIN resources_fts f ON r.id = f.id
 		 WHERE resources_fts MATCH ?
 		 ORDER BY rank
 		 LIMIT ?`,
-		query, limit,
+		ftsSafeQuery(query), limit,
 	)
 	if err != nil {
 		return nil, err
@@ -616,7 +619,39 @@ func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 		}
 		results = append(results, json.RawMessage(data))
 	}
+	if results == nil {
+		results = []json.RawMessage{}
+	}
 	return results, rows.Err()
+}
+
+// ftsMetaChars are FTS5 query-language metacharacters. A token containing any
+// of these must be quoted so it is treated as literal text rather than syntax.
+const ftsMetaChars = "\"`():*/+-{}[]^~<>,'"
+
+// ftsKeywords are FTS5 boolean-operator keywords. A bare token equal to one of
+// these (case-insensitively) must be quoted or SQLite raises a MATCH parse
+// error.
+var ftsKeywords = map[string]bool{"and": true, "or": true, "not": true}
+
+// ftsSafeQuery neutralizes FTS5 query-language syntax in a user-supplied
+// search query while preserving implicit-AND semantics for ordinary multi-word
+// queries. A token is quoted (wrapped in double quotes, with embedded quotes
+// doubled per FTS5 string-literal rules) when it contains a metacharacter or
+// is a bare AND/OR/NOT keyword; syntax-free tokens pass through unchanged. A
+// whitespace-only query yields "" so the caller can short-circuit to an empty
+// result instead of constructing MATCH '""'.
+func ftsSafeQuery(query string) string {
+	if strings.TrimSpace(query) == "" {
+		return ""
+	}
+	tokens := strings.Fields(query)
+	for i, tok := range tokens {
+		if strings.ContainsAny(tok, ftsMetaChars) || ftsKeywords[strings.ToLower(tok)] {
+			tokens[i] = `"` + strings.ReplaceAll(tok, `"`, `""`) + `"`
+		}
+	}
+	return strings.Join(tokens, " ")
 }
 
 func extractObjectID(obj map[string]any) string {

--- a/library/media-and-entertainment/movie-goat/internal/store/store.go
+++ b/library/media-and-entertainment/movie-goat/internal/store/store.go
@@ -627,26 +627,28 @@ func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 
 // ftsMetaChars are FTS5 query-language metacharacters. A token containing any
 // of these must be quoted so it is treated as literal text rather than syntax.
-const ftsMetaChars = "\"`():*/+-{}[]^~<>,'"
+const ftsMetaChars = "\"`():*/+-{}[]^~<>,'&#?!@$%=;\\|."
 
-// ftsKeywords are FTS5 boolean-operator keywords. A bare token equal to one of
-// these (case-insensitively) must be quoted or SQLite raises a MATCH parse
-// error.
-var ftsKeywords = map[string]bool{"and": true, "or": true, "not": true}
+// ftsKeywords are FTS5 operator keywords. A bare token equal to one of these
+// (case-insensitively) must be quoted or SQLite interprets it as query
+// operators (NEAR/ANDNOT) instead of a literal term, which can raise a MATCH
+// parse error or silently change semantics.
+var ftsKeywords = map[string]bool{"and": true, "or": true, "not": true, "near": true, "andnot": true}
 
 // ftsSafeQuery neutralizes FTS5 query-language syntax in a user-supplied
 // search query while preserving implicit-AND semantics for ordinary multi-word
-// queries. A token is quoted (wrapped in double quotes, with embedded quotes
-// doubled per FTS5 string-literal rules) when it contains a metacharacter or
-// is a bare AND/OR/NOT keyword; syntax-free tokens pass through unchanged. A
-// whitespace-only query yields "" so the caller can short-circuit to an empty
-// result instead of constructing MATCH '""'.
+// queries and prefix search for trailing-* tokens. A token is quoted (wrapped
+// in double quotes, with embedded quotes doubled per FTS5 string-literal rules)
+// when it contains a metacharacter or is a bare AND/OR/NOT/NEAR/ANDNOT keyword;
+// syntax-free tokens pass through unchanged. A trailing-* prefix token with no
+// other metacharacter passes through unquoted so FTS5 keeps prefix semantics.
 func ftsSafeQuery(query string) string {
-	if strings.TrimSpace(query) == "" {
-		return ""
-	}
 	tokens := strings.Fields(query)
 	for i, tok := range tokens {
+		prefix := strings.TrimSuffix(tok, "*")
+		if prefix != tok && prefix != "" && !strings.ContainsAny(prefix, ftsMetaChars) {
+			continue // legal prefix search, e.g. "incept*"
+		}
 		if strings.ContainsAny(tok, ftsMetaChars) || ftsKeywords[strings.ToLower(tok)] {
 			tokens[i] = `"` + strings.ReplaceAll(tok, `"`, `""`) + `"`
 		}

--- a/library/media-and-entertainment/movie-goat/internal/store/store_fts_test.go
+++ b/library/media-and-entertainment/movie-goat/internal/store/store_fts_test.go
@@ -9,6 +9,7 @@ package store
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -30,6 +31,11 @@ func seedFTSStore(t *testing.T) *Store {
 		{"3", `{"id":3,"title":"Inception: Music from the Motion Picture","type":"movie"}`},
 		{"4", `{"id":4,"title":"A \"quoted\" title","type":"movie"}`},
 		{"5", `{"id":5,"title":"the movie inception is a film","type":"movie"}`},
+		{"6", `{"id":6,"title":"Lilo & Stitch","type":"movie"}`},
+		{"7", `{"id":7,"title":"Airplane!","type":"movie"}`},
+		{"8", `{"id":8,"title":"Who Framed Roger Rabbit?","type":"movie"}`},
+		{"9", `{"id":9,"title":"50% Off","type":"movie"}`},
+		{"10", `{"id":10,"title":"hello@example.com","type":"movie"}`},
 	}
 	for _, f := range fixtures {
 		if err := s.Upsert("movies", f.id, json.RawMessage(f.data)); err != nil {
@@ -52,10 +58,24 @@ func TestSearchFTSQueryEscapingNeverErrors(t *testing.T) {
 		"AND",
 		"OR",
 		"NOT",
+		"NEAR",
+		"ANDNOT",
+		"near moon",
 		"inception OR batman",
 		"NEAR/",
 		"^",
 		"{a b}",
+		"Lilo & Stitch",
+		"Airplane!",
+		"Who Framed Roger Rabbit?",
+		"50% Off",
+		"hello@example.com",
+		"e=mc2",
+		"a|b",
+		"a;b",
+		"a$b",
+		"a#b",
+		"a\\b",
 		"  ",
 	} {
 		got, err := s.Search(query, 50)
@@ -104,6 +124,29 @@ func TestSearchFTSQueryMultiWordAND(t *testing.T) {
 	// inception is a film") both contain both tokens non-adjacently.
 	if len(got) < 2 {
 		t.Fatalf("Search(inception movie) = %d rows, want >= 2 (implicit-AND preserved): %v", len(got), got)
+	}
+	// Every returned row must contain both tokens — pins AND, not OR.
+	for _, r := range got {
+		if !strings.Contains(string(r), "inception") && !strings.Contains(string(r), "Inception") {
+			t.Fatalf("Search(inception movie) returned a row without 'inception': %s", r)
+		}
+		if !strings.Contains(string(r), "movie") && !strings.Contains(string(r), "Movie") {
+			t.Fatalf("Search(inception movie) returned a row without 'movie': %s", r)
+		}
+	}
+}
+
+// TestSearchFTSPrefixSearch asserts a trailing-* prefix token keeps FTS5 prefix
+// semantics rather than being quoted into a literal.
+func TestSearchFTSPrefixSearch(t *testing.T) {
+	s := seedFTSStore(t)
+
+	got, err := s.Search("incept*", 50)
+	if err != nil {
+		t.Fatalf("Search(incept*) errored: %v", err)
+	}
+	if len(got) < 2 {
+		t.Fatalf("Search(incept*) = %d rows, want >= 2 (prefix search preserved): %v", len(got), got)
 	}
 }
 

--- a/library/media-and-entertainment/movie-goat/internal/store/store_fts_test.go
+++ b/library/media-and-entertainment/movie-goat/internal/store/store_fts_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Trevin Chow and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-written tests for the FTS5 query-escaping fix: a user query containing
+// FTS5 syntax (e.g. "Space: 1999", a bare AND/OR/NOT, quotes, wildcards) must
+// search literally and never raise a MATCH parse error, while ordinary
+// multi-word queries keep implicit-AND semantics.
+
+package store
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// seedFTSStore opens a temp-dir file-backed store with known titles.
+func seedFTSStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "fts_test.db"))
+	if err != nil {
+		t.Fatalf("opening temp store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	fixtures := []struct {
+		id   string
+		data string
+	}{
+		{"1", `{"id":1,"title":"Space: 1999","type":"movie"}`},
+		{"2", `{"id":2,"title":"Inception","type":"movie"}`},
+		{"3", `{"id":3,"title":"Inception: Music from the Motion Picture","type":"movie"}`},
+		{"4", `{"id":4,"title":"A \"quoted\" title","type":"movie"}`},
+		{"5", `{"id":5,"title":"the movie inception is a film","type":"movie"}`},
+	}
+	for _, f := range fixtures {
+		if err := s.Upsert("movies", f.id, json.RawMessage(f.data)); err != nil {
+			t.Fatalf("upserting fixture %s: %v", f.id, err)
+		}
+	}
+	return s
+}
+
+// TestSearchFTSQueryEscapingNeverErrors asserts that queries containing FTS5
+// syntax characters or bare keywords return rows-or-empty, never a MATCH parse
+// error.
+func TestSearchFTSQueryEscapingNeverErrors(t *testing.T) {
+	s := seedFTSStore(t)
+	for _, query := range []string{
+		"Space: 1999",
+		`A "quoted" title`,
+		`"`,
+		"*",
+		"AND",
+		"OR",
+		"NOT",
+		"inception OR batman",
+		"NEAR/",
+		"^",
+		"{a b}",
+		"  ",
+	} {
+		got, err := s.Search(query, 50)
+		if err != nil {
+			t.Fatalf("Search(%q) errored: %v", query, err)
+		}
+		if got == nil {
+			t.Fatalf("Search(%q) returned nil slice", query)
+		}
+	}
+}
+
+// TestSearchFTSQueryLiteralMatch asserts FTS-syntax queries match the literal
+// text they denote.
+func TestSearchFTSQueryLiteralMatch(t *testing.T) {
+	s := seedFTSStore(t)
+
+	got, err := s.Search("Space: 1999", 50)
+	if err != nil {
+		t.Fatalf("Search(Space: 1999) errored: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Search(Space: 1999) = %d rows, want 1", len(got))
+	}
+
+	got, err = s.Search(`A "quoted" title`, 50)
+	if err != nil {
+		t.Fatalf("Search(quoted title) errored: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Search(A \"quoted\" title) = %d rows, want 1", len(got))
+	}
+}
+
+// TestSearchFTSQueryMultiWordAND asserts ordinary multi-word queries keep
+// implicit-AND semantics: tokens may match anywhere in a row, not only as an
+// adjacent phrase.
+func TestSearchFTSQueryMultiWordAND(t *testing.T) {
+	s := seedFTSStore(t)
+
+	got, err := s.Search("inception movie", 50)
+	if err != nil {
+		t.Fatalf("Search(inception movie) errored: %v", err)
+	}
+	// Row 3 ("Inception: Music from the Motion Picture") and row 5 ("the movie
+	// inception is a film") both contain both tokens non-adjacently.
+	if len(got) < 2 {
+		t.Fatalf("Search(inception movie) = %d rows, want >= 2 (implicit-AND preserved): %v", len(got), got)
+	}
+}
+
+// TestSearchFTSEmptyQuery asserts an empty/whitespace query returns an empty
+// result rather than constructing MATCH '""'.
+func TestSearchFTSEmptyQuery(t *testing.T) {
+	s := seedFTSStore(t)
+	for _, query := range []string{"", "   "} {
+		got, err := s.Search(query, 50)
+		if err != nil {
+			t.Fatalf("Search(%q) errored: %v", query, err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("Search(%q) = %d rows, want 0", query, len(got))
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1848

`movie-goat-pp-cli search "<query>"` returned an empty `results: []` whenever it read from the local store — with explicit `--data-source local` and in the `auto`-mode fallback after an API failure. The command exited 0 either way, so a script saw a successful search over an empty corpus.

The generated search command's untyped branch (no `--type`) was a stub: it allocated a `seen` map, discarded it, and never assigned `results`. The `--type zzzz` path worked because an unrecognized type falls through to the generic `db.Search(query, limit)` arm and returns real FTS hits. The untyped branch now calls `db.Search(query, limit)` like the default arm, so offline search returns the same hits the typed search already returned.

While reviewing that fix, a second defect surfaced on the same path: a query containing FTS5 syntax — `Space: 1999` (the `:` is a column operator), `Lilo & Stitch`, a bare `AND`/`OR`/`NEAR`, quotes, or wildcards — was interpolated raw into the `MATCH` expression and raised a parse error, making the command exit. `Store.Search` now neutralizes the query before it becomes FTS5 syntax: tokens containing FTS5 metacharacters or bare operator keywords are quoted per token (embedded quotes doubled), while plain multi-word queries keep implicit-AND semantics and trailing-`*` prefix search is preserved. FTS-syntax queries now search literally and return rows or an empty array — never a parse error.

Regression tests cover:
- untyped `--data-source local` returns the same non-empty, ordered FTS hits as the `--type zzzz` control;
- the `auto` fallback (unreachable API, `--no-cache`) returns the same hits with `reason: api_unreachable`;
- a no-match query returns an empty array, not an error;
- a raw FTS-syntax query (`Space: 1999`) returns the literal hit through the untyped local path;
- the full FTS5 metacharacter set and bare `AND`/`OR`/`NOT`/`NEAR`/`ANDNOT` keywords return rows-or-empty with no MATCH parse error;
- plain multi-word queries keep implicit-AND; prefix search (`incept*`) is preserved.

The hand-edits to the generated files are recorded in `.printing-press-patches/search-untyped-local-results.json` per the repo convention.

## Checks

- `go build ./...` green from the CLI root
- `go vet ./...` green from the CLI root
- `go test -count=1 ./...` green from the CLI root (full module suite)
- store + CLI search tests pass (FTS5 escaping matrix, implicit-AND, prefix search, parity, auto fallback, no-match, literal FTS-syntax hit)
- patch ledger record added and canonical (normalize-patches output)
