### PR TITLE
feat(drug-enforcement): wrap Product and Reason to the block's width budget

### DIFF
--- a/library/health/drug-enforcement/.printing-press-patches/wrap-prose-fields-to-block-width.json
+++ b/library/health/drug-enforcement/.printing-press-patches/wrap-prose-fields-to-block-width.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "wrap-prose-fields-to-block-width",
+  "applied_at": "2026-09-05",
+  "base_run_id": "20260707-200719-bf61d987",
+  "base_printing_press_version": "4.25.0",
+  "summary": "Every line of a rendered recall record shares one width budget: the prose fields (product description, reason for recall) are bounded then wrapped to the same geometry as the lot/expiry line, and truncation is measured in runes, not bytes.",
+  "reason": "The prose fields were emitted as single unwrapped lines while the lot/expiry line was wrapped to the block width, so the block only appeared width-bounded until two lines ran well past it. A bound is still right for prose — these fields have a long tail that would otherwise triple the height of a multi-record listing — but the bound belongs before the wrap, not instead of it, and it must be generous enough that a typical record survives whole rather than being cut mid-sentence. The lot/expiry line stays deliberately unbounded: a lot number is identifying data, where a truncated value is wrong rather than merely short. Byte-based truncation could also split a multi-byte character and emit an invalid rune, which real records carrying registered-trademark and degree signs reach.",
+  "files": [
+    "internal/cli/recalls.go",
+    "internal/cli/recalls_test.go"
+  ],
+  "validated_outcome": "Live `reference D-0617-2026` and `reference D-1284-2014` (410-char product description, exercising the truncate-then-wrap path) both render a record block whose widest line is exactly 80 columns, down from 117+. go test ./internal/cli passes."
+}

--- a/library/health/drug-enforcement/internal/cli/recalls.go
+++ b/library/health/drug-enforcement/internal/cli/recalls.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -254,20 +255,30 @@ func runRecallSearch(cmd *cobra.Command, flags *rootFlags, search string, limit 
 	w := cmd.OutOrStdout()
 	fmt.Fprintf(w, "Total matches: %d (showing %d)\n\n", env.Meta.Results.Total, len(env.Results))
 	for _, r := range env.Results {
-		// Lead with the recall number — the FDA source record ID.
-		fmt.Fprintf(w, "[%s] %s\n", dash(r.RecallNumber), dash(r.Classification))
-		fmt.Fprintf(w, "  Firm:         %s\n", dash(r.RecallingFirm))
-		fmt.Fprintf(w, "  Initiated:    %s\n", dash(normalizeRecallDate(r.RecallInitiationDate)))
-		fmt.Fprintf(w, "  Status:       %s\n", dash(r.Status))
-		fmt.Fprintf(w, "  Product:      %s\n", dash(clip(r.ProductDescription, 100)))
-		fmt.Fprintf(w, "  Lots/Expiry:  %s\n", dash(wrapField(r.CodeInfo, recallLineWidth, recallLabelWidth)))
-		fmt.Fprintf(w, "  Reason:       %s\n", dash(clip(r.ReasonForRecall, 100)))
-		fmt.Fprintln(w)
+		printRecallRecord(w, r)
 	}
 	fmt.Fprintln(w, recallClassLegend)
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, recallDisclaimer)
 	return nil
+}
+
+// printRecallRecord prints one recall record block. Product and Reason are clipped
+// to recallProseCap and then wrapped to the same 80/16 geometry as Lots/Expiry,
+// so every line in the block shares one width budget. The clip-then-wrap order
+// matters: wrapping the clipped value keeps the ellipsis on the last line.
+// Lots/Expiry is deliberately NOT clipped — a lot number is identifying data,
+// where a truncated value is wrong rather than merely short.
+func printRecallRecord(w io.Writer, r recallRecord) {
+	// Lead with the recall number — the FDA source record ID.
+	fmt.Fprintf(w, "[%s] %s\n", dash(r.RecallNumber), dash(r.Classification))
+	fmt.Fprintf(w, "  Firm:         %s\n", dash(r.RecallingFirm))
+	fmt.Fprintf(w, "  Initiated:    %s\n", dash(normalizeRecallDate(r.RecallInitiationDate)))
+	fmt.Fprintf(w, "  Status:       %s\n", dash(r.Status))
+	fmt.Fprintf(w, "  Product:      %s\n", dash(wrapField(clip(r.ProductDescription, recallProseCap), recallLineWidth, recallLabelWidth)))
+	fmt.Fprintf(w, "  Lots/Expiry:  %s\n", dash(wrapField(r.CodeInfo, recallLineWidth, recallLabelWidth)))
+	fmt.Fprintf(w, "  Reason:       %s\n", dash(wrapField(clip(r.ReasonForRecall, recallProseCap), recallLineWidth, recallLabelWidth)))
+	fmt.Fprintln(w)
 }
 
 // emitNoRecords prints the guardrail "no recall records found" result. It never
@@ -317,12 +328,15 @@ func dash(s string) string {
 	return s
 }
 
+// clip truncates s to at most n runes, appending an ellipsis when it cuts.
+// Counting and slicing by rune (not byte) keeps a multi-byte character from
+// being split in half, which real records carrying ® and ° signs would hit.
 func clip(s string, n int) string {
 	s = strings.TrimSpace(s)
-	if len(s) <= n {
+	if utf8.RuneCountInString(s) <= n {
 		return s
 	}
-	return s[:n] + "…"
+	return string([]rune(s)[:n]) + "…"
 }
 
 // recallLabelWidth is the width of the label column in the human-readable record
@@ -332,6 +346,12 @@ const (
 	recallLabelWidth = 16
 	recallLineWidth  = 80
 )
+
+// recallProseCap bounds the prose fields (product description, reason for
+// recall) before wrapping. 300 runes admits the p90 record whole while keeping
+// the long tail (up to ~660 runes) from dominating a --limit listing. Unlike
+// code_info, prose is still useful truncated.
+const recallProseCap = 300
 
 // wrapField word-wraps s to fit a total line of width columns when the value
 // starts indent columns in, padding continuation lines by indent so they line up

--- a/library/health/drug-enforcement/internal/cli/recalls.go
+++ b/library/health/drug-enforcement/internal/cli/recalls.go
@@ -331,6 +331,7 @@ func dash(s string) string {
 // clip truncates s to at most n runes, appending an ellipsis when it cuts.
 // Counting and slicing by rune (not byte) keeps a multi-byte character from
 // being split in half, which real records carrying ® and ° signs would hit.
+// Note this counts runes, not terminal display columns.
 func clip(s string, n int) string {
 	s = strings.TrimSpace(s)
 	if utf8.RuneCountInString(s) <= n {
@@ -342,6 +343,15 @@ func clip(s string, n int) string {
 // recallLabelWidth is the width of the label column in the human-readable record
 // block ("  Lots/Expiry:  " and its siblings are all 16 chars wide);
 // recallLineWidth is the total line budget, sized for an 80-column terminal.
+//
+// The budget is a target, not a guarantee. It holds for whitespace-delimited
+// content in single-width characters. Two cases exceed it by design: a token
+// longer than the usable column (a long chemical name, identifier or URL)
+// overflows its line rather than being split, and East Asian or other
+// double-width glyphs occupy two terminal cells while counting as one rune, so
+// a line can be within budget by rune count and past it on screen. Enforcing
+// either would mean display-width measurement and breaking unbreakable tokens —
+// both worse trade-offs than an occasional over-wide line.
 const (
 	recallLabelWidth = 16
 	recallLineWidth  = 80

--- a/library/health/drug-enforcement/internal/cli/recalls_test.go
+++ b/library/health/drug-enforcement/internal/cli/recalls_test.go
@@ -134,7 +134,8 @@ func TestClip(t *testing.T) {
 
 // TestRenderRecordWrapsProse is the wiring check: Product and Reason must go
 // through clip-then-wrap at the shipped geometry, and no line in the rendered
-// block may exceed the 80-column budget.
+// block may exceed the 80-rune budget. Rune count is the measure here, not
+// terminal display width — see the note on recallLineWidth.
 func TestRenderRecordWrapsProse(t *testing.T) {
 	long := strings.TrimSpace(strings.Repeat("alpha bravo charlie delta echo ", 30)) // ~890 chars
 	var buf bytes.Buffer
@@ -173,7 +174,7 @@ func TestRenderRecordWrapsProse(t *testing.T) {
 	}
 	for _, line := range strings.Split(out, "\n") {
 		if n := utf8.RuneCountInString(line); n > recallLineWidth {
-			t.Errorf("line exceeds the %d-column budget at %d runes: %q", recallLineWidth, n, line)
+			t.Errorf("line exceeds the %d-rune budget at %d runes: %q", recallLineWidth, n, line)
 		}
 	}
 }

--- a/library/health/drug-enforcement/internal/cli/recalls_test.go
+++ b/library/health/drug-enforcement/internal/cli/recalls_test.go
@@ -1,6 +1,11 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
 
 func TestPhrase(t *testing.T) {
 	tests := []struct {
@@ -86,6 +91,89 @@ func TestWrapField(t *testing.T) {
 	for _, tc := range tests {
 		if got := wrapField(tc.in, tc.width, tc.indent); got != tc.want {
 			t.Errorf("wrapField(%q,%d,%d)=%q want %q", tc.in, tc.width, tc.indent, got, tc.want)
+		}
+	}
+}
+
+func TestClip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		n    int
+		want string
+	}{
+		{"under the cap", "short value", 20, "short value"},
+		{"trims before measuring", "  short value  ", 20, "short value"},
+		{"over the cap", "abcdefghij", 4, "abcd…"},
+		{
+			// A byte-based slice at n=3 would cut the 2-byte "®" in half and
+			// emit an invalid rune; a rune-based one keeps it whole.
+			"multi-byte value is never split",
+			"a®bc",
+			3,
+			"a®b…",
+		},
+		{
+			// Every rune is 3 bytes here, so len(s) would over-count by 3x and
+			// clip a value that actually fits.
+			"multi-byte value under the cap survives whole",
+			"°°中中中",
+			5,
+			"°°中中中",
+		},
+	}
+	for _, tc := range tests {
+		if got := clip(tc.in, tc.n); got != tc.want {
+			t.Errorf("%s: clip(%q,%d)=%q want %q", tc.name, tc.in, tc.n, got, tc.want)
+		}
+		if !utf8.ValidString(clip(tc.in, tc.n)) {
+			t.Errorf("%s: clip(%q,%d) produced an invalid rune", tc.name, tc.in, tc.n)
+		}
+	}
+}
+
+// TestRenderRecordWrapsProse is the wiring check: Product and Reason must go
+// through clip-then-wrap at the shipped geometry, and no line in the rendered
+// block may exceed the 80-column budget.
+func TestRenderRecordWrapsProse(t *testing.T) {
+	long := strings.TrimSpace(strings.Repeat("alpha bravo charlie delta echo ", 30)) // ~890 chars
+	var buf bytes.Buffer
+	printRecallRecord(&buf, recallRecord{
+		RecallNumber:         "D-0000-2026",
+		Classification:       "Class II",
+		RecallingFirm:        "Example Pharma Inc.",
+		RecallInitiationDate: "20260101",
+		Status:               "Ongoing",
+		ProductDescription:   long,
+		CodeInfo:             "Lot: A1, expires: 04/30/2027",
+		ReasonForRecall:      long,
+	})
+	out := buf.String()
+
+	lines := strings.Split(out, "\n")
+	for _, label := range []string{"  Product:", "  Reason:"} {
+		i := -1
+		for k, line := range lines {
+			if strings.HasPrefix(line, label) {
+				i = k
+				break
+			}
+		}
+		if i < 0 {
+			t.Fatalf("missing %q in output:\n%s", label, out)
+		}
+		// The value must have wrapped: the label line is followed by at least
+		// one continuation line indented to the label width.
+		if i+1 >= len(lines) || !strings.HasPrefix(lines[i+1], strings.Repeat(" ", recallLabelWidth)) {
+			t.Errorf("%q did not wrap", strings.TrimSpace(label))
+		}
+	}
+	if !strings.Contains(out, "…") {
+		t.Error("a value past recallProseCap should have been clipped with an ellipsis")
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if n := utf8.RuneCountInString(line); n > recallLineWidth {
+			t.Errorf("line exceeds the %d-column budget at %d runes: %q", recallLineWidth, n, line)
 		}
 	}
 }


### PR DESCRIPTION
PR #1942 wrapped `Lots/Expiry` to an 80-column budget but left `Product` and `Reason` on `clip(_, 100)`, emitting single lines past 117 columns — the widest lines in the output. The block only looked width-bounded until two lines ran through it. That was flagged there as deliberate scope; this is the follow-up.

Measured over 100 live records:

```
product_description | median 166 | p90 271 | max 664 | over 100 chars: 90
reason_for_recall   | median  94 | p90 264 | max 400 | over 100 chars: 45
```

The 100-char cap truncated 90 of 100 product descriptions, cutting even the median case. Wrapping with no cap is not the answer either: at 64 usable columns a median description is 3 lines and a p90 one is 5, roughly tripling the height of a `--limit` listing.

## Summary

- `Product` and `Reason` are clipped at 300 runes, then wrapped to the same 80/16 geometry as `Lots/Expiry`. 300 admits both p90 values whole while bounding the tail.
- `Lots/Expiry` stays uncapped. That asymmetry is deliberate: a lot number is identifying data, where a truncated value is wrong rather than merely short. Prose stays useful when clipped.
- `clip` now counts and slices by rune rather than byte, so a multi-byte character cannot be split — reachable now that the cap lets longer, symbol-bearing descriptions through.
- Rendering is extracted into `printRecallRecord` so the block is exercisable from a test without a live API call. The name matches the patch record already in the repo from #1942.

## Published CLI Metadata

Not applicable — this PR does not add or modify `library/<category>/<slug>/.printing-press.json`.

## What Changed

`internal/cli/recalls.go`: `recallProseCap`, clip-then-wrap on both prose fields, rune-based `clip`, `printRecallRecord` extraction.

`internal/cli/recalls_test.go`: `TestClip` (under cap, over cap, multi-byte where a byte slice would split a character, and a validity assertion on the result), plus a render test asserting both prose fields wrap with a 16-column continuation indent and that no line exceeds the budget.

`.printing-press-patches/wrap-prose-fields-to-block-width.json`: the record `AGENTS.md` requires for a code-level customization.

## CLI Shape

Output shape only; no flags or subcommands added.

`reference D-0617-2026`:

```
[D-0617-2026] Class II
  Firm:         Direct Rx
  Initiated:    2026-06-22
  Status:       Ongoing
  Product:      DULOXETINE D/R, a) 30 mg (NDC 61919-482-30), 30 Caps; b) 30 mg
                (NDC 61919-482-60), 60 Caps; CYMBALTA, Packaged and Distributed
                by Direct Rx.
  Lots/Expiry:  Lot: a) 09JA2530, 31JA2507, expires: 04/30/2027; b) Lot:
                09DE2412, 09JA2528, 29JA2511, expires: 04/30/2027.
  Reason:       CGMP Deviations: Presence of N-nitroso-duloxetine impurity above
                FDA recommended interim limit
```

`reference D-1284-2014`, a 410-rune product description exercising the clip-then-wrap path:

```
[D-1284-2014] Class II
  Firm:         Caraco Pharmaceutical Laboratories, Ltd.
  Initiated:    2014-03-20
  Status:       Terminated
  Product:      Venlafaxine Hydrochloride Extended-Release Tablets, 37.5 mg,
                packaged in a) 30-count bottles (NDC 41616-760-83, UPC 3 41616
                76083 5); and b) 90-count bottles (NDC 41616-760-81, UPC 3 41616
                76081 1), Rx only, Distributed by: Caraco Pharmaceutical
                Laboratories, Ltd., 1150 Elijah McCoy Drive, Detroit, …
  Lots/Expiry:  Lot #: a) JKL4344A, Exp 07/14; JKL5460A, Exp 10/14; JKL5458A,
                Exp 11/14; b) JKL4344B, Exp 07/14; JKL5460B, Exp 10/14;
                JKL5458B, Exp 11/14.
  Reason:       Failed Dissolution Specifications: Stability results found the
                product out of release dissolution specifications.
```

Widest record-block line in both: exactly 80 columns.

## What This CLI Does

Unchanged — wraps the openFDA `/drug/enforcement.json` endpoint with pre-built search expressions for recall-lookup workflows.

## Validation

- [x] `go build ./...` from the touched CLI root
- [x] `go vet ./...` from the touched CLI root
- [x] `go test ./...` from the touched CLI root
- [ ] `python3 .github/scripts/verify-skill.py --dir library/<category>/<slug>/` — n/a, no skill dir touched
- [ ] `go run ./tools/generate-skills/main.go` — n/a, no `SKILL.md` changed
- [x] `git diff --check`

Five pre-existing test failures are untouched and unrelated: four in `internal/cliutil` and one in `internal/mcp`, all the same Windows home-directory resolution issue.

## Gaps / Follow-Up

The 300 cap is a rune count while the measurements above are character counts from the API payload; for symbol-bearing records the effective cap is marginally more generous than the stated p90. It errs in the right direction but is not precisely calibrated to those figures.

The record block is now coherent at 80 columns, but `recallDisclaimer` is a fixed 117-column string that sits outside the block. It is a static legal notice rather than variable data, so it is left alone — flagging it since "the widest line in the output" is still not 80.