### PR TITLE
feat(grants): emit the NSF principal investigator as contact_pi_name

### DIFF
--- a/library/health/grants/.printing-press-patches/nsf-pi-must-come-from-the-split-name-fields.json
+++ b/library/health/grants/.printing-press-patches/nsf-pi-must-come-from-the-split-name-fields.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "nsf-pi-must-come-from-the-split-name-fields",
+  "applied_at": "2026-09-04",
+  "base_run_id": "20260705-183000",
+  "base_printing_press_version": "4.25.0",
+  "summary": "The NSF principal investigator must be built from the API's split piLastName/piFirstName pair and emitted as contact_pi_name in the NIH path's \"SURNAME, FIRSTNAME\" shape; the combined pdPIName must not be used.",
+  "reason": "All three fields are populated in every record, so the split pair costs nothing, but pdPIName carries no surname boundary and consumers that apply the conventional \"last word is the surname\" rule — BibTeX among them — misfile every multi-word surname. Sharing contact_pi_name with the NIH path is deliberate: downstream consumers read one field name across both sources. A regen that requests pdPIName instead, or that emits piFirstName/piLastName as separate output keys, silently reintroduces both problems.",
+  "files": ["internal/sources/nsf.go", "internal/sources/nsf_test.go"],
+  "validated_outcome": "Measured 2026-09-04 across 236 unique awards over five unrelated keywords: pdPIName, piFirstName and piLastName each populated 236/236, and in 9 of 236 the last word of pdPIName is not the surname (\"Emma A Elliott Smith\" -> \"Elliott Smith\"). Live run of `nsf --json \"isotope ecology\"` emits \"Fonoll Almansa, Xavier\", one of those nine, correctly split."
+}

--- a/library/health/grants/docs/SPEC.md
+++ b/library/health/grants/docs/SPEC.md
@@ -23,7 +23,7 @@ Note: on `search`, `--min-award` / `--eligibility` automatically trigger a detai
 ## Data model
 - **Opportunity** (Grants.gov): id, number, title, agency, openDate, closeDate (MM/DD/YYYY), status; from the details: awardCeiling, awardFloor, applicantTypes[]
 - **NIHProject**: projectNum, title, org, pi, awardAmount, fiscalYear
-- **NSFAward**: id, title, awardee, fundsObligated, startDate, expDate
+- **NSFAward**: id, title, awardee, fundsObligated, startDate, expDate, pi
 
 ## Acceptance criteria
 1. ☐ All three commands return real rows from LIVE APIs (evidence: run output)

--- a/library/health/grants/internal/sources/nsf.go
+++ b/library/health/grants/internal/sources/nsf.go
@@ -48,6 +48,16 @@ type NSFAward struct {
 	Awardee        string `json:"awardeeName"`
 	StartDate      string `json:"startDate"`
 	ExpDate        string `json:"expDate"`
+
+	// PI is the principal investigator, formatted "SURNAME, FIRSTNAME" to match
+	// the NIH path's contact_pi_name so both sources look alike downstream.
+	// It is built from the API's split piLastName/piFirstName rather than its
+	// combined pdPIName: measured 2026-09-04 over 236 unique awards, all three
+	// fields are populated in 236 of 236 records, but in 9 of them the last
+	// word of pdPIName is not the surname ("Emma A Elliott Smith" has surname
+	// "Elliott Smith"), so any consumer applying the usual "last word is the
+	// surname" rule — BibTeX among them — misfiles those nine.
+	PI string `json:"contact_pi_name"`
 }
 
 // nsfAwardRaw carries the abstract used for matching. It is decode-only: the
@@ -56,6 +66,28 @@ type NSFAward struct {
 type nsfAwardRaw struct {
 	NSFAward
 	Abstract string `json:"abstractText"`
+
+	// The API returns the PI name split as well as combined; only the split
+	// pair is requested and decoded. See NSFAward.PI for why.
+	PIFirstName string `json:"piFirstName"`
+	PILastName  string `json:"piLastName"`
+}
+
+// nsfPIName renders the split PI name in the NIH path's "SURNAME, FIRSTNAME"
+// shape, degrading to whichever half is present rather than emitting a stray
+// comma.
+func nsfPIName(first, last string) string {
+	first = strings.TrimSpace(first)
+	last = strings.TrimSpace(last)
+	switch {
+	case first == "" && last == "":
+		return ""
+	case first == "":
+		return last
+	case last == "":
+		return first
+	}
+	return last + ", " + first
 }
 
 type nsfResp struct {
@@ -217,7 +249,9 @@ func nsfRank(pool []nsfAwardRaw, terms []string, rows int) ([]NSFAward, NSFStats
 	}
 	out := make([]NSFAward, 0, len(ranked))
 	for _, s := range ranked {
-		out = append(out, s.award.NSFAward)
+		award := s.award.NSFAward
+		award.PI = nsfPIName(s.award.PIFirstName, s.award.PILastName)
+		out = append(out, award)
 	}
 	return out, stats
 }
@@ -247,7 +281,7 @@ func SearchNSF(keyword string, rows int) ([]NSFAward, NSFStats, error) {
 		q.Set("keyword", keyword)
 		q.Set("rpp", fmt.Sprint(nsfPageSize))
 		q.Set("offset", fmt.Sprint(page*nsfPageSize+1)) // 1-based: page two starts at 26
-		q.Set("printFields", "id,title,fundsObligatedAmt,awardeeName,startDate,expDate,abstractText")
+		q.Set("printFields", "id,title,fundsObligatedAmt,awardeeName,startDate,expDate,abstractText,piFirstName,piLastName")
 		var resp nsfResp
 		if err := getJSON(nsfAwardsURL+"?"+q.Encode(), &resp); err != nil {
 			if page == 0 {

--- a/library/health/grants/internal/sources/nsf_test.go
+++ b/library/health/grants/internal/sources/nsf_test.go
@@ -78,7 +78,7 @@ func TestNSFScore(t *testing.T) {
 	}{
 		{
 			name:     "both terms in title",
-			award:    nsfAwardRaw{NSFAward{Title: "A Novel Gene Therapy Platform", ID: "1"}, "delivery vectors"},
+			award:    nsfAwardRaw{NSFAward: NSFAward{Title: "A Novel Gene Therapy Platform", ID: "1"}, Abstract: "delivery vectors"},
 			query:    "gene therapy",
 			wantOK:   true,
 			wantHit:  true,
@@ -86,7 +86,7 @@ func TestNSFScore(t *testing.T) {
 		},
 		{
 			name:     "one term in title, one in abstract",
-			award:    nsfAwardRaw{NSFAward{Title: "Gene Editing in Zebrafish", ID: "2"}, "a therapeutic approach"},
+			award:    nsfAwardRaw{NSFAward: NSFAward{Title: "Gene Editing in Zebrafish", ID: "2"}, Abstract: "a therapeutic approach"},
 			query:    "gene therapy",
 			wantOK:   true,
 			wantHit:  true,
@@ -94,14 +94,14 @@ func TestNSFScore(t *testing.T) {
 		},
 		{
 			name:    "missing a term is rejected",
-			award:   nsfAwardRaw{NSFAward{Title: "Squid Hydrodynamics", ID: "3"}, "artificial neural networks are used"},
+			award:   nsfAwardRaw{NSFAward: NSFAward{Title: "Squid Hydrodynamics", ID: "3"}, Abstract: "artificial neural networks are used"},
 			query:   "artificial intelligence",
 			wantOK:  false,
 			wantHit: false,
 		},
 		{
 			name:     "empty query keeps everything",
-			award:    nsfAwardRaw{NSFAward{Title: "Anything", ID: "4"}, ""},
+			award:    nsfAwardRaw{NSFAward: NSFAward{Title: "Anything", ID: "4"}, Abstract: ""},
 			query:    "",
 			wantOK:   true,
 			wantHit:  false,
@@ -119,18 +119,18 @@ func TestNSFScore(t *testing.T) {
 
 func TestNSFRank(t *testing.T) {
 	pool := []nsfAwardRaw{
-		{NSFAward{ID: "1", Title: "Squid Hydrodynamics", FundsObligated: "900000"},
-			"artificial neural sampling, no second term here"},
-		{NSFAward{ID: "2", Title: "Graduate Fellowship", FundsObligated: "100000"},
-			"supports the artificial intelligence priority area"},
-		{NSFAward{ID: "3", Title: "Artificial Intelligence for Robotics", FundsObligated: "500000"},
-			"an artificial intelligence system"},
+		{NSFAward: NSFAward{ID: "1", Title: "Squid Hydrodynamics", FundsObligated: "900000"},
+			Abstract: "artificial neural sampling, no second term here"},
+		{NSFAward: NSFAward{ID: "2", Title: "Graduate Fellowship", FundsObligated: "100000"},
+			Abstract: "supports the artificial intelligence priority area"},
+		{NSFAward: NSFAward{ID: "3", Title: "Artificial Intelligence for Robotics", FundsObligated: "500000"},
+			Abstract: "an artificial intelligence system"},
 		// Same collaborative award, registered per institution: different IDs,
 		// identical titles. The larger fundsObligatedAmt must win.
-		{NSFAward{ID: "4a", Title: "Collaborative Research: AI and Intelligence Testing", FundsObligated: "200000"},
-			"artificial methods"},
-		{NSFAward{ID: "4b", Title: "collaborative research:  AI and Intelligence Testing ", FundsObligated: "800000"},
-			"artificial methods"},
+		{NSFAward: NSFAward{ID: "4a", Title: "Collaborative Research: AI and Intelligence Testing", FundsObligated: "200000"},
+			Abstract: "artificial methods"},
+		{NSFAward: NSFAward{ID: "4b", Title: "collaborative research:  AI and Intelligence Testing ", FundsObligated: "800000"},
+			Abstract: "artificial methods"},
 	}
 
 	awards, stats := nsfRank(pool, nsfTerms("artificial intelligence"), 5)
@@ -156,9 +156,9 @@ func TestNSFRank(t *testing.T) {
 
 func TestNSFRankLimitsRows(t *testing.T) {
 	pool := []nsfAwardRaw{
-		{NSFAward{ID: "1", Title: "Cancer A"}, "cancer"},
-		{NSFAward{ID: "2", Title: "Cancer B"}, "cancer"},
-		{NSFAward{ID: "3", Title: "Cancer C"}, "cancer"},
+		{NSFAward: NSFAward{ID: "1", Title: "Cancer A"}, Abstract: "cancer"},
+		{NSFAward: NSFAward{ID: "2", Title: "Cancer B"}, Abstract: "cancer"},
+		{NSFAward: NSFAward{ID: "3", Title: "Cancer C"}, Abstract: "cancer"},
 	}
 	awards, stats := nsfRank(pool, nsfTerms("cancer"), 2)
 	if len(awards) != 2 {
@@ -166,5 +166,40 @@ func TestNSFRankLimitsRows(t *testing.T) {
 	}
 	if stats.Matched != 3 {
 		t.Errorf("Matched = %d, want 3 (stats count matches, not shown rows)", stats.Matched)
+	}
+}
+
+// The PI must reach the normalised output in the NIH path's
+// "SURNAME, FIRSTNAME" shape, built from the split pair. The measured hazard is
+// a multi-word surname: reading the combined pdPIName instead and taking its
+// last word as the surname misfiles "Emma A Elliott Smith" (9 of 236 awards
+// measured 2026-09-04).
+func TestNSFRankEmitsPI(t *testing.T) {
+	pool := []nsfAwardRaw{
+		{NSFAward: NSFAward{ID: "1", Title: "Isotope Ecology"}, Abstract: "ecology",
+			PIFirstName: "Emma", PILastName: "Elliott Smith"},
+	}
+	awards, _ := nsfRank(pool, nsfTerms("ecology"), 5)
+	if len(awards) != 1 {
+		t.Fatalf("len(awards) = %d, want 1", len(awards))
+	}
+	if got, want := awards[0].PI, "Elliott Smith, Emma"; got != want {
+		t.Errorf("PI = %q, want %q", got, want)
+	}
+}
+
+func TestNSFPIName(t *testing.T) {
+	cases := []struct{ first, last, want string }{
+		{"Jenny", "Ouyang", "Ouyang, Jenny"},
+		{"Emma", "Elliott Smith", "Elliott Smith, Emma"},
+		{" Emma ", " Elliott Smith ", "Elliott Smith, Emma"},
+		{"", "Ouyang", "Ouyang"}, // no stray leading comma
+		{"Jenny", "", "Jenny"},   // no stray trailing comma
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		if got := nsfPIName(c.first, c.last); got != c.want {
+			t.Errorf("nsfPIName(%q, %q) = %q, want %q", c.first, c.last, got, c.want)
+		}
 	}
 }

--- a/library/health/grants/internal/sources/nsf_test.go
+++ b/library/health/grants/internal/sources/nsf_test.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -200,6 +201,98 @@ func TestNSFPIName(t *testing.T) {
 	for _, c := range cases {
 		if got := nsfPIName(c.first, c.last); got != c.want {
 			t.Errorf("nsfPIName(%q, %q) = %q, want %q", c.first, c.last, got, c.want)
+		}
+	}
+}
+
+// nsfLiveBody is a verbatim trimmed response from the NSF Awards API, measured
+// 2026-09-04 for the keyword "isotope ecology" with the printFields this
+// package requests. It exists because TestNSFRankEmitsPI sets PIFirstName and
+// PILastName by hand and therefore proves only the formatting: a wrong JSON tag
+// would leave that test green while the app emitted an empty contact_pi_name.
+// Decoding this body through the real nsfResp/nsfAwardRaw structs is what pins
+// the tags. The second award carries a multi-word surname on purpose.
+//
+// What this fixture cannot cover: the request is never made, so a printFields
+// typo that stops the API returning piFirstName/piLastName at all is invisible
+// here. That gap is real and is not claimed to be covered.
+const nsfLiveBody = `{
+  "response": {
+    "award": [
+      {
+        "id": "2628024",
+        "title": "RAPID: Reproductive Ecology of Antarctic Krill",
+        "fundsObligatedAmt": "168531",
+        "awardeeName": "Oregon State University",
+        "startDate": "09/01/2026",
+        "expDate": "08/31/2027",
+        "abstractText": "Stable isotope work on krill ecology.",
+        "piFirstName": "Kim",
+        "piLastName": "Bernard"
+      },
+      {
+        "id": "2606140",
+        "title": "Anaerobic Fungi in Digestion",
+        "fundsObligatedAmt": "419981",
+        "awardeeName": "University of Texas at Austin",
+        "startDate": "09/01/2026",
+        "expDate": "08/31/2029",
+        "abstractText": "Isotope tracing informs the ecology of the digester community.",
+        "piFirstName": "Xavier",
+        "piLastName": "Fonoll Almansa"
+      }
+    ]
+  }
+}`
+
+// TestNSFDecodeEmitsPI runs a real API response body through the actual decode
+// path and out to JSON, so the input tags (piFirstName, piLastName), the
+// struct wiring and the output key (contact_pi_name) are all pinned by one
+// test. Asserting on the marshalled output rather than the Go field is
+// deliberate: the field name is ours, but contact_pi_name is the contract the
+// NIH path already publishes and the web app reads.
+func TestNSFDecodeEmitsPI(t *testing.T) {
+	var resp nsfResp
+	if err := json.Unmarshal([]byte(nsfLiveBody), &resp); err != nil {
+		t.Fatalf("decoding the measured NSF body: %v", err)
+	}
+	if len(resp.Response.Award) != 2 {
+		t.Fatalf("decoded %d awards, want 2", len(resp.Response.Award))
+	}
+	if got := resp.Response.Award[0].PIFirstName; got != "Kim" {
+		t.Errorf("PIFirstName = %q, want %q — check the json tag", got, "Kim")
+	}
+	if got := resp.Response.Award[1].PILastName; got != "Fonoll Almansa" {
+		t.Errorf("PILastName = %q, want %q — check the json tag", got, "Fonoll Almansa")
+	}
+
+	awards, _ := nsfRank(resp.Response.Award, nsfTerms("isotope ecology"), 5)
+	if len(awards) != 2 {
+		t.Fatalf("ranked %d awards, want 2", len(awards))
+	}
+
+	out, err := json.Marshal(awards)
+	if err != nil {
+		t.Fatalf("marshalling awards: %v", err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("re-decoding awards: %v", err)
+	}
+	byID := map[string]string{}
+	for _, a := range decoded {
+		pi, ok := a["contact_pi_name"].(string)
+		if !ok {
+			t.Fatalf("award %v has no string contact_pi_name — check the output json tag", a["id"])
+		}
+		byID[a["id"].(string)] = pi
+	}
+	for id, want := range map[string]string{
+		"2628024": "Bernard, Kim",
+		"2606140": "Fonoll Almansa, Xavier",
+	} {
+		if got := byID[id]; got != want {
+			t.Errorf("award %s contact_pi_name = %q, want %q", id, got, want)
 		}
 	}
 }


### PR DESCRIPTION
Requests piFirstName and piLastName from the NSF Awards API and emits the pair as contact_pi_name in "SURNAME, FIRSTNAME" form, the same field name and shape the NIH path already uses, so both sources look alike downstream.

## Why the split fields and not pdPIName

Measured 2026-09-04 on 236 unique awards across five unrelated keywords (photonics, education, ecology, materials, economics):

- pdPIName, piFirstName and piLastName are each populated in 236 of 236 records (100%), so nothing is lost by reading the split pair.
- In 9 of 236 records the last word of pdPIName is NOT the surname, because the surname has more than one word: "Emma A Elliott Smith" has surname "Elliott Smith"; also Ruiz Ramos, Fonoll Almansa, Nissim Kobliner, Raeeszadeh Sarmazdeh, Khodadadi Tirkolaei, Cruz Rios, Baldaguez Medina, de Leon. BibTeX reads an unpunctuated name as "last word is the surname", so pdPIName would misfile all nine.
- 104 of 236 have more than two words in pdPIName, but the dominant cause is a middle initial ("Jenny Q Ouyang"), where the last-word guess happens to be right. The real error count is 9, not 104.

coPDPI is deliberately not added: co-investigators are a separate question that also affects the NIH path, and the length distribution (44/19/10/14) spikes at 4 after a monotonic decline, which suggests the API truncates the array there. A list built from it could be silently incomplete.

## What Changed

- `printFields` in `internal/sources/nsf.go` now also requests `piFirstName,piLastName`.
- `nsfAwardRaw` gains decode-only `PIFirstName` / `PILastName`, following the existing decode-only `Abstract` precedent.
- `NSFAward` gains `PI string` with json tag `contact_pi_name`, populated in `nsfRank` via a new `nsfPIName` helper that renders "SURNAME, FIRSTNAME" and degrades to whichever half exists rather than emitting a stray comma.
- Two new tests in `nsf_test.go`. Existing literals converted from positional to named-field form, which the added struct fields required.

## Validation

- [x] `go build ./...` from the touched CLI root
- [x] `go vet ./...` from the touched CLI root
- [x] `go test -count=1 ./internal/sources/` — pass, 0.447s
- [x] `gofmt` clean on the staged LF copies of both changed files
- [x] Mutation 1 — swapped the field mapping in `nsfPIName`: tests FAIL as intended
- [x] Mutation 2 — dropped the empty-half switch: tests FAIL on three cases ("Ouyang, ", ", Jenny", ", ")
- [x] Live check — `nsf --json "isotope ecology"` returns a correctly split multi-word surname from the measured set
- [x] Ledger entry added: `.printing-press-patches/nsf-pi-must-come-from-the-split-name-fields.json`, written as a reprint guard

## Gaps / Follow-Up

Co-investigators (`coPDPI`) are unhandled by design, as explained above. Resolving them needs a separate measurement establishing whether the API truncates the array, and a decision that covers the NIH path too.