### PR TITLE
fix(concur): correct live API shape mismatches in expenses apply-rules, sync, and reports list

### DIFF
--- a/library/productivity/concur/.printing-press-patches/expenses-and-reports-list-live-shape-fixes.json
+++ b/library/productivity/concur/.printing-press-patches/expenses-and-reports-list-live-shape-fixes.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 2,
+  "id": "expenses-and-reports-list-live-shape-fixes",
+  "applied_at": "2026-09-05",
+  "base_run_id": "20260812-144651-60addfc5",
+  "base_printing_press_version": "4.30.3",
+  "summary": "Fix 4 independent live-shape mismatches on expenses apply-rules, sync, and reports list commands. (F1: Correct apply-rules endpoint path; F2: Re-align types.Expense fields with live nested structure; F3: Safe honest fallback for expenses sync; F4: Page-based HAL pagination for reports list)",
+  "reason": "Live-verification session revealed shape mismatches against real API: apply-rules fetched report headers instead of expenses; types.Expense expected flat fields when they are actually objects; sync --resources expenses failed with unknown resource when it requires parent context; and reports list returned zero results because Concur uses Spring HATEOAS/HAL envelopes instead of flat cursor models. Reshaping these elements restores correct CLI behaviors without regressions.",
+  "files": [
+    "internal/types/types.go",
+    "internal/cli/expenses_apply_rules.go",
+    "internal/cli/expenses_scan_duplicates.go",
+    "internal/cli/sync.go",
+    "internal/cli/reports_list.go",
+    "internal/cli/helpers.go",
+    "internal/cli/expenses_apply_rules_test.go",
+    "internal/cli/reports_list_test.go"
+  ],
+  "call_sites": [
+    "type Expense struct",
+    "exp.ExpenseType.Name",
+    "knownSyncResourceNames(",
+    "syncResourcePath(",
+    "resolvePaginatedReadWithStrategy(",
+    "hasHALNext"
+  ],
+  "changes": [
+    {
+      "file": "internal/types/types.go",
+      "description": "Reshaped types.Expense and defined nested sub-types (ExpenseTypeRef, Money, VendorRef, PaymentTypeRef) to match live API response structure."
+    },
+    {
+      "file": "internal/cli/expenses_apply_rules.go",
+      "description": "Fixed endpoint path from /reports/{id} to /reports/{id}/expenses, updated preview mock records and rule-checking logic to use nested types.Expense fields."
+    },
+    {
+      "file": "internal/cli/expenses_scan_duplicates.go",
+      "description": "Updated grouping keys and vendor description extraction to use new nested types.Expense fields."
+    },
+    {
+      "file": "internal/cli/sync.go",
+      "description": "Registered 'expenses' under knownSyncResourceNames and updated syncResourcePath to return an informative fallback error stating per-report iteration is required but not yet implemented."
+    },
+    {
+      "file": "internal/cli/reports_list.go",
+      "description": "Re-configured paginated read strategy to use page, page, size (100) and omit hasMore field."
+    },
+    {
+      "file": "internal/cli/helpers.go",
+      "description": "Added content as a canonical pagination collection key, and implemented Spring HAL/HATEOAS link pagination (links and _links next rel checking) in paginatedGet."
+    },
+    {
+      "file": "internal/cli/expenses_apply_rules_test.go",
+      "description": "Added TestExpensesApplyRules_LiveShapeMismatches to verify endpoint path /expenses and F2 struct unmarshal success, and TestSyncExpenses_ReturnsSpecificError to verify F3 fallback."
+    },
+    {
+      "file": "internal/cli/reports_list_test.go",
+      "description": "Added TestReportsList_SpringHALPagination to verify F4 Spring HAL style pagination and content extraction over 2 pages."
+    }
+  ],
+  "validated_outcome": "All unit tests pass cleanly with zero regressions. Validation checks verify that the reports list command can correctly traverse and compile multi-page HAL-style envelopes and that expenses apply-rules correctly targets the expenses list endpoint.",
+  "findings_addressed": [
+    "F1",
+    "F2",
+    "F3",
+    "F4"
+  ],
+  "deferred_to_upstream": [],
+  "upstream_issue": null
+}

--- a/library/productivity/concur/internal/cli/expenses_apply_rules.go
+++ b/library/productivity/concur/internal/cli/expenses_apply_rules.go
@@ -116,7 +116,8 @@ func newExpensesApplyRulesCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if err == nil {
-				path := "/expensereports/v4/users/{user_id}/context/{context_type}/reports/{report_id}"
+				// PATCH(amend-2026-09-05: F1 use correct endpoint /reports/{id}/expenses)
+				path := "/expensereports/v4/users/{user_id}/context/{context_type}/reports/{report_id}/expenses"
 				path = replacePathParam(path, "report_id", reportID)
 				path = replacePathParam(path, "user_id", formatCLIParamValue(flagUserId))
 				path = replacePathParam(path, "context_type", formatCLIParamValue(flagContextType))
@@ -127,9 +128,22 @@ func newExpensesApplyRulesCmd(flags *rootFlags) *cobra.Command {
 						return classifyAPIError(readErr, flags)
 					}
 					fmt.Fprintln(cmd.ErrOrStderr(), "dry-run: could not reach the live API (no/expired session) -- previewing with simulated example data, not your real report")
+					// PATCH(amend-2026-09-05: F2 construct using corrected types.Expense fields)
 					expenses = []types.Expense{
-						{ExpenseId: "exp-1", ExpenseTypeCode: "Mobile/Cellular Phone", TransactionAmount: 65.00, BusinessPurpose: ""},
-						{ExpenseId: "exp-2", ExpenseTypeCode: "Fitness", TransactionAmount: 30.00, BusinessPurpose: "gym"},
+						{
+							ExpenseId: "exp-1",
+							ExpenseType: types.ExpenseTypeRef{Name: "Mobile/Cellular Phone", Code: "CELPH"},
+							TransactionAmount: types.Money{Value: 65.00, CurrencyCode: "USD"},
+							Vendor: types.VendorRef{Description: "on-call cell phone"},
+							BusinessPurpose: "",
+						},
+						{
+							ExpenseId: "exp-2",
+							ExpenseType: types.ExpenseTypeRef{Name: "Fitness", Code: "FITNS"},
+							TransactionAmount: types.Money{Value: 30.00, CurrencyCode: "USD"},
+							Vendor: types.VendorRef{Description: "gym"},
+							BusinessPurpose: "gym",
+						},
 					}
 				} else {
 					var nested struct {
@@ -158,20 +172,34 @@ func newExpensesApplyRulesCmd(flags *rootFlags) *cobra.Command {
 				}
 			} else {
 				fmt.Fprintln(cmd.ErrOrStderr(), "dry-run: no client/auth configured -- previewing with simulated example data, not your real report")
+				// PATCH(amend-2026-09-05: F2 construct using corrected types.Expense fields)
 				expenses = []types.Expense{
-					{ExpenseId: "exp-1", ExpenseTypeCode: "Mobile/Cellular Phone", TransactionAmount: 65.00, BusinessPurpose: ""},
-					{ExpenseId: "exp-2", ExpenseTypeCode: "Fitness", TransactionAmount: 30.00, BusinessPurpose: "gym"},
+					{
+						ExpenseId: "exp-1",
+						ExpenseType: types.ExpenseTypeRef{Name: "Mobile/Cellular Phone", Code: "CELPH"},
+						TransactionAmount: types.Money{Value: 65.00, CurrencyCode: "USD"},
+						Vendor: types.VendorRef{Description: "on-call cell phone"},
+						BusinessPurpose: "",
+					},
+					{
+						ExpenseId: "exp-2",
+						ExpenseType: types.ExpenseTypeRef{Name: "Fitness", Code: "FITNS"},
+						TransactionAmount: types.Money{Value: 30.00, CurrencyCode: "USD"},
+						Vendor: types.VendorRef{Description: "gym"},
+						BusinessPurpose: "gym",
+					},
 				}
 			}
 
+			// PATCH(amend-2026-09-05: F2 update loop to use corrected types.Expense nested structures)
 			var changes []appliedRuleChange
 			for _, exp := range expenses {
-				rule, ok := config[exp.ExpenseTypeCode]
+				rule, ok := config[exp.ExpenseType.Name]
 				if !ok {
 					continue
 				}
 				needsPurpose := exp.BusinessPurpose == ""
-				exceedsCap := rule.ReimbursementCap != nil && exp.TransactionAmount > *rule.ReimbursementCap
+				exceedsCap := rule.ReimbursementCap != nil && exp.TransactionAmount.Value > *rule.ReimbursementCap
 
 				if !needsPurpose && !exceedsCap {
 					continue // already up to date, safe to re-run
@@ -180,7 +208,7 @@ func newExpensesApplyRulesCmd(flags *rootFlags) *cobra.Command {
 				if needsPurpose {
 					if flags.dryRun {
 						changes = append(changes, appliedRuleChange{
-							ExpenseId: exp.ExpenseId, ExpenseType: exp.ExpenseTypeCode,
+							ExpenseId: exp.ExpenseId, ExpenseType: exp.ExpenseType.Name,
 							ChangeType: "would_set_business_purpose",
 							Detail:     fmt.Sprintf("dry-run: would set Business Purpose to %q", rule.BusinessPurpose),
 						})
@@ -194,7 +222,7 @@ func newExpensesApplyRulesCmd(flags *rootFlags) *cobra.Command {
 							return fmt.Errorf("setting business purpose on expense %s: %w", exp.ExpenseId, classifyAPIError(err, flags))
 						}
 						changes = append(changes, appliedRuleChange{
-							ExpenseId: exp.ExpenseId, ExpenseType: exp.ExpenseTypeCode,
+							ExpenseId: exp.ExpenseId, ExpenseType: exp.ExpenseType.Name,
 							ChangeType: "set_business_purpose",
 							Detail:     fmt.Sprintf("Business Purpose set to %q", rule.BusinessPurpose),
 						})
@@ -205,10 +233,10 @@ func newExpensesApplyRulesCmd(flags *rootFlags) *cobra.Command {
 					// See the command's Long description: itemization is
 					// deliberately not automated without a verified endpoint.
 					changes = append(changes, appliedRuleChange{
-						ExpenseId: exp.ExpenseId, ExpenseType: exp.ExpenseTypeCode,
+						ExpenseId: exp.ExpenseId, ExpenseType: exp.ExpenseType.Name,
 						ChangeType: "exceeds_cap_needs_manual_split",
 						Detail: fmt.Sprintf("Amount %.2f exceeds reimbursement cap %.2f -- itemize the personal remainder manually in Concur",
-							exp.TransactionAmount, *rule.ReimbursementCap),
+							exp.TransactionAmount.Value, *rule.ReimbursementCap),
 					})
 				}
 			}

--- a/library/productivity/concur/internal/cli/expenses_apply_rules_test.go
+++ b/library/productivity/concur/internal/cli/expenses_apply_rules_test.go
@@ -4,6 +4,9 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,5 +97,138 @@ func TestExpensesApplyRulesEmptyConfigIsNoOp(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `"changes":null`) && !strings.Contains(out.String(), `"changes": null`) {
 		t.Fatalf("expected empty changes for a missing config, got:\n%s", out.String())
+	}
+}
+
+// TestExpensesApplyRules_LiveShapeMismatches covers F1 and F2:
+// verifies apply-rules GETs /reports/{id}/expenses and successfully
+// parses a real nested live API response shape.
+func TestExpensesApplyRules_LiveShapeMismatches(t *testing.T) {
+	configPath := writeTestExpenseRulesConfig(t)
+
+	// Set up mock HTTP server
+	apiCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls++
+		if r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/reports/some-report-id/expenses") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[
+				{
+					"expenseId": "exp-real-1",
+					"expenseType": {
+						"id": "CELPH",
+						"name": "Mobile/Cellular Phone",
+						"code": "CELPH",
+						"isDeleted": false,
+						"listItemId": "item-1"
+					},
+					"transactionDate": "2026-09-01",
+					"transactionAmount": {
+						"value": 65.00,
+						"currencyCode": "USD"
+					},
+					"vendor": {
+						"id": "vendor-1",
+						"name": null,
+						"description": "on-call cell phone"
+					},
+					"paymentType": {
+						"id": "PAY-1",
+						"name": "Corporate Card",
+						"code": "CORP"
+					},
+					"businessPurpose": "",
+					"hasExceptions": false,
+					"hasBlockingExceptions": false
+				}
+			]`))
+			return
+		}
+		if r.Method == "PATCH" && strings.Contains(r.URL.Path, "/expenses/exp-real-1") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	t.Setenv("CONCUR_BASE_URL", server.URL)
+	t.Setenv("PRINTING_PRESS_VERIFY", "1")
+	t.Setenv("PRINTING_PRESS_VERIFY_LIVE_HTTP", "1")
+
+	cmd := RootCmd()
+	cmd.SetArgs([]string{
+		"expenses", "apply-rules", "some-report-id",
+		"--user-id", "test-user-id",
+		"--config", configPath,
+		"--yes",
+		"--json",
+	})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(os.Stderr)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if apiCalls != 2 {
+		t.Errorf("expected 2 API calls (1 GET, 1 PATCH), got %d", apiCalls)
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(out.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to unmarshal output JSON: %v", err)
+	}
+
+	changes, ok := envelope["changes"].([]any)
+	if !ok || len(changes) == 0 {
+		t.Fatalf("expected at least one rule change, got envelope: %+v", envelope)
+	}
+
+	foundSetPurpose := false
+	foundExceedsCap := false
+	for _, c := range changes {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		changeType := m["change_type"].(string)
+		if changeType == "set_business_purpose" {
+			foundSetPurpose = true
+		}
+		if changeType == "exceeds_cap_needs_manual_split" {
+			foundExceedsCap = true
+		}
+	}
+
+	if !foundSetPurpose {
+		t.Error("expected a business purpose change to be applied/logged")
+	}
+	if !foundExceedsCap {
+		t.Error("expected a cap overage warning to be logged")
+	}
+}
+
+// TestSyncExpenses_ReturnsSpecificError covers F3:
+// asserts a helpful, specific error when syncing expenses.
+func TestSyncExpenses_ReturnsSpecificError(t *testing.T) {
+	cmd := RootCmd()
+	cmd.SetArgs([]string{"sync", "--resources", "expenses"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected sync --resources expenses to fail, got nil")
+	}
+	expectedMsg := "expenses sync requires per-report iteration, not yet implemented"
+	if !strings.Contains(out.String(), expectedMsg) {
+		t.Fatalf("expected output to contain %q, but got:\n%s", expectedMsg, out.String())
 	}
 }

--- a/library/productivity/concur/internal/cli/expenses_scan_duplicates.go
+++ b/library/productivity/concur/internal/cli/expenses_scan_duplicates.go
@@ -110,7 +110,8 @@ func newNovelExpensesScanDuplicatesCmd(flags *rootFlags) *cobra.Command {
 				return printJSONFiltered(cmd.OutOrStdout(), scanDuplicatesResult{DuplicateGroups: nil}, flags)
 			}
 
-			// Group by (vendorDescription case-insensitive, transactionAmount exact match)
+			// PATCH(amend-2026-09-05: F2 update group key generation for types.Expense nested structures)
+			// Group by (vendor.description case-insensitive, transactionAmount.value exact match)
 			type groupKey struct {
 				vendor string
 				amount string
@@ -118,8 +119,8 @@ func newNovelExpensesScanDuplicatesCmd(flags *rootFlags) *cobra.Command {
 			groups := make(map[groupKey][]types.Expense)
 			for _, exp := range expenses {
 				k := groupKey{
-					vendor: strings.ToLower(strings.TrimSpace(exp.VendorDescription)),
-					amount: fmt.Sprintf("%.2f", exp.TransactionAmount),
+					vendor: strings.ToLower(strings.TrimSpace(exp.Vendor.Description)),
+					amount: fmt.Sprintf("%.2f", exp.TransactionAmount.Value),
 				}
 				groups[k] = append(groups[k], exp)
 			}
@@ -174,8 +175,9 @@ func newNovelExpensesScanDuplicatesCmd(flags *rootFlags) *cobra.Command {
 						// safer than fabricated data if it ever does.
 						continue
 					}
+					// PATCH(amend-2026-09-05: F2 update vendor access to nested structure)
 					dupGroups = append(dupGroups, duplicateGroup{
-						Vendor:   group[0].VendorDescription, // Original case
+						Vendor:   group[0].Vendor.Description, // Original case
 						Amount:   amountVal,
 						Expenses: dupInGroup,
 					})

--- a/library/productivity/concur/internal/cli/helpers.go
+++ b/library/productivity/concur/internal/cli/helpers.go
@@ -897,6 +897,60 @@ func paginatedGet(ctx context.Context, c interface {
 						}
 					}
 				}
+				// PATCH(amend-2026-09-05: F4 Spring HAL / HATEOAS pagination support)
+				hasHALNext := false
+				hasHALLinks := false
+				if rawLinks, ok := obj["links"]; ok {
+					var links []struct {
+						Rel  string `json:"rel"`
+						Href string `json:"href"`
+					}
+					if json.Unmarshal(rawLinks, &links) == nil {
+						hasHALLinks = true
+						for _, link := range links {
+							if link.Rel == "next" {
+								hasHALNext = true
+								break
+							}
+						}
+					}
+				}
+				if !hasHALLinks {
+					if rawLinks, ok := obj["_links"]; ok {
+						var links map[string]struct {
+							Href string `json:"href"`
+						}
+						if json.Unmarshal(rawLinks, &links) == nil {
+							hasHALLinks = true
+							if _, ok := links["next"]; ok {
+								hasHALNext = true
+							}
+						}
+					}
+				}
+
+				if hasHALLinks {
+					if hasHALNext {
+						nextPageSize := pageSize
+						if nextPageSize <= 0 {
+							nextPageSize = itemCount
+							if nextPageSize <= 0 {
+								nextPageSize = 1
+							}
+						}
+						if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
+							if page >= paginatedGetMaxPages {
+								emitPaginatedGetMaxPagesWarning(ctx)
+								break
+							}
+							clean[cursorParam] = next
+							continue
+						}
+					}
+					// If links are present but "next" rel is absent, it is the last page, so stop.
+					break
+				}
+
 				if !hasExplicitNoMore && nextCursorPath == "" && hasMoreField == "" {
 					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, itemCount); ok {
 						if page >= paginatedGetMaxPages {
@@ -996,6 +1050,7 @@ func isJSONArray(raw json.RawMessage) bool {
 var canonicalPaginationCollectionKeys = map[string]bool{
 	responsePathItemsKey: true,
 	"data":               true, "items": true, "results": true, "messages": true, "members": true, "values": true,
+	"content":            true, // PATCH(amend-2026-09-05: F4 support content collection field)
 }
 
 func deleteRawPath(obj map[string]json.RawMessage, path string) {
@@ -1203,7 +1258,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 	}
 
 	if allowEmbedded {
-		for _, field := range []string{responsePathItemsKey, "data", "items", "results", "messages", "members", "values"} {
+		for _, field := range []string{responsePathItemsKey, "data", "items", "results", "messages", "members", "values", "content"} {
 			if arr, ok := obj[field]; ok {
 				var nested []json.RawMessage
 				if json.Unmarshal(arr, &nested) == nil {

--- a/library/productivity/concur/internal/cli/reports_list.go
+++ b/library/productivity/concur/internal/cli/reports_list.go
@@ -65,10 +65,11 @@ func newReportsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			path = replacePathParam(path, "user_id", formatCLIParamValue(flagUserId))
 			path = replacePathParam(path, "context_type", formatCLIParamValue(flagContextType))
+			// PATCH(amend-2026-09-05: F4 configure for Spring HAL / page-based pagination)
 			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "live", "reports", path, map[string]string{
 				"status":        formatCLIParamValue(flagStatus),
 				"created_after": formatCLIParamValue(flagCreatedAfter),
-			}, nil, flagAll, "", "page_token", "", 0, "", "hasMore", "", cmd.ErrOrStderr())
+			}, nil, flagAll, "page", "page", "size", 100, "", "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/library/productivity/concur/internal/cli/reports_list_test.go
+++ b/library/productivity/concur/internal/cli/reports_list_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Allen Lew and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// TestReportsList_SpringHALPagination covers F4:
+// asserts reports list can paginate over a Spring HAL style envelope
+// with content and links properties across multiple pages.
+func TestReportsList_SpringHALPagination(t *testing.T) {
+	apiCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls++
+		page := r.URL.Query().Get("page")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if page == "" || page == "1" {
+			_, _ = w.Write([]byte(`{
+				"links": [
+					{
+						"rel": "next",
+						"href": "https://www-us2.api.concursolutions.com/expensereports/v4/users/test-user/context/TRAVELER/reports?page=2&size=100"
+					}
+				],
+				"content": [
+					{
+						"reportId": "report-1",
+						"name": "Report 1",
+						"businessPurpose": "Client site visit",
+						"approvalStatus": "Approved",
+						"total": 120.00,
+						"currencyCode": "USD"
+					}
+				]
+			}`))
+			return
+		}
+
+		if page == "2" {
+			_, _ = w.Write([]byte(`{
+				"links": [],
+				"content": [
+					{
+						"reportId": "report-2",
+						"name": "Report 2",
+						"businessPurpose": "Team building",
+						"approvalStatus": "Submitted",
+						"total": 350.00,
+						"currencyCode": "USD"
+					}
+				]
+			}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	t.Setenv("CONCUR_BASE_URL", server.URL)
+	t.Setenv("PRINTING_PRESS_VERIFY", "1")
+	t.Setenv("PRINTING_PRESS_VERIFY_LIVE_HTTP", "1")
+
+	cmd := RootCmd()
+	cmd.SetArgs([]string{
+		"reports", "list",
+		"--user-id", "test-user-id",
+		"--all",
+		"--json",
+	})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(os.Stderr)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if apiCalls != 2 {
+		t.Errorf("expected 2 API calls (page 1 and page 2), got %d", apiCalls)
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(out.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to unmarshal output JSON: %v", err)
+	}
+
+	results, ok := envelope["results"].([]any)
+	if !ok {
+		t.Fatalf("expected results field in envelope, got %+v", envelope)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 aggregated reports, got %d", len(results))
+	}
+
+	// Verify report names to ensure correct aggregation
+	r1, ok1 := results[0].(map[string]any)
+	r2, ok2 := results[1].(map[string]any)
+	if !ok1 || !ok2 {
+		t.Fatalf("unexpected result shape: %+v", results)
+	}
+
+	if r1["name"].(string) != "Report 1" || r2["name"].(string) != "Report 2" {
+		t.Errorf("expected Report 1 and Report 2, got %q and %q", r1["name"], r2["name"])
+	}
+}

--- a/library/productivity/concur/internal/cli/sync.go
+++ b/library/productivity/concur/internal/cli/sync.go
@@ -391,6 +391,9 @@ func syncResource(ctx context.Context, c interface {
 
 	path, err := syncResourcePath(resource)
 	if err != nil {
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+		}
 		return syncResult{Resource: resource, Err: err, Duration: time.Since(started)}
 	}
 
@@ -1878,6 +1881,7 @@ func knownSyncResourceNames() []string {
 		"attendees",
 		"delegates",
 		"expense_types",
+		"expenses", // PATCH(amend-2026-09-05: F3 register expenses)
 		"lists",
 		"locations",
 		"payment_types",
@@ -1909,6 +1913,10 @@ func describeResourceFailure(count int, label string, resources []string) string
 // For REST APIs this is typically "/<resource>". For non-REST APIs (e.g., Steam)
 // this preserves the actual endpoint path like "/ISteamApps/GetAppList/v2".
 func syncResourcePath(resource string) (string, error) {
+	if resource == "expenses" {
+		// PATCH(amend-2026-09-05: F3 expenses requires per-report iteration, not yet implemented)
+		return "", fmt.Errorf("expenses sync requires per-report iteration, not yet implemented (there is no flat \"all expenses\" endpoint) — 'expenses scan-duplicates' will not have real data until this lands; use 'expenses apply-rules <report_id>' directly against individual reports (it reads live, not from the local store) in the meantime")
+	}
 	paths := map[string]string{ // #nosec G101 -- endpoint paths, not credentials.
 		"attendee_types": "/v4/attendeetypes",
 		"attendees":      "/attendees/v4/attendees",

--- a/library/productivity/concur/internal/types/types.go
+++ b/library/productivity/concur/internal/types/types.go
@@ -33,15 +33,42 @@ type Delegator struct {
 	CanViewReceipts bool   `json:"canViewReceipts"`
 }
 
+// PATCH(amend-2026-09-05: F2 refactor to match live API response structure)
+type ExpenseTypeRef struct {
+	Id         string `json:"id"`
+	Name       string `json:"name"`
+	Code       string `json:"code"`
+	IsDeleted  bool   `json:"isDeleted"`
+	ListItemId string `json:"listItemId"`
+}
+
+type Money struct {
+	Value        float64 `json:"value"`
+	CurrencyCode string  `json:"currencyCode"`
+}
+
+type VendorRef struct {
+	Id          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type PaymentTypeRef struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+	Code string `json:"code"`
+}
+
 type Expense struct {
-	ExpenseId               string  `json:"expenseId"`
-	ExpenseTypeCode         string  `json:"expenseTypeCode"`
-	TransactionDate         string  `json:"transactionDate"`
-	TransactionAmount       float64 `json:"transactionAmount"`
-	TransactionCurrencyCode string  `json:"transactionCurrencyCode"`
-	VendorDescription       string  `json:"vendorDescription"`
-	BusinessPurpose         string  `json:"businessPurpose"`
-	HasException            bool    `json:"hasException"`
+	ExpenseId             string          `json:"expenseId"`
+	ExpenseType           ExpenseTypeRef  `json:"expenseType"`
+	TransactionDate       string          `json:"transactionDate"`
+	TransactionAmount     Money           `json:"transactionAmount"`
+	Vendor                VendorRef       `json:"vendor"`
+	PaymentType           PaymentTypeRef  `json:"paymentType"`
+	BusinessPurpose       string          `json:"businessPurpose"`
+	HasExceptions         bool            `json:"hasExceptions"`
+	HasBlockingExceptions bool            `json:"hasBlockingExceptions"`
 }
 
 type ExpenseType struct {

--- a/library/productivity/concur/internal/types/types.go
+++ b/library/productivity/concur/internal/types/types.go
@@ -3,6 +3,11 @@
 
 package types
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 type Attendee struct {
 	AttendeeId        string  `json:"attendeeId"`
 	FirstName         string  `json:"firstName"`
@@ -42,15 +47,82 @@ type ExpenseTypeRef struct {
 	ListItemId string `json:"listItemId"`
 }
 
+// UnmarshalJSON accepts both the live API's nested object and a bare
+// string, for backward compatibility with any row cached locally before
+// this PR under the old flat expenseTypeCode string field. That old field
+// held the exact-match Concur Expense Type NAME (e.g. "Mobile/Cellular
+// Phone", not a short code, despite its name) -- mapped to Name here to
+// match how expenses_apply_rules.go actually keys off it. PATCH
+// (amend-2026-09-05: P1 review finding "Stored Expenses No Longer
+// Decode").
+func (e *ExpenseTypeRef) UnmarshalJSON(data []byte) error {
+	type alias ExpenseTypeRef
+	var a alias
+	if err := json.Unmarshal(data, &a); err == nil {
+		*e = ExpenseTypeRef(a)
+		return nil
+	}
+	var bare string
+	if err := json.Unmarshal(data, &bare); err == nil {
+		*e = ExpenseTypeRef{Name: bare}
+		return nil
+	}
+	return fmt.Errorf("ExpenseTypeRef: cannot unmarshal %s as either an object or a bare string", string(data))
+}
+
 type Money struct {
 	Value        float64 `json:"value"`
 	CurrencyCode string  `json:"currencyCode"`
+}
+
+// UnmarshalJSON accepts both the live API's nested {value, currencyCode}
+// object and a bare number, for backward compatibility with any row
+// cached locally before this PR under the old flat transactionAmount
+// float64 field. PATCH (amend-2026-09-05: P1 review finding "Stored
+// Expenses No Longer Decode" -- writeThroughCache persists raw API bytes
+// verbatim, so an older cached shape can still be read back). A bare
+// number carries no currency, so CurrencyCode is left empty rather than
+// guessed.
+func (m *Money) UnmarshalJSON(data []byte) error {
+	type alias Money
+	var a alias
+	if err := json.Unmarshal(data, &a); err == nil {
+		*m = Money(a)
+		return nil
+	}
+	var bare float64
+	if err := json.Unmarshal(data, &bare); err == nil {
+		*m = Money{Value: bare}
+		return nil
+	}
+	return fmt.Errorf("Money: cannot unmarshal %s as either {value,currencyCode} or a bare number", string(data))
 }
 
 type VendorRef struct {
 	Id          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+}
+
+// UnmarshalJSON accepts both the live API's nested object and a bare
+// string, for backward compatibility with any row cached locally before
+// this PR under the old flat vendorDescription string field (mapped to
+// Description here, matching how callers read it post-fix). PATCH
+// (amend-2026-09-05: P1 review finding "Stored Expenses No Longer
+// Decode").
+func (v *VendorRef) UnmarshalJSON(data []byte) error {
+	type alias VendorRef
+	var a alias
+	if err := json.Unmarshal(data, &a); err == nil {
+		*v = VendorRef(a)
+		return nil
+	}
+	var bare string
+	if err := json.Unmarshal(data, &bare); err == nil {
+		*v = VendorRef{Description: bare}
+		return nil
+	}
+	return fmt.Errorf("VendorRef: cannot unmarshal %s as either an object or a bare string", string(data))
 }
 
 type PaymentTypeRef struct {
@@ -69,6 +141,56 @@ type Expense struct {
 	BusinessPurpose       string          `json:"businessPurpose"`
 	HasExceptions         bool            `json:"hasExceptions"`
 	HasBlockingExceptions bool            `json:"hasBlockingExceptions"`
+}
+
+// UnmarshalJSON tolerates a locally-cached row written under the pre-F2
+// flat schema (a single "hasException" key) alongside the live API's
+// current "hasExceptions"/"hasBlockingExceptions" pair. PATCH
+// (amend-2026-09-05: P1 review finding "Stored Expenses No Longer
+// Decode" -- writeThroughCache persists raw API bytes verbatim, so any
+// row cached before this PR's struct change can still be read back).
+// The single legacy flag is mapped to HasExceptions only (the more
+// general of the two); HasBlockingExceptions is unknowable from that one
+// old flag and is left false rather than guessed.
+func (e *Expense) UnmarshalJSON(data []byte) error {
+	type alias Expense
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return fmt.Errorf("Expense: %w", err)
+	}
+	*e = Expense(a)
+
+	// The pre-F2 flat schema used entirely different KEY NAMES for these
+	// four fields (expenseTypeCode, transactionCurrencyCode,
+	// vendorDescription, hasException) -- not just a different value
+	// shape under the same key, which Money/ExpenseTypeRef/VendorRef's
+	// own UnmarshalJSON already tolerates. A renamed key never gets fed
+	// to those nested unmarshalers at all: the primary decode above
+	// simply leaves the new-named field at its zero value. Check for the
+	// old key names explicitly and backfill only fields that never
+	// resolved, so a genuinely current-shaped row is never overwritten.
+	var legacy struct {
+		ExpenseTypeCode         *string `json:"expenseTypeCode"`
+		TransactionCurrencyCode *string `json:"transactionCurrencyCode"`
+		VendorDescription       *string `json:"vendorDescription"`
+		HasException            *bool   `json:"hasException"`
+	}
+	if json.Unmarshal(data, &legacy) != nil {
+		return nil // primary decode above already succeeded; this pass is best-effort
+	}
+	if e.ExpenseType.Name == "" && legacy.ExpenseTypeCode != nil {
+		e.ExpenseType.Name = *legacy.ExpenseTypeCode
+	}
+	if e.TransactionAmount.CurrencyCode == "" && legacy.TransactionCurrencyCode != nil {
+		e.TransactionAmount.CurrencyCode = *legacy.TransactionCurrencyCode
+	}
+	if e.Vendor.Description == "" && legacy.VendorDescription != nil {
+		e.Vendor.Description = *legacy.VendorDescription
+	}
+	if !e.HasExceptions && !e.HasBlockingExceptions && legacy.HasException != nil {
+		e.HasExceptions = *legacy.HasException
+	}
+	return nil
 }
 
 type ExpenseType struct {

--- a/library/productivity/concur/internal/types/types_test.go
+++ b/library/productivity/concur/internal/types/types_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Allen Lew and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestExpense_UnmarshalJSON_LegacyFlatShape covers the P1 PR-review finding
+// "Stored Expenses No Longer Decode": writeThroughCache persists raw API
+// bytes verbatim into local SQLite, so any row cached before the F2 struct
+// change (flat expenseTypeCode/transactionAmount/transactionCurrencyCode/
+// vendorDescription/hasException fields) must still decode without error,
+// not crash scan-duplicates on an old cache.
+func TestExpense_UnmarshalJSON_LegacyFlatShape(t *testing.T) {
+	legacy := []byte(`{
+		"expenseId": "exp-legacy-1",
+		"expenseTypeCode": "Mobile/Cellular Phone",
+		"transactionDate": "2025-06-01",
+		"transactionAmount": 65.5,
+		"transactionCurrencyCode": "USD",
+		"vendorDescription": "on-call cell phone",
+		"businessPurpose": "",
+		"hasException": true
+	}`)
+
+	var e Expense
+	if err := json.Unmarshal(legacy, &e); err != nil {
+		t.Fatalf("legacy flat-shaped row failed to decode: %v", err)
+	}
+
+	if e.ExpenseId != "exp-legacy-1" {
+		t.Errorf("ExpenseId = %q, want exp-legacy-1", e.ExpenseId)
+	}
+	if e.ExpenseType.Name != "Mobile/Cellular Phone" {
+		t.Errorf("ExpenseType.Name = %q, want Mobile/Cellular Phone (mapped from legacy expenseTypeCode)", e.ExpenseType.Name)
+	}
+	if e.TransactionAmount.Value != 65.5 {
+		t.Errorf("TransactionAmount.Value = %v, want 65.5 (mapped from legacy bare number)", e.TransactionAmount.Value)
+	}
+	if e.Vendor.Description != "on-call cell phone" {
+		t.Errorf("Vendor.Description = %q, want %q (mapped from legacy vendorDescription)", e.Vendor.Description, "on-call cell phone")
+	}
+	if !e.HasExceptions {
+		t.Error("HasExceptions should be true, mapped from legacy singular hasException")
+	}
+	if e.HasBlockingExceptions {
+		t.Error("HasBlockingExceptions should be false -- unknowable from the single legacy flag, must not be guessed true")
+	}
+}
+
+// TestExpense_UnmarshalJSON_CurrentNestedShape is a regression guard: the
+// live API's actual current shape (confirmed live 2026-09-05) must keep
+// decoding correctly now that legacy-shape tolerance has been added
+// alongside it.
+func TestExpense_UnmarshalJSON_CurrentNestedShape(t *testing.T) {
+	current := []byte(`{
+		"expenseId": "exp-current-1",
+		"expenseType": {"id": "CELPH", "name": "Mobile/Cellular Phone", "code": "OTHER", "isDeleted": false, "listItemId": null},
+		"transactionDate": "2026-08-31",
+		"transactionAmount": {"value": 50, "currencyCode": "USD"},
+		"vendor": {"id": null, "name": null, "description": "T-Mobile"},
+		"paymentType": {"id": "CASH", "name": "Cash", "code": "CASH"},
+		"businessPurpose": "on-call cell phone",
+		"hasExceptions": false,
+		"hasBlockingExceptions": false
+	}`)
+
+	var e Expense
+	if err := json.Unmarshal(current, &e); err != nil {
+		t.Fatalf("current nested-shaped row failed to decode: %v", err)
+	}
+
+	if e.ExpenseType.Name != "Mobile/Cellular Phone" || e.ExpenseType.Id != "CELPH" {
+		t.Errorf("ExpenseType = %+v, want Name=Mobile/Cellular Phone Id=CELPH", e.ExpenseType)
+	}
+	if e.TransactionAmount.Value != 50 || e.TransactionAmount.CurrencyCode != "USD" {
+		t.Errorf("TransactionAmount = %+v, want Value=50 CurrencyCode=USD", e.TransactionAmount)
+	}
+	if e.Vendor.Description != "T-Mobile" {
+		t.Errorf("Vendor.Description = %q, want T-Mobile", e.Vendor.Description)
+	}
+	if e.PaymentType.Id != "CASH" {
+		t.Errorf("PaymentType.Id = %q, want CASH", e.PaymentType.Id)
+	}
+}
+
+// TestMoney_UnmarshalJSON covers both shapes directly, independent of the
+// parent Expense struct.
+func TestMoney_UnmarshalJSON(t *testing.T) {
+	var m Money
+	if err := json.Unmarshal([]byte(`{"value": 12.5, "currencyCode": "USD"}`), &m); err != nil {
+		t.Fatalf("object shape: %v", err)
+	}
+	if m.Value != 12.5 || m.CurrencyCode != "USD" {
+		t.Errorf("object shape: got %+v", m)
+	}
+
+	var m2 Money
+	if err := json.Unmarshal([]byte(`12.5`), &m2); err != nil {
+		t.Fatalf("bare-number shape: %v", err)
+	}
+	if m2.Value != 12.5 || m2.CurrencyCode != "" {
+		t.Errorf("bare-number shape: got %+v, want Value=12.5 CurrencyCode=\"\"", m2)
+	}
+
+	var m3 Money
+	if err := json.Unmarshal([]byte(`"not a number or object"`), &m3); err == nil {
+		t.Error("expected an error for an unparseable shape, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Four independently root-caused bugs, all discovered live against the real tenant during a
monthly expense-filing session (separate scope from #1936, no file overlap):

- **F1**: `expenses apply-rules` GETs `/reports/{id}` (report header, zero expense data) instead
  of `/reports/{id}/expenses`. One-line endpoint fix.
- **F2**: even with F1 fixed, `types.Expense` doesn't match the live shape at all -- reshaped
  with proper nested types, updated both call sites.
- **F3**: `sync --resources expenses` was never actually wired up. Took an honest-error fallback
  instead of inventing new architecture on a single financial-data instance -- no working
  parent-keyed-dependent template exists anywhere in this codebase.
- **F4**: `reports list` silently returns 0 results -- the live API returns a Spring-HATEOAS/HAL
  page envelope, not the `hasMore`/cursor shape the command was configured for. Added HAL
  pagination detection to the shared `paginatedGet` helper -- verified `reports_list.go` is the
  *only* current caller of that code path, so no regression risk to other resources.

**Live-tested against the real tenant post-fix**: `reports list` now returns 145 real reports
across 2 pages (was 0, spanning back to 2014); `apply-rules` against a real $50 report now
parses correctly and correctly determines no changes are needed.

**Update (Greptile P1):** "Stored Expenses No Longer Decode" -- `writeThroughCache` persists raw
API bytes verbatim into local SQLite, so any `expenses.data` row cached before this PR's struct
change could still be read back by `scan-duplicates`, and the straight schema swap would
hard-fail decoding one. Fixed with tolerant `UnmarshalJSON` on `Money`/`ExpenseTypeRef`/
`VendorRef` (accept either the live nested object or a legacy bare scalar) plus a top-level
`Expense.UnmarshalJSON` pass that backfills from the OLD KEY NAMES (`expenseTypeCode`,
`transactionCurrencyCode`, `vendorDescription`, `hasException`) when the new-named field never
resolved -- the legacy schema renamed these keys entirely, not just the value shape underneath
an unchanged key, so nested-type tolerance alone wasn't sufficient (caught this gap empirically
via a failing test before it shipped).

## Findings

| ID | Category | Type | Rationale |
|---|---|---|---|
| F1 | expenses-apply-rules-wrong-endpoint | bug | Report-header endpoint has zero expense data. |
| F2 | expenses-apply-rules-struct-shape-mismatch | bug | `types.Expense` field shapes don't match live nested objects. |
| F3 | sync-expenses-not-implemented | bug | Fetch-path never wired up; no dependent-resource template exists to build the real fix on. |
| F4 | reports-list-wrong-pagination-model | bug | Configured for `hasMore`/cursor, live API is Spring-HAL `content[]`/`links[].rel==next`. |

## Verification

- Build/vet: PASS. Tests: PASS -- full suite, every package, plus scenarios covering F1/F2, F3,
  F4, and the backward-compat fix (legacy-flat-shape decode, current-shape regression guard,
  Money's two shapes in isolation).
- `publish validate`: PASS on every check this change touches. Same 2 checks fail (phase5
  fingerprint drift, verify-skill install-section drift) already proven pre-existing and
  unrelated on a clean `upstream/main` in #1936.
- Live smoke (real tenant): `reports list --all` -> 145 reports across 2 pages (was 0);
  `expenses apply-rules <real-report-id>` -> correctly parses and determines no changes needed.
- Independently re-verified beyond the implementing pass's own report: confirmed F3's
  "no existing template" claim by reading `concur-spec.yaml`/`sync.go` directly; found and fixed
  a bug in the first draft (F3's error referenced the wrong issue number and suggested
  `scan-duplicates` as a workaround despite it sharing the same broken dependency); confirmed
  the `helpers.go` change's blast radius is contained to `reports_list.go` alone; caught the
  backward-compat gap via Greptile review and verified the fix with a failing-then-passing test.

## Evidence

- Patch record: https://github.com/enlewof/printing-press-library/blob//library/productivity/concur/.printing-press-patches/expenses-and-reports-list-live-shape-fixes.json
- Local plan doc (not in this PR): `~/printing-press/manuscripts/concur/amend-2026-09-05T0402/proofs/2026-09-05-amend-concur-pp-cli.md`

Closes #1939
