### PR TITLE
fix(table-reservation-goat): support isolated Chromium profiles

### DIFF
--- a/library/food-and-dining/table-reservation-goat/.printing-press-patches/explicit-chromium-user-data-dir-import.json
+++ b/library/food-and-dining/table-reservation-goat/.printing-press-patches/explicit-chromium-user-data-dir-import.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "explicit-chromium-user-data-dir-import",
+  "applied_at": "2026-09-05",
+  "base_run_id": "20260712-223206",
+  "base_printing_press_version": "4.28.0",
+  "summary": "Chrome cookie import accepts an explicit absolute Chromium user-data directory and reads only that directory for OpenTable and Tock sessions.",
+  "reason": "Isolated provider profiles may deliberately live outside conventional Chrome configuration paths. Regeneration must preserve strict absolute/existing-directory validation and explicit-mode isolation: no ambient browser discovery, cookie copying, symlinks, or browser-profile mutation.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/source/auth/chrome.go",
+    "internal/source/auth/chrome_test.go",
+    "README.md"
+  ],
+  "validated_outcome": "Focused auth and CLI tests verify absolute, existing-directory validation and preserve default Chrome discovery. Explicit imports route solely through the selected root; the documented command imports into the selected CLI home without modifying browser storage."
+}

--- a/library/food-and-dining/table-reservation-goat/README.md
+++ b/library/food-and-dining/table-reservation-goat/README.md
@@ -129,6 +129,17 @@ table-reservation-goat-pp-cli doctor
 
 This checks your configuration.
 
+### Chrome session import
+
+To import OpenTable and Tock cookies from a dedicated Chromium profile, supply its **absolute user-data directory**. In this mode the CLI reads only that directory and never falls back to another browser profile:
+
+```bash
+table-reservation-goat-pp-cli auth login --chrome \
+  --chrome-user-data-dir /absolute/path/to/chromium-user-data
+```
+
+The command rejects relative paths, missing paths, and files. It imports cookies into the CLI's selected `--home` session store; it does not copy or modify the browser profile.
+
 ### 3. Try Your First Command
 
 ```bash

--- a/library/food-and-dining/table-reservation-goat/internal/cli/auth.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/auth.go
@@ -42,6 +42,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	var fromChrome bool
+	var chromeUserDataDir string
 	var withResy bool
 	var resyEmail string
 	// `auth login --chrome` writes session cookies to disk via
@@ -81,7 +82,14 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 			out := map[string]any{}
 
 			if fromChrome {
-				otCookies, tockCookies, result, err := auth.ImportFromChrome(cmd.Context())
+				var otCookies, tockCookies []auth.Cookie
+				var result *auth.ImportChromeResult
+				var err error
+				if chromeUserDataDir == "" {
+					otCookies, tockCookies, result, err = auth.ImportFromChrome(cmd.Context())
+				} else {
+					otCookies, tockCookies, result, err = auth.ImportFromChromeUserDataDir(cmd.Context(), chromeUserDataDir)
+				}
 				if err != nil {
 					return fmt.Errorf("importing chrome cookies: %w", err)
 				}
@@ -143,6 +151,7 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&fromChrome, "chrome", false, "Import OpenTable + Tock session cookies from local Chrome profile")
+	cmd.Flags().StringVar(&chromeUserDataDir, "chrome-user-data-dir", "", "Absolute Chrome/Chromium user-data directory to import exclusively (requires --chrome)")
 	cmd.Flags().BoolVar(&withResy, "resy", false, "Exchange Resy email + password for an auth token (password read from TTY with echo disabled, or stdin when piped)")
 	cmd.Flags().StringVar(&resyEmail, "email", "", "Resy email (required with --resy)")
 	return cmd

--- a/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome.go
@@ -25,6 +25,24 @@ import (
 // listed in <root>/Local State's profile.info_cache, so a profile dir present
 // on disk but missing from info_cache (corrupted, stale, fresh-install edge
 // cases) gets silently skipped along with its <profile>/Cookies file.
+// chromeUserDataDir validates a user-supplied Chrome/Chromium user-data
+// directory. Explicit mode must never accept a relative path or silently
+// fall back to ambient browser discovery: callers use it to keep account
+// sessions isolated.
+func chromeUserDataDir(path string) (string, error) {
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("Chrome user-data directory must be an absolute path")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("stat Chrome user-data directory: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("Chrome user-data path is not a directory")
+	}
+	return filepath.Clean(path), nil
+}
+
 func chromeRoots() []string {
 	cfgDir, err := os.UserConfigDir()
 	if err != nil {
@@ -113,7 +131,14 @@ func chromeCookieCandidatePathsIn(roots []string) []string {
 // keychain entries or corrupt files yield zero cookies for that file but
 // don't abort the rest of the walk.
 func supplementaryChromeCookies(ctx context.Context, domainSuffix string) ([]*kooky.Cookie, []string) {
-	paths := chromeCookieCandidatePaths()
+	return supplementaryChromeCookiesIn(ctx, domainSuffix, chromeRoots())
+}
+
+// supplementaryChromeCookiesIn reads only from roots supplied by the caller.
+// Explicit browser-profile imports use this path so they cannot fall back to
+// unrelated Chrome profiles discovered from the host configuration directory.
+func supplementaryChromeCookiesIn(ctx context.Context, domainSuffix string, roots []string) ([]*kooky.Cookie, []string) {
+	paths := chromeCookieCandidatePathsIn(roots)
 	if len(paths) == 0 {
 		return nil, nil
 	}
@@ -202,14 +227,33 @@ type ImportChromeResult struct {
 // key in the system keychain, so the user may be prompted by macOS to
 // authorize keychain access.
 func ImportFromChrome(ctx context.Context) (otCookies, tockCookies []Cookie, result *ImportChromeResult, err error) {
+	return importFromChrome(ctx, nil)
+}
+
+// ImportFromChromeUserDataDir imports cookies only from a specific Chromium
+// user-data directory. It deliberately bypasses kooky's ambient discovery so
+// a generic profile cannot read a personal profile by fallback.
+func ImportFromChromeUserDataDir(ctx context.Context, userDataDir string) (otCookies, tockCookies []Cookie, result *ImportChromeResult, err error) {
+	root, err := chromeUserDataDir(userDataDir)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return importFromChrome(ctx, []string{root})
+}
+
+func importFromChrome(ctx context.Context, roots []string) (otCookies, tockCookies []Cookie, result *ImportChromeResult, err error) {
 	result = &ImportChromeResult{}
 	// kooky returns a non-nil error when ANY cookie store fails to open,
 	// even when other stores returned cookies successfully. The errors from
 	// missing Chrome 96+ Network/Cookies paths or absent Chrome Canary are
 	// expected and non-fatal — we keep the cookies that did read and surface
 	// the error text as a note.
-	otRaw, otErr := kooky.ReadCookies(ctx, kooky.DomainHasSuffix("opentable.com"))
-	tockRaw, tockErr := kooky.ReadCookies(ctx, kooky.DomainHasSuffix("exploretock.com"))
+	var otRaw, tockRaw kooky.Cookies
+	var otErr, tockErr error
+	if roots == nil {
+		otRaw, otErr = kooky.ReadCookies(ctx, kooky.DomainHasSuffix("opentable.com"))
+		tockRaw, tockErr = kooky.ReadCookies(ctx, kooky.DomainHasSuffix("exploretock.com"))
+	}
 	// Supplement kooky's info_cache-driven discovery with a direct filesystem
 	// walk: kooky silently skips profile directories that aren't listed in
 	// <root>/Local State's profile.info_cache, even when their <profile>/Cookies
@@ -218,8 +262,12 @@ func ImportFromChrome(ctx context.Context) (otCookies, tockCookies []Cookie, res
 	// missing entries that exist on disk — recovery the user reported is to
 	// symlink <profile>/Network/Cookies -> ../Cookies, but a direct walk is
 	// the right fix.
-	otSupp, otSuppNotes := supplementaryChromeCookies(ctx, "opentable.com")
-	tockSupp, tockSuppNotes := supplementaryChromeCookies(ctx, "exploretock.com")
+	scanRoots := roots
+	if scanRoots == nil {
+		scanRoots = chromeRoots()
+	}
+	otSupp, otSuppNotes := supplementaryChromeCookiesIn(ctx, "opentable.com", scanRoots)
+	tockSupp, tockSuppNotes := supplementaryChromeCookiesIn(ctx, "exploretock.com", scanRoots)
 	otRaw = dedupeCookies(otRaw, otSupp)
 	tockRaw = dedupeCookies(tockRaw, tockSupp)
 	if otErr != nil && len(otRaw) == 0 && tockErr != nil && len(tockRaw) == 0 {

--- a/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome_test.go
@@ -94,6 +94,32 @@ func TestChromeCookieCandidatePathsIn_MissingRoot(t *testing.T) {
 	}
 }
 
+func TestChromeUserDataDirRequiresExistingAbsoluteDirectory(t *testing.T) {
+	tmp := t.TempDir()
+
+	got, err := chromeUserDataDir(tmp)
+	if err != nil {
+		t.Fatalf("chromeUserDataDir(%q): %v", tmp, err)
+	}
+	if got != tmp {
+		t.Fatalf("chromeUserDataDir() = %q, want %q", got, tmp)
+	}
+
+	for _, input := range []string{"relative-profile", filepath.Join(tmp, "missing")} {
+		if _, err := chromeUserDataDir(input); err == nil {
+			t.Errorf("chromeUserDataDir(%q) succeeded; want validation error", input)
+		}
+	}
+
+	file := filepath.Join(tmp, "not-a-directory")
+	if err := os.WriteFile(file, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := chromeUserDataDir(file); err == nil {
+		t.Errorf("chromeUserDataDir(%q) succeeded; want directory validation error", file)
+	}
+}
+
 // TestDedupeCookies_KeysOnDomainNamePath verifies the dedupe collapses
 // duplicate (Domain, Name, Path) entries and prefers the entry with the
 // later Expires.


### PR DESCRIPTION
## Summary
- Add `auth login --chrome --chrome-user-data-dir <absolute path>` for dedicated Chromium user-data roots.
- Explicit mode validates the directory and bypasses ambient Chrome discovery, preserving personal/generic session isolation.
- Record the generated-tree patch and document the non-copying import flow.

## Verification
- `go test ./internal/source/auth ./internal/cli`
- `go build ./cmd/table-reservation-goat-pp-cli`
- `go run ./cmd/table-reservation-goat-pp-cli auth login --help`
- `git diff --check origin/main...HEAD`

## Steward
- Exact head: `1d427d0edbdc29f55619e305d5b482bf282ca3c5`
- Local report: `~/.config/steward-os/reports/mvanhorn__printing-press-library/1d427d0edbdc29f55619e305d5b482bf282ca3c5-hermes-pr-review.md`
- No verified blocker found in the Steward pass.