### PR TITLE
fix(clinical-trials): score the registry's UNKNOWN status as an unknown state

### DIFF
--- a/library/health/clinical-trials/.printing-press-patches/risk-unknown-status-scores-as-unknown-state.json
+++ b/library/health/clinical-trials/.printing-press-patches/risk-unknown-status-scores-as-unknown-state.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "risk-unknown-status-scores-as-unknown-state",
+  "applied_at": "2026-09-01",
+  "base_run_id": "20260623-164233-df565e8d",
+  "base_printing_press_version": "4.25.0",
+  "summary": "scoreRisk's status switch must give ClinicalTrials.gov's UNKNOWN status its own branch, scored the same as a status that was never posted, rather than letting it reach the default arm at zero points.",
+  "reason": "UNKNOWN means a trial was last posted as recruiting and has passed its estimated completion date by over two years with no sponsor update, so its present state cannot be verified from the record. Falling to the default arm scored it 0 — below the 10 points this same switch gives a status that was never posted at all, although UNKNOWN asserts strictly more. Both now score 10 because both leave the current state unknown; a higher figure would claim stale trials terminate more often than unposted ones, which is not measured. Guarded by TestScoreRiskStatusFactorPoints and one case in TestNovelRiskBehavior.",
+  "files": ["internal/cli/risk.go", "internal/cli/risk_test.go"],
+  "validated_outcome": "go test ./internal/cli/ passes with per-branch status-factor assertions; renaming the UNKNOWN case fails three subtests, so the branch is genuinely guarded."
+}

--- a/library/health/clinical-trials/internal/cli/risk.go
+++ b/library/health/clinical-trials/internal/cli/risk.go
@@ -2,9 +2,10 @@
 
 // risk.go implements the `risk` command: an explainable, deterministic risk
 // read on a single trial. It fetches one study by NCT id, then scores it across
-// four observable signals — overall status / termination history, posted
-// enrollment, geographic breadth, and the lead sponsor's track record — and
-// returns each factor's contribution so the score is auditable, never a black box.
+// five observable signals — overall status / termination history, posted
+// enrollment, geographic breadth, the lead sponsor's track record, and trial
+// phase — and returns each factor's contribution so the score is auditable,
+// never a black box.
 package cli
 
 import (
@@ -39,10 +40,11 @@ func newNovelRiskCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "risk <nct-id>",
 		Short: "Get an explainable risk read on a single trial from termination, enrollment, site count, sponsor track record, and phase factor (earlier phases = higher risk).",
-		Long: "Score one trial's risk of failure across four observable signals — overall\n" +
-			"status / termination history, posted enrollment, geographic breadth, and the\n" +
-			"lead sponsor's track record. Each factor's point contribution is returned so\n" +
-			"the 0-100 score is fully explainable rather than a black box.",
+		Long: "Score one trial's risk of failure across five observable signals — overall\n" +
+			"status / termination history, posted enrollment, geographic breadth, the\n" +
+			"lead sponsor's track record, and trial phase. Each factor's point\n" +
+			"contribution is returned so the 0-100 score is fully explainable rather\n" +
+			"than a black box.",
 		Example: "  clinical-trials-pp-cli risk NCT07011732 --json\n" +
 			"  clinical-trials-pp-cli risk NCT04280705",
 		Args:        cobra.ExactArgs(1),
@@ -110,6 +112,19 @@ func scoreRisk(t Trial, sponsorTrials int) riskView {
 		v.Factors = append(v.Factors, riskFactor{Name: "status", Detail: detail, Points: 50})
 	case "COMPLETED":
 		v.Factors = append(v.Factors, riskFactor{Name: "status", Detail: "trial already completed; low forward risk", Points: 0})
+	case "UNKNOWN":
+		// The registry assigns UNKNOWN when a trial was last posted as
+		// recruiting and has passed its own estimated completion date by more
+		// than two years with no sponsor update. That is a different absence
+		// from the "" case below: there a status was never posted, here one was
+		// posted and has since gone stale, so the trial's present state cannot
+		// be verified from the record. Scored at the same 10 points because
+		// both describe an unknown current state; a higher figure would assert
+		// that stale trials terminate more often than unposted ones, which is
+		// not measured. Without this case UNKNOWN reached the default arm and
+		// scored 0 — less than a status that was never posted at all, which
+		// contradicts this table's own treatment of missing information.
+		v.Factors = append(v.Factors, riskFactor{Name: "status", Detail: "status not updated for over two years; current state unverifiable", Points: 10})
 	case "":
 		v.Factors = append(v.Factors, riskFactor{Name: "status", Detail: "overall status not posted", Points: 10})
 	default:

--- a/library/health/clinical-trials/internal/cli/risk_test.go
+++ b/library/health/clinical-trials/internal/cli/risk_test.go
@@ -93,6 +93,21 @@ func TestNovelRiskBehavior(t *testing.T) {
 			wantLevel:     "high",
 			minScore:      55, maxScore: 100,
 		},
+		{
+			// Identical to the healthy trial above except for the status, which
+			// the registry has marked UNKNOWN. Every other factor scores 0, so
+			// the whole score is the status factor and nothing else can mask a
+			// regression here.
+			name: "stale UNKNOWN status is the only risk signal",
+			trial: Trial{
+				NCTID: "NCT5", Status: "UNKNOWN", Enrollment: 500,
+				Countries: []string{"United States", "Germany"}, Phases: []string{"PHASE3"},
+				Sponsor: "Pfizer",
+			},
+			sponsorTrials: 200,
+			wantLevel:     "low",
+			minScore:      10, maxScore: 10,
+		},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -118,6 +133,75 @@ func TestNovelRiskBehavior(t *testing.T) {
 			}
 			if v.Score != sum {
 				t.Errorf("score %d != capped factor sum %d", v.Score, sum)
+			}
+		})
+	}
+}
+
+// TestScoreRiskStatusFactorPoints pins the point value of every status branch
+// by name, which the table test above cannot do: that one reads only the total
+// and the bucket, so a status arm could lose or gain points and stay inside its
+// range as long as another factor moved the other way.
+//
+// UNKNOWN is the case this test was written for. The registry assigns it when a
+// trial was last posted as recruiting and has passed its estimated completion
+// date by more than two years with no update, and 97,164 studies carry it. It
+// had no branch of its own and reached the default arm at 0 points — below the
+// 10 given to a trial whose status was never posted, though UNKNOWN says strictly
+// more: a status was posted and has since stopped being true. Both now score 10,
+// since both leave the current state unknown.
+//
+// The default arm is asserted alongside it so a later reader can see that 0 is
+// deliberate for a live, self-reported status — not the same silence UNKNOWN used
+// to fall into.
+func TestScoreRiskStatusFactorPoints(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     string
+		whyStopped string
+		wantPoints int
+	}{
+		{name: "recruiting", status: "RECRUITING", wantPoints: 0},
+		{name: "active not recruiting", status: "ACTIVE_NOT_RECRUITING", wantPoints: 0},
+		{name: "completed", status: "COMPLETED", wantPoints: 0},
+		{name: "terminated", status: "TERMINATED", whyStopped: "lack of efficacy", wantPoints: 50},
+		{name: "withdrawn", status: "WITHDRAWN", wantPoints: 50},
+		{name: "suspended", status: "SUSPENDED", wantPoints: 50},
+		{name: "unknown", status: "UNKNOWN", wantPoints: 10},
+		{name: "lowercase unknown is upcased before matching", status: "unknown", wantPoints: 10},
+		{name: "status not posted", status: "", wantPoints: 10},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Every other factor is deliberately at 0 points, so the status
+			// factor is isolated.
+			trial := Trial{
+				NCTID: "NCT0", Status: tc.status, WhyStopped: tc.whyStopped,
+				Enrollment: 500, Countries: []string{"United States", "Germany"},
+				Phases: []string{"PHASE3"}, Sponsor: "Acme",
+			}
+			v := scoreRisk(trial, 100)
+			var status *riskFactor
+			for i := range v.Factors {
+				if v.Factors[i].Name == "status" {
+					status = &v.Factors[i]
+					break
+				}
+			}
+			if status == nil {
+				t.Fatalf("status %q: no %q factor entry in %+v", tc.status, "status", v.Factors)
+			}
+			if status.Points != tc.wantPoints {
+				t.Errorf("status %q: status factor points = %d, want %d", tc.status, status.Points, tc.wantPoints)
+			}
+			if status.Detail == "" {
+				t.Errorf("status %q: status factor has empty detail", tc.status)
+			}
+			// With every other factor at 0, the total IS the status factor.
+			if v.Score != tc.wantPoints {
+				t.Errorf("status %q: score = %d, want %d (other factors should contribute 0)", tc.status, v.Score, tc.wantPoints)
 			}
 		})
 	}


### PR DESCRIPTION
## What

`scoreRisk`'s status switch has no branch for ClinicalTrials.gov's `UNKNOWN`
status, so it reaches the `default` arm and scores **0 points** — the same as an
actively recruiting trial.

The registry assigns `UNKNOWN` when a trial was last posted as recruiting and has
passed its own estimated completion date by more than two years with no sponsor
update. **97,164 studies currently carry it**
(`filter.overallStatus=UNKNOWN&countTotal=true`).

## Why it is wrong on the switch's own terms

The very next case in the same switch gives **10 points** to a status that was
never posted:

```go
case "":
    // "overall status not posted", Points: 10
```

So a trial that withholds its status scores higher than one that posted a status
which has since stopped being true — although `UNKNOWN` asserts strictly more.
Both leave the present state unverifiable from the record.

## The change

A `case "UNKNOWN"` branch scoring **10**, deliberately equal to the unposted case
rather than above it. A higher figure would assert that stale trials terminate
more often than trials whose status was never posted, and nothing here measures
that.

## This rewrites past verdicts

A trial whose only other signals are a single country (8) and an unposted phase
(5) moves from **21 to 31**, crossing the low/moderate boundary at 25. That is the
intended effect — a trial nobody has updated in over two years should not read as
low risk — but it is a behaviour change, not a no-op, and reviewers should weigh
it as one.

## Tests

Two, because neither is sufficient alone:

- a case in `TestNovelRiskBehavior` runs the whole of `scoreRisk` with every other
  factor at zero, so the total **is** the status factor (`minScore`/`maxScore` both
  10, not a range)
- `TestScoreRiskStatusFactorPoints` pins every status arm by name — the table test
  reads only the total and the bucket, so one arm could shift while another moved
  the opposite way and stay inside its range

**Mutation check:** renaming the case to `UNKNOWN_MUTATION_TEST` (so the file still
compiles but `UNKNOWN` falls through to `default`) fails three subtests:

```
--- FAIL: TestNovelRiskBehavior/stale_UNKNOWN_status_is_the_only_risk_signal
    score = 0, want in [10,10]
--- FAIL: TestScoreRiskStatusFactorPoints/unknown
    status factor points = 0, want 10
--- FAIL: TestScoreRiskStatusFactorPoints/lowercase_unknown_is_upcased_before_matching
    status factor points = 0, want 10
```

Restoring the case returns `internal/cli` to green.
## Also in this PR

The doc comment and `--help` text said the command scores **four** signals. It
scores five; the phase factor was added later and the prose was not updated. No
test asserted on that string, so nothing else moved.

## Ledger

`.printing-press-patches/risk-unknown-status-scores-as-unknown-state.json`

## Note on the test run

`go test ./...` on this module also fails five pre-existing tests in
`internal/cliutil` and `internal/mcp`, all about home-directory and tilde path
resolution on Windows. They fail identically on unmodified `main` (verified with
`git stash`) and are unrelated to this change. `internal/cli` is green.

