### PR TITLE
feat(kvmctl): add OCR-grounded observation loop

### DIFF
--- a/library/devices/kvmctl/.printing-press-patches/20260902-ocr-observation-boundary.json
+++ b/library/devices/kvmctl/.printing-press-patches/20260902-ocr-observation-boundary.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "20260902-ocr-observation-boundary",
+  "applied_at": "2026-09-02",
+  "base_run_id": "20260831-161927",
+  "base_printing_press_version": "4.31.3",
+  "files": [
+    "internal/ocr/engine.go",
+    "internal/ocr/observation.go"
+  ],
+  "summary": "Preserve an opt-in argv-only OCR engine with strict evidence parsing and a short-lived bounded in-memory observation store.",
+  "reason": "OCR observations must be grounded in configured executable output and expire before they can authorize stale screen actions.",
+  "validated_outcome": "Focused OCR tests and race test exercise real local Tesseract TSV input, strict JSON rejection, deterministic evidence hashes, expiration, eviction, and defensive copying."
+}

--- a/library/devices/kvmctl/.printing-press-patches/ocr-observation-loop-presentation-is-write-gated.json
+++ b/library/devices/kvmctl/.printing-press-patches/ocr-observation-loop-presentation-is-write-gated.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "ocr-observation-loop-presentation-is-write-gated",
+  "applied_at": "2026-09-02",
+  "base_run_id": "20260831-161927",
+  "base_printing_press_version": "4.31.3",
+  "summary": "A regen must preserve the intent-level observe, verify, and act command tree over the fail-closed semantic OCR observation loop.",
+  "reason": "Agents need discoverable commands that forward only the approved OCR operations while requiring an explicit observation ID and --yes before any HID mutation; generic JSON arguments obscure both requirements.",
+  "files": [
+    "internal/cli/ocr_loop_novel.go",
+    "internal/cli/ocr_loop_novel_test.go",
+    "internal/mcp/semantic_novel.go",
+    "internal/mcp/semantic_novel_test.go"
+  ],
+  "validated_outcome": "Focused CLI and MCP tests cover command discovery, argument forwarding, and both write gates; full Go test, vet, build, CLI help, and MCP tool-schema smoke are run before commit."
+}

--- a/library/devices/kvmctl/.printing-press-patches/semantic-ocr-actions-require-fresh-evidence.json
+++ b/library/devices/kvmctl/.printing-press-patches/semantic-ocr-actions-require-fresh-evidence.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "semantic-ocr-actions-require-fresh-evidence",
+  "applied_at": "2026-09-02",
+  "base_run_id": "20260831-161927",
+  "base_printing_press_version": "4.31.3",
+  "summary": "Semantic OCR actions must consume fresh, configured OCR observations and fail closed rather than inventing screen evidence.",
+  "reason": "KVMD snapshots and OCR are the safety boundary for text-directed mouse and keyboard actions; preserving observation IDs, exact high-confidence matching, write gating, and post-action recapture prevents stale or fabricated UI evidence from driving HID input.",
+  "files": [
+    "internal/semantic/dispatch.go",
+    "internal/semantic/ocr_loop.go"
+  ],
+  "validated_outcome": "go test ./... passes, including httptest-backed semantic observation, action, ambiguity, and unavailable-evidence coverage."
+}

--- a/library/devices/kvmctl/README.md
+++ b/library/devices/kvmctl/README.md
@@ -133,6 +133,25 @@ kvmctl-pp-cli semantic host-identity --agent
 
 The MCP server exposes the same structured `semantic_dispatch` surface for agents.
 
+### OCR observation loop
+
+Use the purpose-built commands for the bounded observe → act → verify loop. They delegate only to the semantic core; they are not a planner and never infer a next UI action.
+
+```bash
+# Configure a local OCR command. It receives screenshot bytes on stdin.
+export KVMCTL_OCR_COMMAND=tesseract
+export KVMCTL_OCR_PROTOCOL=json
+
+kvmctl-pp-cli observe --agent
+kvmctl-pp-cli act click-text "Advanced" --observation <observation-id> --yes --agent
+kvmctl-pp-cli act press-key F10 --observation <observation-id> --yes --agent
+kvmctl-pp-cli verify --expect-text "Save Changes" --agent
+```
+
+`observe` returns the OCR observation ID. Both actions require that exact `--observation` value and explicit `--yes`; the semantic core captures the screen again and refuses a stale, unavailable, ambiguous, or non-matching observation. `verify` always captures a new observation and checks one exact high-confidence text match. `KVMCTL_OCR_PROTOCOL=json` selects the JSON OCR protocol expected by the configured command. These commands have automated HTTP/OCR fixtures only; no live BIOS interaction is claimed.
+
+For MCP, call `semantic_dispatch` with `operation: "observe"`, `"verify-text"`, `"click-text"`, or `"press-key"`. The tool schema describes the required arguments; mutating operations additionally need `arguments.write_enabled: true` and the MCP host must permit writes with `KVMCTL_WRITE_ENABLED=1`.
+
 ### Immutable workflows
 
 Workflows are loaded from JSON, listed deterministically, inspected with action values redacted, authorized once, and then executed only against the resolved target and revision.
@@ -205,6 +224,8 @@ Supported environment variables include:
 | `KVMCTL_STATE_DIR` | override runtime state directory |
 | `KVMCTL_CACHE_DIR` | override cache directory |
 | `KVMCTL_NO_LEARN` | disable the local learning loop |
+| `KVMCTL_OCR_COMMAND` | local OCR executable; it receives fresh screenshot bytes on stdin |
+| `KVMCTL_OCR_PROTOCOL` | OCR response protocol (`json` for the structured observation loop) |
 | `KVMCTL_LOCK_DIR` | shared directory used to serialize physical device actions (default `/tmp/kvmctl-locks`) |
 
 For MCP, put these variables in the host's MCP server environment. The MCP binary does not receive CLI flags.

--- a/library/devices/kvmctl/SKILL.md
+++ b/library/devices/kvmctl/SKILL.md
@@ -73,6 +73,25 @@ These capabilities aren't available in any other tool for this API.
   kvmctl-pp-cli semantic verify --agent
   ```
 
+### OCR observation loop
+
+Use this exact non-planning loop when an operator has already chosen the intended UI action:
+
+```bash
+# The OCR command receives fresh screenshot bytes on stdin and emits JSON OCR.
+export KVMCTL_OCR_COMMAND=tesseract
+export KVMCTL_OCR_PROTOCOL=json
+
+kvmctl-pp-cli observe --agent
+kvmctl-pp-cli act click-text "Advanced" --observation <observation-id> --yes --agent
+kvmctl-pp-cli act press-key F10 --observation <observation-id> --yes --agent
+kvmctl-pp-cli verify --expect-text "Save Changes" --agent
+```
+
+`observe` is read-only and returns an observation ID. `act click-text` and `act press-key` reject requests without both `--yes` and `--observation`; the semantic core then recaptures the screen and refuses stale, unavailable, ambiguous, or non-matching evidence. `verify` captures a new image and accepts only one exact high-confidence text match. Do not convert OCR output into an autonomous plan or guess another action. These commands have fixture-backed tests; no live BIOS test is claimed.
+
+For MCP, use `semantic_dispatch`: `observe` takes no arguments; `verify-text` needs `arguments.text`; `click-text` needs `arguments.text`, `arguments.observation_id`, and `arguments.write_enabled=true`; `press-key` needs `arguments.key`, `arguments.observation_id`, and `arguments.write_enabled=true`. The MCP host must also set `KVMCTL_WRITE_ENABLED=1` for mutating operations.
+
 ## Command Reference
 
 **hid** — Manage hid

--- a/library/devices/kvmctl/docs/superpowers/specs/2026-09-01-ocr-observation-loop-design.md
+++ b/library/devices/kvmctl/docs/superpowers/specs/2026-09-01-ocr-observation-loop-design.md
@@ -1,0 +1,103 @@
+# OCR Observation Loop Design
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Give an LLM planner grounded, fail-closed screen perception and bounded KVM actions without embedding BIOS knowledge or a goal planner in `kvmctl`.
+
+**Architecture:** The LLM owns intent and chooses each next step. `kvmctl` owns fresh screen capture, real OCR, immutable observation evidence, exact/unique text resolution, observation-bound HID execution, and post-action verification. It never translates a goal such as “enable IOMMU” into BIOS navigation or reports invented OCR/UI state.
+
+**Tech Stack:** Go; KVMD streamer snapshot and HID APIs; existing `internal/ocr` contracts; optional external OCR executable invoked only when configured; CLI/MCP semantic dispatcher; SHA-256 evidence hashes.
+
+---
+
+## Scope
+
+The first slice adds four primitives to the semantic CLI/MCP surface:
+
+- `kvm_observe`: capture a fresh snapshot, perform real OCR, and return an observation ID, image hash, timestamp, image dimensions, and bounded OCR regions.
+- `kvm_click_text`: accept `text`, `observation_id`, and `--yes`; recapture the current screen, reject it if its image hash differs from the referenced observation, require exactly one OCR match above threshold, then click the text region’s center.
+- `kvm_press_key`: accept `key`, `observation_id`, and `--yes`; recapture and require the same current image before sending the bounded HID key tap.
+- `kvm_verify_text`: capture a fresh observation and report whether one expected text assertion and optional forbidden assertions are satisfied. It does not mutate hardware.
+
+All returned observations and actions are evidence envelopes with operation, timestamp, source observation ID, image hashes, candidate/match data, and failure reason. A mutation requires `--yes` through the existing CLI and `write_enabled` through the dispatcher/MCP path.
+
+## Explicit non-goals
+
+- No direct BIOS-setting API.
+- No LLM API key, prompt, planner, or autonomous multi-step controller in `kvmctl`.
+- No OCR fallback that fabricates text, coordinates, dimensions, or success when OCR is unavailable.
+- No stale-screen coordinate action.
+- No click selection heuristic when OCR has zero or multiple eligible matches.
+- No remote write in an observe/verify command.
+
+## OCR runtime contract
+
+`internal/ocr` remains the pure analysis boundary. A production engine implementation invokes an explicitly configured OCR executable (`KVMCTL_OCR_COMMAND`) with a bounded input/output protocol, or returns a typed `ocr_unavailable` result when it is absent/fails. It must return image dimensions and word-level text, confidence, and bounding boxes; stdout is parsed as a documented JSON schema. Test engines are injected and do not stand in for live OCR claims.
+
+This avoids choosing a platform-specific OCR library or silently depending on a globally installed Tesseract binary. `kvmctl observe` must expose the actual engine name/version (when available) and the source image hash. It must not return a placeholder such as `ocr-bytes-N`.
+
+## Observation validity
+
+An observation is canonical JSON, SHA-256 identified, and includes:
+
+```json
+{
+  "observation_id": "sha256:<hash>",
+  "captured_at": "RFC3339Nano UTC",
+  "image_sha256": "<hex>",
+  "width": 1920,
+  "height": 1080,
+  "ocr": {"engine": "…", "regions": [{"text":"Advanced","confidence":95.2,"box":[…],"pixel":[…]}]}
+}
+```
+
+The process-local observation store is bounded (TTL ≤60 seconds, bounded entry count) and defensive-copies data. An action receives the observation ID; `kvmctl` retrieves it, captures a new image, hashes it, and refuses if it differs. The store does not contain credentials. An expired/missing observation is rejected.
+
+For exact state stability, a byte-level image hash is used in v1. This deliberately fails closed on video noise or cursor movement. A future policy can add perceptual comparison only with separate safety evidence and tests.
+
+## Click and key execution
+
+`click-text` resolves case-insensitive substring matching only in the referenced observation. It uses the existing ≥30 confidence floor plus a configurable high-confidence default (80) for physical action. The match count must equal one. The click target is derived from the OCR box’s center; no center-of-screen default exists. The current-image preflight happens immediately before HID input. Mouse press and release errors are propagated; a release is attempted after a successful press.
+
+`press-key` is intentionally smaller: accepted key name, fresh-observation preflight, HID down/up, and evidence. It does not infer hotkeys or navigation sequences.
+
+## Verification
+
+`verify-text` always obtains a new observation. It accepts a required `expect_text` and optional bounded `forbid_text[]`. Its output distinguishes `matched`, `missing_expected`, `forbidden_present`, `ocr_unavailable`, and `capture_failed`. It never calls HID APIs and does not claim that a BIOS value changed—only that observed OCR text meets the requested assertion.
+
+## CLI and MCP surface
+
+Expose dedicated human commands under `kvmctl-pp-cli observe`, `act click-text`, `act press-key`, and `verify-text`, plus equivalent semantic/MCP operations. Each command prints structured JSON with `--agent`/`--json`. Help includes examples showing the observation ID flow. `act` commands require `--yes`; the runtime MCP metadata must classify them as external writes.
+
+## Testing and validation
+
+Use strict TDD. Tests must first fail against the current placeholder implementation and exercise real package boundaries using `httptest` snapshots plus injected OCR engines/command fixtures.
+
+Required cases:
+
+1. observe emits OCR text/boxes and hashes from actual snapshot bytes; OCR absence/failure is explicit, never fabricated.
+2. text click rejects missing, expired, altered, ambiguous, and low-confidence observations without emitting HID requests.
+3. a unique text match produces the exact box-center HID mouse request only after a fresh-image hash match and explicit write authorization.
+4. key press rejects stale observations and sends down/up only after authorization and hash match.
+5. verify-text returns correct expected/forbidden states from a fresh observation and is never write-gated.
+6. all evidence/journal output redacts secrets and bounds text/regions.
+7. CLI help/flag behavior and MCP registration agree with semantic behavior.
+8. live acceptance remains separate: run one read-only observation against KVMD only after source changes settle; no BIOS action or key/mouse write is performed as part of acceptance.
+
+Full gates: `gofmt -l .`, focused package tests, `go test ./...`, `go vet ./...`, `go build ./...`, race test for the observation store, Windows/Linux/macOS cross-builds, `git diff --check`, Printing Press package/policy validators, and fresh Phase 5/live proof only if source fingerprint rules require it.
+
+## Files expected to change
+
+- `internal/ocr/`: observation model, production-engine boundary, store, and tests.
+- `internal/semantic/dispatch.go`: replace placeholder OCR handlers; add observation/action/verification operations.
+- `internal/semantic/*_test.go`: dispatcher and HTTP/HID integration tests.
+- `internal/cli/semantic_novel.go` and/or dedicated novel command file: flags, help, and action gating.
+- `internal/mcp/semantic_novel.go`: typed metadata and write classification.
+- `README.md`, `SKILL.md`, and `.printing-press-patches/<id>.json`: documented contract and durable generated-tree patch record.
+
+## Risks and trade-offs
+
+- OCR quality is hardware/font dependent. The v1 contract fails closed; the LLM receives uncertainty and selects the next safe observation, not a guessed click.
+- Screenshot byte hashes are strict. This may stop actions on animated/noisy screens, which is preferable to acting on stale evidence.
+- A generic OCR command runner introduces an external dependency; it is opt-in, schema-validated, timeout-bounded, and never an implicit placeholder.
+- Cross-process observation reuse is intentionally excluded in v1. The observation ID is a short-lived proof tied to the running process and current screen.

--- a/library/devices/kvmctl/internal/cli/ocr_loop_novel.go
+++ b/library/devices/kvmctl/internal/cli/ocr_loop_novel.go
@@ -1,0 +1,111 @@
+// PATCH(library): present the bounded OCR observation loop as intent-level commands.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/devices/kvmctl/internal/semantic"
+	"github.com/spf13/cobra"
+)
+
+func init() { registerNovelCommand(registerOCRLoopCommands) }
+
+// pp:data-source live
+func registerOCRLoopCommands(root *cobra.Command, flags *rootFlags) {
+	observe := &cobra.Command{
+		Use:         "observe",
+		Short:       "Capture a fresh screenshot and OCR observation",
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{"pp:novel": "true", "mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return dispatchOCRPresentation(cmd, flags, "observe", nil)
+		},
+	}
+
+	verify := &cobra.Command{
+		Use:         "verify",
+		Short:       "Verify exact high-confidence text in a fresh observation",
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{"pp:novel": "true", "mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			expected, _ := cmd.Flags().GetString("expect-text")
+			return dispatchOCRPresentation(cmd, flags, "verify-text", map[string]any{"text": expected})
+		},
+	}
+	verify.Flags().String("expect-text", "", "exact text expected in the fresh OCR observation")
+	_ = verify.MarkFlagRequired("expect-text")
+
+	act := &cobra.Command{
+		Use:         "act",
+		Short:       "Perform an OCR-observation-gated KVM action",
+		Annotations: map[string]string{"pp:novel": "true"},
+	}
+	act.AddCommand(newOCRClickTextCommand(flags), newOCRPressKeyCommand(flags))
+
+	addNovelCommandIfAbsent(root, observe)
+	addNovelCommandIfAbsent(root, verify)
+	addNovelCommandIfAbsent(root, act)
+}
+
+func newOCRClickTextCommand(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "click-text <text>",
+		Short:       "Click one exact high-confidence OCR text match",
+		Args:        cobra.ExactArgs(1),
+		Annotations: map[string]string{"pp:novel": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			observation, err := requiredObservationFlag(cmd, flags)
+			if err != nil {
+				return err
+			}
+			return dispatchOCRPresentation(cmd, flags, "click-text", map[string]any{"text": args[0], "observation_id": observation, "write_enabled": true})
+		},
+	}
+	cmd.Flags().String("observation", "", "observation ID returned by kvmctl observe")
+	_ = cmd.MarkFlagRequired("observation")
+	return cmd
+}
+
+func newOCRPressKeyCommand(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "press-key <key>",
+		Short:       "Press an allowed key against one fresh OCR observation",
+		Args:        cobra.ExactArgs(1),
+		Annotations: map[string]string{"pp:novel": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			observation, err := requiredObservationFlag(cmd, flags)
+			if err != nil {
+				return err
+			}
+			return dispatchOCRPresentation(cmd, flags, "press-key", map[string]any{"key": args[0], "observation_id": observation, "write_enabled": true})
+		},
+	}
+	cmd.Flags().String("observation", "", "observation ID returned by kvmctl observe")
+	_ = cmd.MarkFlagRequired("observation")
+	return cmd
+}
+
+func requiredObservationFlag(cmd *cobra.Command, flags *rootFlags) (string, error) {
+	if !flags.yes {
+		return "", usageErr(fmt.Errorf("--yes is required for %s (write-gated)", cmd.CommandPath()))
+	}
+	observation, _ := cmd.Flags().GetString("observation")
+	if strings.TrimSpace(observation) == "" {
+		return "", usageErr(fmt.Errorf("--observation is required for %s", cmd.CommandPath()))
+	}
+	return observation, nil
+}
+
+func dispatchOCRPresentation(cmd *cobra.Command, flags *rootFlags, operation string, args map[string]any) error {
+	c, err := flags.newClient()
+	if err != nil {
+		return err
+	}
+	out, err := semantic.Dispatch(cmd.Context(), c, operation, args)
+	if err != nil {
+		return err
+	}
+	return flags.printJSON(cmd, json.RawMessage(out))
+}

--- a/library/devices/kvmctl/internal/cli/ocr_loop_novel.go
+++ b/library/devices/kvmctl/internal/cli/ocr_loop_novel.go
@@ -24,17 +24,17 @@ func registerOCRLoopCommands(root *cobra.Command, flags *rootFlags) {
 		},
 	}
 
+	var expectedText string
 	verify := &cobra.Command{
 		Use:         "verify",
 		Short:       "Verify exact high-confidence text in a fresh observation",
 		Args:        cobra.NoArgs,
 		Annotations: map[string]string{"pp:novel": "true", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			expected, _ := cmd.Flags().GetString("expect-text")
-			return dispatchOCRPresentation(cmd, flags, "verify-text", map[string]any{"text": expected})
+			return dispatchOCRPresentation(cmd, flags, "verify-text", map[string]any{"text": expectedText})
 		},
 	}
-	verify.Flags().String("expect-text", "", "exact text expected in the fresh OCR observation")
+	verify.Flags().StringVar(&expectedText, "expect-text", "", "exact text expected in the fresh OCR observation")
 	_ = verify.MarkFlagRequired("expect-text")
 
 	act := &cobra.Command{
@@ -50,6 +50,7 @@ func registerOCRLoopCommands(root *cobra.Command, flags *rootFlags) {
 }
 
 func newOCRClickTextCommand(flags *rootFlags) *cobra.Command {
+	var observation string
 	cmd := &cobra.Command{
 		Use:         "click-text <text>",
 		Short:       "Click one exact high-confidence OCR text match",
@@ -63,12 +64,13 @@ func newOCRClickTextCommand(flags *rootFlags) *cobra.Command {
 			return dispatchOCRPresentation(cmd, flags, "click-text", map[string]any{"text": args[0], "observation_id": observation, "write_enabled": true})
 		},
 	}
-	cmd.Flags().String("observation", "", "observation ID returned by kvmctl observe")
+	cmd.Flags().StringVar(&observation, "observation", "", "observation ID returned by kvmctl observe")
 	_ = cmd.MarkFlagRequired("observation")
 	return cmd
 }
 
 func newOCRPressKeyCommand(flags *rootFlags) *cobra.Command {
+	var observation string
 	cmd := &cobra.Command{
 		Use:         "press-key <key>",
 		Short:       "Press an allowed key against one fresh OCR observation",
@@ -82,7 +84,7 @@ func newOCRPressKeyCommand(flags *rootFlags) *cobra.Command {
 			return dispatchOCRPresentation(cmd, flags, "press-key", map[string]any{"key": args[0], "observation_id": observation, "write_enabled": true})
 		},
 	}
-	cmd.Flags().String("observation", "", "observation ID returned by kvmctl observe")
+	cmd.Flags().StringVar(&observation, "observation", "", "observation ID returned by kvmctl observe")
 	_ = cmd.MarkFlagRequired("observation")
 	return cmd
 }

--- a/library/devices/kvmctl/internal/cli/ocr_loop_novel_test.go
+++ b/library/devices/kvmctl/internal/cli/ocr_loop_novel_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOCRPresentationCommandsAreNonOverlapping(t *testing.T) {
+	root := RootCmd()
+	for _, path := range []string{"observe", "verify", "act", "act click-text", "act press-key"} {
+		if _, _, err := root.Find(strings.Fields(path)); err != nil {
+			t.Fatalf("expected command %q in root tree: %v", path, err)
+		}
+	}
+	if command, _, err := root.Find([]string{"semantic", "observe"}); err != nil || command == nil {
+		t.Fatalf("generic semantic observe compatibility command missing: %v", err)
+	}
+}
+
+func TestOCRPresentationActionsRequireYesAndObservation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"click needs yes", []string{"act", "click-text", "Advanced", "--observation", "sha256:observation"}, "--yes is required"},
+		{"click needs observation", []string{"act", "click-text", "Advanced", "--yes"}, "required flag(s) \"observation\" not set"},
+		{"press needs yes", []string{"act", "press-key", "F10", "--observation", "sha256:observation"}, "--yes is required"},
+		{"press needs observation", []string{"act", "press-key", "F10", "--yes"}, "required flag(s) \"observation\" not set"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := RootCmd()
+			root.SetOut(&bytes.Buffer{})
+			root.SetErr(&bytes.Buffer{})
+			root.SetArgs(tc.args)
+			err := root.Execute()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("args %v error = %v, want %q", tc.args, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestOCRPresentationVerifyForwardsExpectedText(t *testing.T) {
+	t.Setenv("KVMCTL_OCR_PROTOCOL", "json")
+	t.Setenv("KVMCTL_OCR_COMMAND", writePresentationFakeOCR(t, `{"width":100,"height":50,"words":[{"text":"Save Changes","confidence":95,"x":10,"y":10,"width":40,"height":10}]}`))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/streamer/snapshot" {
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte("snapshot"))
+	}))
+	defer srv.Close()
+	t.Setenv("KVMCTL_URL", srv.URL)
+	t.Setenv("KVMCTL_TOKEN", "test-token")
+
+	root := RootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"verify", "--expect-text", "Save Changes", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("verify output is not JSON: %v\n%s", err, out.String())
+	}
+	if got["operation"] != "verify-text" {
+		t.Fatalf("operation = %#v, want verify-text", got["operation"])
+	}
+	evidence := got["evidence"].(map[string]any)
+	if evidence["text"] != "Save Changes" {
+		t.Fatalf("verify text = %#v, want forwarded expected text", evidence["text"])
+	}
+}
+
+func writePresentationFakeOCR(t *testing.T, response string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-ocr")
+	program := "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '" + response + "'\n"
+	if err := os.WriteFile(path, []byte(program), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/library/devices/kvmctl/internal/mcp/semantic_novel.go
+++ b/library/devices/kvmctl/internal/mcp/semantic_novel.go
@@ -12,9 +12,9 @@ import (
 
 func registerSemanticTool(s *server.MCPServer) {
 	tool := mcp.NewTool("semantic_dispatch",
-		mcp.WithDescription("Dispatch one structured semantic KVM operation with evidence envelope (operation, transport, read_only, ok, evidence, state). Full TOOL_SPEC: capabilities, snapshot, ocr, verify, host.identity.inspect, host.graphics.inspect, service.render_access.inspect, host.reboot, select, hid_reset, rearm_otg, kvm_send_text, kvm_send_keys, kvm_hold_key, kvm_release_all, kvm_mouse_move, kvm_mouse_move_pct, kvm_mouse_click, kvm_mouse_scroll, kvm_status, kvm_screenshot_to_file, kvm_ocr_screenshot, kvm_ocr_click, exec_command, kvm_sequence_plan, kvm_sequence_authorize, kvm_sequence_execute, kvm_workflow_authorize, kvm_workflow_list, kvm_workflow_inspect, kvm_workflow_execute (plus legacy aliases status/keyboard/mouse/target-switch/sequence). Write-gated ops require KVMCTL_WRITE_ENABLED=1. Evidence is redacted via results.Build."),
+		mcp.WithDescription("Dispatch one structured semantic KVM operation with evidence envelope (operation, transport, read_only, ok, evidence, state). OCR observation loop: observe: no arguments; verify-text: arguments.text; click-text: arguments.text and arguments.observation_id; requires write_enabled=true; press-key: arguments.key and arguments.observation_id; requires write_enabled=true. Observation IDs come from observe and are rechecked against a fresh screen capture; do not plan or infer UI actions. Write-gated ops require KVMCTL_WRITE_ENABLED=1. Evidence is redacted via results.Build."),
 		mcp.WithString("operation", mcp.Required(), mcp.Description("One of: "+strings.Join(semantic.Operations, ", "))),
-		mcp.WithObject("arguments", mcp.Description("Operation arguments; include write_enabled gating, bounded numeric validation, and secret-free evidence. Exec requires transport=ssh, shell metachars rejected.")),
+		mcp.WithObject("arguments", mcp.Description("Operation arguments. OCR: observe has none; verify-text needs text; click-text needs text plus observation_id and write_enabled=true; press-key needs key plus observation_id and write_enabled=true. Exec requires transport=ssh; shell metachars rejected.")),
 	)
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		c, session, err := newMCPClient(ctx)

--- a/library/devices/kvmctl/internal/mcp/semantic_novel.go
+++ b/library/devices/kvmctl/internal/mcp/semantic_novel.go
@@ -29,11 +29,8 @@ func registerSemanticTool(s *server.MCPServer) {
 		if raw == nil {
 			raw = map[string]any{}
 		}
-		raw["write_enabled"] = envTruthy(os.Getenv("KVMCTL_WRITE_ENABLED"))
-		// propagate per-invocation flags from arguments envelope
-		if v, ok := args["write_enabled"].(bool); ok {
-			raw["write_enabled"] = v
-		}
+		rawRequestedWrite := raw["write_enabled"]
+		raw["write_enabled"] = mcpWriteEnabled(envTruthy(os.Getenv("KVMCTL_WRITE_ENABLED")), rawRequestedWrite)
 		out, err := semantic.Dispatch(ctx, c, stringArg(args, "operation"), raw)
 		if err != nil {
 			return mcpToolError(err.Error()), nil
@@ -43,6 +40,11 @@ func registerSemanticTool(s *server.MCPServer) {
 }
 
 func stringArg(m map[string]any, k string) string { v, _ := m[k].(string); return v }
+
+func mcpWriteEnabled(hostPolicy bool, raw any) bool {
+	explicit, ok := raw.(bool)
+	return hostPolicy && ok && explicit
+}
 
 func envTruthy(v string) bool {
 	switch strings.ToLower(strings.TrimSpace(v)) {

--- a/library/devices/kvmctl/internal/mcp/semantic_novel_test.go
+++ b/library/devices/kvmctl/internal/mcp/semantic_novel_test.go
@@ -26,3 +26,24 @@ func TestSemanticDispatchDescribesOCRObservationLoopArguments(t *testing.T) {
 		}
 	}
 }
+
+func TestMCPWriteGateRequiresHostPolicyAndExplicitArgument(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		host bool
+		raw  any
+		want bool
+	}{
+		{"both true", true, true, true},
+		{"host policy false", false, true, false},
+		{"argument omitted", true, nil, false},
+		{"argument false", true, false, false},
+		{"argument wrong type", true, "true", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mcpWriteEnabled(tc.host, tc.raw); got != tc.want {
+				t.Fatalf("mcpWriteEnabled(%v, %#v) = %v, want %v", tc.host, tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/library/devices/kvmctl/internal/mcp/semantic_novel_test.go
+++ b/library/devices/kvmctl/internal/mcp/semantic_novel_test.go
@@ -1,0 +1,28 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func TestSemanticDispatchDescribesOCRObservationLoopArguments(t *testing.T) {
+	s := server.NewMCPServer("kvmctl", "test")
+	RegisterTools(s)
+	registered, ok := s.ListTools()["semantic_dispatch"]
+	if !ok {
+		t.Fatal("semantic_dispatch tool is not registered")
+	}
+	description := registered.Tool.Description
+	for _, want := range []string{
+		"observe: no arguments",
+		"verify-text: arguments.text",
+		"click-text: arguments.text and arguments.observation_id; requires write_enabled=true",
+		"press-key: arguments.key and arguments.observation_id; requires write_enabled=true",
+	} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("semantic_dispatch description missing %q: %s", want, description)
+		}
+	}
+}

--- a/library/devices/kvmctl/internal/ocr/engine.go
+++ b/library/devices/kvmctl/internal/ocr/engine.go
@@ -1,0 +1,240 @@
+package ocr
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	// ErrOCRUnavailable means no production OCR executable was configured.
+	ErrOCRUnavailable = errors.New("ocr unavailable")
+	// ErrOCRFailed means an explicitly configured OCR executable could not return valid OCR.
+	ErrOCRFailed = errors.New("ocr failed")
+)
+
+const (
+	defaultOCRTimeout = 5 * time.Second
+	maxOCRInputBytes  = 16 << 20
+	maxOCROutputBytes = 4 << 20
+)
+
+type ocrProtocol string
+
+const (
+	tesseractTSVProtocol ocrProtocol = "tesseract-tsv"
+	jsonProtocol         ocrProtocol = "json"
+)
+
+// CommandEngine invokes an explicitly configured OCR executable without a shell.
+// KVMCTL_OCR_COMMAND is an executable path, never a shell command line. By default
+// it is called as: <path> stdin stdout tsv, which is Tesseract's stdin-to-TSV
+// protocol. Set KVMCTL_OCR_PROTOCOL=json to call <path> with no arguments; that
+// program must write one strict JSON object to stdout:
+// {"width":1920,"height":1080,"words":[{"text":"Advanced","confidence":95.2,"x":1,"y":2,"width":3,"height":4}]}.
+type CommandEngine struct {
+	command  string
+	protocol ocrProtocol
+	timeout  time.Duration
+}
+
+// CommandEngineFromEnvironment returns a real engine only when KVMCTL_OCR_COMMAND
+// names an executable. It never falls back to a globally installed OCR binary.
+func CommandEngineFromEnvironment() (*CommandEngine, error) {
+	command := os.Getenv("KVMCTL_OCR_COMMAND")
+	if command == "" {
+		return nil, ErrOCRUnavailable
+	}
+	protocol := ocrProtocol(os.Getenv("KVMCTL_OCR_PROTOCOL"))
+	switch protocol {
+	case "", "tesseract", tesseractTSVProtocol:
+		protocol = tesseractTSVProtocol
+	case jsonProtocol:
+	default:
+		return nil, fmt.Errorf("%w: unsupported OCR protocol %q", ErrOCRUnavailable, protocol)
+	}
+	return &CommandEngine{command: command, protocol: protocol, timeout: defaultOCRTimeout}, nil
+}
+
+// Name identifies the configured executable path without probing it or executing a shell.
+func (e *CommandEngine) Name() string { return e.command }
+
+// Recognize writes image bytes to the configured executable's standard input and
+// validates bounded TSV or JSON output. It never invents OCR output on failure.
+func (e *CommandEngine) Recognize(imageBytes []byte) (int, int, []Word, error) {
+	if e == nil || e.command == "" {
+		return 0, 0, nil, ErrOCRUnavailable
+	}
+	if len(imageBytes) == 0 || len(imageBytes) > maxOCRInputBytes {
+		return 0, 0, nil, fmt.Errorf("%w: image input size is invalid", ErrOCRFailed)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+	defer cancel()
+
+	args := []string{}
+	if e.protocol == tesseractTSVProtocol {
+		args = []string{"stdin", "stdout", "tsv"}
+	}
+	command := exec.CommandContext(ctx, e.command, args...)
+	command.Stdin = bytes.NewReader(imageBytes)
+	stdout := &limitedBuffer{limit: maxOCROutputBytes}
+	stderr := &limitedBuffer{limit: maxOCROutputBytes}
+	command.Stdout = stdout
+	command.Stderr = stderr
+	if err := command.Run(); err != nil {
+		if ctx.Err() != nil {
+			return 0, 0, nil, fmt.Errorf("%w: command timed out", ErrOCRFailed)
+		}
+		if stdout.exceeded || stderr.exceeded {
+			return 0, 0, nil, fmt.Errorf("%w: command output exceeded limit", ErrOCRFailed)
+		}
+		return 0, 0, nil, fmt.Errorf("%w: command execution failed: %v", ErrOCRFailed, err)
+	}
+	if stdout.exceeded || stderr.exceeded {
+		return 0, 0, nil, fmt.Errorf("%w: command output exceeded limit", ErrOCRFailed)
+	}
+	if e.protocol == jsonProtocol {
+		return parseJSONResponse(stdout.Bytes())
+	}
+	return parseTesseractTSV(stdout.Bytes())
+}
+
+type limitedBuffer struct {
+	bytes.Buffer
+	limit    int
+	exceeded bool
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.Len()
+	if remaining <= 0 || len(p) > remaining {
+		if remaining > 0 {
+			_, _ = b.Buffer.Write(p[:remaining])
+		}
+		b.exceeded = true
+		return 0, errors.New("OCR output limit exceeded")
+	}
+	return b.Buffer.Write(p)
+}
+
+type jsonResponse struct {
+	Width  *int        `json:"width"`
+	Height *int        `json:"height"`
+	Words  *[]jsonWord `json:"words"`
+}
+
+type jsonWord struct {
+	Text       *string  `json:"text"`
+	Confidence *float64 `json:"confidence"`
+	X          *int     `json:"x"`
+	Y          *int     `json:"y"`
+	Width      *int     `json:"width"`
+	Height     *int     `json:"height"`
+}
+
+func parseJSONResponse(data []byte) (int, int, []Word, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var response jsonResponse
+	if err := decoder.Decode(&response); err != nil {
+		return 0, 0, nil, fmt.Errorf("%w: invalid JSON response", ErrOCRFailed)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return 0, 0, nil, fmt.Errorf("%w: invalid JSON response", ErrOCRFailed)
+	}
+	if response.Width == nil || response.Height == nil || response.Words == nil || *response.Width <= 0 || *response.Height <= 0 {
+		return 0, 0, nil, fmt.Errorf("%w: JSON response lacks valid dimensions or words", ErrOCRFailed)
+	}
+	words := make([]Word, 0, len(*response.Words))
+	for _, word := range *response.Words {
+		if word.Text == nil || word.Confidence == nil || word.X == nil || word.Y == nil || word.Width == nil || word.Height == nil {
+			return 0, 0, nil, fmt.Errorf("%w: JSON word lacks required fields", ErrOCRFailed)
+		}
+		words = append(words, Word{Text: *word.Text, Confidence: *word.Confidence, X: *word.X, Y: *word.Y, Width: *word.Width, Height: *word.Height})
+	}
+	if err := validateWords(words, *response.Width, *response.Height); err != nil {
+		return 0, 0, nil, err
+	}
+	return *response.Width, *response.Height, words, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return errors.New("extra JSON data")
+	}
+	return nil
+}
+
+func parseTesseractTSV(data []byte) (int, int, []Word, error) {
+	reader := csv.NewReader(bytes.NewReader(data))
+	reader.Comma = '	'
+	records, err := reader.ReadAll()
+	if err != nil || len(records) < 2 {
+		return 0, 0, nil, fmt.Errorf("%w: invalid Tesseract TSV", ErrOCRFailed)
+	}
+	header := []string{"level", "page_num", "block_num", "par_num", "line_num", "word_num", "left", "top", "width", "height", "conf", "text"}
+	if len(records[0]) != len(header) {
+		return 0, 0, nil, fmt.Errorf("%w: invalid Tesseract TSV header", ErrOCRFailed)
+	}
+	for i := range header {
+		if records[0][i] != header[i] {
+			return 0, 0, nil, fmt.Errorf("%w: invalid Tesseract TSV header", ErrOCRFailed)
+		}
+	}
+	width, height := 0, 0
+	words := make([]Word, 0)
+	for _, record := range records[1:] {
+		if len(record) != len(header) {
+			return 0, 0, nil, fmt.Errorf("%w: invalid Tesseract TSV row", ErrOCRFailed)
+		}
+		level, err := strconv.Atoi(record[0])
+		if err != nil {
+			return 0, 0, nil, fmt.Errorf("%w: invalid Tesseract TSV level", ErrOCRFailed)
+		}
+		x, xErr := strconv.Atoi(record[6])
+		y, yErr := strconv.Atoi(record[7])
+		w, wErr := strconv.Atoi(record[8])
+		h, hErr := strconv.Atoi(record[9])
+		if xErr != nil || yErr != nil || wErr != nil || hErr != nil {
+			return 0, 0, nil, fmt.Errorf("%w: invalid Tesseract TSV bounds", ErrOCRFailed)
+		}
+		if level == 1 {
+			width, height = w, h
+			continue
+		}
+		if level != 5 || strings.TrimSpace(record[11]) == "" {
+			continue
+		}
+		confidence, err := strconv.ParseFloat(record[10], 64)
+		if err != nil {
+			return 0, 0, nil, fmt.Errorf("%w: invalid Tesseract TSV confidence", ErrOCRFailed)
+		}
+		words = append(words, Word{Text: record[11], Confidence: confidence, X: x, Y: y, Width: w, Height: h})
+	}
+	if err := validateWords(words, width, height); err != nil {
+		return 0, 0, nil, err
+	}
+	return width, height, words, nil
+}
+
+func validateWords(words []Word, width, height int) error {
+	if width <= 0 || height <= 0 {
+		return fmt.Errorf("%w: invalid image dimensions", ErrOCRFailed)
+	}
+	for _, word := range words {
+		if word.X < 0 || word.Y < 0 || word.Width <= 0 || word.Height <= 0 || word.X+word.Width > width || word.Y+word.Height > height {
+			return fmt.Errorf("%w: word outside image bounds", ErrOCRFailed)
+		}
+	}
+	return nil
+}

--- a/library/devices/kvmctl/internal/ocr/engine_test.go
+++ b/library/devices/kvmctl/internal/ocr/engine_test.go
@@ -1,0 +1,47 @@
+package ocr
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestCommandEngineFromEnvironmentRequiresExplicitCommand(t *testing.T) {
+	t.Setenv("KVMCTL_OCR_COMMAND", "")
+	_, err := CommandEngineFromEnvironment()
+	if !errors.Is(err, ErrOCRUnavailable) {
+		t.Fatalf("error = %v, want OCR unavailable", err)
+	}
+}
+
+func TestCommandEngineRecognizesTesseractTSVFromStandardInput(t *testing.T) {
+	tesseract, err := exec.LookPath("tesseract")
+	if err != nil {
+		t.Skip("tesseract is not installed")
+	}
+	t.Setenv("KVMCTL_OCR_COMMAND", tesseract)
+	t.Setenv("KVMCTL_OCR_PROTOCOL", "")
+	engine, err := CommandEngineFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	image := makePNG(t, 31, 17)
+	width, height, words, err := engine.Recognize(image)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if width != 31 || height != 17 {
+		t.Fatalf("dimensions = %dx%d, want 31x17", width, height)
+	}
+	if words == nil {
+		t.Fatal("words must be a non-nil empty slice when no text is recognized")
+	}
+}
+
+func TestParseJSONResponseRejectsMissingWordConfidence(t *testing.T) {
+	_, _, _, err := parseJSONResponse([]byte(`{"width":10,"height":10,"words":[{"text":"ok","x":1,"y":2,"width":3,"height":4}]}`))
+	if !errors.Is(err, ErrOCRFailed) {
+		t.Fatalf("error = %v, want OCR failure", err)
+	}
+}

--- a/library/devices/kvmctl/internal/ocr/observation.go
+++ b/library/devices/kvmctl/internal/ocr/observation.go
@@ -62,7 +62,21 @@ func NewObservation(imageBytes []byte, capturedAt time.Time, engine string, widt
 			Regions: cloneRegions(regions),
 		},
 	}
-	canonical, err := json.Marshal(observation)
+	// The identifier intentionally excludes CapturedAt: a fresh recapture of an
+	// unchanged screen must validate the same observation ID, while timestamp
+	// remains evidence metadata for callers.
+	identity := struct {
+		ImageSHA256 string         `json:"image_sha256"`
+		Width       int            `json:"width"`
+		Height      int            `json:"height"`
+		OCR         OCRObservation `json:"ocr"`
+	}{
+		ImageSHA256: observation.ImageSHA256,
+		Width:       observation.Width,
+		Height:      observation.Height,
+		OCR:         observation.OCR,
+	}
+	canonical, err := json.Marshal(identity)
 	if err != nil {
 		return Observation{}, fmt.Errorf("canonicalize OCR observation: %w", err)
 	}

--- a/library/devices/kvmctl/internal/ocr/observation.go
+++ b/library/devices/kvmctl/internal/ocr/observation.go
@@ -1,0 +1,167 @@
+package ocr
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	maxObservationTTL     = 60 * time.Second
+	maxObservationEntries = 64
+)
+
+// Region is a bounded OCR word-level observation region.
+type Region struct {
+	Text       string  `json:"text"`
+	Confidence float64 `json:"confidence"`
+	Box        [4]int  `json:"box"`
+	Pixel      [2]int  `json:"pixel"`
+}
+
+// OCRObservation is the OCR evidence associated with a snapshot.
+type OCRObservation struct {
+	Engine  string   `json:"engine"`
+	Regions []Region `json:"regions"`
+}
+
+// Observation is immutable, short-lived screen evidence. It contains no image
+// bytes or credentials; ImageSHA256 binds it to the captured image.
+type Observation struct {
+	ID          string         `json:"observation_id"`
+	CapturedAt  time.Time      `json:"captured_at"`
+	ImageSHA256 string         `json:"image_sha256"`
+	Width       int            `json:"width"`
+	Height      int            `json:"height"`
+	OCR         OCRObservation `json:"ocr"`
+}
+
+// NewObservation returns canonical SHA-256 identified OCR evidence.
+func NewObservation(imageBytes []byte, capturedAt time.Time, engine string, width, height int, regions []Region) (Observation, error) {
+	if len(imageBytes) == 0 || engine == "" || width <= 0 || height <= 0 {
+		return Observation{}, errors.New("invalid OCR observation")
+	}
+	for _, region := range regions {
+		x, y, w, h := region.Box[0], region.Box[1], region.Box[2], region.Box[3]
+		if x < 0 || y < 0 || w <= 0 || h <= 0 || x+w > width || y+h > height || region.Pixel[0] < x || region.Pixel[0] > x+w || region.Pixel[1] < y || region.Pixel[1] > y+h {
+			return Observation{}, errors.New("invalid OCR observation region")
+		}
+	}
+	imageHash := sha256.Sum256(imageBytes)
+	observation := Observation{
+		CapturedAt:  capturedAt.UTC(),
+		ImageSHA256: hex.EncodeToString(imageHash[:]),
+		Width:       width,
+		Height:      height,
+		OCR: OCRObservation{
+			Engine:  engine,
+			Regions: cloneRegions(regions),
+		},
+	}
+	canonical, err := json.Marshal(observation)
+	if err != nil {
+		return Observation{}, fmt.Errorf("canonicalize OCR observation: %w", err)
+	}
+	idHash := sha256.Sum256(canonical)
+	observation.ID = "sha256:" + hex.EncodeToString(idHash[:])
+	return observation, nil
+}
+
+// ObservationStore keeps process-local OCR evidence. Its TTL never exceeds 60
+// seconds and capacity never exceeds 64 entries.
+type ObservationStore struct {
+	mu       sync.Mutex
+	ttl      time.Duration
+	capacity int
+	now      func() time.Time
+	entries  map[string]storedObservation
+	sequence uint64
+}
+
+type storedObservation struct {
+	observation Observation
+	expiresAt   time.Time
+	sequence    uint64
+}
+
+// NewObservationStore creates a bounded in-memory store. Non-positive limits
+// use safe defaults; larger requested limits are capped.
+func NewObservationStore(ttl time.Duration, capacity int, now func() time.Time) *ObservationStore {
+	if ttl <= 0 || ttl > maxObservationTTL {
+		ttl = maxObservationTTL
+	}
+	if capacity <= 0 || capacity > maxObservationEntries {
+		capacity = maxObservationEntries
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &ObservationStore{ttl: ttl, capacity: capacity, now: now, entries: make(map[string]storedObservation)}
+}
+
+// Put stores a defensive copy unless the observation is already expired.
+func (s *ObservationStore) Put(observation Observation) {
+	if s == nil || observation.ID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	s.purgeExpired(now)
+	expiresAt := observation.CapturedAt.Add(s.ttl)
+	if !expiresAt.After(now) {
+		return
+	}
+	s.sequence++
+	s.entries[observation.ID] = storedObservation{observation: cloneObservation(observation), expiresAt: expiresAt, sequence: s.sequence}
+	for len(s.entries) > s.capacity {
+		var oldestID string
+		var oldest uint64
+		for id, entry := range s.entries {
+			if oldestID == "" || entry.sequence < oldest {
+				oldestID, oldest = id, entry.sequence
+			}
+		}
+		delete(s.entries, oldestID)
+	}
+}
+
+// Get returns a defensive copy only while the observation remains valid.
+func (s *ObservationStore) Get(id string) (Observation, bool) {
+	if s == nil || id == "" {
+		return Observation{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	s.purgeExpired(now)
+	entry, ok := s.entries[id]
+	if !ok {
+		return Observation{}, false
+	}
+	return cloneObservation(entry.observation), true
+}
+
+func (s *ObservationStore) purgeExpired(now time.Time) {
+	for id, entry := range s.entries {
+		if !entry.expiresAt.After(now) {
+			delete(s.entries, id)
+		}
+	}
+}
+
+func cloneObservation(observation Observation) Observation {
+	observation.OCR.Regions = cloneRegions(observation.OCR.Regions)
+	return observation
+}
+
+func cloneRegions(regions []Region) []Region {
+	if regions == nil {
+		return nil
+	}
+	return append([]Region(nil), regions...)
+}

--- a/library/devices/kvmctl/internal/ocr/observation_test.go
+++ b/library/devices/kvmctl/internal/ocr/observation_test.go
@@ -21,6 +21,10 @@ func TestNewObservationHashesImageAndCanonicalEvidence(t *testing.T) {
 	if observation.CapturedAt.Location() != time.UTC || observation.CapturedAt.Nanosecond() != 123 {
 		t.Fatalf("captured at = %s, want UTC with nanoseconds", observation.CapturedAt)
 	}
+	fresh, err := NewObservation([]byte("snapshot"), capturedAt.Add(time.Second), "tesseract", 100, 50, []Region{{Text: "Advanced", Confidence: 95.2, Box: [4]int{10, 5, 40, 10}, Pixel: [2]int{30, 10}}})
+	if err != nil || fresh.ID != observation.ID {
+		t.Fatalf("unchanged screen identity = %q (%v), want %q", fresh.ID, err, observation.ID)
+	}
 }
 
 func TestObservationStoreExpiresEntriesAndDefensivelyCopies(t *testing.T) {

--- a/library/devices/kvmctl/internal/ocr/observation_test.go
+++ b/library/devices/kvmctl/internal/ocr/observation_test.go
@@ -1,0 +1,72 @@
+package ocr
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewObservationHashesImageAndCanonicalEvidence(t *testing.T) {
+	capturedAt := time.Date(2026, 9, 2, 12, 0, 0, 123, time.FixedZone("offset", -7*60*60))
+	observation, err := NewObservation([]byte("snapshot"), capturedAt, "tesseract", 100, 50, []Region{{Text: "Advanced", Confidence: 95.2, Box: [4]int{10, 5, 40, 10}, Pixel: [2]int{30, 10}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(observation.ID, "sha256:") {
+		t.Fatalf("ID = %q, want sha256 prefix", observation.ID)
+	}
+	if observation.ImageSHA256 != "16a0eeb0791b6c92451fd284dd9f599e0a7dbe7f6ebea6e2d2d06c7f74aec112" {
+		t.Fatalf("image hash = %q", observation.ImageSHA256)
+	}
+	if observation.CapturedAt.Location() != time.UTC || observation.CapturedAt.Nanosecond() != 123 {
+		t.Fatalf("captured at = %s, want UTC with nanoseconds", observation.CapturedAt)
+	}
+}
+
+func TestObservationStoreExpiresEntriesAndDefensivelyCopies(t *testing.T) {
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	store := NewObservationStore(60*time.Second, 2, func() time.Time { return now })
+	observation, err := NewObservation([]byte("snapshot"), now, "test", 100, 50, []Region{{Text: "Original", Confidence: 90, Box: [4]int{1, 2, 3, 4}, Pixel: [2]int{2, 4}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.Put(observation)
+
+	observation.OCR.Regions[0].Text = "mutated after put"
+	got, ok := store.Get(observation.ID)
+	if !ok || got.OCR.Regions[0].Text != "Original" {
+		t.Fatalf("stored observation = %#v, ok=%v", got, ok)
+	}
+	got.OCR.Regions[0].Text = "mutated after get"
+	got, ok = store.Get(observation.ID)
+	if !ok || got.OCR.Regions[0].Text != "Original" {
+		t.Fatalf("returned observation was not copied: %#v", got)
+	}
+
+	now = now.Add(61 * time.Second)
+	if _, ok := store.Get(observation.ID); ok {
+		t.Fatal("expired observation returned")
+	}
+}
+
+func TestObservationStoreEvictsOldestAtCapacity(t *testing.T) {
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	store := NewObservationStore(time.Minute, 2, func() time.Time { return now })
+	first, _ := NewObservation([]byte("one"), now, "test", 1, 1, nil)
+	store.Put(first)
+	now = now.Add(time.Nanosecond)
+	second, _ := NewObservation([]byte("two"), now, "test", 1, 1, nil)
+	store.Put(second)
+	now = now.Add(time.Nanosecond)
+	third, _ := NewObservation([]byte("three"), now, "test", 1, 1, nil)
+	store.Put(third)
+	if _, ok := store.Get(first.ID); ok {
+		t.Fatal("oldest observation was not evicted")
+	}
+	if _, ok := store.Get(second.ID); !ok {
+		t.Fatal("second observation was evicted")
+	}
+	if _, ok := store.Get(third.ID); !ok {
+		t.Fatal("third observation was not stored")
+	}
+}

--- a/library/devices/kvmctl/internal/ocr/test_helpers_test.go
+++ b/library/devices/kvmctl/internal/ocr/test_helpers_test.go
@@ -1,0 +1,24 @@
+package ocr
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+)
+
+func makePNG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.White)
+		}
+	}
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, img); err != nil {
+		t.Fatal(err)
+	}
+	return encoded.Bytes()
+}

--- a/library/devices/kvmctl/internal/semantic/dispatch.go
+++ b/library/devices/kvmctl/internal/semantic/dispatch.go
@@ -20,7 +20,7 @@ import (
 )
 
 var Operations = []string{
-	"capabilities", "snapshot", "ocr", "verify",
+	"capabilities", "snapshot", "ocr", "verify", "observe", "click-text", "press-key", "verify-text",
 	"host.identity.inspect", "host.graphics.inspect", "service.render_access.inspect",
 	"host.reboot", "select", "hid_reset", "rearm_otg",
 	"kvm_send_text", "kvm_send_keys", "kvm_hold_key", "kvm_release_all",
@@ -38,6 +38,8 @@ var writeRequired = map[string]bool{
 	"kvm_send_text": true, "kvm_send_keys": true, "kvm_hold_key": true, "kvm_release_all": true,
 	"kvm_mouse_move": true, "kvm_mouse_move_pct": true, "kvm_mouse_click": true, "kvm_mouse_scroll": true,
 	"kvm_ocr_click":          true,
+	"click-text":             true,
+	"press-key":              true,
 	"exec_command":           true,
 	"kvm_sequence_authorize": true, "kvm_sequence_execute": true,
 	"kvm_workflow_authorize": true, "kvm_workflow_execute": true,
@@ -47,6 +49,7 @@ var writeRequired = map[string]bool{
 
 var readOnlyOps = map[string]bool{
 	"capabilities": true, "snapshot": true, "ocr": true, "verify": true,
+	"observe": true, "verify-text": true,
 	"host.identity.inspect": true, "host.graphics.inspect": true, "service.render_access.inspect": true,
 	"kvm_status": true, "kvm_screenshot_to_file": true, "kvm_ocr_screenshot": true,
 	"kvm_sequence_plan": true, "kvm_workflow_list": true, "kvm_workflow_inspect": true,
@@ -79,6 +82,14 @@ func Dispatch(ctx context.Context, c *client.Client, name string, args map[strin
 		out, err = opOCR(ctx, c, args)
 	case "verify":
 		out, err = opVerify(ctx, c, args)
+	case "observe":
+		out, err = opObserve(ctx, c)
+	case "click-text":
+		out, err = opClickText(ctx, c, args)
+	case "press-key":
+		out, err = opPressKey(ctx, c, args)
+	case "verify-text":
+		out, err = opVerifyText(ctx, c, args)
 	case "host.identity.inspect", "host.graphics.inspect", "service.render_access.inspect":
 		out, err = opHostProbe(name)
 	case "host.reboot":

--- a/library/devices/kvmctl/internal/semantic/dispatch_test.go
+++ b/library/devices/kvmctl/internal/semantic/dispatch_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/devices/kvmctl/internal/config"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -35,4 +38,145 @@ func TestDispatchRejectsUnknownAndWriteWithoutGate(t *testing.T) {
 	if _, err := Dispatch(context.Background(), c, "keyboard", map[string]any{"key": "A"}); err == nil {
 		t.Fatal("write without gate accepted")
 	}
+}
+
+func TestClickTextRequiresFreshObservationWritesAndReturnsPostObservation(t *testing.T) {
+	t.Setenv("KVMCTL_OCR_PROTOCOL", "json")
+	t.Setenv("KVMCTL_OCR_COMMAND", writeFakeOCR(t, `{"width":100,"height":50,"words":[{"text":"Proceed","confidence":95,"x":10,"y":10,"width":40,"height":10}]}`))
+	var snapshots int
+	var events []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/streamer/snapshot":
+			snapshots++
+			_, _ = w.Write([]byte("snapshot"))
+		case "/api/hid/events/send_mouse_move", "/api/hid/events/send_mouse_button":
+			events = append(events, r.URL.Path+"?"+r.URL.RawQuery)
+			_, _ = w.Write([]byte(`{"result":{}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	c := client.New(&config.Config{BaseURL: srv.URL}, 0, 0)
+
+	observed := dispatchObject(t, c, "observe", nil)
+	id := observed["evidence"].(map[string]any)["observation"].(map[string]any)["observation_id"].(string)
+	if _, err := Dispatch(context.Background(), c, "click-text", map[string]any{"observation_id": id, "text": "Proceed"}); err == nil {
+		t.Fatal("click-text accepted without write_enabled")
+	}
+	out := dispatchObject(t, c, "click-text", map[string]any{"write_enabled": true, "observation_id": id, "text": "  proceed  "})
+	if out["ok"] != true || snapshots != 2 || len(events) != 3 {
+		t.Fatalf("output=%#v snapshots=%d events=%v", out, snapshots, events)
+	}
+	if _, ok := out["evidence"].(map[string]any)["post_observation"]; !ok {
+		t.Fatalf("missing post observation: %#v", out)
+	}
+}
+
+func TestPressKeyAndVerifyTextFailClosedOnAmbiguity(t *testing.T) {
+	t.Setenv("KVMCTL_OCR_PROTOCOL", "json")
+	t.Setenv("KVMCTL_OCR_COMMAND", writeFakeOCR(t, `{"width":100,"height":50,"words":[{"text":"Ready","confidence":95,"x":10,"y":10,"width":20,"height":10},{"text":"Ready","confidence":95,"x":50,"y":10,"width":20,"height":10}]}`))
+	var keyEvents []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/streamer/snapshot":
+			_, _ = w.Write([]byte("snapshot"))
+		case "/api/hid/events/send_key":
+			keyEvents = append(keyEvents, r.URL.RawQuery)
+			_, _ = w.Write([]byte(`{"result":{}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	c := client.New(&config.Config{BaseURL: srv.URL}, 0, 0)
+	observed := dispatchObject(t, c, "observe", nil)
+	id := observed["evidence"].(map[string]any)["observation"].(map[string]any)["observation_id"].(string)
+	if _, err := Dispatch(context.Background(), c, "press-key", map[string]any{"write_enabled": true, "observation_id": "wrong", "key": "Enter"}); err == nil {
+		t.Fatal("press-key accepted a stale observation")
+	}
+	out := dispatchObject(t, c, "press-key", map[string]any{"write_enabled": true, "observation_id": id, "key": "Enter"})
+	if out["ok"] != true || len(keyEvents) != 2 {
+		t.Fatalf("press-key output=%#v events=%v", out, keyEvents)
+	}
+	verified := dispatchObject(t, c, "verify-text", map[string]any{"text": "ready"})
+	if verified["ok"] != false || verified["evidence"].(map[string]any)["outcome"] != "ambiguous" {
+		t.Fatalf("verify-text did not report ambiguity: %#v", verified)
+	}
+}
+
+func TestObserveReturnsUnavailableEnvelopeWithoutSnapshotOrOCR(t *testing.T) {
+	t.Setenv("KVMCTL_OCR_COMMAND", "")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { http.Error(w, "down", http.StatusServiceUnavailable) }))
+	defer srv.Close()
+	c := client.New(&config.Config{BaseURL: srv.URL}, 0, 0)
+	out := dispatchObject(t, c, "observe", nil)
+	if out["ok"] != false || out["state"] != "unavailable" || out["evidence"].(map[string]any)["unavailable"] != true {
+		t.Fatalf("expected unavailable envelope, got %#v", out)
+	}
+}
+
+func TestObserveReturnsUnavailableEnvelopeWithoutConfiguredOCR(t *testing.T) {
+	t.Setenv("KVMCTL_OCR_COMMAND", "")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("live-snapshot")) }))
+	defer srv.Close()
+	c := client.New(&config.Config{BaseURL: srv.URL}, 0, 0)
+	out := dispatchObject(t, c, "observe", nil)
+	if out["ok"] != false || out["state"] != "unavailable" || out["evidence"].(map[string]any)["unavailable"] != true {
+		t.Fatalf("expected OCR-unavailable envelope, got %#v", out)
+	}
+	if !strings.Contains(out["error"].(map[string]any)["code"].(string), "ocr unavailable") {
+		t.Fatalf("missing OCR unavailable error: %#v", out)
+	}
+}
+
+func TestObserveCapturesFreshSnapshotAndConfiguredOCREvidence(t *testing.T) {
+	t.Setenv("KVMCTL_OCR_PROTOCOL", "json")
+	command := writeFakeOCR(t, `{"width":100,"height":50,"words":[{"text":"Continue","confidence":95,"x":10,"y":10,"width":40,"height":10}]}`)
+	t.Setenv("KVMCTL_OCR_COMMAND", command)
+
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/streamer/snapshot" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		requests++
+		_, _ = w.Write([]byte("live-snapshot"))
+	}))
+	defer srv.Close()
+
+	c := client.New(&config.Config{BaseURL: srv.URL}, 0, 0)
+	out := dispatchObject(t, c, "observe", nil)
+	if requests != 1 || out["ok"] != true || out["operation"] != "observe" {
+		t.Fatalf("observe output=%#v requests=%d", out, requests)
+	}
+	evidence := out["evidence"].(map[string]any)
+	observation := evidence["observation"].(map[string]any)
+	if observation["observation_id"] == "" || observation["image_sha256"] == "" {
+		t.Fatalf("missing canonical observation evidence: %#v", observation)
+	}
+}
+
+func dispatchObject(t *testing.T, c *client.Client, operation string, args map[string]any) map[string]any {
+	t.Helper()
+	raw, err := Dispatch(context.Background(), c, operation, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func writeFakeOCR(t *testing.T, response string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-ocr")
+	program := "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '" + response + "'\n"
+	if err := os.WriteFile(path, []byte(program), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/library/devices/kvmctl/internal/semantic/dispatch_test.go
+++ b/library/devices/kvmctl/internal/semantic/dispatch_test.go
@@ -3,6 +3,7 @@ package semantic
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/mvanhorn/printing-press-library/library/devices/kvmctl/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/devices/kvmctl/internal/config"
 	"net/http"
@@ -66,11 +67,39 @@ func TestClickTextRequiresFreshObservationWritesAndReturnsPostObservation(t *tes
 		t.Fatal("click-text accepted without write_enabled")
 	}
 	out := dispatchObject(t, c, "click-text", map[string]any{"write_enabled": true, "observation_id": id, "text": "  proceed  "})
-	if out["ok"] != true || snapshots != 2 || len(events) != 3 {
+	if out["ok"] != true || snapshots != 3 || len(events) != 3 {
 		t.Fatalf("output=%#v snapshots=%d events=%v", out, snapshots, events)
 	}
 	if _, ok := out["evidence"].(map[string]any)["post_observation"]; !ok {
 		t.Fatalf("missing post observation: %#v", out)
+	}
+}
+
+func TestClickTextRefusesChangedScreenBeforeHID(t *testing.T) {
+	t.Setenv("KVMCTL_OCR_PROTOCOL", "json")
+	t.Setenv("KVMCTL_OCR_COMMAND", writeFakeOCR(t, `{"width":100,"height":50,"words":[{"text":"Proceed","confidence":95,"x":10,"y":10,"width":40,"height":10}]}`))
+	var snapshots, hidEvents int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/streamer/snapshot":
+			snapshots++
+			_, _ = w.Write([]byte(fmt.Sprintf("snapshot-%d", snapshots)))
+		case "/api/hid/events/send_mouse_move", "/api/hid/events/send_mouse_button":
+			hidEvents++
+			_, _ = w.Write([]byte(`{"result":{}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	c := client.New(&config.Config{BaseURL: srv.URL}, 0, 0)
+	observed := dispatchObject(t, c, "observe", nil)
+	id := observed["evidence"].(map[string]any)["observation"].(map[string]any)["observation_id"].(string)
+	if _, err := Dispatch(context.Background(), c, "click-text", map[string]any{"write_enabled": true, "observation_id": id, "text": "Proceed"}); err == nil {
+		t.Fatal("changed screen did not refuse click")
+	}
+	if hidEvents != 0 {
+		t.Fatalf("changed screen sent %d HID events", hidEvents)
 	}
 }
 

--- a/library/devices/kvmctl/internal/semantic/ocr_loop.go
+++ b/library/devices/kvmctl/internal/semantic/ocr_loop.go
@@ -1,0 +1,188 @@
+package semantic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/devices/kvmctl/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/devices/kvmctl/internal/ocr"
+	"github.com/mvanhorn/printing-press-library/library/devices/kvmctl/internal/results"
+)
+
+const highConfidence = 80.0
+
+var observations = ocr.NewObservationStore(60*time.Second, 64, time.Now)
+
+func opObserve(ctx context.Context, c *client.Client) (results.Operation, error) {
+	observation, unavailable := captureObservation(ctx, c)
+	if unavailable != nil {
+		return unavailableOperation("observe", true, nil, unavailable), nil
+	}
+	return results.Build("observe", "kvm", true, "", true, false, "observed", map[string]any{"observation": observation}, nil), nil
+}
+
+func opClickText(ctx context.Context, c *client.Client, args map[string]any) (results.Operation, error) {
+	observation, err := requiredObservation(args)
+	if err != nil {
+		return results.Operation{}, err
+	}
+	text := stringArg(args, "text")
+	if normalizeText(text) == "" {
+		return results.Operation{}, fmt.Errorf("text is required")
+	}
+	region, outcome := exactHighConfidenceRegion(observation, text)
+	if outcome != "match" {
+		return results.Build("click-text", "kvm", false, "", false, false, "refused", map[string]any{"observation_id": observation.ID, "text": text, "outcome": outcome}, &results.Error{Code: "text " + outcome}), nil
+	}
+	if err := c.KVMDMouseMove(ctx, region.Pixel[0], region.Pixel[1]); err != nil {
+		return unavailableOperation("click-text", false, map[string]any{"observation_id": observation.ID, "region": region}, err), nil
+	}
+	if err := c.KVMDMouseButton(ctx, "left", true); err != nil {
+		return unavailableOperation("click-text", false, map[string]any{"observation_id": observation.ID, "region": region}, err), nil
+	}
+	if err := c.KVMDMouseButton(ctx, "left", false); err != nil {
+		return unavailableOperation("click-text", false, map[string]any{"observation_id": observation.ID, "region": region}, err), nil
+	}
+	post, unavailable := captureObservation(ctx, c)
+	if unavailable != nil {
+		return unavailableOperation("click-text", false, map[string]any{"observation_id": observation.ID, "region": region, "clicked": true}, unavailable), nil
+	}
+	return results.Build("click-text", "kvm", false, "", true, true, "completed", map[string]any{"observation_id": observation.ID, "region": region, "post_observation": post}, nil), nil
+}
+
+func opPressKey(ctx context.Context, c *client.Client, args map[string]any) (results.Operation, error) {
+	observation, err := requiredObservation(args)
+	if err != nil {
+		return results.Operation{}, err
+	}
+	key := stringArg(args, "key")
+	if !allowedKey(key) {
+		return results.Operation{}, fmt.Errorf("key is not allowed")
+	}
+	if err := c.KVMDKey(ctx, key, true); err != nil {
+		return unavailableOperation("press-key", false, map[string]any{"observation_id": observation.ID, "key": key}, err), nil
+	}
+	if err := c.KVMDKey(ctx, key, false); err != nil {
+		return unavailableOperation("press-key", false, map[string]any{"observation_id": observation.ID, "key": key}, err), nil
+	}
+	post, unavailable := captureObservation(ctx, c)
+	if unavailable != nil {
+		return unavailableOperation("press-key", false, map[string]any{"observation_id": observation.ID, "key": key, "pressed": true}, unavailable), nil
+	}
+	return results.Build("press-key", "kvm", false, "", true, true, "completed", map[string]any{"observation_id": observation.ID, "key": key, "post_observation": post}, nil), nil
+}
+
+func opVerifyText(ctx context.Context, c *client.Client, args map[string]any) (results.Operation, error) {
+	text := stringArg(args, "text")
+	if normalizeText(text) == "" {
+		return results.Operation{}, fmt.Errorf("text is required")
+	}
+	observation, unavailable := captureObservation(ctx, c)
+	if unavailable != nil {
+		return unavailableOperation("verify-text", true, map[string]any{"text": text}, unavailable), nil
+	}
+	region, outcome := exactHighConfidenceRegion(observation, text)
+	ok := outcome == "match"
+	var resultError *results.Error
+	if !ok {
+		resultError = &results.Error{Code: "text " + outcome}
+	}
+	evidence := map[string]any{"text": text, "outcome": outcome, "observation": observation}
+	if ok {
+		evidence["region"] = region
+	}
+	return results.Build("verify-text", "kvm", true, "", ok, false, "observed", evidence, resultError), nil
+}
+
+func captureObservation(ctx context.Context, c *client.Client) (ocr.Observation, error) {
+	imageBytes, err := c.GetWithHeadersNoCache(ctx, "/api/streamer/snapshot", nil, map[string]string{"Accept": "image/jpeg", client.BinaryResponseHeader: "true"})
+	if err != nil || len(imageBytes) == 0 {
+		if err == nil {
+			err = errors.New("empty snapshot")
+		}
+		return ocr.Observation{}, fmt.Errorf("snapshot unavailable: %w", err)
+	}
+	engine, err := ocr.CommandEngineFromEnvironment()
+	if err != nil {
+		return ocr.Observation{}, fmt.Errorf("ocr unavailable: %w", err)
+	}
+	width, height, words, err := engine.Recognize(imageBytes)
+	if err != nil {
+		return ocr.Observation{}, fmt.Errorf("ocr unavailable: %w", err)
+	}
+	regions := make([]ocr.Region, 0, len(words))
+	for _, word := range words {
+		regions = append(regions, ocr.Region{Text: strings.TrimSpace(word.Text), Confidence: word.Confidence, Box: [4]int{word.X, word.Y, word.Width, word.Height}, Pixel: [2]int{word.X + word.Width/2, word.Y + word.Height/2}})
+	}
+	observation, err := ocr.NewObservation(imageBytes, time.Now(), engine.Name(), width, height, regions)
+	if err != nil {
+		return ocr.Observation{}, fmt.Errorf("ocr unavailable: %w", err)
+	}
+	observations.Put(observation)
+	return observation, nil
+}
+
+func requiredObservation(args map[string]any) (ocr.Observation, error) {
+	id := stringArg(args, "observation_id")
+	if id == "" {
+		return ocr.Observation{}, fmt.Errorf("observation_id is required")
+	}
+	observation, ok := observations.Get(id)
+	if !ok || observation.ID != id {
+		return ocr.Observation{}, fmt.Errorf("observation_id is unavailable or stale")
+	}
+	return observation, nil
+}
+
+func exactHighConfidenceRegion(observation ocr.Observation, text string) (ocr.Region, string) {
+	wanted := normalizeText(text)
+	matches := make([]ocr.Region, 0, 1)
+	for _, region := range observation.OCR.Regions {
+		if region.Confidence >= highConfidence && normalizeText(region.Text) == wanted {
+			matches = append(matches, region)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return ocr.Region{}, "not_found"
+	case 1:
+		return matches[0], "match"
+	default:
+		return ocr.Region{}, "ambiguous"
+	}
+}
+
+func normalizeText(text string) string {
+	return strings.ToLower(strings.Join(strings.Fields(text), " "))
+}
+
+func unavailableOperation(operation string, readOnly bool, evidence map[string]any, err error) results.Operation {
+	if evidence == nil {
+		evidence = map[string]any{}
+	}
+	evidence["unavailable"] = true
+	return results.Build(operation, "kvm", readOnly, "", false, false, "unavailable", evidence, &results.Error{Code: err.Error(), Retryable: true})
+}
+
+func allowedKey(key string) bool {
+	if strings.HasPrefix(key, "Key") && len(key) == 4 && key[3] >= 'A' && key[3] <= 'Z' {
+		return true
+	}
+	if strings.HasPrefix(key, "Digit") && len(key) == 6 && key[5] >= '0' && key[5] <= '9' {
+		return true
+	}
+	if strings.HasPrefix(key, "F") && len(key) >= 2 && len(key) <= 3 {
+		if key == "F1" || key == "F2" || key == "F3" || key == "F4" || key == "F5" || key == "F6" || key == "F7" || key == "F8" || key == "F9" || key == "F10" || key == "F11" || key == "F12" {
+			return true
+		}
+	}
+	switch key {
+	case "Enter", "Escape", "Tab", "Space", "Backspace", "Delete", "Insert", "Home", "End", "PageUp", "PageDown", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight":
+		return true
+	default:
+		return false
+	}
+}

--- a/library/devices/kvmctl/internal/semantic/ocr_loop.go
+++ b/library/devices/kvmctl/internal/semantic/ocr_loop.go
@@ -25,7 +25,7 @@ func opObserve(ctx context.Context, c *client.Client) (results.Operation, error)
 }
 
 func opClickText(ctx context.Context, c *client.Client, args map[string]any) (results.Operation, error) {
-	observation, err := requiredObservation(args)
+	observation, err := requiredFreshObservation(ctx, c, args)
 	if err != nil {
 		return results.Operation{}, err
 	}
@@ -54,7 +54,7 @@ func opClickText(ctx context.Context, c *client.Client, args map[string]any) (re
 }
 
 func opPressKey(ctx context.Context, c *client.Client, args map[string]any) (results.Operation, error) {
-	observation, err := requiredObservation(args)
+	observation, err := requiredFreshObservation(ctx, c, args)
 	if err != nil {
 		return results.Operation{}, err
 	}
@@ -125,14 +125,17 @@ func captureObservation(ctx context.Context, c *client.Client) (ocr.Observation,
 	return observation, nil
 }
 
-func requiredObservation(args map[string]any) (ocr.Observation, error) {
+func requiredFreshObservation(ctx context.Context, c *client.Client, args map[string]any) (ocr.Observation, error) {
 	id := stringArg(args, "observation_id")
 	if id == "" {
 		return ocr.Observation{}, fmt.Errorf("observation_id is required")
 	}
-	observation, ok := observations.Get(id)
-	if !ok || observation.ID != id {
-		return ocr.Observation{}, fmt.Errorf("observation_id is unavailable or stale")
+	observation, unavailable := captureObservation(ctx, c)
+	if unavailable != nil {
+		return ocr.Observation{}, unavailable
+	}
+	if observation.ID != id {
+		return ocr.Observation{}, fmt.Errorf("observation_id is stale: screen changed")
 	}
 	return observation, nil
 }


### PR DESCRIPTION
## Summary
- Add a configured, argv-only OCR command engine and bounded in-memory observation evidence.
- Add `observe`, `verify`, `act click-text`, and `act press-key` commands plus discoverable MCP semantic operations.
- Bind HID actions to a fresh matching screenshot; refuse stale, missing, ambiguous, or low-confidence OCR evidence.
- Require `--yes` for CLI actions and both `KVMCTL_WRITE_ENABLED=1` plus explicit `arguments.write_enabled: true` through MCP.

## Safety
- No OCR executable configured or any snapshot/OCR failure returns an unavailable envelope; no screen text or coordinates are synthesized.
- `click-text` accepts exactly one normalized high-confidence match and never falls back to a generic click coordinate.
- Successful actions return fresh post-action observation evidence.

## Verification
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `go test -race ./internal/ocr ./internal/semantic ./internal/cli ./internal/mcp`
- publish-package, supply-chain, attribution, and documentation-skill validators
- CLI help and MCP `tools/list` smoke tests
