### PR TITLE
fix(peloton): mark workouts as a critical sync resource

### DIFF
--- a/library/health/peloton/.printing-press-patches/workouts-marked-critical-resource.json
+++ b/library/health/peloton/.printing-press-patches/workouts-marked-critical-resource.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "workouts-marked-critical-resource",
+  "applied_at": "2026-09-11",
+  "base_run_id": "20260714-231159",
+  "base_printing_press_version": "4.28.0",
+  "summary": "criticalResources (internal/cli/sync.go), the template-time projection of the spec's x-critical extension consulted by sync's exit-code policy, now marks \"workouts\" true. A regen that touches this map must keep \"workouts\" critical: it's the root of this CLI's dependent graph (performance, workout_details, and classes_detail all fan out from it via planDependentSync/planClassDetailSync), so a failed flat workouts sync empties every resource that depends on it and must not exit 0 by default.",
+  "reason": "Live-tested: an archive run with the flat \"workouts\" resource failing outright still printed {\"event\":\"sync_summary\",\"total_records\":500,\"resources\":5,\"success\":1,\"warned\":3,\"errored\":1,\"duration_ms\":6271} and exited 0, because criticalResources classified no resource as critical -- the new default (added by an earlier patch, per sync's own exit-code-policy comment) treats non-critical failures as warnings. That masked a completely empty workout sync behind a green result, since workflow archive delegates directly to this same sync command and inherits its exit-code policy.",
+  "files": [
+    "internal/cli/sync.go",
+    "internal/cli/sync_hint_test.go"
+  ],
+  "validated_outcome": "go build/vet/test/govulncheck and verify_skill.py all green. New test TestWorkoutsIsMarkedCriticalForSyncExitCode guards criticalResources[\"workouts\"] == true directly; the actual exit-code branch that consumes it (sync's RunE closure) has no prior unit-test harness in this codebase to extend without a larger, out-of-scope refactor, so this is a direct regression guard on the map value rather than a full end-to-end exit-code test."
+}

--- a/library/health/peloton/.printing-press-patches/workouts-marked-critical-resource.json
+++ b/library/health/peloton/.printing-press-patches/workouts-marked-critical-resource.json
@@ -10,5 +10,5 @@
     "internal/cli/sync.go",
     "internal/cli/sync_hint_test.go"
   ],
-  "validated_outcome": "go build/vet/test/govulncheck and verify_skill.py all green. New test TestWorkoutsIsMarkedCriticalForSyncExitCode guards criticalResources[\"workouts\"] == true directly; the actual exit-code branch that consumes it (sync's RunE closure) has no prior unit-test harness in this codebase to extend without a larger, out-of-scope refactor, so this is a direct regression guard on the map value rather than a full end-to-end exit-code test."
+  "validated_outcome": "go build/vet/test/govulncheck and verify_skill.py all green. TestWorkoutsIsMarkedCriticalForSyncExitCode guards criticalResources[\"workouts\"] == true directly; TestSyncFailedWorkoutsExitsNonZero drives the real sync command end-to-end against a fake server with a failing workouts request and a succeeding classes request, asserting a non-zero exit naming workouts as the critical failure while classes still synced."
 }

--- a/library/health/peloton/internal/cli/sync.go
+++ b/library/health/peloton/internal/cli/sync.go
@@ -3051,7 +3051,16 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 // Includes both flat resources and dependent (parent-child) resources so a
 // failed child sync flagged x-critical: true exits non-zero just like a
 // flat-resource critical failure.
-var criticalResources = map[string]bool{}
+//
+// "workouts" is hand-marked critical: it's the root of this CLI's dependent
+// graph (performance, workout_details, and classes_detail all fan out from
+// it via planDependentSync/planClassDetailSync), so a failed "workouts"
+// flat sync empties every resource that depends on it. Left at the default
+// non-critical classification, an archive run where workouts fails outright
+// still exits 0 -- reported live: a 5-resource archive with workouts errored
+// completely still printed sync_summary with no non-zero exit, masking a
+// completely empty workout sync behind a green result.
+var criticalResources = map[string]bool{"workouts": true}
 
 // extractID resolves an item's primary-key field. It consults the
 // per-resource templated override first; on miss, it falls through to the

--- a/library/health/peloton/internal/cli/sync_hint_test.go
+++ b/library/health/peloton/internal/cli/sync_hint_test.go
@@ -173,3 +173,17 @@ func TestHintIfStale_ResourceFilterUsesRequestedResource(t *testing.T) {
 		t.Fatalf("stderr = %q, want unsynced comments hint", got)
 	}
 }
+
+// TestWorkoutsIsMarkedCriticalForSyncExitCode guards a live-tested bug: an
+// archive run where the flat "workouts" resource failed outright still
+// exited 0 by default, because criticalResources classified no resource as
+// critical -- masking a completely empty workout sync (and therefore empty
+// performance/workout_details/classes_detail, all of which fan out from
+// workouts via planDependentSync/planClassDetailSync) behind a green
+// sync_summary. "workouts" must stay marked critical so a failed flat sync
+// of it exits non-zero even without --strict.
+func TestWorkoutsIsMarkedCriticalForSyncExitCode(t *testing.T) {
+	if !criticalResources["workouts"] {
+		t.Fatal(`criticalResources["workouts"] = false, want true -- a failed workouts sync must exit non-zero by default, since performance/workout_details/classes_detail all depend on it`)
+	}
+}

--- a/library/health/peloton/internal/cli/sync_hint_test.go
+++ b/library/health/peloton/internal/cli/sync_hint_test.go
@@ -6,11 +6,14 @@ package cli
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/health/peloton/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/health/peloton/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -185,5 +188,66 @@ func TestHintIfStale_ResourceFilterUsesRequestedResource(t *testing.T) {
 func TestWorkoutsIsMarkedCriticalForSyncExitCode(t *testing.T) {
 	if !criticalResources["workouts"] {
 		t.Fatal(`criticalResources["workouts"] = false, want true -- a failed workouts sync must exit non-zero by default, since performance/workout_details/classes_detail all depend on it`)
+	}
+}
+
+// TestSyncFailedWorkoutsExitsNonZero is the behavioral counterpart to
+// TestWorkoutsIsMarkedCriticalForSyncExitCode: it drives the real `sync`
+// command end-to-end against a fake server where the flat workouts request
+// fails, with classes succeeding normally, and asserts the command actually
+// returns a non-zero exit naming workouts as the critical failure --
+// guarding the wiring between criticalResources and sync's exit-code
+// decision, not just the map's contents. Without workouts marked critical,
+// this exact scenario used to exit 0 (live-tested: a 5-resource archive
+// with workouts errored completely still exited 0).
+func TestSyncFailedWorkoutsExitsNonZero(t *testing.T) {
+	home := t.TempDir()
+	restore, err := cliutil.SetHomeOverride(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restore()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/workouts") {
+			// A plain 404 (not 403/429/5xx, and not a 400 with an
+			// access-policy body) fails the resource immediately without
+			// triggering the client's retry-with-backoff path, keeping this
+			// test fast.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[{"id":"class-1","title":"Test Ride","duration":1800}]`))
+	}))
+	defer server.Close()
+	t.Setenv("PELOTON_BASE_URL", server.URL)
+	t.Setenv("PELOTON_USER_ID", "u1")
+	seedValidOAuthBundleForLiveFetchTests(t)
+
+	dbPath := filepath.Join(home, "data", "data.db")
+	root := newRootCmd(&rootFlags{})
+	var out, stderr bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"sync", "--resources", "workouts,classes", "--db", dbPath, "--home", home, "--json"})
+
+	execErr := root.Execute()
+	if execErr == nil {
+		t.Fatalf("sync with a failed critical resource (workouts) exited 0, want non-zero\nstdout: %s\nstderr: %s", out.String(), stderr.String())
+	}
+	if !strings.Contains(execErr.Error(), "workouts") || !strings.Contains(execErr.Error(), "critical") {
+		t.Fatalf("sync error = %q, want it to name workouts as the critical failure", execErr.Error())
+	}
+
+	// classes should still have synced successfully -- a critical failure
+	// in one resource must not be reported as if nothing happened at all.
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if count, err := db.Count("classes"); err != nil || count == 0 {
+		t.Fatalf("classes count = %d, err = %v; classes should have synced despite workouts failing", count, err)
 	}
 }


### PR DESCRIPTION
Issue 6 of a live-tested handoff review of \`peloton-pp-mcp\`/\`peloton-pp-cli\` (see #1980, #1981 for Issues 1-2). Fixes filed as one PR per issue.

## What changed

\`sync\`'s exit-code policy treats a failed resource as a warning (exit 0) unless the resource is flagged critical (\`x-critical: true\` in the spec) or \`--strict\` is passed. \`criticalResources\` (\`internal/cli/sync.go\`) was an empty map, so **no** resource was ever classified critical.

Live-tested: an archive run with the flat \`workouts\` resource failing outright still printed

\`\`\`json
{"event":"sync_summary","total_records":500,"resources":5,"success":1,"warned":3,"errored":1,"duration_ms":6271}
\`\`\`

and exited 0. \`workouts\` is the root of this CLI's dependent graph — \`performance\`, \`workout_details\`, and \`classes_detail\` all fan out from it via \`planDependentSync\`/\`planClassDetailSync\` — so a failed \`workouts\` sync archives nothing of value downstream, but the run still reported success. \`workflow archive\` delegates directly to this same \`sync\` command, so it inherited the same masking.

This PR marks \`workouts\` critical in \`criticalResources\`, so a failed flat \`workouts\` sync now exits non-zero by default (matching the existing \`--strict\`-independent critical-failure exit path), without changing behavior for any other resource.

## Testing

- \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` — all green
- \`govulncheck ./...\` — no vulnerabilities found
- \`python3 .github/scripts/verify-skill/verify_skill.py --dir library/health/peloton/\` — all checks passed
- New test: \`TestWorkoutsIsMarkedCriticalForSyncExitCode\` — a direct regression guard on the map value. The actual exit-code branch that consumes it lives inline in \`sync\`'s cobra \`RunE\` closure with no prior unit-test harness in this codebase to extend without a larger, out-of-scope refactor (noted in the patch entry).

Patch recorded at \`library/health/peloton/.printing-press-patches/workouts-marked-critical-resource.json\` per this repo's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XVyses8UttenAe7nyzfCW