### PR TITLE
docs(amazon-orders): clarify headless auth validation (leftover from #1007)

### DIFF
--- a/library/commerce/amazon-orders/SKILL.md
+++ b/library/commerce/amazon-orders/SKILL.md
@@ -281,7 +281,7 @@ If `doctor` reports a stale or missing browser-session proof, refresh from a cur
 
 ```bash
 python3 -m pip install --user pycookiecheat  # if doctor says cookie_tool not found
-export PATH="$PATH:$HOME/go/bin:$HOME/Library/Python/3.9/bin"
+export PATH="$PATH:$HOME/go/bin:$(python3 -m site --user-base)/bin"
 amazon-orders-pp-cli auth login --chrome --no-input --yes
 amazon-orders-pp-cli doctor --agent
 ```
@@ -289,7 +289,7 @@ amazon-orders-pp-cli doctor --agent
 If new cookies were captured from Chrome and you want other headless agents to use them, update the 1Password document without printing cookie contents:
 
 ```bash
-TMP=$(mktemp -t amazon-orders-session.XXXXXX.json)
+TMP=$(mktemp "${TMPDIR:-/tmp}/amazon-orders-session.XXXXXX")
 chmod 600 "$TMP"
 amazon-orders-pp-cli auth export --output "$TMP" --note "captured $(date -u +%FT%TZ) from $(hostname)"
 op document edit 'amazon-orders-session' --vault Agent "$TMP"

--- a/library/commerce/amazon-orders/SKILL.md
+++ b/library/commerce/amazon-orders/SKILL.md
@@ -268,7 +268,33 @@ op read "op://Agent/amazon-orders-session/file" \
   | amazon-orders-pp-cli auth import --stdin
 ```
 
-Either form lands the cookie material in `~/.config/amazon-orders-pp-cli/config.toml` and you're authenticated. Validate with `amazon-orders-pp-cli auth status`.
+Either form lands the cookie material in `~/.config/amazon-orders-pp-cli/config.toml` and you're authenticated. Validate with both:
+
+```bash
+amazon-orders-pp-cli auth status
+amazon-orders-pp-cli doctor --agent
+```
+
+`auth status` only confirms that cookie material is configured. It can say `Authenticated` while `doctor` still reports `browser_session_proof` as missing/stale; in that state live commands can return empty or `null` results instead of orders. Treat `doctor` as the end-to-end validation step for headless 1Password imports.
+
+If `doctor` reports a stale or missing browser-session proof, refresh from a currently logged-in Chrome profile and re-run `doctor`:
+
+```bash
+python3 -m pip install --user pycookiecheat  # if doctor says cookie_tool not found
+export PATH="$PATH:$HOME/go/bin:$HOME/Library/Python/3.9/bin"
+amazon-orders-pp-cli auth login --chrome --no-input --yes
+amazon-orders-pp-cli doctor --agent
+```
+
+If new cookies were captured from Chrome and you want other headless agents to use them, update the 1Password document without printing cookie contents:
+
+```bash
+TMP=$(mktemp -t amazon-orders-session.XXXXXX.json)
+chmod 600 "$TMP"
+amazon-orders-pp-cli auth export --output "$TMP" --note "captured $(date -u +%FT%TZ) from $(hostname)"
+op document edit 'amazon-orders-session' --vault Agent "$TMP"
+shred -u "$TMP" 2>/dev/null || rm -f "$TMP"
+```
 
 **Refresh when Amazon rotates `session-id`** (typically every few weeks; signaled by 401s from `orders list`):
 

--- a/library/commerce/amazon-orders/SKILL.md
+++ b/library/commerce/amazon-orders/SKILL.md
@@ -291,8 +291,8 @@ If new cookies were captured from Chrome and you want other headless agents to u
 ```bash
 TMP=$(mktemp "${TMPDIR:-/tmp}/amazon-orders-session.XXXXXX")
 chmod 600 "$TMP"
-amazon-orders-pp-cli auth export --output "$TMP" --note "captured $(date -u +%FT%TZ) from $(hostname)"
-op document edit 'amazon-orders-session' --vault Agent "$TMP"
+amazon-orders-pp-cli auth export --output "$TMP" --note "captured $(date -u +%FT%TZ) from $(hostname)" &&
+  op document edit 'amazon-orders-session' --vault Agent "$TMP"
 shred -u "$TMP" 2>/dev/null || rm -f "$TMP"
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Origin leftover from [#1007](https://github.com/mvanhorn/printing-press-library/pull/1007) by [@bwishan](https://github.com/bwishan) (Brian Wishan).

#1007 is a fork PR (`bwishan:docs/amazon-orders-auth-proof`) that is DIRTY against `main`. This branch starts from current `main` and lands **only** the SKILL.md headless-auth clarification. It does **not** touch repo-root `.go-version`.

Leave [#1007](https://github.com/mvanhorn/printing-press-library/pull/1007) open. Do not close it from this leftover.

## Original work (#1007)

After a 1Password `auth import`, `auth status` only checks that cookie material is configured. It can report `Authenticated` while `doctor` still reports `browser_session_proof` as missing/stale, and live commands then return empty/`null` instead of orders.

The amazon-orders skill now:

- Treats `doctor --agent` as the end-to-end validation step for headless 1Password imports
- Documents the stale/missing `browser_session_proof` pitfall
- Shows a Chrome refresh via `pycookiecheat` + `auth login --chrome`
- Shows how to update the 1Password document without printing cookie contents

Original commit preserved: `docs(amazon-orders): clarify headless auth validation` by Brian Wishan.

## Maintainer leftover

Two Greptile P1s from #1007, applied only in the **new** recipes (the pre-existing stash snippet on main is unchanged):

- PATH uses `$(python3 -m site --user-base)/bin` instead of a macOS/Python 3.9-pinned `$HOME/Library/Python/3.9/bin`
- `mktemp` uses `"${TMPDIR:-/tmp}/amazon-orders-session.XXXXXX"` so GNU and BSD `mktemp` both accept the template

## Intentionally omitted

- Repo-root `.go-version` — already on main (`1.26.6`). Verify uses `go-version-file: .go-version`. Greptile's "remove this file" finding on #1007 is stale.
- `.github/workflows/**`, `registry.json`, `cli-skills/**`, other CLIs, release-ledger files

No push to `bwishan/printing-press-library`.

## Validation

- [x] Diff vs `main` is `library/commerce/amazon-orders/SKILL.md` only
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/commerce/amazon-orders/`
- [x] `git diff --check`

## Gaps / Follow-Up

- #1007 remains the original fork PR. Close or supersede it after this lands; do not rebase that fork.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cb6014a-443b-4cd8-8b7e-dc94b14a4488?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cb6014a-443b-4cd8-8b7e-dc94b14a4488&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

