### PR TITLE
fix(retraction-checker): read Crossref updated-by, not update-by

### DIFF
--- a/library/other/retraction-checker/.printing-press-patches/crossref-updated-by-field-name.json
+++ b/library/other/retraction-checker/.printing-press-patches/crossref-updated-by-field-name.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "crossref-updated-by-field-name",
+  "applied_at": "2026-09-05",
+  "base_run_id": "20260702-090842-5bac53b7",
+  "base_printing_press_version": "4.25.0",
+  "summary": "Correct the Crossref work-response struct tag from update-by to updated-by so retraction notices and their metadata reach the verdict, and align the two MCP tool descriptions that named the old field.",
+  "description": "Correct the Crossref work-response struct tag from update-by to updated-by so retraction notices and their metadata reach the verdict, and align the two MCP tool descriptions that named the old field.",
+  "reason": "Crossref names the field updated-by. encoding/json leaves a slice empty on a struct-tag mismatch without raising an error, so signals 1 and 2 in checkDOI never fired and only the RETRACTED title-prefix signal remained. Any retracted paper whose title carries no RETRACTED or WITHDRAWN prefix was reported as not retracted, and date, source, notice_doi and notice_url were always empty. Regeneration must not restore the old name.",
+  "files": [
+    "internal/cli/retraction.go",
+    "internal/cli/retraction_test.go",
+    "internal/mcp/tools.go"
+  ],
+  "safety": "Read-only Crossref lookups. No new network hosts, no credentials, no mutation commands.",
+  "validated_outcome": "check 10.1538/expanim.54.1, a retraction with no title prefix, now reports retracted with date 2022-08-01, source retraction-watch and notice 10.1538/expanim.54.1.r1; before the fix it reported the paper as clean. check 10.1016/S0140-6736(97)11096-0 reports both signals with date 2010-02-06, skips the 2004 correction that precedes the retraction in the updated-by array, and leaves published at 1998-02. retraction_test.go pins all of this, including the empty-date case where only the title prefix fires."
+}

--- a/library/other/retraction-checker/internal/cli/retraction.go
+++ b/library/other/retraction-checker/internal/cli/retraction.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/other/retraction-checker/internal/cliutil"
 )
 
-// retractionTypes are the Crossref update-to/update-by types that indicate a
+// retractionTypes are the Crossref update-to/updated-by types that indicate a
 // paper has been retracted or otherwise flagged.
 var retractionTypes = map[string]bool{
 	"retraction":            true,
@@ -40,7 +40,7 @@ type retractionVerdict struct {
 	Error      string   `json:"error,omitempty"`
 }
 
-// crossrefUpdate mirrors an entry of message.update-to / message.update-by.
+// crossrefUpdate mirrors an entry of message.update-to / message.updated-by.
 type crossrefUpdate struct {
 	DOI     string          `json:"DOI"`
 	Type    string          `json:"type"`
@@ -80,7 +80,7 @@ type crossrefWorkMessage struct {
 	Title     []string         `json:"title"`
 	Type      string           `json:"type"`
 	UpdateTo  []crossrefUpdate `json:"update-to"`
-	UpdateBy  []crossrefUpdate `json:"update-by"`
+	UpdateBy  []crossrefUpdate `json:"updated-by"`
 	Published crossrefDateObj  `json:"published"`
 	Issued    crossrefDateObj  `json:"issued"`
 }
@@ -200,7 +200,7 @@ func checkDOI(ctx context.Context, c crossrefGetter, mailto, doi string) (retrac
 		v.Published = m.Issued.iso()
 	}
 
-	// Signal 1: update-by records pointing at this work (retraction notices).
+	// Signal 1: updated-by records pointing at this work (retraction notices).
 	// Signal 2: update-to records of type retraction on this record itself.
 	updates := append([]crossrefUpdate{}, m.UpdateBy...)
 	updates = append(updates, m.UpdateTo...)

--- a/library/other/retraction-checker/internal/cli/retraction_test.go
+++ b/library/other/retraction-checker/internal/cli/retraction_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 laci141 and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored tests for retraction.go. Not generated — safe to edit.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// stubCrossref returns a canned Crossref envelope, so checkDOI can be
+// exercised against exact JSON payloads without a network call.
+type stubCrossref struct {
+	payload string
+}
+
+func (s stubCrossref) Get(_ context.Context, _ string, _ map[string]string) (json.RawMessage, error) {
+	return json.RawMessage(s.payload), nil
+}
+
+// TestCheckDOICrossrefFieldNames pins the Crossref field names that checkDOI
+// unmarshals. encoding/json fails silently on a struct-tag mismatch: the slice
+// is left empty, no error is raised, and the retraction goes undetected. These
+// cases fail loudly if the tags drift.
+func TestCheckDOICrossrefFieldNames(t *testing.T) {
+	cases := []struct {
+		name          string
+		payload       string
+		wantRetracted bool
+		wantType      string
+		wantDate      string
+		wantNoticeDOI string
+		wantSignals   []string
+	}{
+		{
+			// The regression this test exists for. The field is "updated-by",
+			// not "update-by", and the title carries no RETRACTED prefix, so
+			// the tag is the only thing that can surface the retraction.
+			name: "updated-by retraction without title prefix",
+			payload: `{"message":{
+				"DOI":"10.1538/expanim.54.1",
+				"title":["Effect of Treadmill Exercise on Bone Mass in Female Rats"],
+				"issued":{"date-parts":[[2005,1,1]]},
+				"updated-by":[{
+					"DOI":"10.1538/expanim.54.1.r1",
+					"type":"retraction",
+					"label":"Retraction",
+					"source":"retraction-watch",
+					"updated":{"date-parts":[[2022,8,1]]}
+				}]
+			}}`,
+			wantRetracted: true,
+			wantType:      "retraction",
+			wantDate:      "2022-08-01",
+			wantNoticeDOI: "10.1538/expanim.54.1.r1",
+			wantSignals:   []string{"crossref-update:retraction"},
+		},
+		{
+			// A correction precedes the retraction in the array. Selecting the
+			// first entry would report the wrong type and the wrong date.
+			name: "correction before retraction is skipped",
+			payload: `{"message":{
+				"DOI":"10.1016/s0140-6736(97)11096-0",
+				"title":["RETRACTED: Ileal-lymphoid-nodular hyperplasia"],
+				"published":{"date-parts":[[1998,2]]},
+				"updated-by":[
+					{"DOI":"10.1016/s0140-6736(04)15715-2","type":"correction","label":"Correction","source":"retraction-watch","updated":{"date-parts":[[2004,3,6]]}},
+					{"DOI":"10.1016/s0140-6736(10)60175-4","type":"retraction","label":"Retraction","source":"retraction-watch","updated":{"date-parts":[[2010,2,6]]}}
+				]
+			}}`,
+			wantRetracted: true,
+			wantType:      "retraction",
+			wantDate:      "2010-02-06",
+			wantNoticeDOI: "10.1016/s0140-6736(10)60175-4",
+			wantSignals:   []string{"crossref-update:retraction", "title-prefix"},
+		},
+		{
+			// update-to on the record itself is the second supported shape.
+			name: "update-to retraction on the record",
+			payload: `{"message":{
+				"DOI":"10.1007/s11277-021-09072-0",
+				"title":["Deep Reinforcement Learning-Based Smart Manufacturing Plants"],
+				"issued":{"date-parts":[[2021]]},
+				"update-to":[{
+					"DOI":"10.1007/s11277-021-09072-0",
+					"type":"retraction",
+					"label":"Retraction",
+					"source":"publisher",
+					"updated":{"date-parts":[[2022,12,6]]}
+				}]
+			}}`,
+			wantRetracted: true,
+			wantType:      "retraction",
+			wantDate:      "2022-12-06",
+			wantNoticeDOI: "10.1007/s11277-021-09072-0",
+			wantSignals:   []string{"crossref-update:retraction"},
+		},
+		{
+			// No update record at all: the title prefix still flags it, but
+			// there is no date to report and none must be invented.
+			name: "title prefix alone yields no date",
+			payload: `{"message":{
+				"DOI":"10.1000/example",
+				"title":["RETRACTED ARTICLE: Something"],
+				"issued":{"date-parts":[[2019,5,4]]}
+			}}`,
+			wantRetracted: true,
+			wantType:      "retraction",
+			wantDate:      "",
+			wantNoticeDOI: "",
+			wantSignals:   []string{"title-prefix"},
+		},
+		{
+			name: "clean record stays clean",
+			payload: `{"message":{
+				"DOI":"10.1016/s1557-0843(07)80009-1",
+				"title":["Insulin delivery devices"],
+				"issued":{"date-parts":[[2007]]}
+			}}`,
+			wantRetracted: false,
+			wantType:      "",
+			wantDate:      "",
+			wantNoticeDOI: "",
+			wantSignals:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			v, err := checkDOI(context.Background(), stubCrossref{payload: tc.payload}, "", "unused")
+			if err != nil {
+				t.Fatalf("checkDOI returned error: %v", err)
+			}
+			if v.Retracted != tc.wantRetracted {
+				t.Errorf("Retracted = %v, want %v", v.Retracted, tc.wantRetracted)
+			}
+			if v.UpdateType != tc.wantType {
+				t.Errorf("UpdateType = %q, want %q", v.UpdateType, tc.wantType)
+			}
+			if v.Date != tc.wantDate {
+				t.Errorf("Date = %q, want %q", v.Date, tc.wantDate)
+			}
+			if v.NoticeDOI != tc.wantNoticeDOI {
+				t.Errorf("NoticeDOI = %q, want %q", v.NoticeDOI, tc.wantNoticeDOI)
+			}
+			if len(v.Signals) != len(tc.wantSignals) {
+				t.Fatalf("Signals = %v, want %v", v.Signals, tc.wantSignals)
+			}
+			for i, want := range tc.wantSignals {
+				if v.Signals[i] != want {
+					t.Errorf("Signals[%d] = %q, want %q", i, v.Signals[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TestCheckDOIPublishedIsNotRetractionDate guards the distinction the retraction
+// date exists to make: published is when the article appeared, date is when it
+// was retracted. Collapsing the two would misreport a 1998 paper as retracted
+// in 1998.
+func TestCheckDOIPublishedIsNotRetractionDate(t *testing.T) {
+	payload := `{"message":{
+		"DOI":"10.1016/s0140-6736(97)11096-0",
+		"title":["RETRACTED: Ileal-lymphoid-nodular hyperplasia"],
+		"published":{"date-parts":[[1998,2]]},
+		"updated-by":[{
+			"DOI":"10.1016/s0140-6736(10)60175-4",
+			"type":"retraction",
+			"label":"Retraction",
+			"source":"retraction-watch",
+			"updated":{"date-parts":[[2010,2,6]]}
+		}]
+	}}`
+	v, err := checkDOI(context.Background(), stubCrossref{payload: payload}, "", "unused")
+	if err != nil {
+		t.Fatalf("checkDOI returned error: %v", err)
+	}
+	if v.Published != "1998-02" {
+		t.Errorf("Published = %q, want %q", v.Published, "1998-02")
+	}
+	if v.Date != "2010-02-06" {
+		t.Errorf("Date = %q, want %q", v.Date, "2010-02-06")
+	}
+	if v.Published == v.Date {
+		t.Error("Published and Date must not collapse into the same value")
+	}
+}

--- a/library/other/retraction-checker/internal/mcp/tools.go
+++ b/library/other/retraction-checker/internal/mcp/tools.go
@@ -748,13 +748,13 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 		// Command-mirror capabilities are exposed through MCP by shelling out
 		// to the companion CLI binary.
 		"command_mirror_capabilities": []map[string]string{
-			{"name": "Retraction check", "command": "check", "description": "Tell whether a paper (by DOI or PMID) has been retracted, when, why, and where the notice is.", "rationale": "Crossref embeds Retraction Watch update records; we parse update-to/update-by plus the RETRACTED title signal into one structured verdict no raw API call returns.", "via": "mcp-command-mirror"},
+			{"name": "Retraction check", "command": "check", "description": "Tell whether a paper (by DOI or PMID) has been retracted, when, why, and where the notice is.", "rationale": "Crossref embeds Retraction Watch update records; we parse update-to/updated-by plus the RETRACTED title signal into one structured verdict no raw API call returns.", "via": "mcp-command-mirror"},
 			{"name": "Bibliography scan", "command": "scan", "description": "Batch-check a reading list or .bib file and flag every retracted entry.", "rationale": "Reuses the batch-file line pattern (skip blank/# lines) and fans out DOI/PMID lookups against Crossref with a single command.", "via": "mcp-command-mirror"},
 			{"name": "Superseding research", "command": "superseded", "description": "For a retracted or older paper, find related more-recent research on the same topic, ranked by citation count.", "rationale": "Joins Crossref retraction/date context with OpenAlex citation-ranked related works published after the original — a cross-source view no single API provides.", "via": "mcp-command-mirror"},
 			{"name": "Retraction watch", "command": "watch", "description": "Monitor a topic or reading list for newly-announced retractions since the last run.", "rationale": "Persists a baseline of seen retraction notices and diffs on each run, using the snapshot/first-run-baseline pattern.", "via": "mcp-command-mirror"},
 		},
 		"playbook": []map[string]string{
-			{"topic": "Retraction check", "insight": "Crossref embeds Retraction Watch update records; we parse update-to/update-by plus the RETRACTED title signal into one structured verdict no raw API call returns."},
+			{"topic": "Retraction check", "insight": "Crossref embeds Retraction Watch update records; we parse update-to/updated-by plus the RETRACTED title signal into one structured verdict no raw API call returns."},
 			{"topic": "Bibliography scan", "insight": "Reuses the batch-file line pattern (skip blank/# lines) and fans out DOI/PMID lookups against Crossref with a single command."},
 			{"topic": "Superseding research", "insight": "Joins Crossref retraction/date context with OpenAlex citation-ranked related works published after the original — a cross-source view no single API provides."},
 			{"topic": "Retraction watch", "insight": "Persists a baseline of seen retraction notices and diffs on each run, using the snapshot/first-run-baseline pattern."},


### PR DESCRIPTION
## Problem

The struct tag on `crossrefWorkMessage.UpdateBy` reads `json:"update-by"`, but the Crossref API field is named `updated-by`. `encoding/json` silently leaves the slice empty on a name mismatch — no error, no warning.

The consequence is that signals 1 and 2 in `checkDOI` never fire. Only the RETRACTED title-prefix check remains, so:

- a retracted paper without a `RETRACTED`/`WITHDRAWN` title prefix is reported as **not retracted**
- `date`, `source`, `notice_doi` and `notice_url` are always empty, even when Crossref supplies them

## Evidence

`10.1538/expanim.54.1` — *Effect of Treadmill Exercise on Bone Mass in Female Rats*. No title prefix, one `updated-by` record:

```
$ curl -s "https://api.crossref.org/works/10.1538/expanim.54.1" \
  | python -c "import sys,json; m=json.load(sys.stdin)['message']; \
    print(m['title'][0]); print(len(m.get('updated-by',[])))"
Effect of Treadmill Exercise on Bone Mass in Female Rats
1
```

Before this change the CLI reported it as clean. After:

```
RETRACTED
  DOI:    10.1538/expanim.54.1
  Title:  Effect of Treadmill Exercise on Bone Mass in Female Rats
  Type:   retraction
  Date:   2022-08-01
  Source: retraction-watch
  Notice: https://doi.org/10.1538/expanim.54.1.r1
```

## Regression check

`10.1016/S0140-6736(97)11096-0` has both a title prefix and `updated-by` records. Its `updated-by` array holds a 2004 `correction` followed by the 2010 `retraction`, so it also exercises the `retractionTypes` filter:

```json
"retracted": true,
"update_type": "retraction",
"date": "2010-02-06",
"notice_doi": "10.1016/s0140-6736(10)60175-4",
"published": "1998-02",
"signals": ["crossref-update:retraction", "title-prefix"]
```

The correction entry is correctly skipped and `published` is unchanged.

## Scope

One struct tag, three comments, and two MCP tool descriptions that named the field. No behavioural change beyond the fields now being populated.