### PR TITLE
feat(thelancet): sync arbitrary archive slices with --from-year/--to-year

### DIFF
--- a/library/developer-tools/thelancet/.printing-press-patches/thelancet-refresh-date-range.json
+++ b/library/developer-tools/thelancet/.printing-press-patches/thelancet-refresh-date-range.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "thelancet-refresh-date-range",
+  "applied_at": "2026-09-05",
+  "base_run_id": "20260617-072858-2f9fe13e",
+  "base_printing_press_version": "4.24.0",
+  "summary": "The 'refresh' command accepts absolute --from-year/--to-year publication-year bounds alongside the rolling --years window, and propagates the resolved pair into the OpenAlex from_publication_date and to_publication_date filters; a regen must preserve both flags, the mutual-exclusion rule between --years and the absolute bounds, and the upper-bound parameter on lancet.Refresh.",
+  "reason": "--years can only express a window ending today, so an archive slice older than the rolling window was unreachable and a local mirror could never be backfilled: affiliation-growth returned an empty prior window at any wider setting because the mirror itself only reached back as far as the most recent sync. The absolute bounds let older years be synced a slice at a time. --years is rejected when combined with either bound rather than silently losing to one of them, and the check tests whether the flag was named rather than whether its value is non-zero, so an explicit '--years 0' also collides instead of quietly running the absolute range.",
+  "files": [
+    "internal/cli/refresh.go",
+    "internal/cli/refresh_date_range_test.go",
+    "internal/cli/lancet_common.go",
+    "internal/lancet/sync.go",
+    "internal/lancet/refresh_date_range_test.go"
+  ],
+  "validated_outcome": "Unit coverage asserts the resolved bounds and every rejected flag combination, plus the emitted filter strings via a recording Fetcher including a no-flags regression guard. Against the live OpenAlex API, '--from-year 1990 --to-year 1999' and '--from-year 2020 --to-year 2024' each stored 2000 works and produced disjoint results (John Radcliffe Hospital topping the first, University College London the second), confirming the bounds reach the API rather than only shaping the filter string."
+}

--- a/library/developer-tools/thelancet/internal/cli/lancet_common.go
+++ b/library/developer-tools/thelancet/internal/cli/lancet_common.go
@@ -66,7 +66,7 @@ func ensureLancetStore(cmd *cobra.Command, flags *rootFlags, dbPath string) (*st
 		journs, _ := lancet.Lookup("lancet")
 		ctx, cancel := boundCtx(cmd.Context(), flags)
 		defer cancel()
-		if _, rerr := lancet.Refresh(ctx, c, st.DB(), journs, 0, maxPages, nil); rerr != nil {
+		if _, rerr := lancet.Refresh(ctx, c, st.DB(), journs, 0, 0, maxPages, nil); rerr != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "auto-sync failed (%v); returning local data only\n", rerr)
 		}
 	}

--- a/library/developer-tools/thelancet/internal/cli/refresh.go
+++ b/library/developer-tools/thelancet/internal/cli/refresh.go
@@ -16,6 +16,8 @@ import (
 func newLancetRefreshCmd(flags *rootFlags) *cobra.Command {
 	var journal string
 	var years int
+	var fromYear int
+	var toYear int
 	var maxPages int
 	var dbPath string
 
@@ -24,15 +26,24 @@ func newLancetRefreshCmd(flags *rootFlags) *cobra.Command {
 		Short: "Sync Lancet articles from OpenAlex into the local analytics store",
 		Long: "Populate the local SQLite store the analytics commands (rank-authors, mesh,\n" +
 			"affiliation-growth, drift, curate, visibility-gap) read from. Scopes to a\n" +
-			"Lancet journal slug, the flagship 'lancet', or 'all' for the whole family.",
+			"Lancet journal slug, the flagship 'lancet', or 'all' for the whole family.\n\n" +
+			"Use --years for a rolling window ending today, or --from-year/--to-year to\n" +
+			"sync an absolute slice of the archive, which is how older years are\n" +
+			"backfilled a slice at a time. --years cannot be combined with either\n" +
+			"absolute bound.",
 		Example: "  thelancet-pp-cli refresh --journal lancet\n" +
 			"  thelancet-pp-cli refresh --journal lancet-oncology --years 8\n" +
+			"  thelancet-pp-cli refresh --journal lancet --from-year 1990 --to-year 1999\n" +
 			"  thelancet-pp-cli refresh --journal all --max-pages 3",
 		Annotations: map[string]string{"mcp:read-only": "false"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
 				fmt.Fprintf(cmd.OutOrStdout(), "would sync journal %q from OpenAlex into the local store\n", journal)
 				return nil
+			}
+			fromBound, toBound, err := refreshYearBounds(cmd, years, cmd.Flags().Changed("years"), fromYear, toYear)
+			if err != nil {
+				return err
 			}
 			journs, ok := lancet.Lookup(journal)
 			if !ok {
@@ -69,7 +80,7 @@ func newLancetRefreshCmd(flags *rootFlags) *cobra.Command {
 			if flags.asJSON || flags.agent {
 				progress = nil
 			}
-			results, err := lancet.Refresh(ctx, c, s.DB(), journs, yearLowerBound(years), maxPages, progress)
+			results, err := lancet.Refresh(ctx, c, s.DB(), journs, fromBound, toBound, maxPages, progress)
 			if err != nil {
 				return fmt.Errorf("refresh: %w", err)
 			}
@@ -89,7 +100,9 @@ func newLancetRefreshCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&journal, "journal", "lancet", "Journal slug, 'lancet' (flagship), or 'all' for the whole Lancet family")
-	cmd.Flags().IntVar(&years, "years", 0, "Only sync works published in the last N years (0 = all available)")
+	cmd.Flags().IntVar(&years, "years", 0, "Only sync works published in the last N years (0 = all available; not combinable with --from-year/--to-year)")
+	cmd.Flags().IntVar(&fromYear, "from-year", 0, "Only sync works published in or after this calendar year (0 = no lower bound)")
+	cmd.Flags().IntVar(&toYear, "to-year", 0, "Only sync works published in or before this calendar year (0 = no upper bound)")
 	cmd.Flags().IntVar(&maxPages, "max-pages", 5, "Maximum 200-item pages to fetch per journal (bounds cost)")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default ~/.local/share/thelancet-pp-cli/data.db)")
 	return cmd
@@ -103,4 +116,44 @@ func yearLowerBound(years int) int {
 	}
 	currentYear := time.Now().Year()
 	return currentYear - years + 1
+}
+
+// earliestSyncYear is the oldest calendar year a refresh may be bounded by;
+// anything older is a typo rather than a real request.
+const earliestSyncYear = 1800
+
+// refreshYearBounds resolves the three year flags into the absolute lower and
+// upper publication-year bounds handed to lancet.Refresh. --years is a rolling
+// window and cannot be mixed with the absolute --from-year/--to-year bounds.
+//
+// yearsSet reports whether --years was named on the command line, which is not
+// the same as years being non-zero: an explicit "--years 0" must still collide
+// with an absolute bound. Testing the value alone would let that combination
+// through silently, which is the behaviour this flag pair exists to prevent.
+func refreshYearBounds(cmd *cobra.Command, years int, yearsSet bool, fromYear, toYear int) (int, int, error) {
+	if yearsSet && (fromYear > 0 || toYear > 0) {
+		_ = cmd.Usage()
+		return 0, 0, usageErr(fmt.Errorf("--years is a rolling window and cannot be combined with --from-year or --to-year; use --years for the last N years, or --from-year/--to-year for an absolute slice"))
+	}
+	maxYear := time.Now().Year() + 1
+	for _, b := range []struct {
+		name  string
+		value int
+	}{{"--from-year", fromYear}, {"--to-year", toYear}} {
+		if b.value == 0 {
+			continue
+		}
+		if b.value < earliestSyncYear || b.value > maxYear {
+			_ = cmd.Usage()
+			return 0, 0, usageErr(fmt.Errorf("%s must be a calendar year between %d and %d, got %d", b.name, earliestSyncYear, maxYear, b.value))
+		}
+	}
+	if fromYear > 0 && toYear > 0 && fromYear > toYear {
+		_ = cmd.Usage()
+		return 0, 0, usageErr(fmt.Errorf("--from-year must not be after --to-year: got --from-year %d and --to-year %d", fromYear, toYear))
+	}
+	if years > 0 {
+		return yearLowerBound(years), 0, nil
+	}
+	return fromYear, toYear, nil
 }

--- a/library/developer-tools/thelancet/internal/cli/refresh_date_range_test.go
+++ b/library/developer-tools/thelancet/internal/cli/refresh_date_range_test.go
@@ -1,0 +1,90 @@
+// Hand-authored coverage for the refresh year-flag validation. Not generated.
+
+package cli
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// quietCmd is a stand-in command whose usage output is discarded, so the
+// validation helper can be exercised without noise on the test log.
+func quietCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "refresh"}
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	return cmd
+}
+
+func TestRefreshYearBoundsAccepted(t *testing.T) {
+	cases := []struct {
+		name     string
+		years    int
+		yearsSet bool
+		fromYear int
+		toYear   int
+		wantFrom int
+		wantTo   int
+	}{
+		{"no flags", 0, false, 0, 0, 0, 0},
+		{"from-year alone", 0, false, 1990, 0, 1990, 0},
+		{"to-year alone", 0, false, 0, 2000, 0, 2000},
+		{"both absolute bounds", 0, false, 1990, 2000, 1990, 2000},
+		{"equal bounds", 0, false, 1995, 1995, 1995, 1995},
+		{"rolling window", 3, true, 0, 0, time.Now().Year() - 2, 0},
+		// An explicit "--years 0" on its own still means "no bound", so it
+		// must keep working for scripts that pass the default through.
+		{"explicit zero years alone", 0, true, 0, 0, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			from, to, err := refreshYearBounds(quietCmd(), tc.years, tc.yearsSet, tc.fromYear, tc.toYear)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if from != tc.wantFrom || to != tc.wantTo {
+				t.Errorf("bounds = (%d, %d), want (%d, %d)", from, to, tc.wantFrom, tc.wantTo)
+			}
+		})
+	}
+}
+
+func TestRefreshYearBoundsRejected(t *testing.T) {
+	nextYear := time.Now().Year() + 1
+	cases := []struct {
+		name     string
+		years    int
+		yearsSet bool
+		fromYear int
+		toYear   int
+		wantMsg  string
+	}{
+		{"years with from-year", 5, true, 1990, 0, "cannot be combined"},
+		{"years with to-year", 5, true, 0, 2000, "cannot be combined"},
+		{"years with both", 5, true, 1990, 2000, "cannot be combined"},
+		// Regression guard: an explicit "--years 0" is still the flag being
+		// named, so it must collide with an absolute bound. Testing the value
+		// instead of whether the flag was set let this combination run the
+		// absolute range silently, contrary to the documented rule.
+		{"explicit zero years with from-year", 0, true, 1990, 0, "cannot be combined"},
+		{"explicit zero years with to-year", 0, true, 0, 1999, "cannot be combined"},
+		{"from after to", 0, false, 2000, 1990, "must not be after"},
+		{"from-year too old", 0, false, 1799, 0, "--from-year must be a calendar year"},
+		{"to-year in the future", 0, false, 0, nextYear + 1, "--to-year must be a calendar year"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := refreshYearBounds(quietCmd(), tc.years, tc.yearsSet, tc.fromYear, tc.toYear)
+			if err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tc.wantMsg)
+			}
+		})
+	}
+}

--- a/library/developer-tools/thelancet/internal/lancet/refresh_date_range_test.go
+++ b/library/developer-tools/thelancet/internal/lancet/refresh_date_range_test.go
@@ -1,0 +1,71 @@
+// Hand-authored coverage for the refresh date-range bounds. Not generated.
+
+package lancet
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// recordingFetcher captures the query params of every OpenAlex call and
+// returns an empty page so Refresh stops after the first request.
+type recordingFetcher struct {
+	params []map[string]string
+}
+
+func (r *recordingFetcher) Get(_ context.Context, _ string, params map[string]string) (json.RawMessage, error) {
+	copied := make(map[string]string, len(params))
+	for k, v := range params {
+		copied[k] = v
+	}
+	r.params = append(r.params, copied)
+	return json.RawMessage(`{"results":[],"meta":{"next_cursor":""}}`), nil
+}
+
+// refreshFilterFor runs Refresh against a throwaway store and returns the
+// OpenAlex filter string it built for the single journal it was given.
+func refreshFilterFor(t *testing.T, fromYear, toYear int) string {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	f := &recordingFetcher{}
+	journ := []Journal{{Slug: "lancet", ISSN: "0140-6736", Display: "The Lancet"}}
+	if _, err := Refresh(context.Background(), f, db, journ, fromYear, toYear, 1, nil); err != nil {
+		t.Fatalf("Refresh(from=%d, to=%d): %v", fromYear, toYear, err)
+	}
+	if len(f.params) != 1 {
+		t.Fatalf("expected 1 OpenAlex call, got %d", len(f.params))
+	}
+	return f.params[0]["filter"]
+}
+
+func TestRefreshFilterYearBounds(t *testing.T) {
+	const base = "primary_location.source.issn:0140-6736"
+	cases := []struct {
+		name     string
+		fromYear int
+		toYear   int
+		want     string
+	}{
+		// Regression guard: with no bounds the filter must be exactly what it
+		// was before --from-year / --to-year existed.
+		{"no bounds", 0, 0, base},
+		{"lower bound only", 1990, 0, base + ",from_publication_date:1990-01-01"},
+		{"upper bound only", 0, 2000, base + ",to_publication_date:2000-12-31"},
+		{"both bounds", 1990, 2000, base + ",from_publication_date:1990-01-01,to_publication_date:2000-12-31"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := refreshFilterFor(t, tc.fromYear, tc.toYear); got != tc.want {
+				t.Errorf("filter = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/library/developer-tools/thelancet/internal/lancet/sync.go
+++ b/library/developer-tools/thelancet/internal/lancet/sync.go
@@ -123,9 +123,10 @@ type RefreshResult struct {
 }
 
 // Refresh syncs works for each journal into the local store using OpenAlex
-// cursor pagination. fromYear of 0 means no lower bound. maxPages caps the
-// number of 200-item pages fetched per journal (bounds cost and time).
-func Refresh(ctx context.Context, c Fetcher, db *sql.DB, journ []Journal, fromYear, maxPages int, progress io.Writer) ([]RefreshResult, error) {
+// cursor pagination. fromYear of 0 means no lower bound and toYear of 0 means
+// no upper bound. maxPages caps the number of 200-item pages fetched per
+// journal (bounds cost and time).
+func Refresh(ctx context.Context, c Fetcher, db *sql.DB, journ []Journal, fromYear, toYear, maxPages int, progress io.Writer) ([]RefreshResult, error) {
 	if err := EnsureSchema(ctx, db); err != nil {
 		return nil, err
 	}
@@ -142,6 +143,9 @@ func Refresh(ctx context.Context, c Fetcher, db *sql.DB, journ []Journal, fromYe
 		filter := "primary_location.source.issn:" + j.ISSN
 		if fromYear > 0 {
 			filter += ",from_publication_date:" + strconv.Itoa(fromYear) + "-01-01"
+		}
+		if toYear > 0 {
+			filter += ",to_publication_date:" + strconv.Itoa(toYear) + "-12-31"
 		}
 		cursor := "*"
 		stored := 0


### PR DESCRIPTION
## Summary
- `refresh` could only express a rolling "last N years" window via `--years`, which always cuts from the present. There was no way to sync an older slice of the archive, so a local mirror could not be backfilled and `affiliation-growth` had an empty prior window at any wider setting.
- `Refresh` now takes an absolute upper bound alongside the existing lower one and emits `to_publication_date` next to `from_publication_date`. `--years` stays a rolling window and is rejected when combined with either absolute bound rather than silently losing to one of them.

## Published CLI Metadata

**API:** `thelancet` | **Category:** `developer-tools` | **Press version:** `<fill from .printing-press-release.json>`
**Spec:** `<fill from .printing-press.json>`
**Required env:** none

## What Changed
- `internal/lancet/sync.go` — `Refresh` gains a `toYear` parameter after `fromYear`; `to_publication_date:<year>-12-31` is appended only when `toYear > 0`. Sort-order behaviour untouched.
- `internal/cli/refresh.go` — new `--from-year` / `--to-year` int flags, both defaulting to 0 (unset), plus a bounds-resolving helper returning `usageErr(...)` in the package's existing style for three cases: `--years` combined with either absolute bound, a bound outside `1800..currentYear+1`, and `--from-year` greater than `--to-year`. Long help gained a paragraph on rolling vs. absolute windows.
- `internal/cli/lancet_common.go` — the auto-sync caller passes `0, 0` for the new bound.
- Two new hand-written test files: `internal/cli/refresh_date_range_test.go` (accepted and rejected flag combinations) and `internal/lancet/refresh_date_range_test.go` (filter-string assertions via a recording Fetcher, including a no-flags regression guard). No `DO NOT EDIT` file was touched.

## CLI Shape

```bash
$ thelancet-pp-cli refresh --help
Populate the local SQLite store the analytics commands (rank-authors, mesh,
affiliation-growth, drift, curate, visibility-gap) read from. Scopes to a
Lancet journal slug, the flagship 'lancet', or 'all' for the whole family.

Use --years for a rolling window ending today, or --from-year/--to-year to
sync an absolute slice of the archive, which is how older years are
backfilled a slice at a time. --years cannot be combined with either
absolute bound.

Usage:
  thelancet-pp-cli refresh [flags]

Examples:
  thelancet-pp-cli refresh --journal lancet
  thelancet-pp-cli refresh --journal lancet-oncology --years 8
  thelancet-pp-cli refresh --journal lancet --from-year 1990 --to-year 1999
  thelancet-pp-cli refresh --journal all --max-pages 3

Flags:
      --db string        Database path (default ~/.local/share/thelancet-pp-cli/data.db)
      --from-year int    Only sync works published in or after this calendar year (0 = no lower bound)
  -h, --help             help for refresh
      --journal string   Journal slug, 'lancet' (flagship), or 'all' for the whole Lancet family (default "lancet")
      --max-pages int    Maximum 200-item pages to fetch per journal (bounds cost) (default 5)
      --to-year int      Only sync works published in or before this calendar year (0 = no upper bound)
      --years int        Only sync works published in the last N years (0 = all available; not combinable with --from-year/--to-year)
```

## What This CLI Does

`thelancet-pp-cli` mirrors Lancet-family publication metadata from OpenAlex into a local SQLite store, then runs analytics over that mirror: author rankings, MeSH term drift, institutional affiliation growth, and curation helpers. The read commands work against the local mirror by default, with a live fallback controlled by `--data-source`.

## Manuscripts

Not applicable — this modifies an already-published CLI rather than adding one, so there is no new run under `.manuscripts/`.

## Validation
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/developer-tools/thelancet/`
- [x] `go build ./...` from the touched CLI root
- [x] `go vet ./internal/cli/ ./internal/lancet/`
- [x] `go test ./internal/cli/ ./internal/lancet/` — both packages pass, 14 new subtests
- [ ] `go test ./...` — not clean on my machine, but for reasons unrelated to this change: `internal/cliutil` and `internal/mcp` fail because real `~/.config` and `~/.local/share` directories defeat the tests' temp-dir overrides. Pre-existing.
- [ ] `govulncheck ./...` — not run
- [x] `git diff --check`
- n/a `go run ./tools/generate-skills/main.go` — no `library/**/SKILL.md` changed

## Verification beyond the unit tests

The unit tests assert filter strings via a recording Fetcher, which would pass even if the bound never reached the API. Verified against the live OpenAlex endpoint instead:

| flags | works stored | top institution |
|---|---|---|
| `--from-year 1990 --to-year 1999` | 2000 | John Radcliffe Hospital (23) |
| `--from-year 2020 --to-year 2024` | 2000 | University College London (99) |

Identical commands differing only in the date range produced disjoint results. `rank-authors` on the 1990s mirror returns Stephen MacMahon and the Qizilbash/Godwin meta-analysis circle rather than present-day authors.

## Gaps / Follow-Up
- `govulncheck` not run locally; CI coverage assumed.
- The bounds are year-granular. Finer granularity would mean taking dates rather than years, which seemed like more surface than the use case needs.