### PR TITLE
ci: require cli-printing-press 4.31.7 for new library CLIs

### DIFF
--- a/.github/scripts/verify-press-version/verify_press_version.py
+++ b/.github/scripts/verify-press-version/verify_press_version.py
@@ -12,7 +12,7 @@ from pathlib import Path, PurePosixPath
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-MIN_PRESS_VERSION = "4.10.0"
+MIN_PRESS_VERSION = "4.31.7"
 MIN_VERSION_PARTS = tuple(int(part) for part in MIN_PRESS_VERSION.split("."))
 
 

--- a/.github/scripts/verify-press-version/verify_press_version.py
+++ b/.github/scripts/verify-press-version/verify_press_version.py
@@ -79,13 +79,39 @@ def is_new_cli(base_ref: str, cli_dir: Path) -> bool:
     return not git_exists(base_ref, cli_dir / ".printing-press.json")
 
 
+_SEMVER_RE = re.compile(
+    r"^v?(\d+)\.(\d+)\.(\d+)(?:-([^+]*))?(?:\+(.*))?$"
+)
+
+
 def parse_semver(value: object) -> tuple[int, int, int] | None:
+    parsed = _parse_version(value)
+    if parsed is None:
+        return None
+    return parsed[0]
+
+
+def _parse_version(value: object) -> tuple[tuple[int, int, int], bool] | None:
     if not isinstance(value, str):
         return None
-    match = re.match(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$", value.strip())
+    match = _SEMVER_RE.match(value.strip())
     if match is None:
         return None
-    return tuple(int(part) for part in match.groups())
+    parts = tuple(int(part) for part in match.group(1, 2, 3))
+    is_prerelease = match.group(4) is not None
+    return parts, is_prerelease
+
+
+def version_meets_floor(value: object) -> bool:
+    parsed = _parse_version(value)
+    if parsed is None:
+        return False
+    parts, is_prerelease = parsed
+    if parts > MIN_VERSION_PARTS:
+        return True
+    if parts < MIN_VERSION_PARTS:
+        return False
+    return not is_prerelease
 
 
 def upgrade_message(actual: object) -> str:
@@ -124,8 +150,7 @@ def validate_cli_dir(cli_dir: Path) -> list[Problem]:
         return [Problem(manifest_path, ".printing-press.json must contain a JSON object")]
 
     raw_version = manifest.get("printing_press_version")
-    parsed = parse_semver(raw_version)
-    if parsed is None or parsed < MIN_VERSION_PARTS:
+    if not version_meets_floor(raw_version):
         return [Problem(manifest_path, upgrade_message(raw_version))]
 
     return []

--- a/.github/scripts/verify-press-version/verify_press_version_test.py
+++ b/.github/scripts/verify-press-version/verify_press_version_test.py
@@ -86,7 +86,7 @@ class PressVersionVerifierTest(unittest.TestCase):
     def test_new_cli_with_old_press_version_fails(self) -> None:
         base = self.commit_base()
         self.git("switch", "-c", "feature")
-        self.write_manifest("library/cloud/new", "4.9.9")
+        self.write_manifest("library/cloud/new", "4.31.6")
         self.write("library/cloud/new/README.md", "# New\n")
         self.git("add", ".")
         self.git("commit", "-m", "add stale cli")
@@ -96,7 +96,7 @@ class PressVersionVerifierTest(unittest.TestCase):
     def test_new_cli_with_current_press_version_passes(self) -> None:
         base = self.commit_base()
         self.git("switch", "-c", "feature")
-        self.write_manifest("library/cloud/new", "4.10.0")
+        self.write_manifest("library/cloud/new", "4.31.7")
         self.write("library/cloud/new/README.md", "# New\n")
         self.git("add", ".")
         self.git("commit", "-m", "add current cli")
@@ -106,7 +106,7 @@ class PressVersionVerifierTest(unittest.TestCase):
     def test_v_prefixed_newer_version_passes(self) -> None:
         base = self.commit_base()
         self.git("switch", "-c", "feature")
-        self.write_manifest("library/cloud/newer", "v4.11.0")
+        self.write_manifest("library/cloud/newer", "v4.32.0")
         self.write("library/cloud/newer/README.md", "# Newer\n")
         self.git("add", ".")
         self.git("commit", "-m", "add newer cli")

--- a/.github/scripts/verify-press-version/verify_press_version_test.py
+++ b/.github/scripts/verify-press-version/verify_press_version_test.py
@@ -113,6 +113,35 @@ class PressVersionVerifierTest(unittest.TestCase):
 
         self.assertEqual(0, self.run_quiet(base))
 
+    def test_prerelease_at_floor_fails(self) -> None:
+        base = self.commit_base()
+        self.git("switch", "-c", "feature")
+        self.write_manifest("library/cloud/new", "4.31.7-rc1")
+        self.write("library/cloud/new/README.md", "# New\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "add prerelease cli")
+
+        self.assertEqual(1, self.run_quiet(base))
+
+    def test_prerelease_newer_than_floor_passes(self) -> None:
+        base = self.commit_base()
+        self.git("switch", "-c", "feature")
+        self.write_manifest("library/cloud/newer", "4.32.0-rc1")
+        self.write("library/cloud/newer/README.md", "# Newer\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "add newer prerelease cli")
+
+        self.assertEqual(0, self.run_quiet(base))
+
+    def test_prerelease_at_floor_reports_below_required(self) -> None:
+        cli_dir = self.tmp / "library" / "cloud" / "rc"
+        self.write_manifest("library/cloud/rc", "4.31.7-rc1")
+
+        problems = verifier.validate_cli_dir(cli_dir)
+
+        self.assertEqual(1, len(problems))
+        self.assertIn("printing_press_version '4.31.7-rc1' is below the required", problems[0].message)
+
     def test_missing_version_fails_with_upgrade_guidance(self) -> None:
         cli_dir = self.tmp / "library" / "cloud" / "missing"
         self.write_manifest("library/cloud/missing", "")

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -40,10 +40,11 @@ name: Verify library conventions
 #    then published from that workflow.
 #
 # 6. Newly added library CLIs must have been printed by cli-printing-press
-#    v4.10.0 or newer. That release renamed the generator binary from
-#    `printing-press` to `cli-printing-press`; stale local generator
-#    checkouts and skill installs should fail with direct upgrade
-#    instructions instead of publishing ambiguous old artifacts. Existing
+#    v4.31.7 or newer so they ship with the current generator (including
+#    recent operator fixes: MCP clientHooks, sync default-filter/history,
+#    non-JSON default sync, binary `--deliver`, etc.). Stale local
+#    generator checkouts and skill installs should fail with direct
+#    upgrade instructions instead of publishing old artifacts. Existing
 #    published CLIs can still receive narrow bugfixes even when their
 #    historical manifest records an older Printing Press version.
 #


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The new-CLI `printing_press_version` floor was still `4.10.0`, set in PR #748 (2026-05-21) when the generator binary was renamed. Latest `cli-printing-press` is **v4.31.7** (2026-09-04), after the September operator-fix waves.

This bump requires newly added `library/<cat>/<slug>/` directories to declare `printing_press_version` ≥ 4.31.7 so they ship with the current generator (MCP clientHooks, sync default-filter/history, non-JSON default sync, binary `--deliver`, and related operator fixes). Stale checkouts then fail with the existing upgrade guidance (`go install @latest`, update skills, re-run publish).

**Scope:** new CLIs only. The gate still keys off `.printing-press.json` present on the PR and absent on the base ref. Existing published CLIs may keep older historical manifests for narrow bugfix PRs. No library CLI trees, `verify-release-ledger`, or `go.mod` floors are changed.

**Files:**
- `.github/scripts/verify-press-version/verify_press_version.py` — `MIN_PRESS_VERSION = "4.31.7"` (`MIN_VERSION_PARTS` still derived); prereleases of the floor (e.g. `4.31.7-rc1`) no longer satisfy it
- `.github/scripts/verify-press-version/verify_press_version_test.py` — floor fixtures (`4.31.6` fail, `4.31.7` pass, `v4.32.0` newer-pass) plus prerelease boundary coverage
- `.github/workflows/verify-library-conventions.yml` — header comment for the new floor

**Tests:** `python3 -m unittest verify_press_version_test -v` in `.github/scripts/verify-press-version/` — 11/11 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fa852b2-8540-4db4-af09-69c5eacdfde1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa852b2-8540-4db4-af09-69c5eacdfde1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

