### PR TITLE
fix(grants): normalise whitespace in Grants.gov titles and agency names

### DIFF
--- a/library/health/grants/.printing-press-patches/grants-normalise-agency-text-whitespace.json
+++ b/library/health/grants/.printing-press-patches/grants-normalise-agency-text-whitespace.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "grants-normalise-agency-text-whitespace",
+  "applied_at": "2026-09-03",
+  "base_run_id": "20260705-183000",
+  "base_printing_press_version": "4.25.0",
+  "summary": "Grants.gov titles and agency names carry doubled interior spaces and trailing spaces; normalizeText collapses them, and must run AFTER html.UnescapeString rather than before.",
+  "reason": "Order is load-bearing: unescaping itself produces whitespace (&nbsp; becomes U+00A0, &#32; a plain space), so normalising first leaves it behind. strings.Fields rather than a regexp for two reasons that must survive a regen: this module has no external dependencies and stdlib keeps it that way, and Fields splits on unicode.IsSpace so it folds U+00A0, whereas Go's regexp \\s class is ASCII-only and would not. Agency also gains html.UnescapeString, which it never had.",
+  "files": ["internal/sources/grantsgov.go", "internal/sources/grantsgov_test.go"],
+  "validated_outcome": "48-row live search for 'climate' measured 2026-09-03: three titles with doubled interior spaces and two agency names with trailing spaces before, zero after. TestNormalizeText fails on a mutation that joins with \"\" instead of \" \"."
+}

--- a/library/health/grants/internal/sources/grantsgov.go
+++ b/library/health/grants/internal/sources/grantsgov.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"strings"
 	"time"
 )
 
@@ -46,6 +47,27 @@ const grantsStaleAfter = 2 * 365 * 24 * time.Hour
 
 // grantsDateLayout is the MM/DD/YYYY format the API returns.
 const grantsDateLayout = "01/02/2006"
+
+// normalizeText collapses interior whitespace runs to a single space and trims
+// the ends.
+//
+// Grants.gov ships raw agency-entered text. Measured on 2026-09-03 for the
+// keyword "climate" (48 results): three titles carried doubled interior
+// spaces — "Egypt  Annual Program Statement" (DFOP0018819), "Science &
+// Technology  Broad Agency Announcement" (HM047623BAA0001) and "Notice of
+// Intent:  Program to End Modern Slavery" (SFOP0008547) — and two agency
+// names carried a trailing space: "National Geospatial-Intelligence Agency "
+// (HM047623BAA0001) and "DOT Federal Highway Administration "
+// (693JJ323NF00014).
+//
+// strings.Fields rather than a regexp, for two reasons. This module has no
+// external dependencies and stdlib keeps it that way; and Fields splits on
+// unicode.IsSpace, so it also folds the non-breaking space that
+// html.UnescapeString produces from &nbsp;. Go's regexp \s class is ASCII-only
+// and would leave U+00A0 in place.
+func normalizeText(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
 
 type Opportunity struct {
 	ID         json.Number `json:"id"`
@@ -137,7 +159,11 @@ func SearchOpportunities(keyword, agencyCode string, rows int) ([]Opportunity, i
 	}
 	opps := resp.Data.OppHits
 	for i := range opps {
-		opps[i].Title = html.UnescapeString(opps[i].Title) // titles contain entities such as &ndash;
+		// Unescape first, normalize second. The order matters: unescaping can
+		// itself produce whitespace (&nbsp; becomes U+00A0, &#32; a plain
+		// space), so normalizing first would leave that behind.
+		opps[i].Title = normalizeText(html.UnescapeString(opps[i].Title)) // titles contain entities such as &ndash;
+		opps[i].Agency = normalizeText(html.UnescapeString(opps[i].Agency))
 	}
 	return opps, resp.Data.HitCount, nil
 }

--- a/library/health/grants/internal/sources/grantsgov_test.go
+++ b/library/health/grants/internal/sources/grantsgov_test.go
@@ -1,0 +1,85 @@
+package sources
+
+import "testing"
+
+// TestNormalizeText pins the two defect shapes measured in live Grants.gov
+// data on 2026-09-03, plus the non-breaking space that html.UnescapeString
+// produces from &nbsp;.
+//
+// The last case is the reason this uses strings.Fields rather than a regexp:
+// Go's regexp \s class is ASCII-only, so a `\s+` implementation passes every
+// case here except that one.
+func TestNormalizeText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// DFOP0018819, measured.
+			name: "doubled interior space",
+			in:   "Egypt  Annual Program Statement",
+			want: "Egypt Annual Program Statement",
+		},
+		{
+			// SFOP0008547, measured.
+			name: "doubled space after colon",
+			in:   "Notice of Intent:  Program to End Modern Slavery FY 2022",
+			want: "Notice of Intent: Program to End Modern Slavery FY 2022",
+		},
+		{
+			// HM047623BAA0001, measured.
+			name: "trailing space",
+			in:   "National Geospatial-Intelligence Agency ",
+			want: "National Geospatial-Intelligence Agency",
+		},
+		{
+			// 693JJ323NF00014, measured.
+			name: "trailing space on agency",
+			in:   "DOT Federal Highway Administration ",
+			want: "DOT Federal Highway Administration",
+		},
+		{
+			name: "non-breaking space from &nbsp;",
+			in:   "Forest Legacy\u00a0Program",
+			want: "Forest Legacy Program",
+		},
+		{
+			name: "tab and newline",
+			in:   "Broad Agency\tAnnouncement\n(BAA)",
+			want: "Broad Agency Announcement (BAA)",
+		},
+		{
+			name: "already clean is unchanged",
+			in:   "Museums for America (2027)",
+			want: "Museums for America (2027)",
+		},
+		{
+			name: "empty stays empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "whitespace only collapses to empty",
+			in:   "   ",
+			want: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := normalizeText(c.in); got != c.want {
+				t.Errorf("normalizeText(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeTextPreservesSingleSpaces guards the mutation that would make
+// normalizeText strip ALL whitespace instead of collapsing runs — a
+// strings.Join with "" rather than " " still passes a trailing-space test.
+func TestNormalizeTextPreservesSingleSpaces(t *testing.T) {
+	const in = "Water, Landscape, and Critical Zone Processes"
+	if got := normalizeText(in); got != in {
+		t.Errorf("normalizeText(%q) = %q; single spaces must survive", in, got)
+	}
+}


### PR DESCRIPTION
## What

Grants.gov ships raw agency-entered text. `SearchOpportunities` already
unescaped HTML entities in `Title`; this adds whitespace normalisation to
`Title` and `Agency`, and unescaping to `Agency`.

## Measured

A 48-result live search for `climate` on 2026-09-03, before the change:

| Field | Opportunity | Value |
|---|---|---|
| Title | DFOP0018819 | `Egypt  Annual Program Statement` |
| Title | HM047623BAA0001 | `Science & Technology  Broad Agency Announcement` |
| Title | SFOP0008547 | `Notice of Intent:  Program to End Modern Slavery` |
| Agency | HM047623BAA0001 | `National Geospatial-Intelligence Agency ` |
| Agency | 693JJ323NF00014 | `DOT Federal Highway Administration ` |

Five defects in 48 rows. After the change: zero.

## Two decisions worth reviewing

**Order.** `normalizeText` runs *after* `html.UnescapeString`, not before.
Unescaping itself produces whitespace — `&nbsp;` becomes U+00A0, `&#32;` a
plain space — so normalising first would leave that behind.

**`strings.Fields`, not a regexp.** This module has no external
dependencies and stdlib keeps it that way. More importantly, `Fields`
splits on `unicode.IsSpace`, so it folds the non-breaking space that
unescaping produces; Go's regexp `\s` class is ASCII-only and would leave
U+00A0 in place. A test case pins that difference.

## What is precaution rather than a measured fix

`Agency` also gains `html.UnescapeString`, which it never had while
`Title` did. No entity was observed in an agency name in the measured
sample. Happy to drop that half if you'd rather keep the change to what
was actually observed.

## Tests

Nine table cases plus a single-space guard. Both fail on the mutation that
joins with `""` instead of `" "` — verified by making that change,
confirming the package still builds, and watching eight cases fail.

The call site inside `SearchOpportunities` is **not** covered; it would
need a network round trip or an injected transport. The function is
tested, the wiring is not.