### PR TITLE
feat(drug-enforcement): emit full code_info as wrapped Lots/Expiry

### DIFF
--- a/library/health/drug-enforcement/internal/cli/recalls.go
+++ b/library/health/drug-enforcement/internal/cli/recalls.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/mvanhorn/printing-press-library/library/health/drug-enforcement/internal/client"
 
@@ -45,6 +46,7 @@ type recallRecord struct {
 	ReasonForRecall      string `json:"reason_for_recall"`
 	DistributionPattern  string `json:"distribution_pattern"`
 	ProductDescription   string `json:"product_description"`
+	CodeInfo             string `json:"code_info"`
 	RecallInitiationDate string `json:"recall_initiation_date"`
 	ReportDate           string `json:"report_date"`
 	State                string `json:"state"`
@@ -258,6 +260,7 @@ func runRecallSearch(cmd *cobra.Command, flags *rootFlags, search string, limit 
 		fmt.Fprintf(w, "  Initiated:    %s\n", dash(normalizeRecallDate(r.RecallInitiationDate)))
 		fmt.Fprintf(w, "  Status:       %s\n", dash(r.Status))
 		fmt.Fprintf(w, "  Product:      %s\n", dash(clip(r.ProductDescription, 100)))
+		fmt.Fprintf(w, "  Lots/Expiry:  %s\n", dash(wrapField(r.CodeInfo, recallLineWidth, recallLabelWidth)))
 		fmt.Fprintf(w, "  Reason:       %s\n", dash(clip(r.ReasonForRecall, 100)))
 		fmt.Fprintln(w)
 	}
@@ -320,4 +323,49 @@ func clip(s string, n int) string {
 		return s
 	}
 	return s[:n] + "…"
+}
+
+// recallLabelWidth is the width of the label column in the human-readable record
+// block ("  Lots/Expiry:  " and its siblings are all 16 chars wide);
+// recallLineWidth is the total line budget, sized for an 80-column terminal.
+const (
+	recallLabelWidth = 16
+	recallLineWidth  = 80
+)
+
+// wrapField word-wraps s to fit a total line of width columns when the value
+// starts indent columns in, padding continuation lines by indent so they line up
+// under the first line's value. Unlike clip it never drops characters: code_info
+// carries lot numbers and expiry dates, where a truncated value is not partially
+// useful, it is wrong. Breaks are on whitespace only, so a lot number is never
+// split across lines; a lone token wider than the available column overflows its
+// line for that same reason (and so an unbreakable token can never loop).
+// Counts runes, not bytes, so a multi-byte character is never cut in half.
+func wrapField(s string, width, indent int) string {
+	s = strings.TrimSpace(s)
+	avail := width - indent
+	if s == "" || avail < 1 {
+		return s
+	}
+	pad := strings.Repeat(" ", indent)
+	var b strings.Builder
+	lineLen := 0
+	for i, word := range strings.Fields(s) {
+		n := utf8.RuneCountInString(word)
+		switch {
+		case i == 0:
+			b.WriteString(word)
+			lineLen = n
+		case lineLen+1+n <= avail:
+			b.WriteByte(' ')
+			b.WriteString(word)
+			lineLen += 1 + n
+		default:
+			b.WriteByte('\n')
+			b.WriteString(pad)
+			b.WriteString(word)
+			lineLen = n
+		}
+	}
+	return b.String()
 }

--- a/library/health/drug-enforcement/internal/cli/recalls_test.go
+++ b/library/health/drug-enforcement/internal/cli/recalls_test.go
@@ -43,3 +43,49 @@ func TestClassToLabel(t *testing.T) {
 		t.Error("class 4 should not be valid")
 	}
 }
+
+func TestWrapField(t *testing.T) {
+	tests := []struct {
+		in            string
+		width, indent int
+		want          string
+	}{
+		{"", 80, 16, ""},               // empty stays empty; dash() supplies the placeholder
+		{" \t ", 80, 16, ""},           // whitespace-only trimmed away, as clip does
+		{"abc def", 10, 10, "abc def"}, // no room for a value at all: emit, never loop
+		{
+			"Lot: A1, expires: 04/30/2027", 80, 16,
+			"Lot: A1, expires: 04/30/2027", // fits the column, returned untouched
+		},
+		{
+			"  Lot:  A1   B2  ", 40, 10,
+			"Lot: A1 B2", // trimmed, and internal whitespace runs collapse to one space
+		},
+		{
+			"aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk", 30, 10,
+			"aaaa bbbb cccc dddd\n          eeee ffff gggg hhhh\n          iiii jjjj kkkk",
+		},
+		{
+			"supercalifragilisticexpialidocious", 20, 10,
+			"supercalifragilisticexpialidocious", // lone oversized token overflows, never split
+		},
+		{
+			"aaaaaaaaaaaaaaa bb cc", 20, 10,
+			"aaaaaaaaaaaaaaa\n          bb cc", // an overflowing token still ends its line
+		},
+		{
+			"\u03b1\u03b1\u03b1\u03b1 \u03b2\u03b2\u03b2\u03b2", 20, 10,
+			"\u03b1\u03b1\u03b1\u03b1 \u03b2\u03b2\u03b2\u03b2", // 9 runes fits; 17 bytes would not — runes win
+		},
+		{ // real openFDA code_info at the shipped 80/16 geometry
+			"Lot: a) 09JA2530, 31JA2507, expires: 04/30/2027; b) Lot: 09DE2412, 09JA2528, 29JA2511, expires: 04/30/2027",
+			recallLineWidth, recallLabelWidth,
+			"Lot: a) 09JA2530, 31JA2507, expires: 04/30/2027; b) Lot:\n                09DE2412, 09JA2528, 29JA2511, expires: 04/30/2027",
+		},
+	}
+	for _, tc := range tests {
+		if got := wrapField(tc.in, tc.width, tc.indent); got != tc.want {
+			t.Errorf("wrapField(%q,%d,%d)=%q want %q", tc.in, tc.width, tc.indent, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
openFDA enforcement records carry lot numbers and expiry dates in `code_info`, which the CLI dropped from human-readable output entirely.

Measured over 100 live records: median 50 chars, p90 261, max 829. Truncating at a fixed width loses data in ~22% of records. Unlike Product and Reason, which are descriptive prose that stays useful when clipped, `code_info` is identifying data — a partial lot number is not partially useful, and reads as a valid value when it is a fragment.

Adds `wrapField`, which word-wraps to the block's existing 16-column indent and never splits a token, so a lot number is never broken across lines.

## Summary

- `recallRecord` gains `CodeInfo` (`json:"code_info"`); the decoder previously discarded the field
- The record block prints a `Lots/Expiry:` line between `Product:` and `Reason:`
- `wrapField` wraps on whitespace only, counts runes, and lets an oversized single token overflow its line rather than hard-breaking it — splitting a lot number would defeat copy-paste and exact matching just as thoroughly as truncating it, and would do so silently
- `Product:` and `Reason:` are deliberately unchanged and keep `clip`

## Published CLI Metadata

Not applicable — this PR does not add or modify `library/<category>/<slug>/`.

## What Changed

`internal/cli/recalls.go`: struct field, one output line, `wrapField` plus its two width constants.
`internal/cli/recalls_test.go`: `TestWrapField`, table-driven, expectations hand-derived from the algorithm rather than captured from a run. Covers empty input, whitespace-only input, a value that fits, multi-line wrapping, an oversized single token, a zero-width geometry, and a multi-byte case where a byte count would wrap but a rune count does not.

## CLI Shape

Output shape only; no flags or subcommands added.

Before (`reference D-0617-2026`) — the field was absent entirely.

After:

```
[D-0617-2026] Class II
  Firm:         Direct Rx
  Initiated:    2026-06-22
  Status:       Ongoing
  Product:      DULOXETINE D/R, a) 30 mg (NDC 61919-482-30), 30 Caps…
  Lots/Expiry:  Lot: a) 09JA2530, 31JA2507, expires: 04/30/2027; b) Lot:
                09DE2412, 09JA2528, 29JA2511, expires: 04/30/2027.
  Reason:       CGMP Deviations: Presence of N-nitroso-duloxetine impurity…
```


The multi-line path on the longest `code_info` in a 100-record sample (D-0690-2026, CareFusion 213 / BD ChloraPrep, 965 runes, 96 lot numbers across 18 expiry groups):

```
  Lots/Expiry:  Lots: 4062535, 4065201, 4066446, Exp. 2/28/2027; 4180288,
                4197695, 4197697, 4180291, Exp. 6/30/2027; 4219454, 4221945,
                ...
                6111107, Exp. 4/30/2029.
```

Round-tripped mechanically rather than by eye: the raw `code_info` was re-fetched and the printed block's tokens re-joined and compared. Lossless on both records. Every continuation line starts at exactly column 16.

## What This CLI Does

Unchanged — wraps the openFDA `/drug/enforcement.json` endpoint with pre-built search expressions for recall-lookup workflows.

## Validation

- [x] `go build ./...` from the touched CLI root
- [x] `go vet ./...` from the touched CLI root
- [x] `go test ./...` from the touched CLI root — `internal/cli` passes including `TestWrapField`
- [ ] `python3 .github/scripts/verify-skill.py --dir library/<category>/<slug>/` — n/a, no skill dir touched
- [ ] `go run ./tools/generate-skills/main.go` — n/a, no `SKILL.md` changed
- [x] `git diff --check`

Five pre-existing test failures are untouched and unrelated: four in `internal/cliutil` and one in `internal/mcp`, all the same Windows home-directory resolution issue.

## Gaps / Follow-Up

The record block is now internally inconsistent: `Lots/Expiry:` reflows to 80 columns while `Product:` and `Reason:` still emit lines past it, which are in fact the widest lines in the output above. That is a deliberate scope call — this PR fixes a data-loss bug with one justification, and reflowing the prose fields is a separate cosmetic change. Happy to fold it in if you'd prefer the block coherent in one pass.

`strings.Fields` collapses internal whitespace runs, so D-0690's 965 runes print as 963 (two `";  "` became `"; "`). Whitespace runs are not identifying, and the same normalization protects the block from `code_info` values that carry embedded newlines. Flagging it because "prints the value in full" is true of the tokens, not byte-for-byte.

