### PR TITLE
fix(clinical-trials): align the Go floor with its siblings and drop a dead toolchain line

### DIFF
--- a/library/health/clinical-trials/README.md
+++ b/library/health/clinical-trials/README.md
@@ -37,7 +37,7 @@ npx -y @mvanhorn/printing-press-library install clinical-trials --agent claude-c
 
 ### Without Node (Go fallback)
 
-If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.4 or newer):
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.6 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/health/clinical-trials/cmd/clinical-trials-pp-cli@latest

--- a/library/health/clinical-trials/SKILL.md
+++ b/library/health/clinical-trials/SKILL.md
@@ -29,7 +29,7 @@ This skill drives the `clinical-trials-pp-cli` binary. **You must verify the CLI
 2. Verify: `clinical-trials-pp-cli --version`
 3. Ensure the reported install directory is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.4 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.6 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/health/clinical-trials/cmd/clinical-trials-pp-cli@latest

--- a/library/health/clinical-trials/go.mod
+++ b/library/health/clinical-trials/go.mod
@@ -1,8 +1,7 @@
 module github.com/mvanhorn/printing-press-library/library/health/clinical-trials
 
-go 1.26.5
+go 1.26.6
 
-toolchain go1.26.4
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4


### PR DESCRIPTION
## What

Three places in this module name three different Go versions:

| Where | Says |
|---|---|
| `go.mod` `go` directive | 1.26.5 |
| `go.mod` `toolchain` directive | go1.26.4 |
| `README.md` and `SKILL.md` | "requires Go 1.26.4 or newer" |

All six sibling CLIs — thelancet, drug-enforcement, grants, nejm,
retraction-checker, scientific-consensus — declare `go 1.26.6` and carry no
toolchain directive.

## The toolchain line was dead

`toolchain go1.26.4` sits below the `go 1.26.5` floor above it. Toolchain
selection takes the higher of the two, so the directive changed nothing.

#1737 removed redundant toolchain directives across the library on 2026-08-17.
This CLI landed on main three days later (#1356, 2026-08-20) and was not in
that sweep. The docs then took their number from the lowest of the three
declarations, which is how they came to advertise 1.26.4 — a version no part of
the build actually requires.

## On the security evidence — I am not repeating it

#1757 raised nejm's floor to 1.26.6 citing five reachable stdlib
vulnerabilities (GO-2026-6218, 6090, 6089, 5972, 5026).

Running `govulncheck ./...` on this module today reports **No vulnerabilities
found** — but `-show verbose` shows why that is not evidence either way:

Govulncheck scanned the following 20 modules and the go1.27.0 standard library


It scans against the newest stdlib available to it, not against the floor the
module declares. A clean result here says nothing about what 1.26.5 exposes, so
I cannot reproduce #1757's measurement and am not going to assert it second
hand.

The case this PR actually rests on is consistency: one module out of seven on
an older floor, a directive that does nothing, and documentation naming a third
version.

## Verification

go build ./... ok
go test ./internal/cli/ -count=1 ok
govulncheck ./... No vulnerabilities found


## No ledger entry

`go.mod` is not under `internal/cli/`, and AGENTS.md:256 places README and
SKILL.md edits outside the patch convention ("SKILL.md / README.md edits are
owned by `tools/sweep-canonical/` or direct edit and don't need a patch
entry"). The `cli-skills/` mirror is untouched.